### PR TITLE
Added New Bullets Fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
     -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <!--Search Engine App Description-->
+    <meta name="description" content="em is a multi-hierarchical mind-mapping app for personal sensemaking">
 
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png?v=1">

--- a/src/App.css
+++ b/src/App.css
@@ -774,8 +774,8 @@ h1 .num-contexts {
   margin-right: -7px; /* compensate for inline-block */
   transform: rotate(90deg);
   transform-origin: -11px 9px;
-  margin-left: -2.8px;
-  margin-top: 1.5px;
+  margin-left: -2.50px;
+  margin-top: 2.5px;
 }
 
 .opera .dragging {

--- a/src/App.css
+++ b/src/App.css
@@ -763,7 +763,7 @@ h1 .num-contexts {
 .opera .child.leaf > .bullet::before {
   content: '•';
   left: -1.1px;
-  top: 3.1;
+  top: 1px;
 }
 
 .opera .child.expanded:not(.leaf) > .bullet,

--- a/src/App.css
+++ b/src/App.css
@@ -612,13 +612,13 @@ h1 .num-contexts {
 
 .child > .bullet {
   transition: transform 0.1s ease-in-out;
+  margin-left: -4.4px;
 }
 
 .child > .bullet::before {
   content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
   position: relative;
-  /*margin-right: 10px;    this causes the li to break at the beginning with longer text */
-  margin-left: -15px;
+  margin-left: -16.8px;
   opacity: 0.8;
   transition: opacity 0.75s ease-in-out;
 }
@@ -673,8 +673,8 @@ h1 .num-contexts {
 }
 
 .mobile .child.leaf > .bullet::before {
-  left: -0.05em;
-  top: 0.03em;
+  left: -2px;
+  top: 3.1;
 }
 
 .child.leaf > .bullet.show-contexts::before {

--- a/src/App.css
+++ b/src/App.css
@@ -612,13 +612,12 @@ h1 .num-contexts {
 
 .child > .bullet {
   transition: transform 0.1s ease-in-out;
-  margin-left: -4.4px;
 }
 
 .child > .bullet::before {
   content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
   position: relative;
-  margin-left: -16.8px;
+  margin-left: -15px;
   opacity: 0.8;
   transition: opacity 0.75s ease-in-out;
 }
@@ -673,8 +672,8 @@ h1 .num-contexts {
 }
 
 .mobile .child.leaf > .bullet::before {
-  left: -2px;
-  top: 3.1;
+  left: -0.05em;
+  top: 0.03em;
 }
 
 .child.leaf > .bullet.show-contexts::before {
@@ -687,6 +686,26 @@ h1 .num-contexts {
   top: 0;
   left: -0.30em;
   margin-right: -0.6em;
+}
+
+/* Android Section */
+
+.android .child > .bullet {
+  transition: transform 0.1s ease-in-out;
+  margin-left: -4.4px;
+}
+
+ .android .child > .bullet::before {
+  content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
+  position: relative;
+  margin-left: -16.8px;
+  opacity: 0.8;
+  transition: opacity 0.75s ease-in-out;
+}
+
+  .android .child.leaf > .bullet::before {
+   left: -2px;
+   top: 3.1;
 }
 
 /*.context-chain > .child > .bullet::before {

--- a/src/App.css
+++ b/src/App.css
@@ -762,7 +762,7 @@ h1 .num-contexts {
   
 .opera .child.leaf > .bullet::before {
   content: '•';
-  left: -2px;
+  left: -1.1px;
   top: 3.1;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -169,17 +169,6 @@ a.text-link {
 
 .context-breadcrumbs {
   float: left;
-  margin-bottom: -1px;
-}
-
-.context-breadcrumbs .superscript-container {
-  position: relative;
-  left: -2px;
-  top: -3px;
-}
-
-.thought-annotation .context-breadcrumbs {
-  margin-right: 2px;
 }
 
 .context-breadcrumbs .depth-bar {
@@ -211,7 +200,7 @@ a.text-link {
   box-sizing: border-box;
 }
 
-.subthought-text, .thought-annotation .breadcrumbs {
+.subthought-text {
   visibility: hidden;
 }
 
@@ -617,6 +606,7 @@ h1 .num-contexts {
 .child > .bullet::before {
   content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
   position: relative;
+  /*margin-right: 10px;    this causes the li to break at the beginning with longer text */
   margin-left: -15px;
   opacity: 0.8;
   transition: opacity 0.75s ease-in-out;
@@ -688,26 +678,6 @@ h1 .num-contexts {
   margin-right: -0.6em;
 }
 
-/* Android Section */
-
-.android .child > .bullet {
-  transition: transform 0.1s ease-in-out;
-  margin-left: -4.4px;
-}
-
- .android .child > .bullet::before {
-  content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
-  position: relative;
-  margin-left: -16.8px;
-  opacity: 0.8;
-  transition: opacity 0.75s ease-in-out;
-}
-
-  .android .child.leaf > .bullet::before {
-   left: -2px;
-   top: 3.1;
-}
-
 /*.context-chain > .child > .bullet::before {
   font-size: 10px;
   content: '◀';
@@ -736,7 +706,85 @@ h1 .num-contexts {
   margin-left: -17px;
   top: -0.15em;
 }
-*/
+
+/* Android Section */
+
+.android .child > .bullet {
+  left: -2px;
+}
+
+.android .child > .bullet::before {
+  content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
+  position: relative;
+  margin-left: -16.8px;
+  opacity: 0.8;
+  transition: opacity 0.75s ease-in-out;
+}
+
+.android .child > .bullet::after {
+  top: -1px;
+}
+ 
+.android .child.expanded:not(.leaf) > .bullet,
+.android .child.editing:not(.leaf) > .bullet,
+.android .child.cursor-parent:not(.leaf) > .bullet,
+.android .child.cursor-grandparent:not(.leaf) > .bullet {
+  display: inline-block;
+  margin-right: -7px; /* compensate for inline-block */
+  transform: rotate(90deg);
+  transform-origin: -11px 9px;
+  margin-left: -2.8px;
+  margin-top: 1.5px;
+}
+
+.android .dragging {
+  color: green;
+}
+
+.android .child.child.child.dragging > .thought::before {
+  color: green;
+  opacity: 1;
+}
+
+/* Opera Section */
+
+.opera .child > .bullet {
+  left: -2px;
+}
+
+.opera .child > .bullet::before {
+  content: '▸'; /* •◦◂◄◀︎ ➤▹▸►◥ */
+  position: relative;
+  margin-left: -15.8px;
+  opacity: 0.8;
+  transition: opacity 0.75s ease-in-out;
+}
+  
+.opera .child.leaf > .bullet::before {
+   left: -2px;
+   top: 3.1;
+}
+
+.opera .child.expanded:not(.leaf) > .bullet,
+.opera .child.editing:not(.leaf) > .bullet,
+.opera .child.cursor-parent:not(.leaf) > .bullet,
+.opera .child.cursor-grandparent:not(.leaf) > .bullet {
+  display: inline-block;
+  margin-right: -7px; /* compensate for inline-block */
+  transform: rotate(90deg);
+  transform-origin: -11px 9px;
+  margin-left: -2.8px;
+  margin-top: 1.5px;
+}
+
+.opera .dragging {
+  color: red;
+}
+
+.opera .child.child.child.dragging > .thought::before {
+  color: red;
+  opacity: 1;
+}
 
 /* overlay bullet for cursor */
 .child.editing > .thought::before,

--- a/src/App.css
+++ b/src/App.css
@@ -761,8 +761,9 @@ h1 .num-contexts {
 }
   
 .opera .child.leaf > .bullet::before {
-   left: -2px;
-   top: 3.1;
+  content: '•';
+  left: -2px;
+  top: 3.1;
 }
 
 .opera .child.expanded:not(.leaf) > .bullet,

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,6 +5,7 @@ import * as uuid from 'uuid/v4'
 export const isMobile = /Mobile/.test(navigator.userAgent)
 export const isMac = navigator.platform === 'MacIntel'
 export const isAndroid = navigator.platform === 'Android'
+export const isWindows = navigator.platform === 'Windows'
 
 // Use clientId to ignore value events from firebase originating from this client in this session
 // This approach has a possible race condition though. See https://stackoverflow.com/questions/32087031/how-to-prevent-value-event-on-the-client-that-issued-set#comment100885493_32107959

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,6 +4,7 @@ import * as uuid from 'uuid/v4'
 
 export const isMobile = /Mobile/.test(navigator.userAgent)
 export const isMac = navigator.platform === 'MacIntel'
+export const isAndroid = navigator.platform === 'Android'
 
 // Use clientId to ignore value events from firebase originating from this client in this session
 // This approach has a possible race condition though. See https://stackoverflow.com/questions/32087031/how-to-prevent-value-event-on-the-client-that-issued-set#comment100885493_32107959

--- a/src/components/AppComponent.js
+++ b/src/components/AppComponent.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import * as classNames from 'classnames'
-import { isMobile, isAndroid } from '../browser.js'
+import { isMobile, isAndroid, isWindows } from '../browser.js'
 import { store } from '../store.js'
 import globals from '../globals.js'
 import { handleGesture } from '../shortcuts.js'
@@ -84,10 +84,12 @@ export const AppComponent = connect(({ dataNonce, focus, search, showContexts, u
     container: true,
     // mobile safari must be detected because empty and full bullet points in Helvetica Neue have different margins
     mobile: isMobile,
-    android: isAndroid,
+    windows: isWindows,
+    android: /Chrome/.test(navigator.userAgent),
     'drag-in-progress': dragInProgress,
+    opera: /OPR/.test(navigator.userAgent),
     chrome: /Chrome/.test(navigator.userAgent),
-    safari: /Safari/.test(navigator.userAgent)
+    safari: /Safari/.test(navigator.userAgent),
   })}><MultiGesture onEnd={handleGesture}>
 
     <HelperWelcome />

--- a/src/components/AppComponent.js
+++ b/src/components/AppComponent.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import * as classNames from 'classnames'
-import { isMobile } from '../browser.js'
+import { isMobile, isAndroid } from '../browser.js'
 import { store } from '../store.js'
 import globals from '../globals.js'
 import { handleGesture } from '../shortcuts.js'
@@ -84,6 +84,7 @@ export const AppComponent = connect(({ dataNonce, focus, search, showContexts, u
     container: true,
     // mobile safari must be detected because empty and full bullet points in Helvetica Neue have different margins
     mobile: isMobile,
+    android: isAndroid,
     'drag-in-progress': dragInProgress,
     chrome: /Chrome/.test(navigator.userAgent),
     safari: /Safari/.test(navigator.userAgent)


### PR DESCRIPTION
Our great app was not 'Cascading' with style our bullets elements for our Android Users. We decide to make a clean and fix some issues #103 

### Unexpected Behaviour

- [ ] Open Arrow down - for expanded thoughts with context view activated
![bad](https://user-images.githubusercontent.com/41552663/69217153-4f0aa200-0b44-11ea-9073-65f5d2637f33.png)



As soon as we pop up new toughts whether it is with child or not. Our bullet were not rendering properly and make looked our app unresponsive.


The Arrow down looks akward where we lay our toughts with childrens

![unexpected](https://user-images.githubusercontent.com/41552663/69215723-d6eead00-0b40-11ea-9181-05af4582cf41.gif)


### Expected Behaviour

- [ ] Open Arrow down - for expanded thoughts with context view activated

- [ ] Closed Circle - for thoughts with no children

It rendering as expected

![good](https://user-images.githubusercontent.com/41552663/69217987-2edbe280-0b46-11ea-9f06-15ac22be8540.gif)

Just after we create a new tought our beautiful 'Bullet Circle' automatically renders accordingly the new style rules

![smooth](https://user-images.githubusercontent.com/41552663/69215506-4ca64900-0b40-11ea-889e-e7c118ab7b4c.gif)

### Testing

- Android GO
- Android Debugging Interface
- Chrome