### PR TITLE
Fix for Firefox selection position bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -591,7 +591,6 @@ h1 .num-contexts {
 /* :empty does not work because item may contain <br> */
 [placeholder]:empty::before {
   content: attr(placeholder);
-  display: block;
   cursor: text;
 }
 


### PR DESCRIPTION
#146 

Removing 'display: block' fixed the issue in Firefox, although I assume it was there for a reason. In an attempt to test my changes, I ran through both tutorials using Brave, Chrome, Firefox and Edge on my Windows machine. I also tested the change using Chrome and Safari on my iPhone. Everything looked good to me.

Being that I am unfamiliar with the app, you may want to check out the changes yourself and test features that are not included in the tutorials. If you notice something funky, let me know and I'll find a solution that doesn't involve deleting css rules :)