### PR TITLE
[Small Tutorial fix] Intented to use Roman Capital numbers

### DIFF
--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -221,7 +221,7 @@ export const Tutorial = connect(({ contextChildren, contextViews, cursor, data, 
         </React.Fragment>,
 
         [TUTORIAL_STEP_SUCCESS]: <React.Fragment>
-          <p>Congratulations... You have completed Part <span style={{ fontFamily: 'serif' }}>I < /span> of the tutorial. You now know the basics of creating thoughts in <b>em</b>.</p>
+          <p>Congratulations... You have completed Part <span style={{ fontFamily: 'serif' }}>I </span> of the tutorial. You now know the basics of creating thoughts in <b>em</b>.</p>
           <p>How are you feeling? Would you like to learn more or play on your own?</p>
         </React.Fragment>,
 

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -221,7 +221,7 @@ export const Tutorial = connect(({ contextChildren, contextViews, cursor, data, 
         </React.Fragment>,
 
         [TUTORIAL_STEP_SUCCESS]: <React.Fragment>
-          <p>Congratulations... You have completed Part <span style={{ fontFamily: 'serif' }}>i < /span> of the tutorial. You now know the basics of creating thoughts in <b>em</b>.</p>
+          <p>Congratulations... You have completed Part <span style={{ fontFamily: 'serif' }}>I < /span> of the tutorial. You now know the basics of creating thoughts in <b>em</b>.</p>
           <p>How are you feeling? Would you like to learn more or play on your own?</p>
         </React.Fragment>,
 
@@ -443,7 +443,7 @@ export const Tutorial = connect(({ contextChildren, contextViews, cursor, data, 
         </React.Fragment>,
 
         [TUTORIAL2_STEP_SUCCESS]: <React.Fragment>
-          <p>Congratulations! You have completed Part <span style={{ fontFamily: 'serif' }}>Ii < /span> of the tutorial. You now have the skills to create a vast web of thoughts in <b>em</b>.</p>
+          <p>Congratulations! You have completed Part <span style={{ fontFamily: 'serif' }}>II < /span> of the tutorial. You now have the skills to create a vast web of thoughts in <b>em</b>.</p>
           <p>That's right; you're on your own now. But you can always replay this tutorial or explore all of the available {isMobile ? 'gestures' : 'keyboard shortcuts'} by clicking the <a onClick={() => dispatch({ type: 'showHelper', id: 'help' })}>Help</a> link in the footer.</p>
           <p>Happy Sensemaking!</p>
         </React.Fragment>,


### PR DESCRIPTION
On the part one of the tutorial congratulations you may see a lower case ' roman number'
![cap1](https://user-images.githubusercontent.com/41552663/69758516-17988880-1136-11ea-8041-63616f76b1df.png)

And it reflects the issue on the tutorial step success 2

![capital](https://user-images.githubusercontent.com/41552663/69758522-1c5d3c80-1136-11ea-9ad7-ac9a53159b8d.png)

I suppose it is intented to use capital roman numbers so I step in and changed it.
- [ ] With fixes

![part1](https://user-images.githubusercontent.com/41552663/69758770-cd63d700-1136-11ea-9dd4-1dd59783c98a.png)


![part2](https://user-images.githubusercontent.com/41552663/69758775-cfc63100-1136-11ea-8305-4df5b0bebb11.png)
