### PR TITLE
Add link icon to parent with child link

### DIFF
--- a/src/components/Child.js
+++ b/src/components/Child.js
@@ -42,6 +42,7 @@ import {
   subsetItems,
   unrank,
   unroot,
+  isURL,
 } from '../util.js'
 
 /** A recursive child element that consists of a <li> containing a <div> and <ul>
@@ -172,6 +173,8 @@ export const Child = connect(({ cursor, cursorBeforeEdit, expanded, expandedCont
 
   const children = childrenForced || getChildrenWithRank(itemsRankedLive)
 
+  const isLinkParent = children.length === 1 && children[0].key && isURL(children[0].key)
+
   // if rendering as a context and the item is the root, render home icon instead of Editable
   const homeContext = showContexts && isRoot([signifier(intersections(itemsRanked))])
 
@@ -234,7 +237,7 @@ export const Child = connect(({ cursor, cursorBeforeEdit, expanded, expandedCont
       }} />
     <span className='drop-hover' style={{ display: globals.simulateDropHover || isHovering ? 'inline' : 'none' }}></span>
 
-    <ThoughtAnnotation itemsRanked={itemsRanked} showContexts={showContexts} showContextBreadcrumbs={showContextBreadcrumbs} contextChain={contextChain} homeContext={homeContext} minContexts={allowSingleContext ? 0 : 2} />
+    <ThoughtAnnotation itemsRanked={itemsRanked} showContexts={showContexts} showContextBreadcrumbs={showContextBreadcrumbs} contextChain={contextChain} homeContext={homeContext} minContexts={allowSingleContext ? 0 : 2} isLinkParent={isLinkParent} />
 
     <div className='thought' style={homeContext ? { height: '1em', marginLeft: 8 } : null}>
 

--- a/src/components/Child.js
+++ b/src/components/Child.js
@@ -174,6 +174,7 @@ export const Child = connect(({ cursor, cursorBeforeEdit, expanded, expandedCont
   const children = childrenForced || getChildrenWithRank(itemsRankedLive)
 
   const isLinkParent = children.length === 1 && children[0].key && isURL(children[0].key)
+  const childLink = isLinkParent && children[0].key
 
   // if rendering as a context and the item is the root, render home icon instead of Editable
   const homeContext = showContexts && isRoot([signifier(intersections(itemsRanked))])
@@ -237,7 +238,7 @@ export const Child = connect(({ cursor, cursorBeforeEdit, expanded, expandedCont
       }} />
     <span className='drop-hover' style={{ display: globals.simulateDropHover || isHovering ? 'inline' : 'none' }}></span>
 
-    <ThoughtAnnotation itemsRanked={itemsRanked} showContexts={showContexts} showContextBreadcrumbs={showContextBreadcrumbs} contextChain={contextChain} homeContext={homeContext} minContexts={allowSingleContext ? 0 : 2} isLinkParent={isLinkParent} />
+    <ThoughtAnnotation itemsRanked={itemsRanked} showContexts={showContexts} showContextBreadcrumbs={showContextBreadcrumbs} contextChain={contextChain} homeContext={homeContext} minContexts={allowSingleContext ? 0 : 2} isLinkParent={isLinkParent} childLink={childLink} />
 
     <div className='thought' style={homeContext ? { height: '1em', marginLeft: 8 } : null}>
 

--- a/src/components/ThoughtAnnotation.js
+++ b/src/components/ThoughtAnnotation.js
@@ -35,7 +35,7 @@ export const ThoughtAnnotation = connect(({ cursor, cursorBeforeEdit, focusOffse
     isEditing,
     focusOffset
   }
-})(({ itemsRanked, showContexts, showContextBreadcrumbs, contextChain, homeContext, isEditing, focusOffset, minContexts = 2, isLinkParent }) => {
+})(({ itemsRanked, showContexts, showContextBreadcrumbs, contextChain, homeContext, isEditing, focusOffset, minContexts = 2, isLinkParent, childLink }) => {
 
   // disable intrathought linking until add, edit, delete, and expansion can be implemented
   // get all subthoughts and the subthought under the selection
@@ -69,9 +69,12 @@ export const ThoughtAnnotation = connect(({ cursor, cursorBeforeEdit, focusOffse
             : null
           }
           {isLinkParent
-            ? <svg style={{ marginLeft: '2px' }} xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
-                <path fill="#ffffff" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
-              </svg>
+            // eslint-disable-next-line no-undef
+            ? <a href={childLink} rel="noopener noreferrer" target="_blank">
+                <svg style={{ marginLeft: '2px', cursor: 'pointer', pointerEvents: 'all' }} xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+                  <path fill="#ffffff" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
+                </svg>
+              </a>
             : null
           }
         </React.Fragment>

--- a/src/components/ThoughtAnnotation.js
+++ b/src/components/ThoughtAnnotation.js
@@ -35,7 +35,7 @@ export const ThoughtAnnotation = connect(({ cursor, cursorBeforeEdit, focusOffse
     isEditing,
     focusOffset
   }
-})(({ itemsRanked, showContexts, showContextBreadcrumbs, contextChain, homeContext, isEditing, focusOffset, minContexts = 2 }) => {
+})(({ itemsRanked, showContexts, showContextBreadcrumbs, contextChain, homeContext, isEditing, focusOffset, minContexts = 2, isLinkParent }) => {
 
   // disable intrathought linking until add, edit, delete, and expansion can be implemented
   // get all subthoughts and the subthought under the selection
@@ -66,6 +66,12 @@ export const ThoughtAnnotation = connect(({ cursor, cursorBeforeEdit, focusOffse
           { // with the default minContexts of 2, do not count the whole thought
             minContexts === 0 || subthought.contexts.length > (subthought.text === key ? 1 : 0)
             ? <StaticSuperscript n={subthought.contexts.length} />
+            : null
+          }
+          {isLinkParent
+            ? <svg style={{ marginLeft: '2px' }} xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+                <path fill="#ffffff" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
+              </svg>
             : null
           }
         </React.Fragment>

--- a/src/util.js
+++ b/src/util.js
@@ -86,6 +86,10 @@ export const escapeSelector = s => '_' + s.replace(regExpEscapeSelector, s => '_
 // checks if string contains html elements
 export const isHTML = s => /<\/?[a-z][\s\S]*>/i.test(s)
 
+// checks if string contains URL
+// eslint-disable-next-line no-useless-escape
+export const isURL = s => /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/i.test(s)
+
 /** Returns a function that calls the given function once then returns the same result forever */
 export const perma = f => {
   let result = null // eslint-disable-line fp/no-let


### PR DESCRIPTION
If a parent thought has a single child thought, and the child is a URL, add a link icon to the right of the thought which navigates to the URL in a new window.

Definition of work
- [X] Parent with single child containing link* should have link icon
- [x] Link icon should navigate to the URL in a new window

Fixes #71 

*should a url like www.google.com be handled or only those including the scheme like http://www.google.com