### PR TITLE
Fix react-split-panel warning

### DIFF
--- a/src/components/AppComponent.js
+++ b/src/components/AppComponent.js
@@ -107,6 +107,7 @@ export const AppComponent = connect(({ dataNonce, focus, search, user, settings,
               <Toolbar />
               <Content />
             </div>
+            {!showSplitView && <div/>}
             {showSplitView && <div className='panel-content'>
               <Toolbar />
               <Content />


### PR DESCRIPTION
Fix react-split-panel library warning

> Warning: Failed prop type: The prop children is marked as required in Pane, but its value is undefined.