### PR TITLE
Flush on Unmount (Throttled Editing)

### DIFF
--- a/src/components/Editable.js
+++ b/src/components/Editable.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { connect } from 'react-redux'
 import he from 'he'
 import classNames from 'classnames'
@@ -193,7 +193,7 @@ export const Editable = connect()(({ isEditing, thoughtsRanked, contextChain, sh
     throttledChangeRef.current.flush()
   })
 
-  React.useEffect(() => () => throttledChangeRef.current.flush(), []) // clean up function when component unmounts (flushing throttle change)
+  useEffect(() => throttledChangeRef.current.flush, []) // clean up function when component unmounts (flushing throttle change)
 
   // add identifiable className for restoreSelection
   return <ContentEditable

--- a/src/components/Editable.js
+++ b/src/components/Editable.js
@@ -193,6 +193,8 @@ export const Editable = connect()(({ isEditing, thoughtsRanked, contextChain, sh
     throttledChangeRef.current.flush()
   })
 
+  React.useEffect(() => () => throttledChangeRef.current.flush(), []) // clean up function when component unmounts (flushing throttle change)
+
   // add identifiable className for restoreSelection
   return <ContentEditable
     className={classNames({
@@ -283,6 +285,7 @@ export const Editable = connect()(({ isEditing, thoughtsRanked, contextChain, sh
           }
         })
       }
+      throttledChangeRef.current.flush() // flushing the throttle change when onblur
     }}
     onChange={throttledChangeRef.current}
     onPaste={e => {


### PR DESCRIPTION
Hi, I have added  clean up function using `React.useEffect` hook to flush the throttled `onChangeHandler` and also called the same flush function on `ContentEditable`.