### PR TITLE
Refactors getSettings function

### DIFF
--- a/src/action-creators/newThought.js
+++ b/src/action-creators/newThought.js
@@ -46,7 +46,7 @@ import {
 
 export const newThought = ({ at, insertNewSubthought, insertBefore, value = '', offset } = {}) => dispatch => {
   const state = store.getState()
-  const tutorialStep = +getSetting('Tutorial Step')[0]
+  const tutorialStep = +getSetting('Tutorial Step')
   const tutorialStepNewThoughtCompleted =
     // new thought
     (!insertNewSubthought && (

--- a/src/action-creators/scaleSize.js
+++ b/src/action-creators/scaleSize.js
@@ -12,7 +12,7 @@ import {
 } from '../constants.js'
 
 export const scaleFontUp = () => {
-  const fontSize = +getSetting('Font Size')[0]
+  const fontSize = +getSetting('Font Size')
   if (fontSize < MAX_FONT_SIZE) {
     store.dispatch({
       type: 'settings',
@@ -23,7 +23,7 @@ export const scaleFontUp = () => {
 }
 
 export const scaleFontDown = () => {
-  const fontSize = +getSetting('Font Size')[0]
+  const fontSize = +getSetting('Font Size')
   if (fontSize > (MIN_FONT_SIZE + FONT_SCALE_INCREMENT)) {
     store.dispatch({
       type: 'settings',

--- a/src/action-creators/tutorial.js
+++ b/src/action-creators/tutorial.js
@@ -13,7 +13,7 @@ import {
 
 /** Advances the tutorial one step (whole step by default; optional hint argument for fractional step). */
 export const tutorialNext = ({ hint } = {}) => {
-  const tutorialStep = +getSetting('Tutorial Step')[0]
+  const tutorialStep = +getSetting('Tutorial Step')
 
   // end
   if (tutorialStep === TUTORIAL_STEP_SUCCESS || tutorialStep === TUTORIAL2_STEP_SUCCESS) {
@@ -34,6 +34,6 @@ export const tutorialNext = ({ hint } = {}) => {
 
 /** Disaddvances the tutorial one step (whole step by default; optional hint argument for fractional step). */
 export const tutorialPrev = ({ hint } = {}) => {
-  const tutorialStep = +getSetting('Tutorial Step')[0]
+  const tutorialStep = +getSetting('Tutorial Step')
   store.dispatch({ type: 'tutorialStep', value: !hint ? Math.floor(tutorialStep) - 1 : tutorialStep - 0.1 })
 }

--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -56,8 +56,8 @@ type typeOfState = ReturnType<typeof initialStateResult>
 
 const mapStateToProps = (state: typeOfState): StateProps => {
   const { dragInProgress, isLoading, showModal, splitPosition, showSplitView } = state
-  const dark = (isLoading ? darkLocal : getSetting('Theme')[0]) !== 'Light'
-  const scale = (isLoading ? fontSizeLocal : getSetting('Font Size')[0] || 16) / 16
+  const dark = (isLoading ? darkLocal : getSetting('Theme')) !== 'Light'
+  const scale = (isLoading ? fontSizeLocal : getSetting('Font Size') || 16) / 16
   return {
     dark,
     dragInProgress,
@@ -134,7 +134,7 @@ const AppComponent: FC<Props> = (props) => {
 
         {showModal
 
-        // modals
+          // modals
           ? (
             <>
               <ModalWelcome />
@@ -143,7 +143,7 @@ const AppComponent: FC<Props> = (props) => {
             </>
           )
 
-        // navigation, content, and footer
+          // navigation, content, and footer
           : (
             <>
 
@@ -166,7 +166,7 @@ const AppComponent: FC<Props> = (props) => {
                       <Content />
                     </Scale>
                   )
-                // children required by SplitPane
+                  // children required by SplitPane
                   : <div />}
               </SplitPane>
               <div className='nav-bottom-wrapper'>

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -33,7 +33,7 @@ const tutorialStepLocal = +(localStorage['Settings/Tutorial Step'] || 1)
 
 const mapStateToProps = ({ focus, search, isLoading, showModal }) => {
   const isTutorial = isLoading ? tutorialLocal : meta([EM_TOKEN, 'Settings', 'Tutorial']).On
-  const tutorialStep = isLoading ? tutorialStepLocal : getSetting('Tutorial Step')[0] || 1
+  const tutorialStep = isLoading ? tutorialStepLocal : getSetting('Tutorial Step') || 1
   const rootThoughts = getThoughtsRanked(RANKED_ROOT)
   return {
     focus,

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -22,7 +22,7 @@ export const Footer = connect(({ authenticated, status, user }) => ({
   authenticated,
   status,
   tutorial: meta([EM_TOKEN, 'Settings', 'Tutorial']).On,
-  tutorialStep: +getSetting('Tutorial Step')[0] || 1,
+  tutorialStep: +getSetting('Tutorial Step') || 1,
   user
 }))(({ authenticated, status, tutorialStep, user, dispatch }) => {
 
@@ -51,7 +51,7 @@ export const Footer = connect(({ authenticated, status, user }) => ({
           : <a tabIndex='-1' onClick={login}>Log In</a>
         }
       </span> : null}
-    </li><br/>
+    </li><br />
     {user ? <li><span className='dim'>Logged in as: </span>{user.email}</li> : null}
     {user ? <li><span className='dim'>User ID: </span><span className='mono'>{user.uid.slice(0, 6)}</span></li> : null}
     <li><span className='dim'>Version: </span><span>{pkg.version}</span></li>

--- a/src/components/ModalExport.js
+++ b/src/components/ModalExport.js
@@ -29,7 +29,7 @@ export const ModalExport = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [wrapperRef, setWrapper] = useState()
 
-  const dark = getSetting('Theme')[0] !== 'Light'
+  const dark = getSetting('Theme') !== 'Light'
   const descendants = cursor ? getDescendants(cursor) : []
   const exportMessage = cursor ? `Export "${ellipsize(headValue(cursor))}"` + (descendants.length > 0 ? ` and ${descendants.length} subthoughts${descendants.length === 1 ? '' : 's'} as ${selected.label}` : '') : null
 
@@ -90,8 +90,7 @@ export const ModalExport = () => {
             color: 'white',
             backgroundColor: 'black',
           }
-        }
-        onClick={onExportClick}
+        } onClick={onExportClick}
         >Export</button>
         <button
           className='modal-btn-cancel'

--- a/src/components/ModalHelp.js
+++ b/src/components/ModalHelp.js
@@ -22,7 +22,7 @@ import {
 } from '../constants.js'
 
 export const ModalHelp = connect(({ showQueue }) => ({
-  tutorialStep: +getSetting('Tutorial Step')[0],
+  tutorialStep: +getSetting('Tutorial Step'),
   showQueue,
 }))(({ queue, tutorialStep, showQueue, dispatch }) =>
   <Modal id='help' title='Help' className='popup'>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,7 +13,7 @@ import { Breadcrumbs } from './Breadcrumbs.js'
 import { HomeLink } from './HomeLink.js'
 
 /** A navigation bar that contains a link to home and breadcrumbs. */
-export const NavBar = connect(({ cursor }) => ({ cursor, tutorialStep: +getSetting('Tutorial Step')[0] }))(({ cursor, position, tutorialStep }) =>
+export const NavBar = connect(({ cursor }) => ({ cursor, tutorialStep: +getSetting('Tutorial Step') }))(({ cursor, position, tutorialStep }) =>
   <div className={classNames({
     nav: true,
     ['nav-' + position]: true

--- a/src/components/NewThoughtInstructions.js
+++ b/src/components/NewThoughtInstructions.js
@@ -22,7 +22,7 @@ import {
 const newThoughtShortcut = shortcutById('newThought')
 assert(newThoughtShortcut)
 
-export const NewThoughtInstructions = connect(({ isLoading, status }) => ({ isLoading, status, tutorialStep: +getSetting('Tutorial Step')[0] }))(({ children, isLoading: localLoading, status, tutorialStep }) =>
+export const NewThoughtInstructions = connect(({ isLoading, status }) => ({ isLoading, status, tutorialStep: +getSetting('Tutorial Step') }))(({ children, isLoading: localLoading, status, tutorialStep }) =>
 
   // loading
   // show loading message if local store is loading or if remote is loading and there are no children
@@ -30,17 +30,17 @@ export const NewThoughtInstructions = connect(({ isLoading, status }) => ({ isLo
     <i className='text-note'>Loading...</i>
   </div>
 
-  // tutorial no children
-  // show special message when there are no children in tutorial
+    // tutorial no children
+    // show special message when there are no children in tutorial
     : isTutorial()
       ? children.length === 0 && (tutorialStep !== TUTORIAL_STEP_FIRSTTHOUGHT || !isMobile)
         ? <div className='center-in-content'>
           <i className='text-note'>Ahhh. Open space. Unlimited possibilities.</i>
         </div>
-      // hide on mobile during TUTORIAL_STEP_FIRSTTHOUGHT since the gesture diagram is displayed
+        // hide on mobile during TUTORIAL_STEP_FIRSTTHOUGHT since the gesture diagram is displayed
         : null
 
-    // default
+      // default
       : <React.Fragment>
         <React.Fragment>{isMobile
           ? <span className='gesture-container'>Swipe <GestureDiagram path={newThoughtShortcut.gesture} size='30' color='darkgray' /></span>

--- a/src/components/Subthoughts.js
+++ b/src/components/Subthoughts.js
@@ -259,7 +259,7 @@ const SubthoughtsComponent = ({
   // <Subthoughts> render
   const [page, setPage] = useState(1)
 
-  const globalSort = getSetting(['Global Sort'])[0] || 'None'
+  const globalSort = getSetting(['Global Sort']) || 'None'
   const sortPreference = contextSort || globalSort
   const { cursor } = store.getState()
   const thought = getThought(headValue(thoughtsRanked), 1)

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -49,7 +49,7 @@ const mapStateToProps = () => ({ cursor, isLoading, toolbarOverlay, scrollPriori
   cursor,
   dark: !meta([EM_TOKEN, 'Settings', 'Theme']).Light,
   isLoading,
-  scale: (isLoading ? fontSizeLocal : getSetting('Font Size')[0] || 16) / 16,
+  scale: (isLoading ? fontSizeLocal : getSetting('Font Size') || 16) / 16,
   scrollPrioritized,
   showHiddenThoughts,
   showSplitView,

--- a/src/components/Tutorial/Tutorial2StepContextViewToggle.js
+++ b/src/components/Tutorial/Tutorial2StepContextViewToggle.js
@@ -18,7 +18,7 @@ import {
 
 /** Returns true if the current tutorialStep is a hint */
 const isHint = () => {
-  const tutorialStep = +getSetting('Tutorial Step')[0]
+  const tutorialStep = +getSetting('Tutorial Step')
   return tutorialStep !== Math.floor(tutorialStep)
 }
 

--- a/src/components/Tutorial/TutorialHint.js
+++ b/src/components/Tutorial/TutorialHint.js
@@ -6,7 +6,7 @@ import {
 } from '../../util'
 
 /** Renders a hint button that will advance the tutorial by a fractional step and show a hint. */
-const TutorialHint = connect(() => ({ tutorialStep: +getSetting('Tutorial Step')[0] }))(({ tutorialStep, children, dispatch }) => {
+const TutorialHint = connect(() => ({ tutorialStep: +getSetting('Tutorial Step') }))(({ tutorialStep, children, dispatch }) => {
 
   // fractional steps are hints
   const hint = tutorialStep !== Math.floor(tutorialStep)

--- a/src/reducers/setCursor.js
+++ b/src/reducers/setCursor.js
@@ -86,8 +86,8 @@ export default (state, { thoughtsRanked, contextChain = [], cursorHistoryClear, 
       : []
   )
 
-  const tutorialChoice = +getSetting('Tutorial Choice', state)[0] || 0
-  const tutorialStep = +getSetting('Tutorial Step', state)[0] || 1
+  const tutorialChoice = +getSetting('Tutorial Choice', state) || 0
+  const tutorialStep = +getSetting('Tutorial Step', state) || 1
   const tutorialNext = (
     tutorialStep === TUTORIAL_STEP_AUTOEXPAND &&
     thoughtsResolved &&

--- a/src/reducers/toggleContextView.js
+++ b/src/reducers/toggleContextView.js
@@ -42,7 +42,7 @@ export default state => {
 
   updateUrlHistory(state.cursor, { thoughtIndex: state.thoughtIndex, contextIndex: state.contextIndex, contextViews })
 
-  const tutorialStep = +getSetting('Tutorial Step', state)[0]
+  const tutorialStep = +getSetting('Tutorial Step', state)
   return {
     contextViews,
     ...settings(state, {

--- a/src/shortcuts/newThought.js
+++ b/src/shortcuts/newThought.js
@@ -31,8 +31,8 @@ const Icon = ({ fill = 'black', size = 20, style }) => <svg version="1.1" classN
 // newThought command handler that does some pre-processing before handing off to newThought
 const exec = (e, { type }) => {
   const { cursor } = store.getState()
-  const tutorial = getSetting('Tutorial')[0] !== 'Off'
-  const tutorialStep = +getSetting('Tutorial Step')[0]
+  const tutorial = getSetting('Tutorial') !== 'Off'
+  const tutorialStep = +getSetting('Tutorial Step')
 
   // cancel if tutorial has just started
   if (tutorial && tutorialStep === TUTORIAL_STEP_START) return

--- a/src/shortcuts/toggleSort.js
+++ b/src/shortcuts/toggleSort.js
@@ -22,7 +22,7 @@ export default {
   svg: Icon,
   exec: () => {
     const { cursor } = store.getState()
-    const globalSort = getSetting(['Global Sort'])[0]
+    const globalSort = getSetting(['Global Sort'])
     const sortPreference = globalSort === 'Alphabetical' ? 'None' : 'Alphabetical'
     if (cursor) {
       store.dispatch(toggleAttribute(pathToContext(cursor), '=sort', sortPreference))

--- a/src/util/dataIntegrityCheck.js
+++ b/src/util/dataIntegrityCheck.js
@@ -25,7 +25,7 @@ export const dataIntegrityCheck = path => {
 
   const { contextIndex, thoughtIndex } = store.getState()
 
-  if (getSetting('Data Integrity Check')[0] !== 'On' || !path) return
+  if (getSetting('Data Integrity Check') !== 'On' || !path) return
 
   const thoughtRanked = head(path)
   const value = headValue(path)

--- a/src/util/getSetting.js
+++ b/src/util/getSetting.js
@@ -10,7 +10,6 @@ import {
 } from '../util.js'
 
 /** Returns subthoughts of /em/Settings/...context, not including meta subthoughts */
-export const getSetting = (context, { thoughtIndex = store.getState().thoughtIndex, contextIndex = store.getState().contextIndex, depth = 0 } = {}) =>
-  getThoughtsRanked([EM_TOKEN, 'Settings'].concat(context), thoughtIndex, contextIndex)
-    .filter(child => !isFunction(child.value))
-    .map(child => child.value)
+export const getSetting = (context, thoughtIndex = store.getState().thoughtIndex, contextIndex = store.getState().contextIndex, depth = 0) =>
+  (getThoughtsRanked([EM_TOKEN, 'Settings'].concat(context), thoughtIndex, contextIndex)
+    .find(child => !isFunction(child.value)) || {}).value

--- a/src/util/getSortPreference.js
+++ b/src/util/getSortPreference.js
@@ -6,6 +6,6 @@ import {
 /** Get the sort setting from the given context meta or, if not provided, the global sort */
 export const getSortPreference = contextMeta => {
   return contextMeta.sort && contextMeta.sort.length !== 0
-    ? Object.keys(contextMeta.sort)[0]
-    : getSetting(['Global Sort'])[0] || 'None'
+    ? Object.keys(contextMeta.sort)
+    : getSetting(['Global Sort']) || 'None'
 }

--- a/src/util/isTutorial.js
+++ b/src/util/isTutorial.js
@@ -4,4 +4,4 @@ import {
 
 // util
 /** Returns true if the tutorial is active. */
-export const isTutorial = state => getSetting('Tutorial', state)[0] === 'On'
+export const isTutorial = state => getSetting('Tutorial', state) === 'On'

--- a/src/util/syncRemote.js
+++ b/src/util/syncRemote.js
@@ -28,7 +28,7 @@ export const syncRemote = (thoughtIndexUpdates = {}, contextIndexUpdates = {}, r
   const prependedDataUpdates = reduceObj(thoughtIndexUpdates, (key, thought) => {
     return key ? {
       // fix undefined/NaN rank
-      ['thoughtIndex/' + (key || EMPTY_TOKEN)]: thought && getSetting('Data Integrity Check')[0] === 'On'
+      ['thoughtIndex/' + (key || EMPTY_TOKEN)]: thought && getSetting('Data Integrity Check') === 'On'
         ? {
           lastUpdated: thought.lastUpdated || timestamp(),
           value: thought.value,
@@ -46,7 +46,7 @@ export const syncRemote = (thoughtIndexUpdates = {}, contextIndexUpdates = {}, r
   )
   const prependedcontextIndexUpdates = reduceObj(contextIndexUpdates, (key, subthoughts) => ({
     // fix undefined/NaN rank
-    ['contextIndex/' + key]: subthoughts && getSetting('Data Integrity Check')[0] === 'On'
+    ['contextIndex/' + key]: subthoughts && getSetting('Data Integrity Check') === 'On'
       ? subthoughts.map(subthought => ({
         value: subthought.value || '', // guard against NaN or undefined,
         rank: subthought.rank || 0, // guard against NaN or undefined


### PR DESCRIPTION
The current `getSetting` function was returning an array with a single item and we're consuming it like `getSettings()[0]` everywhere in the app, which appeared to be confusing. 
With an assumption that the purpose of `getSetting` function is to retrieve the value of a particular setting at a time, this commit refactors the same to return that value as expected.