### PR TITLE
Duplicate rank on empty thought merge fix 

### DIFF
--- a/src/action-creators/deleteEmptyThought.js
+++ b/src/action-creators/deleteEmptyThought.js
@@ -59,12 +59,14 @@ export const deleteEmptyThought = () => dispatch => {
           thoughtsRanked: contextOf(thoughtsRanked).concat(prev)
         })
 
+        const nextRank = getNextRank(thoughtsRankedPrevNew)
+
         // merge children into merged thought
-        children.forEach(child => {
+        children.forEach((child, i) => {
           dispatch({
             type: 'existingThoughtMove',
             oldPath: thoughtsRanked.concat(child),
-            newPath: thoughtsRankedPrevNew.concat({ ...child, rank: getNextRank(thoughtsRankedPrevNew) })
+            newPath: thoughtsRankedPrevNew.concat({ ...child, rank: nextRank + i })
           })
         })
 

--- a/src/action-creators/deleteEmptyThought.js
+++ b/src/action-creators/deleteEmptyThought.js
@@ -9,6 +9,7 @@ import {
 import {
   contextOf,
   deleteThought,
+  getNextRank,
   getThoughtsRanked,
   head,
   headRank,
@@ -21,7 +22,6 @@ import {
   rootedContextOf,
   splitChain,
 } from '../util.js'
-import { getNextRank } from '../util/getNextRank.js'
 
 export const deleteEmptyThought = () => dispatch => {
   const { cursor, contextViews, editing } = store.getState()

--- a/src/action-creators/deleteEmptyThought.js
+++ b/src/action-creators/deleteEmptyThought.js
@@ -21,6 +21,7 @@ import {
   rootedContextOf,
   splitChain,
 } from '../util.js'
+import { getNextRank } from '../util/getNextRank.js'
 
 export const deleteEmptyThought = () => dispatch => {
   const { cursor, contextViews, editing } = store.getState()
@@ -63,7 +64,7 @@ export const deleteEmptyThought = () => dispatch => {
           dispatch({
             type: 'existingThoughtMove',
             oldPath: thoughtsRanked.concat(child),
-            newPath: thoughtsRankedPrevNew.concat(child)
+            newPath: thoughtsRankedPrevNew.concat({ ...child, rank: getNextRank(thoughtsRankedPrevNew) })
           })
         })
 


### PR DESCRIPTION
@raineorshine i used `getRankNext` for each merging children to find unique rank within new context. It works properly. Please review the changes.