### PR TITLE
Fix: cursor disappears after moving parent #276

### DIFF
--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -180,11 +180,18 @@ export default (state, { oldPath, newPath, offset }) => {
     }
   })
 
+  const generateCursorNewPath = () => {
+    const lengthDiff = newPath.length - state.cursor.length
+    if (lengthDiff !== 0) {
+      return [...newPath, ...state.cursor.slice(-Math.abs(lengthDiff))]
+    }
+    return newPath
+  }
   return {
     thoughtIndex,
     dataNonce: state.dataNonce + 1,
-    cursor: editing ? newPath : state.cursor,
-    cursorBeforeEdit: editing ? newPath : state.cursorBeforeEdit,
+    cursor: generateCursorNewPath(),
+    cursorBeforeEdit: generateCursorNewPath(),
     cursorOffset: offset,
     contextIndex: contextIndexNew,
     contextViews: contextViewsNew,


### PR DESCRIPTION
It works, but I am not exactly sure about the rest of the functionality. Cursor always keep old state because `editing` always was false. We tried to check is path equal for cursor and oldPath (oldPath has 2 child and cursor has 3 when we move parent)