### PR TITLE
Changed isTableColumn2 to isTableColumn1 (Table expand fix)

### DIFF
--- a/src/util/expandThoughts.js
+++ b/src/util/expandThoughts.js
@@ -53,15 +53,15 @@ export const expandThoughts = (path, thoughtIndex, contextIndex, contextViews = 
     ? getThoughtsRanked((path || []).concat(children[0]), thoughtIndex, contextIndex)
     : null
 
-  const isTableColumn2 = () => attributeEquals(
+  const isTableColumn1 = () => attributeEquals(
     { contextIndex, thoughtIndex },
-    contextOf(contextOf(pathToContext(thoughtsRanked))),
+    contextOf(pathToContext(thoughtsRanked)),
     '=view',
     'Table'
   )
 
   const isOnlyChildNoUrl = subChildren &&
-    !isTableColumn2() &&
+    !isTableColumn1() &&
     (subChildren.length !== 1 || !isURL(subChildren[0].value))
 
   const isTable = () => attributeEquals({ thoughtIndex, contextIndex }, pathToContext(thoughtsRanked), '=view', 'Table')


### PR DESCRIPTION
@raineorshine Previous PR #569 used `isTableColumn2` . But it didn't actually solve the problem. It should be `isTableColumn1` because `expandThoughts` function expands the current path by default (except if it has reached maximum depth) and the filters its children. 