### PR TITLE
Toolbar highlights

### DIFF
--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -29,7 +29,6 @@ const Note = ({ context }) => {
   const dispatch = useDispatch()
 
   const onKeyDown = e => {
-
     // delete empty note
     // need to get updated note attribute (not the note in the outside scope)
     const note = attribute(context, '=note')

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -32,6 +32,7 @@ import {
 
 // util
 import {
+  attribute,
   getSetting,
   isDocumentEditable,
   pathToContext,
@@ -60,6 +61,8 @@ const mapStateToProps = state => {
     cursorOnAlphabeticalSort: cursor && attributeEquals(state, context, '=sort', 'Alphabetical'),
     cursorPinOpen: cursor && attributeEquals(state, context, '=pin', 'true'),
     cursorPinSubthoughts: cursor && attributeEquals(state, context, '=pinChildren', 'true'),
+    cursorOnNote: cursor && attributeEquals(state, context, '=note', attribute(context, '=note') || ''),
+    cursorOnProseView: cursor && attributeEquals(state, context, '=view', 'Prose'),
     dark: theme(state) !== 'Light',
     isLoading,
     scale: (isLoading ? fontSizeLocal : getSetting('Font Size') || DEFAULT_FONT_SIZE) / BASE_FONT_SIZE,
@@ -70,7 +73,7 @@ const mapStateToProps = state => {
   }
 }
 
-const Toolbar = ({ cursorOnTableView, cursorOnAlphabeticalSort, cursorPinOpen, cursorPinSubthoughts, dark, scale, toolbarOverlay, scrollPrioritized, showHiddenThoughts, showSplitView }) => {
+const Toolbar = ({ cursorOnTableView, cursorOnAlphabeticalSort, cursorPinOpen, cursorPinSubthoughts, cursorOnNote, cursorOnProseView, dark, scale, toolbarOverlay, scrollPrioritized, showHiddenThoughts, showSplitView }) => {
   const [holdTimer, setHoldTimer] = useState()
   const [holdTimer2, setHoldTimer2] = useState()
   const [lastScrollLeft, setLastScrollLeft] = useState()
@@ -218,15 +221,17 @@ const Toolbar = ({ cursorOnTableView, cursorOnAlphabeticalSort, cursorPinOpen, c
               >
                 <Icon id={id}
                   style={{
-                    fill: id === 'toggleTableView' && cursorOnTableView ? 'gray'
-                    : id === 'toggleSplitView' && !showSplitView ? 'gray'
-                    : id === 'undo' ? 'gray'
-                    : id === 'redo' ? 'gray'
-                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? 'gray'
-                    : id === 'toggleSort' && cursorOnAlphabeticalSort ? 'gray'
-                    : id === 'pinOpen' && cursorPinOpen ? 'gray'
-                    : id === 'pinSubthoughts' && cursorPinSubthoughts ? 'gray'
-                    : fg
+                    fill: id === 'toggleTableView' && cursorOnTableView ? fg
+                    : id === 'toggleSplitView' && showSplitView ? fg
+                    : id === 'note' && cursorOnNote ? fg
+                    : id === 'proseView' && cursorOnProseView ? fg
+                    : id === 'undo' ? fg
+                    : id === 'redo' ? fg
+                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? fg
+                    : id === 'toggleSort' && cursorOnAlphabeticalSort ? fg
+                    : id === 'pinOpen' && cursorPinOpen ? fg
+                    : id === 'pinSubthoughts' && cursorPinSubthoughts ? fg
+                    : 'gray'
                   }} />
               </div>
             )

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -61,7 +61,7 @@ const mapStateToProps = state => {
     cursorOnAlphabeticalSort: cursor && attributeEquals(state, context, '=sort', 'Alphabetical'),
     cursorPinOpen: cursor && attributeEquals(state, context, '=pin', 'true'),
     cursorPinSubthoughts: cursor && attributeEquals(state, context, '=pinChildren', 'true'),
-    cursorOnNote: cursor && attributeEquals(state, context, '=note', attribute(context, '=note') || ''),
+    cursorOnNote: cursor && attribute(context, '=note') != null,
     cursorOnProseView: cursor && attributeEquals(state, context, '=view', 'Prose'),
     dark: theme(state) !== 'Light',
     isLoading,

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -221,16 +221,21 @@ const Toolbar = ({ cursorOnTableView, cursorOnAlphabeticalSort, cursorPinOpen, c
               >
                 <Icon id={id}
                   style={{
-                    fill: id === 'toggleTableView' && cursorOnTableView ? fg
-                    : id === 'toggleSplitView' && showSplitView ? fg
-                    : id === 'note' && cursorOnNote ? fg
-                    : id === 'proseView' && cursorOnProseView ? fg
-                    : id === 'undo' ? fg
-                    : id === 'redo' ? fg
-                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? fg
+                    fill: id === 'search' ? fg
+                    : id === 'outdent' ? fg
+                    : id === 'indent' ? fg
+                    : id === 'toggleTableView' && cursorOnTableView ? fg
                     : id === 'toggleSort' && cursorOnAlphabeticalSort ? fg
                     : id === 'pinOpen' && cursorPinOpen ? fg
                     : id === 'pinSubthoughts' && cursorPinSubthoughts ? fg
+                    : id === 'note' && cursorOnNote ? fg
+                    : id === 'delete' ? fg
+                    : id === 'toggleContextView' ? fg
+                    : id === 'proseView' && cursorOnProseView ? fg
+                    : id === 'toggleSplitView' && showSplitView ? fg
+                    : id === 'undo' ? fg
+                    : id === 'redo' ? fg
+                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? fg
                     : 'gray'
                   }} />
               </div>

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -233,9 +233,12 @@ const Toolbar = ({ cursorOnTableView, cursorOnAlphabeticalSort, cursorPinOpen, c
                     : id === 'toggleContextView' ? fg
                     : id === 'proseView' && cursorOnProseView ? fg
                     : id === 'toggleSplitView' && showSplitView ? fg
+                    : id === 'subcategorizeOne' ? fg
+                    : id === 'subcategorizeAll' ? fg
+                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? fg
+                    : id === 'exportContext' ? fg
                     : id === 'undo' ? fg
                     : id === 'redo' ? fg
-                    : id === 'toggleHiddenThoughts' && !showHiddenThoughts ? fg
                     : 'gray'
                   }} />
               </div>


### PR DESCRIPTION
#442

Did some changes. Please point me out, if i missed something. 

There's a issue with note icon highlight. I added attributeEquals check for note icon. It uses current text in note, and bases on context. When we switch between thoughts, context changes. But if you click on Thought's note, context won't change. e.g.
*a
  //note
  *b
  *c
When the cursor is on *b, you are in [a,b] context. If you click on note, context will stay the same [a,b]. Context will be changed only after click on *a.

I think we need to change context somehow, when note is in focus