### PR TITLE
Prevent rank change if thought moves within same context

### DIFF
--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -84,8 +84,8 @@ export default (state, { oldPath, newPath, offset }) => {
       // remove and add the new context of the child
       const contextNew = newThoughts.concat(contextRecursive)
 
-      // update rank of first depth of childs
-      const movedRank = newLastRank ? newLastRank + i : child.rank
+      // update rank of first depth of childs except when a thought has been moved within the same context
+      const movedRank = !sameContext && newLastRank ? newLastRank + i : child.rank
       const childNewThought = removeDuplicatedContext(addContext(removeContext(childThought, pathToContext(oldThoughtsRanked), child.rank), contextNew, movedRank), contextNew)
 
       // update local thoughtIndex so that we do not have to wait for firebase


### PR DESCRIPTION
Fixes #614.

@raineorshine The reason  for  `contextIndex` not getting updated as `thoughtIndex` was because of the logic that prevented `contextIndexDescendantUpdates` from getting new updates when `sameContext` is true. That was in place to prevent unnecessary computation and that is the right thing to do. So instead I prevented updating ranks for the first depth child  (i.e updating `thoughtIndex`)  if thought moves within same context. Please review it. Thanks!