### PR TITLE
add setCursor on change in Editable

### DIFF
--- a/src/components/Editable.js
+++ b/src/components/Editable.js
@@ -187,6 +187,7 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
       )) {
         tutorialNext()
       }
+      dispatch({ type: 'setCursor', thoughtsRanked })
     }
   }
 
@@ -266,6 +267,7 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
       thoughtChangeHandler(newValue, { context, showContexts, rank, thoughtsRanked, contextChain })
     }
     else throttledChangeRef.current(newValue, { context, showContexts, rank, thoughtsRanked, contextChain })
+    dispatch({ type: 'setCursor', thoughtsRanked })
   }
 
   const onPaste = e => {


### PR DESCRIPTION
Issue #540
@raineorshine Raine, these days i was thinking a lot about this issue and trying different options. These 2 lines of code make sorting working in someway, but break backspace logic and cause some bugs. I think i should have published it earlier in order to get different feedbacks and opinions, sorry for that. :( The task is exciting and i'm ready to continue working on it, also it gave better understanding of current codebase, but takes a lot of time. 

As i see, we just need to re-execute `getThoughtsSorted` in Subthought compoentnt and set the cursor back, but the devil in the details
I also tried dispatching `setCursor` in `onChange` method of Editable component, it sorted thoughts but Editable component lose focus  after throttled `thoughtChangeHandler` function invocation. Maybe the problem is that value of Thought changed.

What do you think about it?