### PR TITLE
Duplicate thought in a context after merge (existingThoughtMove) fix

### DIFF
--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -1,3 +1,8 @@
+// constants
+import {
+  ID,
+} from '../constants'
+
 // util
 import {
   addContext,
@@ -72,7 +77,7 @@ export default (state, { oldPath, newPath, offset }) => {
     .filter(child => child.value !== value)
     .concat({
       value,
-      rank: (isDuplicateMerge) ? duplicateSubthought.rank : newRank,
+      rank: isDuplicateMerge ? duplicateSubthought.rank : newRank,
       lastUpdated: timestamp()
     })
 
@@ -183,6 +188,7 @@ export default (state, { oldPath, newPath, offset }) => {
     })
   }
 
+  /** Updates the ranks within the given path to match those in descendantUpdatesResult */
   const updateMergedThoughtsRank = path => path.map(
     child => {
       const updatedThought = descendantUpdatesResult[hashThought(child.value)]
@@ -191,10 +197,12 @@ export default (state, { oldPath, newPath, offset }) => {
   )
 
   // if duplicate subthoughts are merged then update rank of thoughts of cursor descendants
-  const cursorDescendantPath = ((isPathInCursor && isDuplicateMerge) ? updateMergedThoughtsRank : p => p)(state.cursor || []).slice(oldPath.length)
+  const cursorDescendantPath = (isPathInCursor && isDuplicateMerge ? updateMergedThoughtsRank : ID)(state.cursor || []).slice(oldPath.length)
 
-  // if duplicate subthoughts are merged then use rank of the duplicate thought in the new context instead of new rank
-  const updatedNewPath = (isPathInCursor && isDuplicateMerge) ? contextOf(newPath).concat(duplicateSubthought) : newPath
+  // if duplicate subthoughts are merged then use rank of the duplicate thought in the new path instead of the newly calculated rank
+  const updatedNewPath = isPathInCursor && isDuplicateMerge
+    ? contextOf(newPath).concat(duplicateSubthought)
+    : newPath
 
   const newCursorPath = isPathInCursor
     ? updatedNewPath.concat(cursorDescendantPath)

--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -2,6 +2,7 @@
 import {
   addContext,
   compareByRank,
+  contextOf,
   equalArrays,
   equalThoughtRanked,
   equalThoughtValue,
@@ -180,10 +181,21 @@ export default (state, { oldPath, newPath, offset }) => {
     })
   }
 
-  const cursorDescendantPath = (state.cursor || []).slice(oldPath.length)
+  const updateMergedThoughtsRank = path => path.map(
+    child => {
+      const updatedThought = descendantUpdatesResult[hashThought(child.value)]
+      return { ...child, rank: updatedThought ? updatedThought.rank : child.rank }
+    }
+  )
+
+  // if duplicate subthoughts are merged then update rank of thoughts of cursor descendants
+  const cursorDescendantPath = ((duplicateSubthought && !sameContext) ? updateMergedThoughtsRank : p => p)(state.cursor || []).slice(oldPath.length)
+
+  // if duplicate subthoughts are merged then use rank of the duplicate thought in the new context instead of new rank
+  const updatedNewPath = (duplicateSubthought && !sameContext) ? contextOf(newPath).concat(duplicateSubthought) : newPath
 
   const newCursorPath = isPathInCursor
-    ? newPath.concat(cursorDescendantPath)
+    ? updatedNewPath.concat(cursorDescendantPath)
     : state.cursor
 
   // state updates, not including from composed reducers

--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -66,7 +66,7 @@ export default (state, { oldPath, newPath, offset }) => {
     .find(equalThoughtValue(value))
 
   const subthoughtsNew = (state.contextIndex[contextEncodedNew] || [])
-    .filter(child => !equalThoughtRanked(child, { value, rank: oldRank }, sameContext))
+    .filter(child => child.value !== value)
     .concat({
       value,
       rank: (duplicateSubthought && !sameContext) ? duplicateSubthought.rank : newRank,

--- a/src/reducers/existingThoughtMove.js
+++ b/src/reducers/existingThoughtMove.js
@@ -66,11 +66,13 @@ export default (state, { oldPath, newPath, offset }) => {
   const duplicateSubthought = sort((state.contextIndex[contextEncodedNew] || []), compareByRank)
     .find(equalThoughtValue(value))
 
+  const isDuplicateMerge = duplicateSubthought && !sameContext
+
   const subthoughtsNew = (state.contextIndex[contextEncodedNew] || [])
     .filter(child => child.value !== value)
     .concat({
       value,
-      rank: (duplicateSubthought && !sameContext) ? duplicateSubthought.rank : newRank,
+      rank: (isDuplicateMerge) ? duplicateSubthought.rank : newRank,
       lastUpdated: timestamp()
     })
 
@@ -189,10 +191,10 @@ export default (state, { oldPath, newPath, offset }) => {
   )
 
   // if duplicate subthoughts are merged then update rank of thoughts of cursor descendants
-  const cursorDescendantPath = ((duplicateSubthought && !sameContext) ? updateMergedThoughtsRank : p => p)(state.cursor || []).slice(oldPath.length)
+  const cursorDescendantPath = ((isPathInCursor && isDuplicateMerge) ? updateMergedThoughtsRank : p => p)(state.cursor || []).slice(oldPath.length)
 
   // if duplicate subthoughts are merged then use rank of the duplicate thought in the new context instead of new rank
-  const updatedNewPath = (duplicateSubthought && !sameContext) ? contextOf(newPath).concat(duplicateSubthought) : newPath
+  const updatedNewPath = (isPathInCursor && isDuplicateMerge) ? contextOf(newPath).concat(duplicateSubthought) : newPath
 
   const newCursorPath = isPathInCursor
     ? updatedNewPath.concat(cursorDescendantPath)


### PR DESCRIPTION
Fixes #632 
@raineorshine In the current implementation duplicate thoughts in the `subthoughtsNew`  is done by checking if both rank and value are equal. 

https://github.com/cybersemics/em/blob/f5949fb217cfa1c09ba8182e277ac1070e531f33/src/reducers/existingThoughtMove.js#L68-L69

But the rank of duplicate thoughts won't always be the same. 

``` 
- A
  - B (rank 0)
    - x (rank 7)
    - y (rank 8)
- M
  - B (rank 0)
    - z (rank 4.5)
``` 
In this example when M/B is moved to A/B, it filters out the duplicate thought because both thought B have same rank 0.

``` 
- A
  - B (rank 0)
    - x (rank 7)
    - y (rank 8)
- M
  - N (rank 0)
  - B (rank 1)
    - z (rank 4.5)
``` 
If it was something like this then it won't be filtered out causing duplicate thoughts in the context after moving M/B to A/B.

**Solution:** We only check if the value of the thoughts are equal.

```javascript
  .filter(child => child.value !== value)
```

Please review the changes! Thanks. 