### PR TITLE
Move sync side effect to syncQueue store enhancer

### DIFF
--- a/src/reducers/updateThoughts.js
+++ b/src/reducers/updateThoughts.js
@@ -1,7 +1,6 @@
 // util
 import {
   mergeUpdates,
-  sync,
 } from '../util'
 
 // selectors
@@ -18,15 +17,19 @@ export default (state, { thoughtIndexUpdates, contextIndexUpdates, recentlyEdite
   const thoughtIndex = mergeUpdates(state.thoughtIndex, thoughtIndexUpdates)
   const contextIndex = mergeUpdates(state.contextIndex, contextIndexUpdates)
   const recentlyEditedNew = recentlyEdited || state.recentlyEdited
+  const syncQueueOld = state.syncQueue || {}
 
-  setTimeout(() => {
-    sync(thoughtIndexUpdates, contextIndexUpdates, { recentlyEdited: recentlyEditedNew })
-  })
+  // updates are queued, detected by the syncQueue middleware, and sync'd with the local and remote stores
+  const syncQueueNew = {
+    thoughtIndexUpdates: { ...syncQueueOld.thoughtIndexUpdates, ...thoughtIndexUpdates },
+    contextIndexUpdates: { ...syncQueueOld.contextIndexUpdates, ...contextIndexUpdates },
+  }
 
   return {
     contextIndex,
     expanded: expandThoughts(state, state.cursor, contextChain),
     recentlyEdited: recentlyEditedNew,
+    syncQueue: syncQueueNew,
     thoughtIndex,
   }
 }

--- a/src/store-enhancers/syncQueueEnhancer.js
+++ b/src/store-enhancers/syncQueueEnhancer.js
@@ -1,0 +1,38 @@
+import {
+  sync,
+} from '../util'
+
+const initialSyncQueue = {
+  thoughtIndexUpdates: {},
+  contextIndexUpdates: {},
+}
+
+/* Returns true if the state has updates in the syncQueue */
+const hasUpdates = state => state && state.syncQueue && (
+  Object.keys(state.syncQueue.thoughtIndexUpdates).length > 0 ||
+  Object.keys(state.syncQueue.contextIndexUpdates).length > 0
+)
+
+const syncQueueEnhancer = createStore => (
+  reducer,
+  initialState,
+  enhancer
+) => {
+  return createStore((state, action) => {
+    const newState = reducer(state, action)
+
+    // check if the new state has updates in the queue
+    if (hasUpdates(newState)) {
+
+      // sync updates to remote
+      sync(newState.syncQueue.thoughtIndexUpdates, newState.syncQueue.contextIndexUpdates, { recentlyEdited: newState.recentlyEdited })
+
+      // clear sync queue
+      newState.syncQueue = initialSyncQueue
+
+    }
+    return newState
+  }, initialState, enhancer)
+}
+
+export default syncQueueEnhancer

--- a/src/store.js
+++ b/src/store.js
@@ -5,6 +5,7 @@
 import { applyMiddleware, createStore } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import thunk from 'redux-thunk'
+import syncQueueEnhancer from './store-enhancers/syncQueueEnhancer'
 
 // app reducer
 import appReducer from './reducers'
@@ -13,5 +14,5 @@ const composeEnhancers = composeWithDevTools({ trace: true })
 
 export const store = createStore(
   appReducer,
-  composeEnhancers(applyMiddleware(thunk))
+  composeEnhancers(applyMiddleware(thunk), syncQueueEnhancer)
 )


### PR DESCRIPTION
Use a store enhancer to detect, sync, and clear updates in one place. 

Might not be as amenable to debouncing since store enhancers must be synchronous (?).

Contender PR vs #666 for #378.