### PR TITLE
Set oldCursor of Editable on importText

### DIFF
--- a/src/action-creators/importText.js
+++ b/src/action-creators/importText.js
@@ -148,6 +148,10 @@ export default (thoughtsRanked, inputText, { preventSetCursor, preventSync, rawD
         offset: startOffset + newText.length
       })
     }
+
+    return Promise.resolve({
+      newValue
+    })
   }
   else {
 
@@ -177,6 +181,4 @@ export default (thoughtsRanked, inputText, { preventSetCursor, preventSync, rawD
       thoughtIndexUpdates,
     })
   }
-
-  return Promise.resolve({})
 }

--- a/src/components/Editable.js
+++ b/src/components/Editable.js
@@ -308,7 +308,9 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
       dispatch(importText(thoughtsRankedLive, isHTML(plainText)
         ? plainText
         : htmlText || plainText,
-      { rawDestValue }))
+      { rawDestValue })).then(({ newValue }) => {
+        if (newValue) oldValueRef.current = newValue
+      })
     }
   }
 


### PR DESCRIPTION
fixes #686 

### Description
`onPaste` function on `Editable` calls `importText` but doesn't update `oldCursor`. So `oldCursor` gets out of sync and on further edit , it cannot find thought associated with out of sync `oldCursor` , preventing `onExistingThoughtChange` dispatch.

https://github.com/cybersemics/em/blob/b173be7a9160b9c51c3ba4ae996508e71e1dba08/src/components/Editable.js#L162-L165

### Fix

`importText` updates the original thought only when `numLines === 1`. That means we need to update the `oldCursor` when this happens. So I returned `newValue` from the `importText` action creator when original thought is updated. Then I updated `oldCursor` inside `Editable` if `newValue` is returned by `importText` dispatch.

Please review the changes. Thanks!
