### PR TITLE
Prevent selecting meta thoughts on cursor forward

### DIFF
--- a/src/reducers/cursorForward.js
+++ b/src/reducers/cursorForward.js
@@ -3,6 +3,11 @@ import {
   getThoughtsRanked,
 } from '../selectors'
 
+// utils
+import {
+  isFunction,
+} from '../util'
+
 // reducers
 import setCursor from './setCursor'
 
@@ -17,7 +22,7 @@ export default state => {
   // otherwise move cursor to first child
   else {
     const cursorOld = state.cursor
-    const firstSubthought = cursorOld && getThoughtsRanked(state, cursorOld)[0]
+    const firstSubthought = cursorOld && getThoughtsRanked(state, cursorOld).find(children => state.showHiddenThoughts || !isFunction(children.value))
     if (firstSubthought) {
       const cursorNew = cursorOld.concat(firstSubthought)
       return setCursor(state, { thoughtsRanked: cursorNew })

--- a/src/reducers/cursorForward.js
+++ b/src/reducers/cursorForward.js
@@ -1,11 +1,13 @@
 // selectors
 import {
   getThoughtsRanked,
+  meta,
 } from '../selectors'
 
 // utils
 import {
   isFunction,
+  pathToContext,
 } from '../util'
 
 // reducers
@@ -22,7 +24,7 @@ export default state => {
   // otherwise move cursor to first child
   else {
     const cursorOld = state.cursor
-    const firstSubthought = cursorOld && getThoughtsRanked(state, cursorOld).find(children => state.showHiddenThoughts || !isFunction(children.value))
+    const firstSubthought = cursorOld && getThoughtsRanked(state, cursorOld).find(child => state.showHiddenThoughts || (!isFunction(child.value) && !meta(state, [...pathToContext(cursorOld), child.value]).hidden))
     if (firstSubthought) {
       const cursorNew = cursorOld.concat(firstSubthought)
       return setCursor(state, { thoughtsRanked: cursorNew })


### PR DESCRIPTION
fixes #692 

### Description
When `cursorHistory` length is zero `cursor` is moved to first child without checking if the child is a `meta` function and showHiddenThoughts is `false`.

### Fix
Instead of selecting the first child directly, we check if `showHiddenThoughts` is false and find the first child that is not a `meta` thought.

Please review the changes. Thanks!
