### PR TITLE
Fix wrong splitThought behavior

### DIFF
--- a/src/shortcuts/newThought.js
+++ b/src/shortcuts/newThought.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { isMobile } from '../browser'
+import { isMobile, isSafari } from '../browser'
 
 // constants
 import {
@@ -56,14 +56,14 @@ const exec = (dispatch, getState, e, { type }) => {
   // do not split with gesture, as Enter is avialable and separate in the context of mobile
   const split = type !== 'gesture' && cursor && isFocusOnEditable && !showContexts && offset > 0 && offset < headValue(cursor).length
 
-  if (!split || !uneditable) {
-    false && asyncFocus()
+  if ((!split || !uneditable) && isMobile && isSafari) {
+    asyncFocus()
   }
 
   dispatch(split
     ? uneditable
       ? { type: 'error', value: `"${ellipsize(headValue(cursor))}" is uneditable and cannot be split.` }
-      : { type: 'splitThought' }
+      : { type: 'splitThought', offset }
     : { type: 'newThought', value: '' }
   )
 }

--- a/src/shortcuts/newThought.js
+++ b/src/shortcuts/newThought.js
@@ -57,7 +57,7 @@ const exec = (dispatch, getState, e, { type }) => {
   const split = type !== 'gesture' && cursor && isFocusOnEditable && !showContexts && offset > 0 && offset < headValue(cursor).length
 
   if (!split || !uneditable) {
-    asyncFocus()
+    false && asyncFocus()
   }
 
   dispatch(split


### PR DESCRIPTION
Issue #719

@raineorshine The problem is in `asyncFocus` function within newThought shortcut. On desktop this function does nothing, on mobiles it creates input element and set focus on it. I think, that's why expression `offset || window.getSelection().focusOffset` in splitThought.js evaluates to 0. Can you explain me, what is purpose of `asyncFocus` function? I haven't removed it yet.
Another solution - we can leave `asyncFocus` function and just pass offset to `splitThought` reducer