### PR TITLE
Pass id inside context array at addThought.ts

### DIFF
--- a/src/util/addThought.ts
+++ b/src/util/addThought.ts
@@ -10,13 +10,13 @@ export const addThought = (state: PartialStateWithThoughts, value: string, rank:
   return {
     ...thoughtOld,
     value,
-    id,
     contexts: (thoughtOld
       ? thoughtOld.contexts || []
       : []
     ).concat({
       context,
       rank,
+      id
     }),
     created: thoughtOld && thoughtOld.created
       ? thoughtOld.created


### PR DESCRIPTION
fixes #745 

@raineorshine  This error occurred because I had passed id at wrong place inside `addThought.ts`

https://github.com/cybersemics/em/blob/3ab02087e9d329f5f3dc5437daaab476739b9b9a/src/util/addThought.ts#L10-L20

Here you can see I had passed `id` in the wrong place. Since `importHTML` used this function , all the initial settings thought had no `id`. 

It should have been inside contexts array object.
```javascript
.concat({
  context,
  rank,
  id
})
````

I have made the changes and checked creating fresh gmail account. Please review it. Thanks!