### PR TITLE
Prevent override of style in toogleSplitView icon

### DIFF
--- a/src/shortcuts/toggleSplitView.js
+++ b/src/shortcuts/toggleSplitView.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Icon = ({ fill, size = 20, style }) => <svg className="icon" style={{ style }} width={size} height={size} viewBox="0 0 110 110">
+const Icon = ({ fill, size = 20, style }) => <svg className="icon" width={size} height={size} style={style} viewBox="0 0 110 110">
   <path
     d="M97.073 7H13.53C10.49 7 8 9.48 8 12.51v84.01c0 3.03 2.489 5.51 5.53 5.51h83.543c3.041 0 5.53-2.48 5.53-5.51V12.51c0-3.03-2.489-5.51-5.53-5.51zm-85.51 89.52V23.837h41.364V98.48H13.53c-1.066 0-1.967-.897-1.967-1.96zm87.478 0c0 1.063-.901 1.96-1.968 1.96H57.677V23.838H99.04v72.681z"
     fill={fill || style.fill}


### PR DESCRIPTION
**Issue**

![Screen Capture_select-area_20200629210310](https://user-images.githubusercontent.com/25879100/86027114-03ac6080-ba50-11ea-9d93-93ca0c970a37.png)

`toogleSplitView` icon default size overrides style passed as props. It causes icon not to scale.

**Fix**

Prevent override by passing style after default height and width props.
