### PR TITLE
Archive thought from context

### DIFF
--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -108,11 +108,7 @@ it('permanently delete thought from archive', () => {
     newThought('a'),
     newThought('b'),
     archiveThought({}),
-    setCursor({
-      thoughtsRanked: [{ value: '=archive', rank: -1 }, { value: 'b', rank: 0 }]
-    }),
-
-    // delete the archived thought
+    setCursorFirstMatch(['=archive', 'b']),
     archiveThought({}),
   ]
 
@@ -132,7 +128,7 @@ it('permanently delete archive', () => {
     newThought('a'),
     newThought('b'),
     archiveThought({}),
-    setCursor({ thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
+    setCursorFirstMatch(['=archive']),
     archiveThought({}),
   ]
 
@@ -156,7 +152,7 @@ it('permanently delete archive with descendants', () => {
     newSubthought('b'),
     setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
     archiveThought({}),
-    setCursor({ thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
+    setCursorFirstMatch(['=archive']),
     archiveThought({}),
   ]
 
@@ -270,7 +266,8 @@ it('empty thought should be archived if it has descendants', () => {
 })
 
 describe('context view', () => {
-  it('archive thought from context', async () => {
+
+  it('archive thought from context view ', async () => {
     const steps = [
       newThought({ value: 'a' }),
       newThought({ value: 'm', insertNewSubthought: true }),
@@ -279,9 +276,9 @@ describe('context view', () => {
       cursorUp,
       newThought({ value: 'b' }),
       newThought({ value: 'm', insertNewSubthought: true }),
-      setCursor({ thoughtsRanked: [{ value: 'a', rank: 1 }, { value: 'm', rank: 1 }] }),
+      setCursorFirstMatch(['a', 'm']),
       toggleContextView,
-      setCursor({ thoughtsRanked: [{ value: 'a', rank: 1 }, { value: 'm', rank: 1 }, { value: 'b', rank: 2 }] }),
+      setCursorFirstMatch(['a', 'm', 'b']),
       archiveThought({}),
     ]
 
@@ -296,4 +293,30 @@ describe('context view', () => {
       - m`
     expect(exported).toBe(expected)
   })
+
+  it('archive thought with descendants from context view', async () => {
+    const steps = [
+      newThought({ value: 'a' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      newThought({ value: 'x', insertNewSubthought: true }),
+      setCursorFirstMatch(['a']),
+      newThought({ value: 'b' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      toggleContextView,
+      setCursorFirstMatch(['b', 'm', 'a']),
+      archiveThought({}),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [ROOT_TOKEN], 'text/plaintext')
+    const expected = `- ${ROOT_TOKEN}
+  - a
+    - =archive
+      - m
+        - x
+  - b
+    - m`
+    expect(exported).toBe(expected)
+  })
+
 })

--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -267,7 +267,7 @@ it('empty thought should be archived if it has descendants', () => {
 
 describe('context view', () => {
 
-  it('archive thought from context view ', async () => {
+  it('archive thought from context view', async () => {
     const steps = [
       newThought({ value: 'a' }),
       newThought({ value: 'm', insertNewSubthought: true }),
@@ -317,6 +317,54 @@ describe('context view', () => {
   - b
     - m`
     expect(exported).toBe(expected)
+  })
+
+  it('cursor should move to prev sibling', () => {
+
+    // same steps as "archive thought from context view"
+    const steps = [
+      newThought({ value: 'a' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      newThought({ value: 'x', insertNewSubthought: true }),
+      cursorUp,
+      cursorUp,
+      newThought({ value: 'b' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      setCursorFirstMatch(['a', 'm']),
+      toggleContextView,
+      setCursorFirstMatch(['a', 'm', 'b']),
+      archiveThought({}),
+    ]
+
+    // run steps through reducer flow
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(stateNew.cursor)
+      .toMatchObject([{ value: 'a', rank: 0 }, { value: 'm', rank: 0 }, { value: 'a', rank: 0 }])
+
+  })
+
+  it('cursor should move to next sibling if there is no prev sibling', () => {
+
+    // same steps as "archive thought with descendants from context view"
+    const steps = [
+      newThought({ value: 'a' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      newThought({ value: 'x', insertNewSubthought: true }),
+      setCursorFirstMatch(['a']),
+      newThought({ value: 'b' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      toggleContextView,
+      setCursorFirstMatch(['b', 'm', 'a']),
+      archiveThought({}),
+    ]
+
+    // run steps through reducer flow
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(stateNew.cursor)
+      .toMatchObject([{ value: 'b', rank: 1 }, { value: 'm', rank: 0 }, { value: 'b', rank: 1 }])
+
   })
 
 })

--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -268,3 +268,30 @@ it('empty thought should be archived if it has descendants', () => {
   - a`)
 
 })
+
+describe('context view', () => {
+  it('archive thought from context', async () => {
+    const steps = [
+      state => newThought(state, { value: 'a' }),
+      state => newThought(state, { value: 'm', insertNewSubthought: true }),
+      state => newThought(state, { value: 'x', insertNewSubthought: true }),
+      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 1 }] }),
+      state => newThought(state, { value: 'b' }),
+      state => newThought(state, { value: 'm', insertNewSubthought: true }),
+      state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm']) }),
+      toggleContextView,
+      state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm', 'b']) }),
+      archiveThought,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [ROOT_TOKEN], 'text/plaintext')
+    const expected = `- a
+  - m
+    - x
+- b
+  - =archive
+    - m`
+    expect(exported).toBe(expected)
+  })
+})

--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -272,16 +272,17 @@ it('empty thought should be archived if it has descendants', () => {
 describe('context view', () => {
   it('archive thought from context', async () => {
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'm', insertNewSubthought: true }),
-      state => newThought(state, { value: 'x', insertNewSubthought: true }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 1 }] }),
-      state => newThought(state, { value: 'b' }),
-      state => newThought(state, { value: 'm', insertNewSubthought: true }),
-      state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm']) }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      newThought({ value: 'x', insertNewSubthought: true }),
+      cursorUp,
+      cursorUp,
+      newThought({ value: 'b' }),
+      newThought({ value: 'm', insertNewSubthought: true }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 1 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
-      state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm', 'b']) }),
-      archiveThought,
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 1 }, { value: 'm', rank: 1 }, { value: 'b', rank: 2 }] }),
+      archiveThought({}),
     ]
 
     const stateNew = reducerFlow(steps)(initialState())

--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -4,7 +4,8 @@ import { ROOT_TOKEN } from '../../constants'
 import { initialState, reducerFlow } from '../../util'
 
 import { exportContext, getContexts } from '../../selectors'
-import { archiveThought, cursorUp, newSubthought, newThought, setCursor } from '../../reducers'
+import { archiveThought, cursorUp, newSubthought, newThought, setCursor, toggleContextView } from '../../reducers'
+import setCursorFirstMatch from '../../test-helpers/setCursorFirstMatch'
 
 it('archive a thought', () => {
 

--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -286,12 +286,13 @@ describe('context view', () => {
 
     const stateNew = reducerFlow(steps)(initialState())
     const exported = exportContext(stateNew, [ROOT_TOKEN], 'text/plaintext')
-    const expected = `- a
-  - m
-    - x
-- b
-  - =archive
-    - m`
+    const expected = `- ${ROOT_TOKEN}
+  - a
+    - m
+      - x
+  - b
+    - =archive
+      - m`
     expect(exported).toBe(expected)
   })
 })

--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -63,7 +63,6 @@ const archiveThought = (state, { path }) => {
   const context = pathToContext(showContexts && contextChain.length > 1 ? contextChain[contextChain.length - 1]
     : !showContexts && thoughtsRanked.length > 1 ? contextOf(thoughtsRanked) :
     RANKED_ROOT)
-  console.log('thoughtsRanked: ', thoughtsRanked)
   const { value, rank } = head(thoughtsRanked)
   const thoughts = pathToContext(thoughtsRanked)
 

--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -24,6 +24,7 @@ import {
 
 // selectors
 import {
+  getContexts,
   getContextsSortedAndRanked,
   getThoughts,
   hasChild,
@@ -31,6 +32,7 @@ import {
   lastThoughtsFromContextChain,
   nextSibling,
   prevSibling,
+  rankThoughtsFirstMatch,
   splitChain,
   thoughtsEditingFromChain,
 } from '../selectors'
@@ -55,8 +57,18 @@ const archiveThought = (state, { path }) => {
   if (!path) return state
 
   // same as in newThought
-  const contextChain = splitChain(state, path)
   const showContexts = isContextViewActive(state, contextOf(path))
+  if (showContexts) {
+    // Get thought in ContextView
+    const thoughtInContextView = head(contextOf(path))
+    // Get context from which we are going to delete thought
+    const context = getContexts(state, thoughtInContextView.value).map(({ context }) => context).find(context => head(context) === headValue(path))
+    if (context) {
+      // Convert to path
+      path = rankThoughtsFirstMatch(state, [...context, thoughtInContextView.value])
+    }
+  }
+  const contextChain = splitChain(state, path)
   const thoughtsRanked = contextChain.length > 1
     ? lastThoughtsFromContextChain(state, contextChain)
     : path

--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -24,7 +24,6 @@ import {
 
 // selectors
 import {
-  getContexts,
   getContextsSortedAndRanked,
   getThoughts,
   hasChild,
@@ -45,7 +44,6 @@ import {
   newThought,
   setCursor,
 } from '../reducers'
-import { last } from 'lodash'
 
 /** Moves the thought to =archive. If the thought is already in =archive, permanently deletes it.
  *
@@ -63,7 +61,7 @@ const archiveThought = (state, { path }) => {
     // Get thought in ContextView
     const thoughtInContextView = head(contextOf(path))
     // Get context from which we are going to delete thought
-    const context = pathToContext(last(splitChain(state, path)))
+    const context = pathToContext(_.last(splitChain(state, path)))
     if (context) {
       // Convert to path
       path = rankThoughtsFirstMatch(state, [...context, thoughtInContextView.value])

--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -45,6 +45,7 @@ import {
   newThought,
   setCursor,
 } from '../reducers'
+import { last } from 'lodash'
 
 /** Moves the thought to =archive. If the thought is already in =archive, permanently deletes it.
  *
@@ -62,7 +63,7 @@ const archiveThought = (state, { path }) => {
     // Get thought in ContextView
     const thoughtInContextView = head(contextOf(path))
     // Get context from which we are going to delete thought
-    const context = getContexts(state, thoughtInContextView.value).map(({ context }) => context).find(context => head(context) === headValue(path))
+    const context = pathToContext(last(splitChain(state, path)))
     if (context) {
       // Convert to path
       path = rankThoughtsFirstMatch(state, [...context, thoughtInContextView.value])
@@ -72,7 +73,7 @@ const archiveThought = (state, { path }) => {
   const thoughtsRanked = contextChain.length > 1
     ? lastThoughtsFromContextChain(state, contextChain)
     : path
-  const context = pathToContext(showContexts && contextChain.length > 1 ? contextChain[contextChain.length - 2]
+  const context = showContexts ? pathToContext(contextOf(path)) : pathToContext(showContexts && contextChain.length > 1 ? contextChain[contextChain.length - 2]
     : !showContexts && thoughtsRanked.length > 1 ? contextOf(thoughtsRanked) :
     RANKED_ROOT)
 
@@ -122,7 +123,6 @@ const archiveThought = (state, { path }) => {
   if (isMobile && state.editing) {
     asyncFocus()
   }
-
   return reducerFlow([
 
     // set the cursor away from the current cursor before archiving so that existingThoughtMove does not move it

--- a/src/test-helpers/setCursorFirstMatch.ts
+++ b/src/test-helpers/setCursorFirstMatch.ts
@@ -1,0 +1,12 @@
+import _ from 'lodash'
+import { setCursor } from '../reducers'
+import { rankThoughtsFirstMatch } from '../selectors'
+import { State } from '../util/initialState'
+
+/** A reducer that sets the cursor to the given unranked path. Uses rankThoughtsFirstMatch */
+const setCursorFirstMatch = (state: State, pathUnranked: string[]) =>
+  setCursor(state, {
+    thoughtsRanked: rankThoughtsFirstMatch(state, pathUnranked),
+  })
+
+export default _.curryRight(setCursorFirstMatch)

--- a/src/test-helpers/setCursorFirstMatch.ts
+++ b/src/test-helpers/setCursorFirstMatch.ts
@@ -3,7 +3,7 @@ import { setCursor } from '../reducers'
 import { rankThoughtsFirstMatch } from '../selectors'
 import { State } from '../util/initialState'
 
-/** A reducer that sets the cursor to the given unranked path. Uses rankThoughtsFirstMatch */
+/** A reducer that sets the cursor to the given unranked path. Uses rankThoughtsFirstMatch. */
 const setCursorFirstMatch = (state: State, pathUnranked: string[]) =>
   setCursor(state, {
     thoughtsRanked: rankThoughtsFirstMatch(state, pathUnranked),


### PR DESCRIPTION
Fixes #737 

@raineorshine, hi! I'm not really familiar with archive logic, but this issue needs to fix `deleteThought` and `archiveThought` reducers. I decided convert wrong path in **Context View** to correct path in **Normal View** and let remaining logic to do its job. As i get it, reducers works correctly for **Normal View**. Is it correct approach? 

This issue belongs to `deleteThought` reducer, but deleting logic is replaced with archiving now. I have feeling that you forgot about it or maybe i don't understand something? Correct me please! Deleting/Archiving logic from context view works and tests are passed, but after all steps in test code we are having archived thought in **Context View**. It doesn't look like something i expect to see in **Context View.** Is it okay?
![Screenshot from 2020-07-12 17-33-19](https://user-images.githubusercontent.com/32064251/87244351-cb9d1880-c466-11ea-9634-3c0ff29a9d89.png)

