### PR TITLE
Curry reducers

### DIFF
--- a/src/reducers/__tests__/archiveThought.js
+++ b/src/reducers/__tests__/archiveThought.js
@@ -9,9 +9,9 @@ import { archiveThought, cursorUp, newThought, setCursor } from '../../reducers'
 it('archive a thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -28,11 +28,11 @@ it('archive a thought', () => {
 it('deduplicate archived thoughts with the same value', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => newThought(state, { value: 'b' }),
-    archiveThought,
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'b' }),
+    archiveThought({}),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -49,9 +49,9 @@ it('deduplicate archived thoughts with the same value', () => {
 it('do nothing if there is no cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => setCursor(state, { thoughtsRanked: null }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    setCursor({ thoughtsRanked: null }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -66,11 +66,11 @@ it('do nothing if there is no cursor', () => {
 it('move to top of archive', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => newThought(state, { value: 'c' }),
-    archiveThought,
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'c' }),
+    archiveThought({}),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -88,9 +88,9 @@ it('move to top of archive', () => {
 it('permanently delete empty thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: '' }),
-    archiveThought
+    newThought({ value: 'a' }),
+    newThought({ value: '' }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -105,15 +105,15 @@ it('permanently delete empty thought', () => {
 it('permanently delete thought from archive', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    archiveThought,
-    state => setCursor(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    archiveThought({}),
+    setCursor({
       thoughtsRanked: [{ value: '=archive', rank: -1 }, { value: 'b', rank: 0 }]
     }),
 
     // delete the archived thought
-    archiveThought,
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -129,11 +129,11 @@ it('permanently delete thought from archive', () => {
 it('permanently delete archive', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    archiveThought,
-    state => setCursor(state, { thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    archiveThought({}),
+    setCursor({ thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -152,12 +152,12 @@ it('permanently delete archive', () => {
 it('permanently delete archive with descendants', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-    archiveThought,
-    state => setCursor(state, { thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    archiveThought({}),
+    setCursor({ thoughtsRanked: [{ value: '=archive', rank: -1 }] }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -179,12 +179,12 @@ it('permanently delete archive with descendants', () => {
 it('cursor should move to prev sibling', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => newThought(state, { value: 'a3' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    newThought({ value: 'a3' }),
     cursorUp,
-    archiveThought,
+    archiveThought({}),
   ]
 
   // run steps through reducer flow
@@ -198,13 +198,13 @@ it('cursor should move to prev sibling', () => {
 it('cursor should move to next sibling if there is no prev sibling', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => newThought(state, { value: 'a3' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    newThought({ value: 'a3' }),
     cursorUp,
     cursorUp,
-    archiveThought,
+    archiveThought({}),
   ]
 
   // run steps through reducer flow
@@ -218,9 +218,9 @@ it('cursor should move to next sibling if there is no prev sibling', () => {
 it('cursor should move to parent if the deleted thought has no siblings', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow
@@ -234,8 +234,8 @@ it('cursor should move to parent if the deleted thought has no siblings', () => 
 it('cursor should be removed if the last thought is deleted', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    archiveThought,
+    newThought({ value: 'a' }),
+    archiveThought({}),
   ]
 
   // run steps through reducer flow
@@ -248,13 +248,13 @@ it('cursor should be removed if the last thought is deleted', () => {
 it('empty thought should be archived if it has descendants', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: '' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => setCursor(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: '' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    setCursor({
       thoughtsRanked: [{ value: '', rank: 1 }]
     }),
-    archiveThought,
+    archiveThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test

--- a/src/reducers/__tests__/bumpThoughtDown.js
+++ b/src/reducers/__tests__/bumpThoughtDown.js
@@ -12,9 +12,9 @@ import {
 it('bump leaf', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => bumpThoughtDown(state),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -31,9 +31,9 @@ it('bump leaf', () => {
 it('cursor should stay in empty thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => bumpThoughtDown(state),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow
@@ -47,11 +47,11 @@ it('cursor should stay in empty thought', () => {
 it('bump thought with children', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => newThought(state, { value: 'c', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c', insertNewSubthought: true }),
     cursorBack,
-    state => bumpThoughtDown(state),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -69,12 +69,12 @@ it('bump thought with children', () => {
 it('bump thought with children multiple times', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => newThought(state, { value: 'c', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c', insertNewSubthought: true }),
     cursorBack,
-    state => bumpThoughtDown(state),
-    state => bumpThoughtDown(state),
+    bumpThoughtDown({}),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -93,8 +93,8 @@ it('bump thought with children multiple times', () => {
 it('bump root leaf', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => bumpThoughtDown(state),
+    newThought({ value: 'a' }),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -110,10 +110,10 @@ it('bump root leaf', () => {
 it('bump root thought with children', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     cursorBack,
-    state => bumpThoughtDown(state),
+    bumpThoughtDown({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test

--- a/src/reducers/__tests__/cursorBack.js
+++ b/src/reducers/__tests__/cursorBack.js
@@ -7,14 +7,8 @@ import cursorBack from '../cursorBack'
 it('move cursor to parent', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2 in root
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-
-    // cursorBack
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     cursorBack,
   ]
 
@@ -29,11 +23,7 @@ it('move cursor to parent', () => {
 it('remove cursor from root thought', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // cursorBack
+    newThought({ value: 'a' }),
     cursorBack,
   ]
 

--- a/src/reducers/__tests__/cursorDown.js
+++ b/src/reducers/__tests__/cursorDown.js
@@ -18,9 +18,9 @@ describe('normal view', () => {
   it('move cursor to next sibling', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'b' }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'b' }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
       cursorDown,
     ]
 
@@ -35,9 +35,9 @@ describe('normal view', () => {
   it('move cursor from parent first child', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'b', insertNewSubthought: true }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'b', insertNewSubthought: true }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
       cursorDown,
     ]
 
@@ -52,9 +52,9 @@ describe('normal view', () => {
   it('move to first root child when there is no cursor', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'b' }),
-      state => setCursor(state, { thoughtsRanked: null }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'b' }),
+      setCursor({ thoughtsRanked: null }),
       cursorDown,
     ]
 
@@ -77,10 +77,10 @@ describe('normal view', () => {
   it('move cursor to next uncle', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'b' }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-      state => newThought(state, { value: 'a1', insertNewSubthought: true }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'b' }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+      newThought({ value: 'a1', insertNewSubthought: true }),
       cursorDown,
     ]
 
@@ -95,12 +95,12 @@ describe('normal view', () => {
   it('move cursor to nearest uncle', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'b' }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-      state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-      state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
-      state => newThought(state, { value: 'a1.1.1', insertNewSubthought: true }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'b' }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+      newThought({ value: 'a1', insertNewSubthought: true }),
+      newThought({ value: 'a1.1', insertNewSubthought: true }),
+      newThought({ value: 'a1.1.1', insertNewSubthought: true }),
       cursorDown,
     ]
 
@@ -115,11 +115,11 @@ describe('normal view', () => {
   it('work for sorted thoughts', () => {
 
     const steps = [
-      state => newThought(state, { value: 'a' }),
-      state => newThought(state, { value: 'n', insertNewSubthought: true }),
-      state => newThought(state, { value: 'm' }),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-      state => toggleAttribute(state, { context: ['a'], key: '=sort', value: 'Alphabetical' }),
+      newThought({ value: 'a' }),
+      newThought({ value: 'n', insertNewSubthought: true }),
+      newThought({ value: 'm' }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+      toggleAttribute({ context: ['a'], key: '=sort', value: 'Alphabetical' }),
       cursorDown
     ]
 
@@ -145,8 +145,8 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
+      updateThoughts(thoughts),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
       cursorDown,
     ]
@@ -166,8 +166,8 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
+      updateThoughts(thoughts),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
       cursorDown
     ]
@@ -189,10 +189,10 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
+      updateThoughts(thoughts),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }] }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }] }),
       cursorDown
     ]
 
@@ -213,10 +213,10 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
+      updateThoughts(thoughts),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }] }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }] }),
       cursorDown
     ]
 
@@ -239,10 +239,10 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
+      updateThoughts(thoughts),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }] }),
       toggleContextView,
-      state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }, { value: 'x', rank: 2 }] }),
+      setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }, { value: 'a', rank: 0 }, { value: 'x', rank: 2 }] }),
       cursorDown
     ]
 
@@ -266,7 +266,7 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
+      updateThoughts(thoughts),
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm']) }),
       toggleContextView,
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm', 'b', 'y']) }),
@@ -292,7 +292,7 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
+      updateThoughts(thoughts),
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm']) }),
       toggleContextView,
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm', 'b', 'y']) }),

--- a/src/reducers/__tests__/cursorForward.js
+++ b/src/reducers/__tests__/cursorForward.js
@@ -8,17 +8,9 @@ import setCursor from '../setCursor'
 it('reverse cursorBack', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new child
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-
-    // cursorBack
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     cursorForward,
-
-    // cursorForward
     cursorForward,
   ]
 
@@ -33,20 +25,10 @@ it('reverse cursorBack', () => {
 it('move to first child if there is no history', () => {
 
   const steps = [
-
-    // root thought
-    state => newThought(state, { value: 'a' }),
-
-    // child 1
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-
-    // child 2
-    state => newThought(state, { value: 'c' }),
-
-    // manually set cursor on parent so there is no cursor history
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-
-    // cursorForward
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
     cursorForward,
   ]
 
@@ -61,14 +43,8 @@ it('move to first child if there is no history', () => {
 it('do nothing if there is no cursor and no cursor history', () => {
 
   const steps = [
-
-    // root thought
-    state => newThought(state, { value: 'a' }),
-
-    // clear cursor
-    state => setCursor(state, { thoughtsRanked: null }),
-
-    // cursorForward
+    newThought({ value: 'a' }),
+    setCursor({ thoughtsRanked: null }),
     cursorForward,
   ]
 

--- a/src/reducers/__tests__/cursorUp.js
+++ b/src/reducers/__tests__/cursorUp.js
@@ -7,8 +7,8 @@ import { rankThoughtsFirstMatch } from '../../selectors'
 it('move cursor to previous sibling', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     cursorUp,
   ]
 
@@ -23,8 +23,8 @@ it('move cursor to previous sibling', () => {
 it('move cursor from first child to parent', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     cursorUp,
   ]
 
@@ -39,9 +39,9 @@ it('move cursor from first child to parent', () => {
 it('move to last root child when there is no cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: null }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
     cursorUp,
   ]
 
@@ -74,7 +74,7 @@ describe('context view', () => {
 
     const thoughts = await importText(RANKED_ROOT, text)(NOOP, initialState)
     const steps = [
-      state => updateThoughts(state, thoughts),
+      updateThoughts(thoughts),
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm']) }),
       toggleContextView,
       state => setCursor(state, { thoughtsRanked: rankThoughtsFirstMatch(state, ['a', 'm', 'a']) }),

--- a/src/reducers/__tests__/deleteAttribute.js
+++ b/src/reducers/__tests__/deleteAttribute.js
@@ -12,17 +12,17 @@ it('delete attribute', () => {
   const steps = [
 
     // new thought
-    state => newThought(state, { value: 'a' }),
+    newThought({ value: 'a' }),
 
     // set attribute
-    state => setAttribute(state, {
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
 
     // delete attribute
-    state => deleteAttribute(state, {
+    deleteAttribute({
       context: ['a'],
       key: '=test'
     })

--- a/src/reducers/__tests__/deleteEmptyThought.js
+++ b/src/reducers/__tests__/deleteEmptyThought.js
@@ -12,14 +12,8 @@ import setCursor from '../setCursor'
 it('delete empty thought', () => {
 
   const steps = [
-
-    // new thought 1
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2
-    state => newThought(state, { value: '' }),
-
-    // delete thought
+    newThought({ value: 'a' }),
+    newThought({ value: '' }),
     deleteEmptyThought,
   ]
 
@@ -35,11 +29,7 @@ it('delete empty thought', () => {
 it('do not delete non-empty thought', () => {
 
   const steps = [
-
-    // new thought 1
-    state => newThought(state, { value: 'a' }),
-
-    // delete thought
+    newThought({ value: 'a' }),
     deleteEmptyThought,
   ]
 
@@ -55,16 +45,9 @@ it('do not delete non-empty thought', () => {
 it('do not delete thought with children', () => {
 
   const steps = [
-
-    // new thought
-    state => newThought(state, { value: '' }),
-
-    // new child
-    state => newThought(state, { value: '1', insertNewSubthought: true }),
-
+    newThought({ value: '' }),
+    newThought({ value: '1', insertNewSubthought: true }),
     cursorBack,
-
-    // delete thought
     deleteEmptyThought,
   ]
 
@@ -81,17 +64,9 @@ it('do not delete thought with children', () => {
 it('do nothing if there is no cursor', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2 in root
-    state => newThought(state, { value: 'b' }),
-
-    // clear cursor
-    state => setCursor(state, { thoughtsRanked: null }),
-
-    // delete thought
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
     deleteEmptyThought,
   ]
 
@@ -108,14 +83,8 @@ it('do nothing if there is no cursor', () => {
 it('merge thoughts', () => {
 
   const steps = [
-
-    // new thought 1
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2
-    state => newThought(state, { value: 'b' }),
-
-    // delete thought
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     deleteEmptyThought,
   ]
 
@@ -131,22 +100,11 @@ it('merge thoughts', () => {
 it('insert second thought\'s children', () => {
 
   const steps = [
-
-    // new thought 1
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2
-    state => newThought(state, { value: 'b' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: 'b2' }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b2' }),
     cursorBack,
-
-    // delete thought
     deleteEmptyThought,
   ]
 
@@ -164,22 +122,11 @@ it('insert second thought\'s children', () => {
 it('do not change first thought\'s children', () => {
 
   const steps = [
-
-    // new thought 1
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: 'a2' }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     cursorBack,
-
-    // new thought 2
-    state => newThought(state, { value: 'b' }),
-
-    // delete thought
+    newThought({ value: 'b' }),
     deleteEmptyThought,
   ]
 
@@ -197,22 +144,11 @@ it('do not change first thought\'s children', () => {
 it('cursor should move to prev sibling', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: '' }),
-
-    // new subthought 3
-    state => newThought(state, { value: 'a3' }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: '' }),
+    newThought({ value: 'a3' }),
     cursorUp,
-
-    // delete thought
     deleteEmptyThought,
   ]
 
@@ -227,23 +163,12 @@ it('cursor should move to prev sibling', () => {
 it('cursor should move to next sibling if there is no prev sibling', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: '', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: 'a2' }),
-
-    // new subthought 3
-    state => newThought(state, { value: 'a3' }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: '', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    newThought({ value: 'a3' }),
     cursorUp,
     cursorUp,
-
-    // delete thought
     deleteEmptyThought,
   ]
 
@@ -258,14 +183,8 @@ it('cursor should move to next sibling if there is no prev sibling', () => {
 it('cursor should move to parent if the deleted thought has no siblings', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: '', insertNewSubthought: true }),
-
-    // delete thought
+    newThought({ value: 'a' }),
+    newThought({ value: '', insertNewSubthought: true }),
     deleteEmptyThought,
   ]
 
@@ -280,11 +199,7 @@ it('cursor should move to parent if the deleted thought has no siblings', () => 
 it('cursor should be removed if the last thought is deleted', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: '' }),
-
-    // delete thought
+    newThought({ value: '' }),
     deleteEmptyThought,
   ]
 

--- a/src/reducers/__tests__/deleteThought.js
+++ b/src/reducers/__tests__/deleteThought.js
@@ -12,15 +12,9 @@ import cursorUp from '../cursorUp'
 it('delete thought within root', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2 in root
-    state => newThought(state, { value: 'b' }),
-
-    // delete thought
-    deleteThought
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -35,18 +29,10 @@ it('delete thought within root', () => {
 it('delete thought with no cursor should do nothing ', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new thought 2 in root
-    state => newThought(state, { value: 'b' }),
-
-    // clear cursor
-    state => setCursor(state, { thoughtsRanked: null }),
-
-    // delete thought
-    deleteThought
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -62,15 +48,9 @@ it('delete thought with no cursor should do nothing ', () => {
 it('delete thought within context', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // delete thought
-    deleteThought
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -85,20 +65,11 @@ it('delete thought within context', () => {
 it('delete descendants', () => {
 
   const steps = [
-
-    // new thought 1 in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // new subthought
-    state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a1.1', insertNewSubthought: true }),
     cursorBack,
-
-    // delete thought
-    deleteThought
+    deleteThought({}),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -113,54 +84,31 @@ it('delete descendants', () => {
 it('cursor should move to prev sibling', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: 'a2' }),
-
-    // new subthought 3
-    state => newThought(state, { value: 'a3' }),
-
-    cursorUp,
-
-    // delete thought
-    deleteThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    newThought({ value: 'a3' }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow
   const stateNew = reducerFlow(steps)(initialState())
 
   expect(stateNew.cursor)
-    .toMatchObject([{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }])
+    .toMatchObject([{ value: 'a', rank: 0 }, { value: 'a2', rank: 1 }])
 
 })
 
 it('cursor should move to next sibling if there is no prev sibling', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // new subthought 2
-    state => newThought(state, { value: 'a2' }),
-
-    // new subthought 3
-    state => newThought(state, { value: 'a3' }),
-
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    newThought({ value: 'a3' }),
     cursorUp,
     cursorUp,
-
-    // delete thought
-    deleteThought,
+    deleteThought({}),
   ]
 
   // run steps through reducer flow
@@ -174,15 +122,9 @@ it('cursor should move to next sibling if there is no prev sibling', () => {
 it('cursor should move to parent if the deleted thought has no siblings', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // new subthought 1
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-
-    // delete thought
-    deleteThought,
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow
@@ -196,12 +138,8 @@ it('cursor should move to parent if the deleted thought has no siblings', () => 
 it('cursor should be removed if the last thought is deleted', () => {
 
   const steps = [
-
-    // new thought in root
-    state => newThought(state, { value: 'a' }),
-
-    // delete thought
-    deleteThought,
+    newThought({ value: 'a' }),
+    deleteThought({}),
   ]
 
   // run steps through reducer flow

--- a/src/reducers/__tests__/existingThoughtDelete.js
+++ b/src/reducers/__tests__/existingThoughtDelete.js
@@ -6,9 +6,9 @@ import { existingThoughtDelete, newThought } from '../../reducers'
 it('delete from root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => existingThoughtDelete(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    existingThoughtDelete({
       context: [ROOT_TOKEN],
       thoughtRanked: { value: 'b', rank: 1 },
     }),
@@ -32,10 +32,10 @@ it('delete from root', () => {
 it('delete descendants of root thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => newThought(state, { value: 'c', insertNewSubthought: true }),
-    state => existingThoughtDelete(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c', insertNewSubthought: true }),
+    existingThoughtDelete({
       context: [ROOT_TOKEN],
       thoughtRanked: { value: 'a', rank: 0 },
     }),
@@ -59,9 +59,9 @@ it('delete descendants of root thought', () => {
 it('delete thought with duplicate child', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a', insertNewSubthought: true }),
-    state => existingThoughtDelete(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'a', insertNewSubthought: true }),
+    existingThoughtDelete({
       context: [ROOT_TOKEN],
       thoughtRanked: { value: 'a', rank: 0 },
     }),

--- a/src/reducers/__tests__/existingThoughtMove.js
+++ b/src/reducers/__tests__/existingThoughtMove.js
@@ -7,9 +7,9 @@ import { existingThoughtMove, newThought, setCursor, updateThoughts } from '../.
 it('move within root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    existingThoughtMove({
       oldPath: [{ value: 'b', rank: 1 }],
       newPath: [{ value: 'b', rank: -1 }],
     }),
@@ -28,9 +28,9 @@ it('move within root', () => {
 it('persist id on move', () => {
 
   const steps1 = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2', insertNewSubthought: true }),
   ]
 
   const stateNew1 = reducerFlow(steps1)(initialState())
@@ -38,7 +38,7 @@ it('persist id on move', () => {
   const oldId = oldExactThought.id
 
   const steps2 = [
-    state => existingThoughtMove(state, {
+    existingThoughtMove({
       oldPath: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }],
       newPath: [{ value: 'a1', rank: 1 }],
     }),
@@ -54,10 +54,10 @@ it('persist id on move', () => {
 it('move within context', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    existingThoughtMove({
       oldPath: [{ value: 'a', rank: 0 }, { value: 'a2', rank: 1 }],
       newPath: [{ value: 'a', rank: 0 }, { value: 'a2', rank: -1 }],
     }),
@@ -77,11 +77,11 @@ it('move within context', () => {
 it('move across contexts', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    existingThoughtMove({
       oldPath: [{ value: 'b', rank: 0 }, { value: 'b1', rank: 0 }],
       newPath: [{ value: 'a', rank: 0 }, { value: 'b1', rank: 1 }],
     }),
@@ -102,13 +102,13 @@ it('move across contexts', () => {
 it('move descendants', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a1.1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
+    existingThoughtMove({
       oldPath: [{ value: 'b', rank: 1 }],
       newPath: [{ value: 'b', rank: -1 }],
     }),
@@ -131,10 +131,10 @@ it('move descendants', () => {
 it('moving cursor thought should update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    existingThoughtMove({
       oldPath: [{ value: 'a', rank: 0 }, { value: 'a2', rank: 1 }],
       newPath: [{ value: 'a', rank: 0 }, { value: 'a2', rank: -1 }],
     }),
@@ -151,11 +151,11 @@ it('moving cursor thought should update cursor', () => {
 it('moving ancestor of cursor should update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
+    existingThoughtMove({
       oldPath: [{ value: 'b', rank: 1 }],
       newPath: [{ value: 'b', rank: -1 }],
     }),
@@ -173,12 +173,12 @@ it('moving ancestor of cursor should update cursor', () => {
 it('moving unrelated thought should not update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-    state => existingThoughtMove(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    existingThoughtMove({
       oldPath: [{ value: 'b', rank: 1 }],
       newPath: [{ value: 'b', rank: -1 }],
     }),
@@ -203,8 +203,8 @@ it('move descendants with siblings', async () => {
 
   const imported = await importText(RANKED_ROOT, text)(NOOP, initialState)
   const steps = [
-    state => updateThoughts(state, imported),
-    state => existingThoughtMove(state, {
+    updateThoughts(imported),
+    existingThoughtMove({
       oldPath: [{ value: 'a', rank: 0 }, { value: 'b', rank: 1 }],
       newPath: [{ value: 'b', rank: 1 }],
     }),
@@ -234,8 +234,8 @@ it('merge duplicate with new rank', async () => {
   const imported = await importText(RANKED_ROOT, text)(NOOP, initialState)
 
   const steps = [
-    state => updateThoughts(state, imported),
-    state => existingThoughtMove(state, {
+    updateThoughts(imported),
+    existingThoughtMove({
       oldPath: [{ value: 'm', rank: 5 }],
       newPath: [{ value: 'a', rank: 0 }, { value: 'm', rank: 4 }],
     }),
@@ -276,8 +276,8 @@ it('merge with duplicate with duplicate rank', async () => {
   const imported = await importText(RANKED_ROOT, text)(NOOP, initialState)
 
   const steps = [
-    state => updateThoughts(state, imported),
-    state => existingThoughtMove(state, {
+    updateThoughts(imported),
+    existingThoughtMove({
       oldPath: [{ value: 'm', rank: 5 }],
       newPath: [{ value: 'a', rank: 0 }, { value: 'm', rank: 1 }],
     }),

--- a/src/reducers/__tests__/indent.js
+++ b/src/reducers/__tests__/indent.js
@@ -12,9 +12,9 @@ import {
 it('indent within root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    indent
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    indent,
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -30,10 +30,10 @@ it('indent within root', () => {
 it('indent with no cursor should do nothing ', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: null }),
-    indent
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
+    indent,
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -49,9 +49,9 @@ it('indent with no cursor should do nothing ', () => {
 it('indent fully indented thought should do nothing ', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    indent
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    indent,
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -67,9 +67,9 @@ it('indent fully indented thought should do nothing ', () => {
 it('indent within context', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     indent,
   ]
 
@@ -87,9 +87,9 @@ it('indent within context', () => {
 it('indent on cursor thought should update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     indent,
   ]
 

--- a/src/reducers/__tests__/moveThoughtDown.js
+++ b/src/reducers/__tests__/moveThoughtDown.js
@@ -10,9 +10,9 @@ import setCursor from '../setCursor'
 it('move within root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
     moveThoughtDown,
 
   ]
@@ -30,10 +30,10 @@ it('move within root', () => {
 it('move within context', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
     moveThoughtDown,
   ]
 
@@ -51,11 +51,11 @@ it('move within context', () => {
 it('move to next uncle', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
     moveThoughtDown,
   ]
 
@@ -74,13 +74,13 @@ it('move to next uncle', () => {
 it('move descendants', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a1.1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
     moveThoughtDown,
   ]
 
@@ -101,8 +101,8 @@ it('move descendants', () => {
 it('trying to move last thought of root should do nothing', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     moveThoughtDown,
 
   ]
@@ -120,11 +120,11 @@ it('trying to move last thought of root should do nothing', () => {
 it('trying to move last thought of context with no next uncle should do nothing', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a1.1', insertNewSubthought: true }),
     moveThoughtDown,
 
   ]
@@ -144,9 +144,9 @@ it('trying to move last thought of context with no next uncle should do nothing'
 it('do nothing when there is no cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: null }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
     moveThoughtDown,
   ]
 
@@ -163,10 +163,10 @@ it('do nothing when there is no cursor', () => {
 it('move cursor thought should update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }, { value: 'a1', rank: 0 }] }),
     moveThoughtDown,
   ]
 

--- a/src/reducers/__tests__/moveThoughtUp.js
+++ b/src/reducers/__tests__/moveThoughtUp.js
@@ -10,8 +10,8 @@ import setCursor from '../setCursor'
 it('move within root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     moveThoughtUp,
 
   ]
@@ -29,9 +29,9 @@ it('move within root', () => {
 it('move within context', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     moveThoughtUp,
   ]
 
@@ -49,10 +49,10 @@ it('move within context', () => {
 it('move to prev uncle', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
     moveThoughtUp,
   ]
 
@@ -71,13 +71,13 @@ it('move to prev uncle', () => {
 it('move descendants', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a1.1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b', at: [{ value: 'a', rank: 0 }] }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'b', rank: 1 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a1.1', insertNewSubthought: true }),
+    newThought({ value: 'b', at: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'b', rank: 1 }] }),
     moveThoughtUp,
   ]
 
@@ -98,9 +98,9 @@ it('move descendants', () => {
 it('trying to move last thought of root should do nothing', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
     moveThoughtUp,
 
   ]
@@ -118,10 +118,10 @@ it('trying to move last thought of root should do nothing', () => {
 it('trying to move first thought of context with no prev uncle should do nothing', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => newThought(state, { value: 'b1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'b1.1', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    newThought({ value: 'b1', insertNewSubthought: true }),
+    newThought({ value: 'b1.1', insertNewSubthought: true }),
     moveThoughtUp,
 
   ]
@@ -141,9 +141,9 @@ it('trying to move first thought of context with no prev uncle should do nothing
 it('do nothing when there is no cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
-    state => setCursor(state, { thoughtsRanked: null }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursor({ thoughtsRanked: null }),
     moveThoughtUp,
 
   ]
@@ -161,9 +161,9 @@ it('do nothing when there is no cursor', () => {
 it('move cursor thought should update cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     moveThoughtUp,
   ]
 

--- a/src/reducers/__tests__/newThought.js
+++ b/src/reducers/__tests__/newThought.js
@@ -16,8 +16,8 @@ it('new thought in root', () => {
 it('new thought after', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -33,8 +33,8 @@ it('new thought after', () => {
 it('new thought before', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertBefore: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertBefore: true }),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -50,8 +50,8 @@ it('new thought before', () => {
 it('new subthought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -66,10 +66,10 @@ it('new subthought', () => {
 it('new subthought top', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => newThought(state, { value: 'c' }),
-    state => newThought(state, { value: 'd', at: [{ value: 'a', rank: 0 }], insertNewSubthought: true, insertBefore: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c' }),
+    newThought({ value: 'd', at: [{ value: 'a', rank: 0 }], insertNewSubthought: true, insertBefore: true }),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -95,8 +95,8 @@ it('update cursor to first new thought', () => {
 it('update cursor to new thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
   ]
 
   // run steps through reducer flow

--- a/src/reducers/__tests__/outdent.js
+++ b/src/reducers/__tests__/outdent.js
@@ -9,9 +9,13 @@ import setCursor from '../setCursor'
 
 it('outdent within root', () => {
 
+  // console.log('A', !!newThought(initialState(), { value: 'a' }))
+  // console.log('B', !!newThought({ value: 'a' })(initialState()))
+  // console.log('C', newThought(initialState()))
+
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
     outdent
   ]
 
@@ -28,10 +32,10 @@ it('outdent within root', () => {
 it('outdent with no cursor should do nothing ', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: null }),
-    outdent
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: null }),
+    state => outdent(state)
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -47,8 +51,8 @@ it('outdent with no cursor should do nothing ', () => {
 it('outdent root thought should do nothing ', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     outdent
   ]
 
@@ -65,9 +69,9 @@ it('outdent root thought should do nothing ', () => {
 it('outdent within context', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2', insertNewSubthought: true }),
     outdent
   ]
 
@@ -85,9 +89,9 @@ it('outdent within context', () => {
 it('preserve cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2', insertNewSubthought: true }),
     outdent
   ]
 

--- a/src/reducers/__tests__/setAttribute.js
+++ b/src/reducers/__tests__/setAttribute.js
@@ -10,8 +10,8 @@ import setAttribute from '../setAttribute'
 it('set', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => setAttribute(state, {
+    newThought({ value: 'a' }),
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
@@ -32,13 +32,13 @@ it('set', () => {
 it('different value should override existing value', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => setAttribute(state, {
+    newThought({ value: 'a' }),
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
-    state => setAttribute(state, {
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'goodbye'
@@ -59,15 +59,15 @@ it('different value should override existing value', () => {
 it('add attribute if key has already been created', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: '=test', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-    state => setAttribute(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: '=test', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
-    state => setAttribute(state, {
+    setAttribute({
       context: ['a'],
       key: '=test',
       value: 'goodbye'

--- a/src/reducers/__tests__/splitThought.js
+++ b/src/reducers/__tests__/splitThought.js
@@ -9,8 +9,8 @@ import splitThought from '../splitThought'
 it('split thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'apple' }),
-    state => splitThought(state, { offset: 2 })
+    newThought({ value: 'apple' }),
+    splitThought({ offset: 2 }),
   ]
 
   // run steps through reducer flow and export as plaintext for readable test
@@ -26,8 +26,8 @@ it('split thought', () => {
 it('cursor moves to second thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'apple' }),
-    state => splitThought(state, { offset: 2 })
+    newThought({ value: 'apple' }),
+    splitThought({ offset: 2 })
   ]
 
   // run steps through reducer flow

--- a/src/reducers/__tests__/subCategorizeAll.js
+++ b/src/reducers/__tests__/subCategorizeAll.js
@@ -10,9 +10,9 @@ import setCursor from '../setCursor'
 it('subcategorize multiple thoughts', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => newThought(state, { value: 'c' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'c' }),
     subCategorizeAll,
 
   ]
@@ -32,8 +32,8 @@ it('subcategorize multiple thoughts', () => {
 it('subcategorize multiple thoughts in the root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
     subCategorizeAll,
 
   ]
@@ -52,9 +52,9 @@ it('subcategorize multiple thoughts in the root', () => {
 it('should do nothing with no cursor', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: null }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: null }),
     subCategorizeAll,
 
   ]
@@ -72,9 +72,9 @@ it('should do nothing with no cursor', () => {
 it('set cursor on new empty thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'a1', insertNewSubthought: true }),
-    state => newThought(state, { value: 'a2' }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'a1', insertNewSubthought: true }),
+    newThought({ value: 'a2' }),
     subCategorizeAll,
 
   ]

--- a/src/reducers/__tests__/subCategorizeOne.js
+++ b/src/reducers/__tests__/subCategorizeOne.js
@@ -10,8 +10,8 @@ import setCursor from '../setCursor'
 it('subcategorize a thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     subCategorizeOne,
   ]
 
@@ -29,7 +29,7 @@ it('subcategorize a thought', () => {
 it('subcategorize a thought in the root', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
+    newThought({ value: 'a' }),
     subCategorizeOne,
   ]
 
@@ -46,9 +46,9 @@ it('subcategorize a thought in the root', () => {
 it('subcategorize with no cursor should do nothing', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: null }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: null }),
     subCategorizeOne,
   ]
 
@@ -65,8 +65,8 @@ it('subcategorize with no cursor should do nothing', () => {
 it('set cursor on new empty thought', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: 'b', insertNewSubthought: true }),
+    newThought({ value: 'a' }),
+    newThought({ value: 'b', insertNewSubthought: true }),
     subCategorizeOne,
   ]
 

--- a/src/reducers/__tests__/toggleAttribute.js
+++ b/src/reducers/__tests__/toggleAttribute.js
@@ -10,8 +10,8 @@ import toggleAttribute from '../toggleAttribute'
 it('toggle on', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => toggleAttribute(state, {
+    newThought({ value: 'a' }),
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
@@ -32,13 +32,13 @@ it('toggle on', () => {
 it('toggle off', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => toggleAttribute(state, {
+    newThought({ value: 'a' }),
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
-    state => toggleAttribute(state, {
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
@@ -57,13 +57,13 @@ it('toggle off', () => {
 it('different value should override existing value', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => toggleAttribute(state, {
+    newThought({ value: 'a' }),
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
-    state => toggleAttribute(state, {
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'goodbye'
@@ -84,15 +84,15 @@ it('different value should override existing value', () => {
 it('add attribute if key has already been created', () => {
 
   const steps = [
-    state => newThought(state, { value: 'a' }),
-    state => newThought(state, { value: '=test', insertNewSubthought: true }),
-    state => setCursor(state, { thoughtsRanked: [{ value: 'a', rank: 0 }] }),
-    state => toggleAttribute(state, {
+    newThought({ value: 'a' }),
+    newThought({ value: '=test', insertNewSubthought: true }),
+    setCursor({ thoughtsRanked: [{ value: 'a', rank: 0 }] }),
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'hello'
     }),
-    state => toggleAttribute(state, {
+    toggleAttribute({
       context: ['a'],
       key: '=test',
       value: 'goodbye'

--- a/src/reducers/alert.ts
+++ b/src/reducers/alert.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 interface Options {
@@ -12,4 +13,4 @@ const alert = (state: State, { value, showCloseLink, alertType }: Options) => ({
   alert: value ? { value, showCloseLink, alertType } : null
 })
 
-export default alert
+export default _.curryRight(alert)

--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import React from 'react'
 import { isMobile } from '../browser'
 import { store } from '../store'
@@ -47,7 +48,7 @@ import {
  *
  * @param path     Defaults to cursor.
  */
-const archiveThought = (state, { path } = {}) => {
+const archiveThought = (state, { path }) => {
 
   path = path || state.cursor
 
@@ -113,14 +114,14 @@ const archiveThought = (state, { path } = {}) => {
   return reducerFlow([
 
     // set the cursor away from the current cursor before archiving so that existingThoughtMove does not move it
-    state => setCursor(state, {
+    setCursor({
       thoughtsRanked: cursorNew,
       editing: state.editing,
       offset,
     }),
 
     isDeletable
-      ? state => existingThoughtDelete(state, {
+      ? existingThoughtDelete({
         context: contextOf(pathToContext(thoughtsRanked)),
         showContexts,
         thoughtRanked: head(thoughtsRanked),
@@ -128,8 +129,8 @@ const archiveThought = (state, { path } = {}) => {
       : reducerFlow([
 
         // create =archive if it does not exist
-        !hasChild(state, context, '=archive')
-          ? state => newThought(state, {
+        state => !hasChild(state, context, '=archive')
+          ? newThought(state, {
             at: context,
             insertNewSubthought: true,
             insertBefore: true,
@@ -139,7 +140,7 @@ const archiveThought = (state, { path } = {}) => {
           : null,
 
         // undo alert
-        state => alert(state, {
+        alert({
           value: <div>Deleted "{ellipsize(headValue(path))}"&nbsp;
             <a onClick={() => {
               store.dispatch({
@@ -165,4 +166,4 @@ const archiveThought = (state, { path } = {}) => {
   ])(state)
 }
 
-export default archiveThought
+export default _.curryRight(archiveThought)

--- a/src/reducers/authenticate.ts
+++ b/src/reducers/authenticate.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 interface Options {
@@ -18,4 +19,4 @@ const authenticate = (state: State, { value, user, userRef }: Options) => ({
   userRef,
 })
 
-export default authenticate
+export default _.curryRight(authenticate)

--- a/src/reducers/bumpThoughtDown.ts
+++ b/src/reducers/bumpThoughtDown.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { existingThoughtChange, existingThoughtMove, newThoughtSubmit, setCursor, subCategorizeOne } from '../reducers'
 import { getPrevRank, getRankBefore, getThoughts, lastThoughtsFromContextChain, splitChain } from '../selectors'
 import { contextOf, headValue, pathToContext, reducerFlow, rootedContextOf, unroot } from '../util'
@@ -5,7 +6,7 @@ import { State } from '../util/initialState'
 import { Path } from '../types'
 
 /** Clears a thought's text, moving it to its first child. */
-const bumpThoughtDown = (state: State, { path }: { path?: Path } = {}) => {
+const bumpThoughtDown = (state: State, { path }: { path?: Path }) => {
   path = path || state.cursor as Path
   const value = path && headValue(path)
 
@@ -31,13 +32,13 @@ const bumpThoughtDown = (state: State, { path }: { path?: Path } = {}) => {
   return reducerFlow([
 
     // modify the rank to get the thought to re-render (via the Subthoughts child key)
-    state => existingThoughtMove(state, {
+    existingThoughtMove({
       oldPath: thoughtsRanked,
       newPath: thoughtsRankedWithNewRank,
     }),
 
     // clear text
-    state => existingThoughtChange(state, {
+    existingThoughtChange({
       oldValue: value,
       newValue: '',
       context: rootedContextOf(context),
@@ -56,11 +57,11 @@ const bumpThoughtDown = (state: State, { path }: { path?: Path } = {}) => {
     },
 
     // set cursor
-    state => setCursor(state, {
+    setCursor({
       thoughtsRanked: thoughtsRankedWithNewRankAndValue,
     }),
 
   ])(state)
 }
 
-export default bumpThoughtDown
+export default _.curryRight(bumpThoughtDown)

--- a/src/reducers/cursorBack.ts
+++ b/src/reducers/cursorBack.ts
@@ -22,10 +22,10 @@ const cursorBack = (state: State) => {
 
       // move cursor back
       // @ts-ignore
-      state => setCursor(state, { thoughtsRanked: cursorNew.length > 0 ? cursorNew : null, editing }),
+      setCursor({ thoughtsRanked: cursorNew!.length > 0 ? cursorNew : null, editing }),
 
       // append to cursor history to allow 'forward' gesture
-      state => cursorHistory(state, { cursor: cursorOld }),
+      cursorHistory({ cursor: cursorOld }),
 
       // SIDE EFFECT
       cursorNew?.length === 0 ? state => {
@@ -38,12 +38,12 @@ const cursorBack = (state: State) => {
     : search === '' ? [
 
       // close the search
-      state => searchReducer(state, { value: null }),
+      searchReducer({ value: null }),
 
       // restore the cursor
-      state => state.cursorBeforeSearch
-        ? setCursor(state, { thoughtsRanked: state.cursorBeforeSearch, editing })
-        : state,
+      state.cursorBeforeSearch
+        ? setCursor({ thoughtsRanked: state.cursorBeforeSearch, editing })
+        : null,
 
       // SIDE EFFECT
       // scroll cursor into view

--- a/src/reducers/cursorBeforeSearch.ts
+++ b/src/reducers/cursorBeforeSearch.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Stores the cursor so that it can be restored after the search is closed. */
@@ -6,4 +7,4 @@ const cursorBeforeSearch = (state: State, { value }: { value: string }) => ({
   cursorBeforeSearch: value
 })
 
-export default cursorBeforeSearch
+export default _.curryRight(cursorBeforeSearch)

--- a/src/reducers/cursorHistory.ts
+++ b/src/reducers/cursorHistory.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { MAX_CURSOR_HISTORY } from '../constants'
 import { State } from '../util/initialState'
 import { Path } from '../types'
@@ -11,4 +12,4 @@ const cursorHistory = (state: State, { cursor }: { cursor: Path }) => ({
     .concat([cursor])
 })
 
-export default cursorHistory
+export default _.curryRight(cursorHistory)

--- a/src/reducers/deleteAttribute.ts
+++ b/src/reducers/deleteAttribute.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { existingThoughtDelete } from '../reducers'
 import { hasChild, rankThoughtsFirstMatch } from '../selectors'
 import { head } from '../util'
@@ -20,4 +21,4 @@ const deleteAtribute = (state: State, { context, key }: { context: Context, key:
     : state
 }
 
-export default deleteAtribute
+export default _.curryRight(deleteAtribute)

--- a/src/reducers/deleteData.ts
+++ b/src/reducers/deleteData.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { deleteThought, updateLastUpdated } from '../db'
 import { hashContext, hashThought, timestamp } from '../util'
 import { getThought, getThoughts } from '../selectors'
@@ -50,4 +51,4 @@ const deleteData = (state: State, { value, forceRender }: { value: string, force
   }
 }
 
-export default deleteData
+export default _.curryRight(deleteData)

--- a/src/reducers/deleteEmptyThought.ts
+++ b/src/reducers/deleteEmptyThought.ts
@@ -35,7 +35,7 @@ import {
 } from '../reducers'
 
 /** Deletes an empty thought or merges two siblings if deleting from the beginning of a thought. */
-const deleteEmpytThought = (state: State) => {
+const deleteEmptyThought = (state: State) => {
   const { cursor, editing } = state
   const sel = window.getSelection()
   const offset = sel ? sel.focusOffset : 0
@@ -54,7 +54,7 @@ const deleteEmpytThought = (state: State) => {
         asyncFocus()
       }
 
-      return deleteThought(state)
+      return deleteThought(state, {})
     }
     // delete from beginning and merge
     else if (offset === 0 && !showContexts) {
@@ -76,7 +76,7 @@ const deleteEmpytThought = (state: State) => {
         return reducerFlow([
 
           // change first thought value to concatenated value
-          state => existingThoughtChange(state, {
+          existingThoughtChange({
             oldValue: prev.value,
             newValue: valueNew,
             context,
@@ -92,13 +92,13 @@ const deleteEmpytThought = (state: State) => {
           ),
 
           // delete second thought
-          state => existingThoughtDelete(state, {
+          existingThoughtDelete({
             context,
             thoughtRanked: head(thoughtsRanked)
           }),
 
           // move the cursor to the new thought at the correct offset
-          state => setCursor(state, {
+          setCursor({
             thoughtsRanked: thoughtsRankedPrevNew,
             offset: prev.value.length,
             editing
@@ -112,4 +112,4 @@ const deleteEmpytThought = (state: State) => {
   return state
 }
 
-export default deleteEmpytThought
+export default deleteEmptyThought

--- a/src/reducers/deleteThought.ts
+++ b/src/reducers/deleteThought.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { RANKED_ROOT } from '../constants'
 import { cursorBack, existingThoughtDelete, setCursor } from '../reducers'
 import { State } from '../util/initialState'
@@ -32,7 +33,7 @@ import {
 } from '../selectors'
 
 /** Deletes a thought. */
-const deleteThought = (state: State, { path }: { path?: Path } = {}) => {
+const deleteThought = (state: State, { path }: { path?: Path }) => {
 
   path = path || state.cursor || undefined
 
@@ -90,7 +91,7 @@ const deleteThought = (state: State, { path }: { path?: Path } = {}) => {
   return reducerFlow([
 
     // delete thought
-    state => existingThoughtDelete(state, {
+    existingThoughtDelete({
       context: contextOf(pathToContext(thoughtsRanked)),
       showContexts,
       thoughtRanked: head(thoughtsRanked)
@@ -126,4 +127,4 @@ const deleteThought = (state: State, { path }: { path?: Path } = {}) => {
 
 }
 
-export default deleteThought
+export default _.curryRight(deleteThought)

--- a/src/reducers/dragHold.ts
+++ b/src/reducers/dragHold.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 import { Path } from '../types'
 
@@ -14,4 +15,4 @@ const dragHold = (state: State, { value = false, draggedThoughtsRanked }: Payloa
   draggedThoughtsRanked: state.draggedThoughtsRanked ? !draggedThoughtsRanked ? undefined : state.draggedThoughtsRanked : draggedThoughtsRanked
 })
 
-export default dragHold
+export default _.curryRight(dragHold)

--- a/src/reducers/dragInProgress.ts
+++ b/src/reducers/dragInProgress.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 import { Path } from '../types'
 
@@ -15,4 +16,4 @@ const dragInProgress = (state: State, { value, draggingThought, hoveringThought 
   hoveringThought
 })
 
-export default dragInProgress
+export default _.curryRight(dragInProgress)

--- a/src/reducers/editing.ts
+++ b/src/reducers/editing.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Track editing independently of cursor to allow navigation when keyboard is hidden. */
@@ -6,4 +7,4 @@ const editing = (state: State, { value }: { value: string }) => ({
   editing: value
 })
 
-export default editing
+export default _.curryRight(editing)

--- a/src/reducers/editingValue.ts
+++ b/src/reducers/editingValue.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the value that is being edited (unthrottled). */
@@ -6,4 +7,4 @@ const editingValue = (state: State, { value }: { value: string }) => ({
   editingValue: value
 })
 
-export default editingValue
+export default _.curryRight(editingValue)

--- a/src/reducers/error.ts
+++ b/src/reducers/error.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets an error. */
@@ -6,4 +7,4 @@ const error = (state: State, { value }: { value: string }) => ({
   error: value
 })
 
-export default error
+export default _.curryRight(error)

--- a/src/reducers/existingThoughtChange.ts
+++ b/src/reducers/existingThoughtChange.ts
@@ -304,4 +304,4 @@ const existingThoughtChange = (state: State, { oldValue, newValue, context, show
   return updateThoughts(stateNew, { thoughtIndexUpdates, contextIndexUpdates, recentlyEdited, contextChain })
 }
 
-export default existingThoughtChange
+export default _.curryRight(existingThoughtChange)

--- a/src/reducers/existingThoughtDelete.ts
+++ b/src/reducers/existingThoughtDelete.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { render, updateThoughts } from '../reducers'
 import { treeDelete } from '../util/recentlyEditedTree'
 import { exists, getThought, getThoughts, getThoughtsRanked, rankThoughtsFirstMatch } from '../selectors'
@@ -166,9 +167,9 @@ const existingThoughtDelete = (state: State, { context, thoughtRanked, showConte
 
   return reducerFlow([
     state => ({ ...state, contextViews: contextViewsNew }),
-    state => updateThoughts(state, { thoughtIndexUpdates, contextIndexUpdates, recentlyEdited }),
+    updateThoughts({ thoughtIndexUpdates, contextIndexUpdates, recentlyEdited }),
     render,
   ])(state)
 }
 
-export default existingThoughtDelete
+export default _.curryRight(existingThoughtDelete)

--- a/src/reducers/existingThoughtMove.ts
+++ b/src/reducers/existingThoughtMove.ts
@@ -250,7 +250,7 @@ const existingThoughtMove = (state: State, { oldPath, newPath, offset }: {
     }),
 
     // update thoughts
-    state => updateThoughts(state, { thoughtIndexUpdates, contextIndexUpdates, recentlyEdited }),
+    updateThoughts({ thoughtIndexUpdates, contextIndexUpdates, recentlyEdited }),
 
     // render
     render,
@@ -258,4 +258,4 @@ const existingThoughtMove = (state: State, { oldPath, newPath, offset }: {
   ])(state)
 }
 
-export default existingThoughtMove
+export default _.curryRight(existingThoughtMove, 2)

--- a/src/reducers/expandContextThought.ts
+++ b/src/reducers/expandContextThought.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { equalPath } from '../util'
 import { State } from '../util/initialState'
 import { Path } from '../types'
@@ -10,4 +11,4 @@ const expandContextThought = (state: State, { thoughtsRanked }: { thoughtsRanked
     : thoughtsRanked
 })
 
-export default expandContextThought
+export default _.curryRight(expandContextThought)

--- a/src/reducers/invalidState.ts
+++ b/src/reducers/invalidState.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Real-time meta validation error status. */
@@ -6,4 +7,4 @@ const invalidState = (state: State, { value }: { value: string }) => ({
   invalidState: value
 })
 
-export default invalidState
+export default _.curryRight(invalidState)

--- a/src/reducers/loadLocalState.ts
+++ b/src/reducers/loadLocalState.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { render } from '../reducers'
 import { State } from '../util/initialState'
 
@@ -12,4 +13,4 @@ const loadLocalState = (state: State, { newState }: { newState: State }) =>
     schemaVersion: newState.schemaVersion,
   })
 
-export default loadLocalState
+export default _.curryRight(loadLocalState)

--- a/src/reducers/loadLocalThoughts.ts
+++ b/src/reducers/loadLocalThoughts.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import render from './render'
 import { State } from '../util/initialState'
 
@@ -29,4 +30,4 @@ const loadLocalThoughts = (state: State, newState: State) =>
     }
   })
 
-export default loadLocalThoughts
+export default _.curryRight(loadLocalThoughts)

--- a/src/reducers/modalComplete.ts
+++ b/src/reducers/modalComplete.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /**
@@ -19,4 +20,4 @@ const modalComplete = (state: State, { id }: { id: string }) => {
   }
 }
 
-export default modalComplete
+export default _.curryRight(modalComplete)

--- a/src/reducers/modalRemindMeLater.ts
+++ b/src/reducers/modalRemindMeLater.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { modalCleanup } from '../util'
 import { State } from '../util/initialState'
 
@@ -23,4 +24,4 @@ const modalRemindMeLater = (state: State, { id, duration = 0 }: { id?: string, d
   }
 }
 
-export default modalRemindMeLater
+export default _.curryRight(modalRemindMeLater)

--- a/src/reducers/newThought.ts
+++ b/src/reducers/newThought.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 import { Path } from '../types'
 
@@ -64,7 +65,8 @@ interface Payload {
  *
  * @param offset The focusOffset of the selection in the new thought. Defaults to end.
  */
-const newThought = (state: State, { at, insertNewSubthought, insertBefore, value = '', offset, preventSetCursor }: Payload = {}) => {
+const newThought = (state: State, { at, insertNewSubthought, insertBefore, value = '', offset, preventSetCursor }: Payload) => {
+
   const tutorialStep = +(getSetting(state, 'Tutorial Step') || 0)
   const tutorialStepNewThoughtCompleted =
     // new thought
@@ -144,7 +146,7 @@ const newThought = (state: State, { at, insertNewSubthought, insertBefore, value
       : null,
 
     // tutorial step 1
-    tutorialStepNewThoughtCompleted ? tutorialNext
+    tutorialStepNewThoughtCompleted ? (state: State) => tutorialNext(state, {})
     // some hints are rolled back when a new thought is created
     : tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ? (state: State) =>
       tutorialStepReducer(state, { value: TUTORIAL2_STEP_CONTEXT1_PARENT })
@@ -160,4 +162,4 @@ const newThought = (state: State, { at, insertNewSubthought, insertBefore, value
   return reducerFlow(reducers)(state)
 }
 
-export default newThought
+export default _.curryRight(newThought)

--- a/src/reducers/newThoughtSubmit.ts
+++ b/src/reducers/newThoughtSubmit.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { render, updateThoughts } from '../reducers'
 import { getNextRank, getThought, getThoughts } from '../selectors'
 import { createId, equalThoughtRanked, hashContext, hashThought, head, reducerFlow, timestamp } from '../util'
@@ -82,9 +83,9 @@ const newThoughtSubmit = (state: State, { context, value, rank, addAsContext }: 
   }
 
   return reducerFlow([
-    state => updateThoughts(state, { thoughtIndexUpdates, contextIndexUpdates }),
+    updateThoughts({ thoughtIndexUpdates, contextIndexUpdates }),
     render,
   ])(state)
 }
 
-export default newThoughtSubmit
+export default _.curryRight(newThoughtSubmit)

--- a/src/reducers/prependRevision.ts
+++ b/src/reducers/prependRevision.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { newThought } from '../reducers'
 import { getThoughts } from '../selectors'
 import { concatMany, concatOne, getPublishUrl, pathToContext, reducerFlow, unroot } from '../util'
@@ -32,9 +33,9 @@ const prependRevision = (state: State, { path, cid }: { path: Path, cid: string 
       : state,
 
     // insert revision url
-    state => newThought(state, { at: concatMany(path, [publishChild(state) as Child, revisionsChild(state) as Child]), insertNewSubthought: true, insertBefore: true, value: getPublishUrl(cid), preventSetCursor: true }),
+    newThought({ at: concatMany(path, [publishChild(state) as Child, revisionsChild(state) as Child]), insertNewSubthought: true, insertBefore: true, value: getPublishUrl(cid), preventSetCursor: true }),
 
   ])(state)
 }
 
-export default prependRevision
+export default _.curryRight(prependRevision)

--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the search. If not null, will open the search screen. */
@@ -7,4 +8,4 @@ const search = (state: State, { value, archived }: { value: string | null, archi
   archived
 })
 
-export default search
+export default _.curryRight(search)

--- a/src/reducers/searchLimit.ts
+++ b/src/reducers/searchLimit.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the search limit. */
@@ -6,4 +7,4 @@ const searchLimits = (state: State, { value }: { value: string }) => ({
   searchLimit: value
 })
 
-export default searchLimits
+export default _.curryRight(searchLimits)

--- a/src/reducers/selectionChange.ts
+++ b/src/reducers/selectionChange.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the focusOffset when the cursor selection is changed. */
@@ -6,4 +7,4 @@ const selectionChange = (state: State, { focusOffset }: { focusOffset?: number }
   focusOffset
 })
 
-export default selectionChange
+export default _.curryRight(selectionChange)

--- a/src/reducers/setAttribute.ts
+++ b/src/reducers/setAttribute.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { getPrevRank, getThoughts } from '../selectors'
 import { newThoughtSubmit, setFirstSubthought } from '../reducers'
 import { pathToContext, reducerFlow } from '../util'
@@ -17,11 +18,11 @@ const setAttribute = (state: State, { context, key, value }: { context: Context,
       })
       : null,
 
-    state => setFirstSubthought(state, {
+    setFirstSubthought({
       context: context.concat(key),
       value,
     })
 
   ])(state)
 
-export default setAttribute
+export default _.curryRight(setAttribute)

--- a/src/reducers/setCursor.ts
+++ b/src/reducers/setCursor.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { store } from '../store'
 import { dataIntegrityCheck, loadResource } from '../action-creators'
 import { TUTORIAL2_STEP_CONTEXT_VIEW_SELECT, TUTORIAL_CONTEXT, TUTORIAL_STEP_AUTOEXPAND, TUTORIAL_STEP_AUTOEXPAND_EXPAND } from '../constants'
@@ -155,4 +156,4 @@ const setCursor = (state: State, {
   return stateNew
 }
 
-export default setCursor
+export default _.curryRight(setCursor)

--- a/src/reducers/setFirstSubthought.ts
+++ b/src/reducers/setFirstSubthought.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { getPrevRank, getThoughts, rankThoughtsFirstMatch } from '../selectors'
 import { existingThoughtChange, newThoughtSubmit } from '../reducers'
 import { State } from '../util/initialState'
@@ -29,4 +30,4 @@ const setFirstSubthoughts = (state: State, { context, value }: { context: Contex
     })
 }
 
-export default setFirstSubthoughts
+export default _.curryRight(setFirstSubthoughts)

--- a/src/reducers/setResourceCache.ts
+++ b/src/reducers/setResourceCache.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets a value in the resource cache. */
@@ -9,4 +10,4 @@ const setResourceCache = (state: State, { key, value }: { key: string, value: st
   }
 })
 
-export default setResourceCache
+export default _.curryRight(setResourceCache)

--- a/src/reducers/settings.ts
+++ b/src/reducers/settings.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { EM_TOKEN } from '../constants'
 import { isFunction } from '../util'
 import { existingThoughtChange } from '../reducers'
@@ -29,4 +30,4 @@ const settings = (state: State, { key, value }: { key: string, value: string }) 
   })
 }
 
-export default settings
+export default _.curryRight(settings)

--- a/src/reducers/showModal.ts
+++ b/src/reducers/showModal.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { canShowModal } from '../selectors'
 import { State } from '../util/initialState'
 
@@ -11,4 +12,4 @@ const showModal = (state: State, { id }: { id: string }) =>
     }
     : state
 
-export default showModal
+export default _.curryRight(showModal)

--- a/src/reducers/splitThought.ts
+++ b/src/reducers/splitThought.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import xhtmlPurifier from 'xhtml-purifier'
 import { ROOT_TOKEN } from '../constants'
 import { contextOf, headRank, headValue, pathToContext, reducerFlow, strip } from '../util'
@@ -11,7 +12,7 @@ import { Path } from '../types'
  * @param path     The path of the thought to split. Defaults to cursor.
  * @param offset   The index within the thought at which to split. Defaults to the browser selection offset.
  */
-const splitThought = (state: State, { path, offset }: { path?: Path, offset?: number } = {}) => {
+const splitThought = (state: State, { path, offset }: { path?: Path, offset?: number }) => {
 
   path = path || state.cursor as Path
   offset = offset || window.getSelection()?.focusOffset
@@ -37,7 +38,7 @@ const splitThought = (state: State, { path, offset }: { path?: Path, offset?: nu
   return reducerFlow([
 
     // set the thought's text to the left of the selection
-    state => existingThoughtChange(state, {
+    existingThoughtChange({
       oldValue: value,
       newValue: valueLeft,
       context,
@@ -45,7 +46,7 @@ const splitThought = (state: State, { path, offset }: { path?: Path, offset?: nu
     }),
 
     // create a new thought with the text to the right of the selection
-    state => newThought(state, {
+    newThought({
       value: valueRight,
       at: thoughtsRankedLeft,
       // selection offset
@@ -59,7 +60,7 @@ const splitThought = (state: State, { path, offset }: { path?: Path, offset?: nu
       const children = getThoughtsRanked(state, thoughtsRankedLeft)
 
       return reducerFlow(children.map(child =>
-        state => existingThoughtMove(state, {
+        existingThoughtMove({
           oldPath: thoughtsRankedLeft.concat(child),
           newPath: thoughtsRankedRight.concat(child)
         })
@@ -72,4 +73,4 @@ const splitThought = (state: State, { path, offset }: { path?: Path, offset?: nu
   ])(state)
 }
 
-export default splitThought
+export default _.curryRight(splitThought)

--- a/src/reducers/status.ts
+++ b/src/reducers/status.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the connection status. */
@@ -6,4 +7,4 @@ const status = (state: State, { value }: { value: string }) => ({
   status: value
 })
 
-export default status
+export default _.curryRight(status)

--- a/src/reducers/subCategorizeOne.ts
+++ b/src/reducers/subCategorizeOne.ts
@@ -50,7 +50,7 @@ const subCategorizeOne = (state: State) => {
   }
 
   return reducerFlow([
-    state => newThought(state, { insertBefore: true }),
+    newThought({ insertBefore: true }),
     state => existingThoughtMove(state, {
       oldPath: cursor,
       newPath: cursorParent.concat(thoughtNew(state) as Child, head(cursor))

--- a/src/reducers/toggleAttribute.ts
+++ b/src/reducers/toggleAttribute.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { existingThoughtDelete, newThoughtSubmit, setFirstSubthought } from '../reducers'
 import { attributeEquals, getPrevRank, hasChild, rankThoughtsFirstMatch } from '../selectors'
 import { head, reducerFlow } from '../util'
@@ -30,7 +31,7 @@ const toggleAttribute = (state: State, { context, key, value }: { context: Conte
         : null,
 
       // set attribute value
-      state => setFirstSubthought(state, {
+      setFirstSubthought({
         context: context.concat(key),
         value,
       })
@@ -38,4 +39,4 @@ const toggleAttribute = (state: State, { context, key, value }: { context: Conte
     ])(state)
 }
 
-export default toggleAttribute
+export default _.curryRight(toggleAttribute)

--- a/src/reducers/toggleCodeView.ts
+++ b/src/reducers/toggleCodeView.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { equalPath } from '../util'
 import { State } from '../util/initialState'
 
@@ -7,4 +8,4 @@ const toggleCodeView = (state: State, { value }: { value?: boolean }) => ({
   codeView: equalPath(state.cursor, state.codeView!) || value === false ? null : state.cursor
 })
 
-export default toggleCodeView
+export default _.curryRight(toggleCodeView)

--- a/src/reducers/toggleSidebar.ts
+++ b/src/reducers/toggleSidebar.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Toggles the sidebar. */
@@ -6,4 +7,4 @@ const toggleSidebar = (state: State, { value }: { value?: boolean }) => ({
   showSidebar: value == null ? !state.showSidebar : value,
 })
 
-export default toggleSidebar
+export default _.curryRight(toggleSidebar)

--- a/src/reducers/toggleSplitView.ts
+++ b/src/reducers/toggleSplitView.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Toggles the Split View. */
@@ -6,4 +7,4 @@ const toggleSplitView = (state: State, { value }: { value?: boolean }) => ({
   showSplitView: value == null ? !state.showSplitView : value
 })
 
-export default toggleSplitView
+export default _.curryRight(toggleSplitView)

--- a/src/reducers/toggleTopControlsAndBreadcrumbs.ts
+++ b/src/reducers/toggleTopControlsAndBreadcrumbs.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Toggles the Toolbar Visibility. */
@@ -7,4 +8,4 @@ const toggleTopControlsAndBreadcrumbs = (state: State, { value }: { value?: bool
   showBreadcrumbs: value ?? !state.showBreadcrumbs,
 })
 
-export default toggleTopControlsAndBreadcrumbs
+export default _.curryRight(toggleTopControlsAndBreadcrumbs)

--- a/src/reducers/toolbarOverlay.ts
+++ b/src/reducers/toolbarOverlay.ts
@@ -1,13 +1,14 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Sets the toolbar overlay id. */
-export const setToolbarOverlay = (state: State, { id }: { id: string | null }) => ({
+export const setToolbarOverlay = _.curry((state: State, { id }: { id: string | null }) => ({
   ...state,
   toolbarOverlay: id
-})
+}))
 
 /** Sets scrollPrioritized. */
-export const prioritizeScroll = (state: State, { val }: { val?: boolean }) => ({
+export const prioritizeScroll = _.curry((state: State, { val }: { val?: boolean }) => ({
   ...state,
   scrollPrioritized: val
-})
+}))

--- a/src/reducers/tutorial.ts
+++ b/src/reducers/tutorial.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import settings from './settings'
 import { State } from '../util/initialState'
 
@@ -8,4 +9,4 @@ const tutorial = (state: State, { value }: { value?: boolean }) =>
     value: value ? 'On' : 'Off'
   })
 
-export default tutorial
+export default _.curryRight(tutorial)

--- a/src/reducers/tutorialChoice.ts
+++ b/src/reducers/tutorialChoice.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import settings from './settings'
 import { State } from '../util/initialState'
 
@@ -8,4 +9,4 @@ const tutorialChoice = (state: State, { value }: { value: string }) =>
     value
   })
 
-export default tutorialChoice
+export default _.curryRight(tutorialChoice)

--- a/src/reducers/tutorialNext.ts
+++ b/src/reducers/tutorialNext.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { TUTORIAL2_STEP_SUCCESS, TUTORIAL_STEP_SUCCESS } from '../constants'
 import { tutorial, tutorialStep as tutorialStepReducer } from '../reducers'
 import { getSetting } from '../selectors'
@@ -19,4 +20,4 @@ const tutorialNext = (state: State, { hint }: { hint?: boolean } = {}) => {
     })
 }
 
-export default tutorialNext
+export default _.curryRight(tutorialNext)

--- a/src/reducers/tutorialPrev.ts
+++ b/src/reducers/tutorialPrev.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { getSetting } from '../selectors'
 import { tutorialStep as tutorialStepReducer } from '../reducers'
 import { State } from '../util/initialState'
@@ -8,4 +9,4 @@ const tutorialPrev = (state: State, { hint }: { hint?: boolean } = {}) => {
   return tutorialStepReducer(state, { value: !hint ? Math.floor(tutorialStep) - 1 : tutorialStep - 0.1 })
 }
 
-export default tutorialPrev
+export default _.curryRight(tutorialPrev)

--- a/src/reducers/tutorialStep.ts
+++ b/src/reducers/tutorialStep.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { settings } from '../reducers'
 import { State } from '../util/initialState'
 
@@ -8,4 +9,4 @@ const tutorialStep = (state: State, { value }: { value: number }) =>
     value: value.toString()
   })
 
-export default tutorialStep
+export default _.curryRight(tutorialStep)

--- a/src/reducers/undoArchive.ts
+++ b/src/reducers/undoArchive.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { pathToContext, reducerFlow, rootedContextOf } from '../util'
 import { getThoughts, getThoughtsRanked } from '../selectors'
 import { alert, existingThoughtDelete, existingThoughtMove, setCursor } from '../reducers'
@@ -20,7 +21,7 @@ const undoArchive = (state: State, { originalPath, currPath, offset }: { origina
     }),
 
     // move thought out of archive
-    state => existingThoughtMove(state, {
+    existingThoughtMove({
       oldPath: currPath,
       newPath: originalPath,
       offset
@@ -35,9 +36,9 @@ const undoArchive = (state: State, { originalPath, currPath, offset }: { origina
       : state,
 
     // hide the undo alert
-    state => alert(state, { value: null })
+    alert({ value: null })
 
   ])(state)
 }
 
-export default undoArchive
+export default _.curryRight(undoArchive)

--- a/src/reducers/updateSplitPosition.ts
+++ b/src/reducers/updateSplitPosition.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { State } from '../util/initialState'
 
 /** Updates the position of the Split View splitter. */
@@ -6,4 +7,4 @@ const updateSplitPosition = (state: State, { value }: { value: number }) => ({
   splitPosition: value
 })
 
-export default updateSplitPosition
+export default _.curryRight(updateSplitPosition)

--- a/src/reducers/updateThoughts.ts
+++ b/src/reducers/updateThoughts.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { clearQueue } from '../reducers'
 import { expandThoughts } from '../selectors'
 import { logWithTime, mergeUpdates } from '../util'
@@ -35,8 +36,8 @@ const updateThoughts = (state: State, { thoughtIndexUpdates, contextIndexUpdates
 
   // updates are queued, detected by the syncQueue middleware, and sync'd with the local and remote stores
   const syncQueueNew = {
-    thoughtIndexUpdates: { ...syncQueue.thoughtIndexUpdates, ...thoughtIndexUpdates },
-    contextIndexUpdates: { ...syncQueue.contextIndexUpdates, ...contextIndexUpdates },
+    thoughtIndexUpdates: { ...syncQueue?.thoughtIndexUpdates, ...thoughtIndexUpdates },
+    contextIndexUpdates: { ...syncQueue?.contextIndexUpdates, ...contextIndexUpdates },
     recentlyEdited, // only sync recentlyEdited if modified
     updates,
     local,
@@ -66,4 +67,4 @@ const updateThoughts = (state: State, { thoughtIndexUpdates, contextIndexUpdates
   }
 }
 
-export default updateThoughts
+export default _.curryRight(updateThoughts)


### PR DESCRIPTION
Curry reducers to clean up `reducerFlow`.

This...

```js
  reducersFlow([
    state => newThought(state, { value: 'a' }),
    state => newThought(state, { value: 'b' }),
    state => existingThoughtMove(state, {
      oldPath: [{ value: 'b', rank: 1 }],
      newPath: [{ value: 'b', rank: -1 }],
    }),
  ])(state)
```

... can now change to:

```js
  reducerFlow([
    newThought({ value: 'a' }),
    newThought({ value: 'b' }),
    existingThoughtMove({
      oldPath: [{ value: 'b', rank: 1 }],
      newPath: [{ value: 'b', rank: -1 }],
    }),
  ])(state)
```

### Notes:

- Reducers with no payload are not curried.
- Payload objects are no longer optional, e.g. ~`archiveThought()`~ `archiveThought({})`. Omitting the payload will return a curried function. This might be corrected with a custom `curry` function, but for now the standard `_.curryRight` is being used.