### PR TITLE
adds check to stop setCursor dispatch when thought value is same

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -387,7 +387,7 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
         // clicking a different thought (when not editing)
         (!state.editing && !equalPath(thoughtsResolved, state.cursorBeforeEdit))
 
-      const thoughtChanged = !state.cursor || thoughtsResolved.some((thought, index) => state.cursor![index].id !== undefined && state.cursor![index].id !== thought.id)
+      const thoughtChanged = !state.cursor || state.cursorOffset || thoughtsResolved.some((thought, index) => state.cursor![index].id !== undefined && state.cursor![index].id !== thought.id)
       if (thoughtChanged) setCursorOnThought({ editing: !falseFocus })
 
       // remove the selection caused by the falseFocus

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -387,7 +387,8 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
         // clicking a different thought (when not editing)
         (!state.editing && !equalPath(thoughtsResolved, state.cursorBeforeEdit))
 
-      setCursorOnThought({ editing: !falseFocus })
+      const thoughtChanged = !state.cursor || thoughtsResolved.some((thought, index) => state.cursor![index].id !== undefined && state.cursor![index].id !== thought.id)
+      if (thoughtChanged) setCursorOnThought({ editing: !falseFocus })
 
       // remove the selection caused by the falseFocus
       if (falseFocus) {

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -387,8 +387,12 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
         // clicking a different thought (when not editing)
         (!state.editing && !equalPath(thoughtsResolved, state.cursorBeforeEdit))
 
-      const thoughtChanged = !state.cursor || state.cursorOffset || thoughtsResolved.some((thought, index) => state.cursor![index].id !== undefined && state.cursor![index].id !== thought.id)
-      if (thoughtChanged) setCursorOnThought({ editing: !falseFocus })
+      const thoughtChanged = !state.cursor || thoughtsResolved.length !== state.cursor.length || thoughtsResolved.some((thought, index) => {
+        const child = state.cursor![index]
+        // eslint-disable-next-line no-extra-parens
+        return child && (Object.keys(child) as (keyof Child)[]).some(key => child[key] !== thought[key])
+      })
+      if ((isMobile && state.editing) || thoughtChanged) setCursorOnThought({ editing: !falseFocus })
 
       // remove the selection caused by the falseFocus
       if (falseFocus) {


### PR DESCRIPTION
fixes #814 

**Issue:**
The setCursor action was being dispatched on every `onFocus` event of the `Editable(Thought)` component. On every `enter` keypress, a new thought is created, and brought to focus, hence dispatching the `setCursor` action fatuously.

**Proposed solution:**
Dispatching the `setCursor` action which ensures that it's fired only when the `thoughtsResolved` and `cursor` differ 