### PR TITLE
Content Editable

### DIFF
--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react'
+import { GenericObject } from '../utilTypes'
+
+interface ContentEditableProps extends React.HTMLProps<HTMLDivElement>{
+    style: GenericObject,
+    html: string,
+    disabled?: boolean,
+    innerRef?: React.RefObject<HTMLDivElement>,
+    onChange: (originalEvt: ContentEditableEvent) => void,
+}
+
+/**
+ * Content Editable Component.
+ */
+const ContentEditable = ({ style, html, disabled, innerRef, onChange, ...props }: ContentEditableProps) => {
+  const contentRef = innerRef || useRef<HTMLDivElement>(null)
+  const prevHtmlRef = useRef<string>(html)
+
+  React.useEffect(() => {
+    if (contentRef.current) contentRef.current!.innerHTML = html
+  }, [])
+
+  React.useEffect(() => {
+    // set innerHTML only when the content editable is not focused
+    if (document.activeElement !== contentRef.current && prevHtmlRef.current !== html) {
+      contentRef.current!.innerHTML = html
+      prevHtmlRef.current = html
+    }
+  }, [html])
+
+  return <div
+    {...props}
+    ref={contentRef}
+    contentEditable={!disabled}
+    style={style}
+    onBlur={(originalEvent: React.FocusEvent<any>) => {
+      const innerHTML = contentRef!.current!.innerHTML
+      // set inner hmtl to decoded html passed from the props
+      contentRef.current!.innerHTML = html
+
+      const event = Object.assign({}, originalEvent, {
+        target: {
+          value: innerHTML
+        }
+      })
+
+      if (props.onBlur) props.onBlur(event)
+    }}
+    onInput={(originalEvent: React.SyntheticEvent<any>) => {
+      const innerHTML = contentRef!.current!.innerHTML
+
+      const event = Object.assign({}, originalEvent, {
+        target: {
+          value: innerHTML
+        }
+      })
+
+      onChange(event)
+    }}
+  />
+}
+
+export declare type ContentEditableEvent = React.SyntheticEvent<any, Event> & {
+    target: {
+        value: string,
+    },
+};
+
+export default ContentEditable

--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -12,7 +12,7 @@ interface ContentEditableProps extends React.HTMLProps<HTMLDivElement>{
 /**
  * Content Editable Component.
  */
-const ContentEditable = ({ style, html, disabled, innerRef, onChange, ...props }: ContentEditableProps) => {
+const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentEditableProps) => {
   const contentRef = innerRef || useRef<HTMLDivElement>(null)
   const prevHtmlRef = useRef<string>(html)
 
@@ -27,6 +27,19 @@ const ContentEditable = ({ style, html, disabled, innerRef, onChange, ...props }
       prevHtmlRef.current = html
     }
   }, [html])
+
+  // eslint-disable-next-line
+  const handleInput = (originalEvent: React.SyntheticEvent<any>) => {
+    const innerHTML = contentRef!.current!.innerHTML
+
+    const event = Object.assign({}, originalEvent, {
+      target: {
+        value: innerHTML
+      }
+    })
+
+    props.onChange(event)
+  }
 
   return <div
     {...props}
@@ -44,17 +57,7 @@ const ContentEditable = ({ style, html, disabled, innerRef, onChange, ...props }
 
       if (props.onBlur) props.onBlur(event)
     }}
-    onInput={(originalEvent: React.SyntheticEvent<any>) => {
-      const innerHTML = contentRef!.current!.innerHTML
-
-      const event = Object.assign({}, originalEvent, {
-        target: {
-          value: innerHTML
-        }
-      })
-
-      onChange(event)
-    }}
+    onInput={handleInput}
   />
 }
 

--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -35,8 +35,6 @@ const ContentEditable = ({ style, html, disabled, innerRef, onChange, ...props }
     style={style}
     onBlur={(originalEvent: React.FocusEvent<any>) => {
       const innerHTML = contentRef!.current!.innerHTML
-      // set inner hmtl to decoded html passed from the props
-      contentRef.current!.innerHTML = html
 
       const event = Object.assign({}, originalEvent, {
         target: {

--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -28,8 +28,8 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
     }
   }, [html])
 
-  // eslint-disable-next-line
-  const handleInput = (originalEvent: React.SyntheticEvent<any>) => {
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  const handleInput = (originalEvent: React.SyntheticEvent<HTMLInputElement>) => {
     const innerHTML = contentRef!.current!.innerHTML
 
     const event = Object.assign({}, originalEvent, {
@@ -46,7 +46,7 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
     ref={contentRef}
     contentEditable={!disabled}
     style={style}
-    onBlur={(originalEvent: React.FocusEvent<any>) => {
+    onBlur={(originalEvent: React.FocusEvent<HTMLInputElement>) => {
       const innerHTML = contentRef!.current!.innerHTML
 
       const event = Object.assign({}, originalEvent, {
@@ -61,10 +61,10 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
   />
 }
 
-export declare type ContentEditableEvent = React.SyntheticEvent<any, Event> & {
-    target: {
-        value: string,
-    },
-};
+export declare type ContentEditableEvent = React.SyntheticEvent<HTMLInputElement, Event> & {
+  target: {
+    value: string,
+  },
+}
 
 export default ContentEditable

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -7,7 +7,7 @@ import { importText, setEditingValue, setInvalidState } from '../action-creators
 import { isMobile } from '../browser'
 import globals from '../globals'
 import { store } from '../store'
-import ContentEditable, { ContentEditableEvent } from 'react-contenteditable'
+import ContentEditable, { ContentEditableEvent } from './ContentEditable'
 import { shortcutEmitter } from '../shortcuts.js'
 import { Child, Connected, Context, Path, TutorialChoice } from '../types'
 import { GenericObject } from '../utilTypes'


### PR DESCRIPTION
`ContentEditable` component that only sets `innerHTML` blur. It prevents setting `innerHTML` when it is currently focused. This will allow `Editable` component to re-render without causing reset of `focusOffset` on `ContentEditable`.