### PR TITLE
replaces component with string in archiveThought's alert

### DIFF
--- a/src/reducers/archiveThought.js
+++ b/src/reducers/archiveThought.js
@@ -29,7 +29,7 @@ import {
   lastThoughtsFromContextChain,
   nextSibling,
   prevSibling,
-  splitChain,g
+  splitChain,
   thoughtsEditingFromChain,
 } from '../selectors'
 


### PR DESCRIPTION
fixes #837 

Replaces component with a string in `archiveThought` alert (as discussed in issue [811](https://github.com/cybersemics/em/pull/811#issuecomment-676296131) )