### PR TITLE
Set selection after paste

### DIFF
--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react'
 import { GenericObject } from '../utilTypes'
+import { setSelection } from '../util'
 
 interface ContentEditableProps extends React.HTMLProps<HTMLDivElement>{
     style: GenericObject,
@@ -7,13 +8,12 @@ interface ContentEditableProps extends React.HTMLProps<HTMLDivElement>{
     disabled?: boolean,
     innerRef?: React.RefObject<HTMLDivElement>,
     isEditing?: boolean,
-    onChange: (originalEvt: ContentEditableEvent) => void,
 }
 
 /**
  * Content Editable Component.
  */
-const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentEditableProps) => {
+const ContentEditable = ({ style, html, disabled, innerRef, isEditing, ...props }: ContentEditableProps) => {
   const contentRef = innerRef || useRef<HTMLDivElement>(null)
   const prevHtmlRef = useRef<string>(html)
   const allowInnerHTMLChange = useRef<boolean>(true)
@@ -27,6 +27,10 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
     if (prevHtmlRef.current !== html && allowInnerHTMLChange.current) {
       contentRef.current!.innerHTML = html
       prevHtmlRef.current = html
+
+      if (isEditing && contentRef.current) {
+        setSelection(contentRef.current, { end: true })
+      }
     }
   }, [html])
 
@@ -43,7 +47,7 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
       }
     })
 
-    props.onChange(event)
+    if (props.onChange) props.onChange(event)
   }
 
   return <div
@@ -73,7 +77,6 @@ const ContentEditable = ({ style, html, disabled, innerRef, ...props }: ContentE
     }}
     onInput={handleInput}
     onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-
       // allow innerHTML update when thought split is triggered
       if (e.key === 'Enter') allowInnerHTMLChange.current = true
       if (props.onKeyDown) props.onKeyDown(e)

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -485,6 +485,7 @@ const Editable = ({ disabled, isEditing, thoughtsRanked, contextChain, cursorOff
     onBlur={onBlur}
     onChange={onChangeHandler}
     onPaste={onPaste}
+    isEditing={isEditing}
     onKeyDown={onKeyDownAction ? onKeyDown : undefined}
     style={{
       ...style, // style prop


### PR DESCRIPTION
@raineorshine I tried to place cursor position at the end of the pasted text after `innerHTML` is updated but it turns out quite tricky to achieve. With this PR I have set the selection at the end of the thought after paste. I will be working on a proper solution in the sidelines. 