### PR TITLE
Makes splitSentences undoable

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -254,6 +254,7 @@ export const UNDOABLE_ACTIONS: Index<string> = {
   setCursor: 'setCursor',
   setFirstSubthought: 'setFirstSubthought',
   settings: 'settings',
+  splitSentences: 'splitSentences',
   splitThought: 'splitThought',
   subCategorizeAll: 'subCategorizeAll',
   subCategorizeOne: 'subCategorizeOne',

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -341,3 +341,37 @@ it('non-undoable actions are ignored', () => {
   expect(store.getState().inversePatches.length).toEqual(0)
 
 })
+
+it('undo splitSentences', () => {
+  const store = createTestStore()
+
+  store.dispatch([
+    {
+      type: 'importText',
+      path: RANKED_ROOT,
+      text: `
+        - First Sentence. Second Sentence
+        - t`
+    },
+    { type: 'setCursor', path: [{ value: 'First Sentence. Second Sentence', rank: 0 }] },
+    { type: 'splitSentences' }
+  ])
+
+  const exportedSplitSentences = exportContext(store.getState(), [ROOT_TOKEN], 'text/plain')
+  const expectedOutputAfterSplit = `- ${ROOT_TOKEN}
+  - First Sentence.
+  - Second Sentence.
+  - t`
+
+  expect(exportedSplitSentences).toEqual(expectedOutputAfterSplit)
+
+  store.dispatch({ type: 'undoAction' })
+
+  const exportedAfterUndo = exportContext(store.getState(), [ROOT_TOKEN], 'text/plain')
+  const expectedOutputAfterUndo = `- ${ROOT_TOKEN}
+  - First Sentence. Second Sentence
+  - t`
+
+  expect(exportedAfterUndo).toEqual(expectedOutputAfterUndo)
+
+})


### PR DESCRIPTION
Makes `splitSentences` action undoable, and adds related tests