### PR TITLE
Adds multiline check to cursorDown shortcut

### DIFF
--- a/src/shortcuts/cursorDown.tsx
+++ b/src/shortcuts/cursorDown.tsx
@@ -43,7 +43,6 @@ const getSelectionAttributes = (): SelectionAttributes | null => {
   const { y: baseNodeY, height: baseNodeHeight } = baseNodeParentEl.getClientRects()[0]
   const [paddingTop, , paddingBottom] = getElementPaddings(baseNodeParentEl)
 
-  // allow error of 5px
   const isMultiline = Math.abs(rangeY - baseNodeY - paddingTop) > 0
   return isMultiline ? { rangeY, rangeHeight, baseNodeY, baseNodeHeight, paddingTop, paddingBottom } : null
 }
@@ -73,7 +72,7 @@ const cursorDownShortcut: Shortcut = {
 
     const selectionAttributes = getSelectionAttributes()
     // use default browser if there is a valid selection and it's not on the last line of a multi-line editable
-    return selectionAttributes ? isSelectionOnLastLine(selectionAttributes) : true
+    return !selectionAttributes || isSelectionOnLastLine(selectionAttributes)
   },
   exec: dispatch => {
     dispatch({ type: 'cursorDown' })

--- a/src/shortcuts/cursorDown.tsx
+++ b/src/shortcuts/cursorDown.tsx
@@ -4,6 +4,15 @@ import { parentOf, getElementPaddings, headValue, pathToContext } from '../util'
 import { attributeEquals } from '../selectors'
 import { scrollCursorIntoView } from '../action-creators'
 
+interface SelectionAttributes {
+   rangeY: number,
+   rangeHeight: number,
+   baseNodeY: number,
+   baseNodeHeight: number,
+   paddingTop: number,
+   paddingBottom: number,
+}
+
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ fill = 'black', size = 20, style }: IconType) => <svg version='1.1' className='icon' xmlns='http://www.w3.org/2000/svg' width={size} height={size} fill={fill} style={style} viewBox='0 0 19.481 19.481' enableBackground='new 0 0 19.481 19.481'>
   <g>
@@ -11,27 +20,36 @@ const Icon = ({ fill = 'black', size = 20, style }: IconType) => <svg version='1
   </g>
 </svg>
 
-/** Returns true if the selection is on the last line of a multi-line editable. */
-const isSelectionOnLastLine = () => {
+/**
+ * Returns selection configuration if exists, null otherwise.
+ */
+const getSelectionAttributes = (): SelectionAttributes | null => {
 
   const selection = window.getSelection()
-  if (!selection) return false
+  if (!selection) return null
 
   const { anchorNode: baseNode, rangeCount } = selection
-  if (rangeCount === 0) return false
+  if (rangeCount === 0) return null
 
   const clientRects = selection.getRangeAt(0).getClientRects()
-  if (!clientRects?.length) return false
+  if (!clientRects?.length) return null
 
   const { y: rangeY, height: rangeHeight } = clientRects[0]
-  if (!rangeY) return false
+  if (!rangeY) return null
 
   const baseNodeParentEl = baseNode?.parentElement as HTMLElement
-  if (!baseNodeParentEl) return false
+  if (!baseNodeParentEl) return null
 
   const { y: baseNodeY, height: baseNodeHeight } = baseNodeParentEl.getClientRects()[0]
   const [paddingTop, , paddingBottom] = getElementPaddings(baseNodeParentEl)
 
+  // allow error of 5px
+  const isMultiline = Math.abs(rangeY - baseNodeY - paddingTop) > 0
+  return isMultiline ? { rangeY, rangeHeight, baseNodeY, baseNodeHeight, paddingTop, paddingBottom } : null
+}
+
+/** Returns true if the selection is on the last line of an editable. */
+const isSelectionOnLastLine = ({ rangeY, rangeHeight, baseNodeY, baseNodeHeight, paddingTop, paddingBottom }: SelectionAttributes) => {
   return rangeY + rangeHeight > baseNodeY + baseNodeHeight - paddingTop - paddingBottom - 5
 }
 
@@ -53,11 +71,9 @@ const cursorDownShortcut: Shortcut = {
     const isProseMode = isProseView && window.getSelection()?.focusOffset as number < headValue(cursor).length - 1
     if (isProseMode) return false
 
-    // use default browser if selection is not on the last line of a multi-line editable
-    const isOnLastLine = isSelectionOnLastLine()
-    if (!isOnLastLine) return false
-
-    return true
+    const selectionAttributes = getSelectionAttributes()
+    // use default browser if there is a valid selection and it's not on the last line of a multi-line editable
+    return selectionAttributes ? isSelectionOnLastLine(selectionAttributes) : true
   },
   exec: dispatch => {
     dispatch({ type: 'cursorDown' })


### PR DESCRIPTION
fixes #913 

Problem - The function [`isSelectionOnLastLine`](https://github.com/cybersemics/em/blob/394cbff80b687031db4a0d76cc6b0618ff72f52c/src/shortcuts/cursorDown.tsx#L15) was being [called](https://github.com/cybersemics/em/blob/394cbff80b687031db4a0d76cc6b0618ff72f52c/src/shortcuts/cursorDown.tsx#L57) for every `cursorDown` action, and is currently based on an assumption that every thought would be either a multiline thought or have a valid `selection`
An empty thought, however, doesn't have any valid selection, and the function always [evaluates to false](https://github.com/cybersemics/em/blob/394cbff80b687031db4a0d76cc6b0618ff72f52c/src/shortcuts/cursorDown.tsx#L24), hence, skipping the shortcut execution.

Solution - Check if a thought has a valid selection at all, before checking the cursor position within a multi-line editable. 
