### PR TITLE
Defers setCursor until `=archive` context is added for archive action

### DIFF
--- a/src/reducers/archiveThought.ts
+++ b/src/reducers/archiveThought.ts
@@ -123,19 +123,16 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
   }
 
   return reducerFlow([
+
     ...isDeletable
+
       ? [
-        // set the cursor away from the current cursor before archiving so that existingThoughtMove does not move it
-        setCursor({
-          path: cursorNew,
-          editing: state.editing,
-          offset,
-        }),
         existingThoughtDelete({
           context: showContexts ? context : parentOf(pathToContext(simplePath)),
           showContexts,
           thoughtRanked: head(simplePath),
         })]
+
       : [
         // create =archive if it does not exist
         (state: State) => !hasChild(state, context, '=archive')
@@ -147,11 +144,6 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
             preventSetCursor: true
           })
           : null,
-        setCursor({
-          path: cursorNew,
-          editing: state.editing,
-          offset,
-        }),
 
         // undo alert
         alert({
@@ -162,15 +154,21 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
         }),
 
         // execute existingThoughtMove after newThought has updated the state
-        (state: State) => {
-          return existingThoughtMove(state, {
-            oldPath: showContexts ? simplePath : path,
-            // TODO: Are we sure pathToArchive cannot return null?
-            newPath: pathToArchive(state, showContexts ? simplePath : path, context)!,
-            offset
-          })
-        }
-      ]
+        (state: State) => existingThoughtMove(state, {
+          oldPath: path,
+          // TODO: Are we sure pathToArchive cannot return null?
+          newPath: pathToArchive(state, showContexts ? simplePath : path, context)!,
+          offset
+        })
+
+      ],
+
+    setCursor({
+      path: cursorNew,
+      editing: state.editing,
+      offset,
+    }),
+
   ])(state)
 }
 

--- a/src/reducers/archiveThought.ts
+++ b/src/reducers/archiveThought.ts
@@ -123,24 +123,22 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
   }
 
   return reducerFlow([
-
-    // set the cursor away from the current cursor before archiving so that existingThoughtMove does not move it
-    setCursor({
-      path: cursorNew,
-      editing: state.editing,
-      offset,
-    }),
-
-    isDeletable
-      ? existingThoughtDelete({
-        context: showContexts ? context : parentOf(pathToContext(simplePath)),
-        showContexts,
-        thoughtRanked: head(simplePath),
-      })
-      : reducerFlow([
-
+    ...isDeletable
+      ? [
+        // set the cursor away from the current cursor before archiving so that existingThoughtMove does not move it
+        setCursor({
+          path: cursorNew,
+          editing: state.editing,
+          offset,
+        }),
+        existingThoughtDelete({
+          context: showContexts ? context : parentOf(pathToContext(simplePath)),
+          showContexts,
+          thoughtRanked: head(simplePath),
+        })]
+      : [
         // create =archive if it does not exist
-        state => !hasChild(state, context, '=archive')
+        (state: State) => !hasChild(state, context, '=archive')
           ? newThought(state, {
             at: pathParent,
             insertNewSubthought: true,
@@ -149,6 +147,11 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
             preventSetCursor: true
           })
           : null,
+        setCursor({
+          path: cursorNew,
+          editing: state.editing,
+          offset,
+        }),
 
         // undo alert
         alert({
@@ -159,7 +162,7 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
         }),
 
         // execute existingThoughtMove after newThought has updated the state
-        state => {
+        (state: State) => {
           return existingThoughtMove(state, {
             oldPath: showContexts ? simplePath : path,
             // TODO: Are we sure pathToArchive cannot return null?
@@ -167,7 +170,7 @@ const archiveThought = (state: State, { path }: { path: Path }): State => {
             offset
           })
         }
-      ])
+      ]
   ])(state)
 }
 


### PR DESCRIPTION
fixes #911 

**Problem**
The cursor is correctly being set to null by [the setCursor call](https://github.com/cybersemics/em/blob/547b2c9049c2cc049897e5bc2e07155f56866f40/src/reducers/archiveThought.ts#L128) within `archiveThought` if there's only one thought. For the very first thought, we don't have `=archive` context in place, so we're [creating a new thought](https://github.com/cybersemics/em/blob/547b2c9049c2cc049897e5bc2e07155f56866f40/src/reducers/archiveThought.ts#L144) for that. However, this eventually triggers the `updateThoughts` reducer, which tries to [decode the cursor from null](https://github.com/cybersemics/em/blob/547b2c9049c2cc049897e5bc2e07155f56866f40/src/reducers/updateThoughts.ts#L137) (based on the assumption that it's due to page load). So the cursor gets reset to the original thought: `{value: "a", rank: 0, id: ""}`. The [`existingThoughtMove`](https://github.com/cybersemics/em/blob/547b2c9049c2cc049897e5bc2e07155f56866f40/src/reducers/archiveThought.ts#L162) [updates the cursor](https://github.com/cybersemics/em/blob/547b2c9049c2cc049897e5bc2e07155f56866f40/src/reducers/existingThoughtMove.ts#L288) yet again, with an underline assumption that the cursor would be null for and won't be updated (which isn't true for the very first thought).

**Solution**
By calling [setCursor](https://github.com/anmolarora1/em/blob/7b454ea4ec28e8ea7ed56a4f07ea639fdeb09e8e/src/reducers/archiveThought.ts#L150) after the [new thought ](https://github.com/anmolarora1/em/blob/7b454ea4ec28e8ea7ed56a4f07ea639fdeb09e8e/src/reducers/archiveThought.ts#L142)(`=archive`) has been created, so that the cursor is correctly set to `null` we can ensure that `existingThoughtMove` doesn't move the cursor to an archive thought (or put simply, update the cursor)

