### PR TITLE
Rerender editable on thoughts bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ yarn-error.log*
 .idea
 .history
 .eslintcache
+
+.vscode

--- a/src/components/__tests__/Editable.ts
+++ b/src/components/__tests__/Editable.ts
@@ -1,0 +1,46 @@
+import { ReactWrapper } from 'enzyme'
+import { store } from '../../store'
+import { RANKED_ROOT } from '../../constants'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import { importText } from '../../action-creators'
+import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
+import executeShortcut from '../../test-helpers/executeShortcut'
+import bumpThoughtDown from '../../shortcuts/bumpThoughtDown'
+import Editable from '../Editable'
+
+let wrapper: ReactWrapper<unknown, unknown> // eslint-disable-line fp/no-let
+
+beforeEach(async () => {
+  wrapper = await createTestApp()
+})
+
+afterEach(cleanupTestApp)
+
+it('reset content editable inner html on thought bump', async () => {
+
+  // import thoughts
+  store.dispatch([
+    importText({
+      path: RANKED_ROOT,
+      text: `
+        - a
+          - b`
+    }),
+    setCursorFirstMatchActionCreator(['a']),
+  ])
+
+  // update DOM
+  wrapper.update()
+
+  /* eslint-disable jsdoc/require-jsdoc */
+  const getContentEditableText = () => wrapper.find(Editable).first().find('div.editable').first().text()
+
+  expect(getContentEditableText()).toBe('a')
+
+  executeShortcut(bumpThoughtDown, { store })
+
+  jest.runOnlyPendingTimers()
+  wrapper.update()
+
+  expect(getContentEditableText()).toBe('')
+})

--- a/src/reducers/bumpThoughtDown.ts
+++ b/src/reducers/bumpThoughtDown.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { existingThoughtChange, existingThoughtMove, newThoughtSubmit, setCursor, subCategorizeOne } from '../reducers'
+import { existingThoughtChange, existingThoughtMove, newThoughtSubmit, setCursor, subCategorizeOne, editableRender } from '../reducers'
 import { getPrevRank, getRankBefore, getAllChildren, simplifyPath } from '../selectors'
 import { parentOf, headValue, pathToContext, reducerFlow, rootedParentOf, unroot } from '../util'
 import { State } from '../util/initialState'
@@ -61,7 +61,7 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
     setCursor({
       path: simplePathWithNewRankAndValue,
     }),
-
+    editableRender
   ])(state)
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "dom",
       "es2019"
     ],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "target": "es5",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
fixes #935

Turns out it was not the problem with `mapStateToProps` logic in `Content`. Actually we had to just call `editableRender` reducer on thoughts bump. This will let `ContentEditable` know that it is safe to set `innerRef` and updates the value.