### PR TITLE
Rerender Sub thought on expand

### DIFF
--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -136,7 +136,8 @@ const mapStateToProps = (state: State, props: SubthoughtsProps) => {
     showHiddenThoughts,
     simplePath: simplePathLive,
     // re-render if children change
-    __render: getAllChildren(state, pathToContext(simplePathLive))
+    __render: getAllChildren(state, pathToContext(simplePathLive)),
+    isExpanded: store.getState().expanded[hashContext(pathToContext(resolvedPath))]
   }
 }
 
@@ -305,6 +306,7 @@ export const SubthoughtsComponent = ({
   showContexts,
   sort: contextSort,
   simplePath,
+  isExpanded
 }: SubthoughtsProps & ReturnType<typeof dropCollect> & ReturnType<typeof mapStateToProps>) => {
 
   // <Subthoughts> render
@@ -316,7 +318,7 @@ export const SubthoughtsComponent = ({
 
   const resolvedPath = path ?? simplePath
 
-  const show = depth < MAX_DEPTH && (isEditingAncestor || store.getState().expanded[hashContext(pathToContext(resolvedPath))])
+  const show = depth < MAX_DEPTH && (isEditingAncestor || isExpanded)
 
   // disable intrathought linking until add, edit, delete, and expansion can be implemented
   // const subthought = once(() => getSubthoughtUnderSelection(headValue(simplePath), 3))

--- a/src/components/__tests__/Subthoughts.ts
+++ b/src/components/__tests__/Subthoughts.ts
@@ -3,12 +3,13 @@ import { store } from '../../store'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import { RANKED_ROOT } from '../../constants'
 import { equalArrays, pathToContext, timestamp } from '../../util'
-import { importText, setCursor } from '../../action-creators'
+import { importText, setCursor, toggleAttribute } from '../../action-creators'
 import Editable from '../Editable'
 import Thought from '../Thought'
 import Subthoughts from '../Subthoughts'
 import { Context, Path, SimplePath } from '../../types'
 import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
+import { getAllChildren } from '../../selectors'
 
 // type for Thoughts or Subthoughts component that has a simplePath prop
 interface ThoughtOrSubthoughtsComponent {
@@ -394,5 +395,63 @@ describe('hidden thoughts', () => {
     // meta thoughts should be visible when it lies in cursor path
     expect(nestedMetaThought2()).toHaveLength(1)
     expect(nestedMetaThought2Child()).toHaveLength(1)
+  })
+})
+
+describe('expand thoughts', () => {
+
+  it('re-render Subthought if it is expanded', () => {
+
+    /* Note: Sometimes children of a Subthought is updated first and then expanded property is updated later.
+      This test checks if the Subthought re-renders in this scenario. https://github.com/cybersemics/em/pull/951
+    */
+
+    // import thoughts
+    store.dispatch([
+      importText({
+        path: RANKED_ROOT,
+        preventSetCursor: true,
+        text: `
+        - a
+          - b
+        - c`,
+      }),
+      // Note: initially setting =pin attribute to false so that on toogling to true children of ['a'] doesn't change
+      toggleAttribute({
+        context: ['a'],
+        key: '=pin',
+        value: 'false',
+      })
+    ])
+
+    // update DOM
+    wrapper.update()
+
+    const childrenContextA = getAllChildren(store.getState(), ['a'])
+
+    /** */
+    const thoughtB = () => wrapper
+      .find(Subthoughts)
+      .filterWhere(wherePath(['a', 'b']))
+
+    // context ['a'] is not yet expanded yet
+    expect(thoughtB()).toHaveLength(0)
+
+    store.dispatch(toggleAttribute({
+      context: ['a'],
+      key: '=pin',
+      value: 'true',
+    }))
+
+    const updatedChildrenContextA = getAllChildren(store.getState(), ['a'])
+
+    // children of context ['a'] shouldn't change as this test requires Subthought to rerender due to change in expanded
+    expect(updatedChildrenContextA).toBe(childrenContextA)
+
+    wrapper.update()
+
+    // on change of isExpanded the Subthought should re-render and render it's children
+    expect(thoughtB()).toHaveLength(1)
+
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "dom",
       "es2019"
     ],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "target": "es5",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
fixes #942 

## Changes
- Added `isExpanded` to `mapStateToProps` of `Subthought` to re-render it's children if thought is either expanded or collapsed.
