### PR TITLE
Fix caret update on empty thought

### DIFF
--- a/src/reducers/setCursor.ts
+++ b/src/reducers/setCursor.ts
@@ -131,7 +131,7 @@ const setCursor = (state: State, {
       : state.cursorHistory,
       // set cursorOffset to null if editingValue is null
       // (prevents Editable from calling setSelection on click since we want the default cursor placement in that case)
-      cursorOffset: offset ?? (state.editingValue ? 0 : null),
+      cursorOffset: offset ?? (state.editingValue !== null ? 0 : null),
       contextViews: newContextViews,
       editing: editing != null ? editing : state.editing,
       expanded,


### PR DESCRIPTION
fixes #936 

## Cause of the issue

Empty strings are falsey in js. This check returns false even for empty string, not just for null value. So on empty thought, `cursorOffset` was being set to `null`

https://github.com/cybersemics/em/blob/4885039066a2315426b0728e2094b6d1f0b92699/src/reducers/setCursor.ts#L134

That prevented `setSelection` from being called in `Editable`.

https://github.com/cybersemics/em/blob/4885039066a2315426b0728e2094b6d1f0b92699/src/components/Editable.tsx#L314-L322

## Changes

Used strict `null` check to prevent falsey empty string.


