### PR TITLE
Add isActive to Shortcut

### DIFF
--- a/src/shortcuts/note.ts
+++ b/src/shortcuts/note.ts
@@ -1,9 +1,10 @@
 import { isTouch } from '../browser'
-import { hasChild } from '../selectors'
+import { attribute, hasChild } from '../selectors'
 import PencilIcon from '../components/icons/PencilIcon'
 import { asyncFocus, editableNode, isDocumentEditable, pathToContext, setSelection } from '../util'
 import { setAttribute } from '../action-creators'
 import { Shortcut } from '../types'
+import { ROOT_TOKEN } from '../constants'
 
 const noteShortcut: Shortcut = {
   id: 'note',
@@ -60,6 +61,12 @@ const noteShortcut: Shortcut = {
         console.warn('Note element not found in DOM.', context)
       }
     }, 0)
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attribute(state, context, '=note') != null
   }
 }
 

--- a/src/shortcuts/pinOpen.tsx
+++ b/src/shortcuts/pinOpen.tsx
@@ -3,6 +3,7 @@ import { attributeEquals } from '../selectors'
 import { parentOf, pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
+import { ROOT_TOKEN } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg xmlns='http://www.w3.org/2000/svg' version='1.1' className='icon' viewBox='0 0 20 20' width={size} height={size} style={style}>
@@ -31,6 +32,12 @@ const pinOpenShortcut: Shortcut = {
       key: '=pin',
       value: isPinned ? 'false' : 'true'
     }))
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attributeEquals(state, context, '=pin', 'true')
   }
 }
 

--- a/src/shortcuts/pinSubthoughts.tsx
+++ b/src/shortcuts/pinSubthoughts.tsx
@@ -3,6 +3,7 @@ import { attributeEquals, simplifyPath } from '../selectors'
 import { pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
+import { ROOT_TOKEN } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg xmlns='http://www.w3.org/2000/svg' className='icon' version='1.1' x='0px' y='0px' viewBox='0 0 23 20' width={size} height={size} style={style}>
@@ -35,6 +36,12 @@ const pinSubthoughtsShortcut: Shortcut = {
       key: '=pinChildren',
       value: isPinned ? 'false' : 'true'
     }))
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attributeEquals(state, context, '=pinChildren', 'true')
   }
 }
 

--- a/src/shortcuts/proseView.tsx
+++ b/src/shortcuts/proseView.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { simplifyPath } from '../selectors'
+import { attributeEquals, simplifyPath } from '../selectors'
 import { isDocumentEditable, pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
+import { ROOT_TOKEN } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ fill = 'black', size = 20, style }: IconType) => <svg version='1.1' className='icon' xmlns='http://www.w3.org/2000/svg' width={size} height={size} fill={fill} style={style} viewBox='0 0 100 100'>
@@ -36,6 +37,12 @@ const proseViewShortcut: Shortcut = {
       key: '=view',
       value: 'Prose'
     }))
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attributeEquals(state, context, '=view', 'Prose')
   }
 }
 

--- a/src/shortcuts/redo.ts
+++ b/src/shortcuts/redo.ts
@@ -15,7 +15,8 @@ const redoShortcut: Shortcut = {
   exec: (dispatch: Dispatch<RedoAction>, getState) => {
     if (!isRedoEnabled(getState())) return
     dispatch({ type: 'redoAction' })
-  }
+  },
+  isActive: getState => isRedoEnabled(getState())
 }
 
 export default redoShortcut

--- a/src/shortcuts/toggleHiddenThoughts.tsx
+++ b/src/shortcuts/toggleHiddenThoughts.tsx
@@ -17,7 +17,8 @@ const toggleHiddenThoughtsShortcut: Shortcut = {
   description: 'Show or hide hidden thoughts.',
   keyboard: { key: 'h', shift: true, alt: true },
   svg: Icon,
-  exec: dispatch => dispatch(toggleHiddenThoughts())
+  exec: dispatch => dispatch(toggleHiddenThoughts()),
+  isActive: getState => getState().showHiddenThoughts
 }
 
 export default toggleHiddenThoughtsShortcut

--- a/src/shortcuts/toggleSort.tsx
+++ b/src/shortcuts/toggleSort.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { RANKED_ROOT } from '../constants'
-import { getSetting, simplifyPath } from '../selectors'
+import { RANKED_ROOT, ROOT_TOKEN } from '../constants'
+import { attributeEquals, getSetting, simplifyPath } from '../selectors'
 import { setCursor, toggleAttribute } from '../action-creators'
 import { pathToContext } from '../util'
 import { Icon as IconType, Shortcut } from '../types'
@@ -41,6 +41,12 @@ const toggleSortShortcut: Shortcut = {
     if (cursor) {
       dispatch(setCursor({ path: state.cursor }))
     }
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attributeEquals(state, context, '=sort', 'Alphabetical')
   }
 }
 

--- a/src/shortcuts/toggleSplitView.tsx
+++ b/src/shortcuts/toggleSplitView.tsx
@@ -18,7 +18,8 @@ const toggleSplitViewShortcut: Shortcut = {
   svg: Icon,
   exec: (dispatch, getState) => {
     dispatch(toggleSplitView({ value: !getState().showSplitView }))
-  }
+  },
+  isActive: getState => getState().showSplitView
 }
 
 export default toggleSplitViewShortcut

--- a/src/shortcuts/toggleTableView.tsx
+++ b/src/shortcuts/toggleTableView.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { simplifyPath } from '../selectors'
+import { attributeEquals, simplifyPath } from '../selectors'
 import { pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
+import { ROOT_TOKEN } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg version='1.1' className='icon' xmlns='http://www.w3.org/2000/svg' width={size} height={size} style={style} viewBox='-2 -2 28 28'>
@@ -33,6 +34,12 @@ const toggleTableViewShortcut: Shortcut = {
       key: '=view',
       value: 'Table'
     }))
+  },
+  isActive: getState => {
+    const state = getState()
+    const { cursor } = state
+    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    return attributeEquals(state, context, '=view', 'Table')
   }
 }
 

--- a/src/shortcuts/undo.ts
+++ b/src/shortcuts/undo.ts
@@ -15,7 +15,8 @@ const undoShortcut: Shortcut = {
   exec: (dispatch: Dispatch<UndoAction>, getState) => {
     if (!isUndoEnabled(getState())) return
     dispatch({ type: 'undoAction' })
-  }
+  },
+  isActive: getState => isUndoEnabled(getState())
 }
 
 export default undoShortcut

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,7 @@ export interface Shortcut {
   gesture?: GesturePath | GesturePath[],
   hideFromInstructions?: boolean,
   keyboard?: Key | string,
+  isActive?: (getState: () => State) => boolean,
   overlay?: {
     gesture?: GesturePath,
     keyboard?: Key | string,


### PR DESCRIPTION
fixes #939 

### Changes

- Added optional `isActive` function to the `Shortcut`.
- Refactored `Toolbar` to use `isActive` to properly fill shortcut's svg.