### PR TITLE
Fix removeRoot

### DIFF
--- a/src/util/__tests__/removeRoot.ts
+++ b/src/util/__tests__/removeRoot.ts
@@ -1,0 +1,24 @@
+import { ROOT_TOKEN } from '../../constants'
+import { removeRoot } from '../removeRoot'
+
+it('remove root thought', () => {
+  const exported = `- ${ROOT_TOKEN}
+  - a
+    - b
+  - c`
+
+  const expectedResult = `- a
+  - b
+- c`
+
+  expect(removeRoot(exported)).toBe(expectedResult)
+})
+
+it('do not remove first thought if it is not a root', () => {
+  const exported = `- k
+  - a
+    - b
+  - c`
+
+  expect(removeRoot(exported)).toBe(exported)
+})

--- a/src/util/__tests__/removeRoot.ts
+++ b/src/util/__tests__/removeRoot.ts
@@ -7,9 +7,11 @@ it('remove root thought', () => {
     - b
   - c`
 
-  const expectedResult = `- a
+  const expectedResult = `
+- a
   - b
-- c`
+- c
+`
 
   expect(removeRoot(exported)).toBe(expectedResult)
 })

--- a/src/util/removeRoot.ts
+++ b/src/util/removeRoot.ts
@@ -9,9 +9,9 @@ export const removeRoot = (exported: string) => {
 
   return isRoot([firstThought])
     ? exported
-      .slice(firstLineBreakIndex + 1)
+      .slice(firstLineBreakIndex)
       .split('\n')
       .map(line => line.slice(2))
-      .join('\n')
+      .join('\n') + '\n'
     : exported
 }

--- a/src/util/removeRoot.ts
+++ b/src/util/removeRoot.ts
@@ -1,8 +1,17 @@
+import { isRoot } from './isRoot'
+
 /**
  * Remove root, de-indent (trim), and append newline.
  */
-export const removeRoot = (exported: string) => exported.slice(exported.indexOf('\n'))
-  .split('\n')
-  .map(line => line.slice(2))
-  .join('\n')
-    + '\n'
+export const removeRoot = (exported: string) => {
+  const firstLineBreakIndex = exported.indexOf('\n')
+  const firstThought = exported.slice(0, firstLineBreakIndex).slice(1).trim()
+
+  return isRoot([firstThought])
+    ? exported
+      .slice(firstLineBreakIndex + 1)
+      .split('\n')
+      .map(line => line.slice(2))
+      .join('\n')
+    : exported
+}


### PR DESCRIPTION
fixes #953 

# Changes

- fix `removeRoot` to remove first thought only if its a `ROOT_TOKEN`.
- remove line break from beginning and end of the exported string after removing root.
- test for `removeRoot`