### PR TITLE
Fix getPrevRank

### DIFF
--- a/src/selectors/__tests__/getPrevRank.ts
+++ b/src/selectors/__tests__/getPrevRank.ts
@@ -1,20 +1,70 @@
-import { initialState, reducerFlow } from '../../util'
-import { getAllChildren } from '../../selectors'
-import { newSubthought, newThought, cursorBack } from '../../reducers'
+import { initialState, isFunction, reducerFlow } from '../../util'
+import { RANKED_ROOT } from '../../constants'
+import { getAllChildrenSorted } from '../../selectors'
+import { importText, newSubthought, newThought } from '../../reducers'
 import getPrevRank from '../getPrevRank'
 
-it('getPrevRank when all the thoughts in the context are hidden', () => {
+it('get rank above all children', () => {
 
   const steps = [
     newThought('a'),
-    newSubthought('=archive'),
-    cursorBack
+    newSubthought('b'),
+    newThought('c'),
   ]
 
   const stateNew = reducerFlow(steps)(initialState())
 
-  const children = getAllChildren(stateNew, ['a'])
+  const children = getAllChildrenSorted(stateNew, ['a'])
 
   expect(getPrevRank(stateNew, ['a'])).toBeLessThan(children[0].rank)
+
+})
+
+it('get rank less than visible children but greater than hidden children', () => {
+
+  const text = `
+    - a
+      - =archive
+      - b
+      - c
+  `
+  const stateNew = importText({ path: RANKED_ROOT, text })(initialState())
+  const children = getAllChildrenSorted(stateNew, ['a'])
+  const firstVisibleIndex = children.findIndex(child => !isFunction(child.value))
+  const firstVisible = children[firstVisibleIndex]
+  const lastHidden = children[firstVisibleIndex - 1]
+
+  expect(getPrevRank(stateNew, ['a'])).toBeLessThan(firstVisible.rank)
+  expect(getPrevRank(stateNew, ['a'])).toBeGreaterThan(lastHidden.rank)
+
+})
+
+it('get rank greater than all hidden children', () => {
+
+  const steps = [
+    newThought('a'),
+    newSubthought('=b'),
+    newThought('=c'),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const children = getAllChildrenSorted(stateNew, ['a'])
+
+  expect(getPrevRank(stateNew, ['a'])).toBeGreaterThan(children[children.length - 1].rank)
+
+})
+
+it('get rank less than all children hidden with aboveMeta: true', () => {
+
+  const steps = [
+    newThought('a'),
+    newSubthought('=b'),
+    newThought('=c'),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const children = getAllChildrenSorted(stateNew, ['a'])
+
+  expect(getPrevRank(stateNew, ['a'], { aboveMeta: true })).toBeLessThan(children[0].rank)
 
 })

--- a/src/selectors/__tests__/getPrevRank.ts
+++ b/src/selectors/__tests__/getPrevRank.ts
@@ -1,0 +1,20 @@
+import { initialState, reducerFlow } from '../../util'
+import { getAllChildren } from '../../selectors'
+import { newSubthought, newThought, cursorBack } from '../../reducers'
+import getPrevRank from '../getPrevRank'
+
+it('getPrevRank when all the thoughts in the context are hidden', () => {
+
+  const steps = [
+    newThought('a'),
+    newSubthought('=archive'),
+    cursorBack
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const children = getAllChildren(stateNew, ['a'])
+
+  expect(getPrevRank(stateNew, ['a'])).toBeLessThan(children[0].rank)
+
+})

--- a/src/selectors/getPrevRank.ts
+++ b/src/selectors/getPrevRank.ts
@@ -11,19 +11,20 @@ const getPrevRank = (state: State, context: Context, { aboveMeta }: { aboveMeta?
   // no children
   if (children.length === 0) return 0
 
-  // first child
-  const i = aboveMeta || state.showHiddenThoughts
-    ? 0
-    : children.findIndex(child => !isFunction(child.value))
+  const aboveHiddenThoughts = aboveMeta || state.showHiddenThoughts
+
+  const firstVisibleChildrenIndex = children.findIndex(child => !isFunction(child.value))
+
+  if (aboveHiddenThoughts || firstVisibleChildrenIndex === 0) return children[0].rank - 1
 
   // there could be no visible thoughts in the context
-  const noVisibleChildren = i === -1
+  const noVisibleChildren = firstVisibleChildrenIndex === -1
 
-  // between last metaprogramming attribute and first visible child
-  if (i === 0 || noVisibleChildren) return children[0].rank - 1
+  // if there are no visible chilren then get rank higher than the last hidden thoughts
+  if (noVisibleChildren) return children[children.length - 1].rank + 1
 
-  const nextChild = children[i]
-  const prevChild = children[i - 1]
+  const nextChild = children[firstVisibleChildrenIndex]
+  const prevChild = children[firstVisibleChildrenIndex - 1]
 
   return (prevChild.rank + nextChild.rank) / 2
 }

--- a/src/selectors/getPrevRank.ts
+++ b/src/selectors/getPrevRank.ts
@@ -16,8 +16,11 @@ const getPrevRank = (state: State, context: Context, { aboveMeta }: { aboveMeta?
     ? 0
     : children.findIndex(child => !isFunction(child.value))
 
+  // there could be no visible thoughts in the context
+  const noVisibleChildren = i === -1
+
   // between last metaprogramming attribute and first visible child
-  if (i === 0) return children[0].rank - 1
+  if (i === 0 || noVisibleChildren) return children[0].rank - 1
 
   const nextChild = children[i]
   const prevChild = children[i - 1]


### PR DESCRIPTION
fixes #970

# Cause of Issue

The logic of `getPrevRank` didn't handled case where all the children in the context are hidden.

# Changes

- Add specific logic to handle above mentioned case in `getPrevRank`.
- Add appropriate selector test for `getPrevRank`.