### PR TITLE
Get simplified context for attribute check in toggle sort

### DIFF
--- a/src/shortcuts/note.ts
+++ b/src/shortcuts/note.ts
@@ -1,10 +1,10 @@
 import { isTouch } from '../browser'
-import { attribute, hasChild } from '../selectors'
+import { attribute, hasChild, simplifyPath } from '../selectors'
 import PencilIcon from '../components/icons/PencilIcon'
 import { asyncFocus, editableNode, isDocumentEditable, pathToContext, setSelection } from '../util'
 import { setAttribute } from '../action-creators'
 import { Shortcut } from '../types'
-import { ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 
 const noteShortcut: Shortcut = {
   id: 'note',
@@ -65,7 +65,7 @@ const noteShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
     return attribute(state, context, '=note') != null
   }
 }

--- a/src/shortcuts/pinOpen.tsx
+++ b/src/shortcuts/pinOpen.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { attributeEquals } from '../selectors'
+import { attributeEquals, simplifyPath } from '../selectors'
 import { parentOf, pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
-import { ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg xmlns='http://www.w3.org/2000/svg' version='1.1' className='icon' viewBox='0 0 20 20' width={size} height={size} style={style}>
@@ -36,7 +36,7 @@ const pinOpenShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
     return attributeEquals(state, context, '=pin', 'true')
   }
 }

--- a/src/shortcuts/pinSubthoughts.tsx
+++ b/src/shortcuts/pinSubthoughts.tsx
@@ -3,7 +3,7 @@ import { attributeEquals, simplifyPath } from '../selectors'
 import { pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
-import { ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg xmlns='http://www.w3.org/2000/svg' className='icon' version='1.1' x='0px' y='0px' viewBox='0 0 23 20' width={size} height={size} style={style}>
@@ -40,7 +40,7 @@ const pinSubthoughtsShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
     return attributeEquals(state, context, '=pinChildren', 'true')
   }
 }

--- a/src/shortcuts/proseView.tsx
+++ b/src/shortcuts/proseView.tsx
@@ -3,7 +3,7 @@ import { attributeEquals, simplifyPath } from '../selectors'
 import { isDocumentEditable, pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
-import { ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ fill = 'black', size = 20, style }: IconType) => <svg version='1.1' className='icon' xmlns='http://www.w3.org/2000/svg' width={size} height={size} fill={fill} style={style} viewBox='0 0 100 100'>
@@ -41,7 +41,7 @@ const proseViewShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
     return attributeEquals(state, context, '=view', 'Prose')
   }
 }

--- a/src/shortcuts/toggleSort.tsx
+++ b/src/shortcuts/toggleSort.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { RANKED_ROOT, ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 import { attributeEquals, getSetting, simplifyPath } from '../selectors'
 import { setCursor, toggleAttribute } from '../action-creators'
 import { pathToContext } from '../util'
@@ -45,7 +45,9 @@ const toggleSortShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
+
     return attributeEquals(state, context, '=sort', 'Alphabetical')
   }
 }

--- a/src/shortcuts/toggleTableView.tsx
+++ b/src/shortcuts/toggleTableView.tsx
@@ -3,7 +3,7 @@ import { attributeEquals, simplifyPath } from '../selectors'
 import { pathToContext } from '../util'
 import { toggleAttribute } from '../action-creators'
 import { Icon as IconType, Shortcut } from '../types'
-import { ROOT_TOKEN } from '../constants'
+import { RANKED_ROOT } from '../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Icon = ({ size = 20, style }: IconType) => <svg version='1.1' className='icon' xmlns='http://www.w3.org/2000/svg' width={size} height={size} style={style} viewBox='-2 -2 28 28'>
@@ -38,7 +38,7 @@ const toggleTableViewShortcut: Shortcut = {
   isActive: getState => {
     const state = getState()
     const { cursor } = state
-    const context = cursor ? pathToContext(cursor) : [ROOT_TOKEN]
+    const context = pathToContext(cursor ? simplifyPath(state, cursor) : RANKED_ROOT)
     return attributeEquals(state, context, '=view', 'Table')
   }
 }


### PR DESCRIPTION
fixes #977 

# Changes
- Use `simplifyPath` to get simplified context for attribute check in `toggleSort`.
