### PR TITLE
Fix duplicate drop indicator

### DIFF
--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
 import assert from 'assert'
@@ -7,8 +7,8 @@ import { store } from '../store'
 import { isTouch } from '../browser'
 import { formatKeyboardShortcut, shortcutById } from '../shortcuts'
 import globals from '../globals'
-import { MAX_DEPTH, MAX_DISTANCE_FROM_CURSOR } from '../constants'
-import { alert, error } from '../action-creators'
+import { DROP_TARGET, MAX_DEPTH, MAX_DISTANCE_FROM_CURSOR } from '../constants'
+import { alert, error, dragInProgress } from '../action-creators'
 import Thought from './Thought'
 import GestureDiagram from './GestureDiagram'
 import { State } from '../util/initialState'
@@ -331,6 +331,18 @@ export const SubthoughtsComponent = ({
   const resolvedPath = path ?? simplePath
 
   const show = depth < MAX_DEPTH && (isEditingAncestor || isExpanded)
+
+  useEffect(() => {
+    if (isHovering) {
+      store.dispatch(dragInProgress({
+        value: true,
+        draggingThought: state.draggingThought,
+        hoveringThought: [...context],
+        hoveringPath: path,
+        hoverId: DROP_TARGET.EmptyDrop
+      }))
+    }
+  }, [isHovering])
 
   // disable intrathought linking until add, edit, delete, and expansion can be implemented
   // const subthought = once(() => getSubthoughtUnderSelection(headValue(simplePath), 3))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -279,5 +279,10 @@ export const MODALS: Index<string> = {
 
 export const BETA_HASH = '8e767ca4e40aff7e22b14e5bf51743d8'
 
+export enum DROP_TARGET {
+  EmptyDrop = 'EmptyDrop',
+  ThoughtDrop = 'ThoughtDrop'
+}
+
 // eslint-disable-next-line no-useless-escape
 export const EMOJI_REGEX = /\p{Emoji_Presentation}|\p{Extended_Pictographic}/u

--- a/src/hooks/useIsChildHovering.ts
+++ b/src/hooks/useIsChildHovering.ts
@@ -1,0 +1,19 @@
+import { useSelector } from 'react-redux'
+import { Context } from '../types'
+import { State } from '../util/initialState'
+
+/**
+ * Returns if any child is being hovered on.
+ */
+const useIsChildHovering = (thoughts: Context, isHovering: boolean, isDeepHovering: boolean) => {
+  /* The motivation for this custom hook is to prevent rendering Thought component each time state.hoveringThought changes.
+    Thought component needs to be reactive to the change of hoveringThought but only rerender when calculated value of isChildHovering changes.
+    So instead of passing it through mapStateToProps which will re-render component everytime, instead use custom hook that will react to the changes.
+  */
+  const hoveringThought = useSelector((state: State) => state.hoveringThought)
+  return isDeepHovering && !isHovering && hoveringThought
+  && thoughts.length === hoveringThought.length
+  && hoveringThought.every((thought: string, index: number) => thought === thoughts[index])
+}
+
+export default useIsChildHovering

--- a/src/reducers/dragInProgress.ts
+++ b/src/reducers/dragInProgress.ts
@@ -1,20 +1,25 @@
 import _ from 'lodash'
 import { State } from '../util/initialState'
-import { Context, SimplePath } from '../types'
+import { Context, Path, SimplePath } from '../types'
+import { DROP_TARGET } from '../constants'
 
 interface Payload {
   value: boolean,
   draggingThought?: SimplePath,
   hoveringThought?: Context,
+  hoveringPath?: Path,
+  hoverId?: DROP_TARGET,
   offset?: number,
 }
 
 /** Sets dragInProgress. */
-const dragInProgress = (state: State, { value, draggingThought, hoveringThought, offset }: Payload): State => ({
+const dragInProgress = (state: State, { value, draggingThought, hoveringThought, hoveringPath, hoverId, offset }: Payload): State => ({
   ...state,
   dragInProgress: value,
   draggingThought,
   hoveringThought,
+  hoveringPath,
+  hoverId,
   cursorOffset: offset || state.cursorOffset,
 })
 

--- a/src/util/initialState.ts
+++ b/src/util/initialState.ts
@@ -1,4 +1,4 @@
-import { ABSOLUTE_TOKEN, EM_TOKEN, MODALS, HOME_TOKEN, SCHEMA_LATEST } from '../constants'
+import { ABSOLUTE_TOKEN, EM_TOKEN, MODALS, HOME_TOKEN, SCHEMA_LATEST, DROP_TARGET } from '../constants'
 import globals from '../globals'
 import { Alert, Child, Context, Index, Lexeme, Parent, Patch, Path, SimplePath, Timestamp, ThoughtsInterface, User } from '../types'
 import { ExistingThoughtChangePayload } from '../reducers/existingThoughtChange'
@@ -65,6 +65,8 @@ export interface State {
   expanded: Index<Path>,
   expandedContextThought?: Path,
   hoveringThought?: Context,
+  hoveringPath?: Path,
+  hoverId?: DROP_TARGET,
   invalidState: boolean,
   inversePatches: Patch[],
   isLoading: boolean,


### PR DESCRIPTION
fixes #1036 

# Changes

- Fix order of drop indicator in the context with alphabetical sort. Specially incase of emojis.
- Fix duplicate nested indicators introduced by `shouldDisplayHover` logic in case of `cursorOnAlphabeticalSort`.

**Image showing the issue.**
![image](https://user-images.githubusercontent.com/25879100/110014360-ce78b080-7d4a-11eb-957a-df2089cad582.png)

**Resolved**
![Screen Capture_select-area_20210305004333](https://user-images.githubusercontent.com/25879100/110015488-02a0a100-7d4c-11eb-9c45-ed2e5dac3692.gif)

- Fix indicator not showing when droping thoughts from descendants into the context with alphabetical sort.

**Gif showing the issue.**
![Screen Capture_select-area_20210305003849](https://user-images.githubusercontent.com/25879100/110014835-5bbc0500-7d4b-11eb-8420-08d0c6d24454.gif)

**Resolved**
![Screen Capture_select-area_20210305004905](https://user-images.githubusercontent.com/25879100/110016018-a722e300-7d4c-11eb-837a-8cc4c72ad30b.gif)

