### PR TITLE
Assume the imported text is html when it starts with a closed html tag

### DIFF
--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -16,8 +16,9 @@ const regexpListItem = /<li(?:\s|>)/gmi
 // '*'' must be followed by a whitespace character to avoid matching *footnotes or *markdown italic*
 const regexpPlaintextBullet = /^\s*(?:[-—▪◦•]|\*\s)/m
 
-// has at least one list item or paragraph
-const regexpHasListItems = /<li|p(?:\s|>).*?>.*<\/li|p>/mi
+// regex that checks if the value starts with closed html tag
+// Note: This regex cannot check properly for a tag nested within itself. However for general cases it works properly.
+const regexStartsWithClosedTag = /^<([A-Z][A-Z0-9]*)\b[^>]*>(.*?)<\/\1>/ism
 
 /** Converts data output from jex-block-parser into HTML.
  *
@@ -76,8 +77,8 @@ const bodyContent = (html: string) => {
 /** Parses plaintext, indented text, or HTML and converts it into HTML that himalaya can parse. */
 const rawTextToHtml = (text: string) => {
 
-  // if the input text has any <li> elements at all, treat it as HTML
-  const isHTML = regexpHasListItems.test(text)
+  // if the input text starts with a closed html tag
+  const isHTML = regexStartsWithClosedTag.test(text.trim())
   const decodedInputText = unescape(text)
 
   // use jex-block-parser to convert indentent plaintext into nested HTML lists

--- a/src/util/__tests__/importText.ts
+++ b/src/util/__tests__/importText.ts
@@ -572,3 +572,19 @@ it('decode HTML entities', () => {
   - one & two
   - three < four`)
 })
+
+// related: https://github.com/cybersemics/em/issues/1008
+it('do not parse as html when value has tags inside indented text', () => {
+
+  expect(importExport(`
+  - a
+    - b
+    - <li>c</li>
+  `))
+    .toBe(
+      `
+- a
+  - b
+  - c
+`)
+})


### PR DESCRIPTION
fixes #1008

# Cause of Issue

On importing the following structure
```
- a
  - b
  - <li>c</li>
```

The current logic detected it as a html text  with one li tag instead of indented text. 

# Solution

We cannot simply assume the imported text is html because there is at least one `li` or `p` tag. It is because intended text can have these tags too. In most html import, the first value starts with a tag. So the better approach would be to assume that the imported text is an html when the text starts with a properly closed html tag. 

# Changes

- Changes assume imported text is html when it starts with a closed html tag instead of checking for at least on li tag.
- Add test for the specific case.