### PR TITLE
adds middleware to fetch pending descendants before existingThoughtMove

### DIFF
--- a/src/redux-middleware/pullBeforeMove.ts
+++ b/src/redux-middleware/pullBeforeMove.ts
@@ -7,7 +7,7 @@ import { State } from '../util/initialState'
 /**
  * Middleware that fetches any pending descendants before a thought-move operation.
  */
-const fetchBeforeMove: ThunkMiddleware<State> = ({ getState, dispatch }) => {
+const pullBeforeMove: ThunkMiddleware<State> = ({ getState, dispatch }) => {
 
   return next => async action => {
 
@@ -32,4 +32,4 @@ const fetchBeforeMove: ThunkMiddleware<State> = ({ getState, dispatch }) => {
   }
 }
 
-export default fetchBeforeMove
+export default pullBeforeMove

--- a/src/redux-middleware/pullBeforeMove.ts
+++ b/src/redux-middleware/pullBeforeMove.ts
@@ -24,7 +24,7 @@ const fetchBeforeMove: ThunkMiddleware<State> = ({ getState, dispatch }) => {
       const isNewContextPending = conflictedPath && isPending(state, newContext)
       if (isNewContextPending) {
         const toPull = { [hashContext(newContext)]: newContext }
-        await pull(toPull, { maxDepth: Infinity })(dispatch, getState)
+        await dispatch(pull(toPull, { maxDepth: Infinity }))
       }
     }
     next(action)

--- a/src/redux-middleware/pullBeforeMove.ts
+++ b/src/redux-middleware/pullBeforeMove.ts
@@ -1,0 +1,35 @@
+import { ThunkMiddleware } from 'redux-thunk'
+import pull from '../action-creators/pull'
+import { isPending, pathExists, simplifyPath } from '../selectors'
+import { hashContext, head, parentOf, pathToContext } from '../util'
+import { State } from '../util/initialState'
+
+/**
+ * Middleware that fetches any pending descendants before a thought-move operation.
+ */
+const fetchBeforeMove: ThunkMiddleware<State> = ({ getState, dispatch }) => {
+
+  return next => async action => {
+
+    if (action.type === 'existingThoughtMove') {
+      const state = getState()
+
+      const oldContext = pathToContext(simplifyPath(state, action.oldPath))
+
+      const newContext = pathToContext(simplifyPath(state, action.newPath))
+
+      const updatedNewContext = [...parentOf(newContext), head(oldContext)]
+      const conflictedPath = pathExists(state, updatedNewContext)
+
+      const isNewContextPending = conflictedPath && isPending(state, newContext)
+      if (isNewContextPending) {
+        const toPull = { [hashContext(newContext)]: newContext }
+        await pull(toPull, { maxDepth: Infinity })(dispatch, getState)
+      }
+    }
+    next(action)
+
+  }
+}
+
+export default fetchBeforeMove

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ import pullQueue from './redux-middleware/pullQueue'
 import updateUrlHistory from './redux-middleware/updateUrlHistory'
 import appReducer from './reducers/app'
 import cursorChangedEnhancer from './redux-enhancers/cursorChanged'
+import pullBeforeMove from './redux-middleware/pullBeforeMove'
 
 // disabled until deepClone performance can be fixed
 // import undoRedoReducerEnhancer from './redux-enhancers/undoRedoReducerEnhancer'
@@ -28,6 +29,7 @@ export const store = createStore(
   composeEnhancers(applyMiddleware(
     multi,
     thunk,
+    pullBeforeMove,
     pushQueue,
     pullQueue,
     updateUrlHistory


### PR DESCRIPTION
fixes #1026 

Uses a middleware to fetch any pending descendants of the destination context before calling `existingThoughtMove` reducer, as explained [here](https://github.com/cybersemics/em/issues/1026#issuecomment-800888062)