### PR TITLE
remove 'the' preposition from comparator inputs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -292,3 +292,5 @@ export enum DROP_TARGET {
 
 // eslint-disable-next-line no-useless-escape
 export const EMOJI_REGEX = /\p{Emoji_Presentation}|\p{Extended_Pictographic}/u
+
+export const IGNORED_PREFIXES = ['the ']

--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -100,4 +100,13 @@ describe('compareReasonable', () => {
     expect(compareReasonable('🍍 a', '🍍 b')).toBe(-1)
   })
 
+  it('sort by removing ignored prefixes', () => {
+    expect(compareReasonable('the apple', 'apple')).toBe(0)
+    expect(compareReasonable('the apple', 'book')).toBe(-1)
+    expect(compareReasonable('theatre', 'book')).toBe(1)
+    expect(compareReasonable('the apple', 'theatre')).toBe(-1)
+    expect(compareReasonable('🍍 the apple', '🍍 book')).toBe(-1)
+    expect(compareReasonable('🍍 the apple', '🍍 apple')).toBe(0)
+  })
+
 })

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -5,9 +5,22 @@ import { EMOJI_REGEX } from '../constants'
 const regexPunctuation = /^[!@#$%^&*()\-_=+[\]{};:'"<>.,?\\/].*/
 const regexShortDateWithDash = /\d{1,2}-\d{1,2}/
 const regexShortDateWithSlash = /\d{1,2}\/\d{1,2}/
+const ignoredPrefixes = ['the ']
 
 /** Remove emojis and trailing/leading spaces from camparator inputs using regex. */
 const removeEmojisAndSpaces = (str: string) => str.replace(EMOJI_REGEX, '').trim()
+
+/** Remove ignored prefixes from comparator inputs. */
+const removeIgnoredPrefixes = (str: string) => {
+  const ignoredKeywords = ignoredPrefixes.join('|')
+  const regex = new RegExp(`^(${ignoredKeywords})(.*)`, 'gm')
+  return str.replace(regex, `$2`)
+}
+
+/** Make comparator inputs reasonable.  */
+const makeReasonable = (str: string) => {
+  return removeIgnoredPrefixes(removeEmojisAndSpaces(str))
+}
 
 /** Parse a date string and handle M/d (e.g. "2/1") for Safari. */
 const parseDate = (s: string) =>
@@ -119,7 +132,7 @@ export const compareReasonable = makeOrderedComparator<string>([
   compareEmpty,
   comparePunctuationAndOther,
   compareStringsWithEmoji,
-  (a, b) => compareReasonableText(removeEmojisAndSpaces(a), removeEmojisAndSpaces(b)),
+  (a, b) => compareReasonableText(makeReasonable(a), makeReasonable(b)),
 ])
 
 /** Compare the value of two thoughts. */

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -1,21 +1,17 @@
 import { lower } from './lower'
 import { Child, ComparatorFunction, ComparatorValue } from '../types'
-import { EMOJI_REGEX } from '../constants'
+import { EMOJI_REGEX, IGNORED_PREFIXES } from '../constants'
 
 const regexPunctuation = /^[!@#$%^&*()\-_=+[\]{};:'"<>.,?\\/].*/
 const regexShortDateWithDash = /\d{1,2}-\d{1,2}/
 const regexShortDateWithSlash = /\d{1,2}\/\d{1,2}/
-const ignoredPrefixes = ['the ']
+const regexIgnoredPrefixes = new RegExp(`^(${IGNORED_PREFIXES.join('|')})(.*)`, 'gm')
 
 /** Remove emojis and trailing/leading spaces from camparator inputs using regex. */
 const removeEmojisAndSpaces = (str: string) => str.replace(EMOJI_REGEX, '').trim()
 
 /** Remove ignored prefixes from comparator inputs. */
-const removeIgnoredPrefixes = (str: string) => {
-  const ignoredKeywords = ignoredPrefixes.join('|')
-  const regex = new RegExp(`^(${ignoredKeywords})(.*)`, 'gm')
-  return str.replace(regex, `$2`)
-}
+const removeIgnoredPrefixes = (str: string) => str.replace(regexIgnoredPrefixes, `$2`)
 
 /** Make comparator inputs reasonable.  */
 const makeReasonable = (str: string) => {


### PR DESCRIPTION
fixes #1079 

Notes: This doesn't work for home context. There is already opened issue related to this #1080 