### PR TITLE
Unroot context before getting value of sort attribute

### DIFF
--- a/src/selectors/getSortPreference.ts
+++ b/src/selectors/getSortPreference.ts
@@ -1,10 +1,11 @@
 import { getSetting, getAllChildren } from '../selectors'
 import { State } from '../util/initialState'
 import { Context } from '../types'
+import { unroot } from '../util'
 
 /** Get the sort setting from the given context meta or, if not provided, the global sort. */
 const getSortPreference = (state: State, context: Context) => {
-  const childrenSort = getAllChildren(state, [...context, '=sort'])
+  const childrenSort = getAllChildren(state, [...unroot(context), '=sort'])
   return childrenSort.length > 0
     ? childrenSort[0].value
     : getSetting(state, ['Global Sort']) || 'None'

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -1,11 +1,11 @@
 import { EM_TOKEN, HOME_PATH } from '../../constants'
 import { createTestStore } from '../../test-helpers/createTestStore'
 import { attribute, rankThoughtsFirstMatch } from '../../selectors'
-import { existingThoughtChange, importText } from '../../action-creators'
+import { existingThoughtChange, importText, setCursor } from '../../action-creators'
 import toggleSortShortcut from '../toggleSort'
 import executeShortcut from '../../test-helpers/executeShortcut'
 import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
-import { Thunk, SimplePath } from '../../types'
+import { SimplePath, Thunk } from '../../types'
 
 it('toggle on sort preference of cursor (initial state without =sort attribute)', () => {
 
@@ -53,6 +53,54 @@ it('toggle off sort preference of cursor (initial state with =sort/Alphabetical)
   executeShortcut(toggleSortShortcut, { store })
 
   expect(attribute(store.getState(), ['a'], '=sort')).toBe(null)
+})
+
+it('toggle on sort preference of home context when cursor is null (initial state without =sort attribute)', () => {
+
+  const store = createTestStore()
+
+  // import thoughts
+  store.dispatch([
+    importText({
+      path: HOME_PATH,
+      text: `
+        - b
+          - 1
+          - 2
+        - a
+          - 3
+          - 4`
+    }),
+
+    setCursor({ path: null }),
+  ])
+
+  executeShortcut(toggleSortShortcut, { store })
+
+  expect(attribute(store.getState(), [], '=sort')).toBe('Alphabetical')
+})
+
+it('toggle off sort preference of home context when cursor is null (initial state with =sort/Alphabetical)', () => {
+
+  const store = createTestStore()
+
+  // import thoughts
+  store.dispatch([
+    importText({
+      path: HOME_PATH,
+      text: `
+        - =sort
+          - Alphabetical
+        -a
+        -b`
+    }),
+
+    setCursor({ path: null }),
+  ])
+
+  executeShortcut(toggleSortShortcut, { store })
+
+  expect(attribute(store.getState(), [], '=sort')).toBe(null)
 })
 
 it('override global Alphabetical with local None', () => {


### PR DESCRIPTION
Fixes: #1080 

We need to unroot the context before getting value of sorting attribute for the context because root token is removed from the context when adding. 

https://github.com/cybersemics/em/blob/e2c66a7c0b46127f43c2978145b490aed0e0458b/src/reducers/toggleAttribute.ts#L35