### PR TITLE
Fix importing html that contains nested tags

### DIFF
--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -125,8 +125,7 @@ const importText = (state: State, { path, text, lastUpdated, preventSetCursor, r
   const destValue = rawDestValue || destThought.value
 
   // if we are only importing a single line of html, then simply modify the current thought
-  if (numLines === 1) {
-
+  if (numLines <= 1 && !isRoam) {
     const textNormalized = strip(convertedText, { preserveFormatting: true })
 
     // get the range if there is one so that we can import over the selected html

--- a/src/util/__tests__/importText.ts
+++ b/src/util/__tests__/importText.ts
@@ -588,3 +588,56 @@ it('do not parse as html when value has tags inside indented text', () => {
   - c
 `)
 })
+
+it('import single-line nested html tags', () => {
+
+  const text = `- ${HOME_TOKEN}
+  - a
+    - b`
+
+  const paste = `<b><i>A</i></b>`
+
+  const stateNew = reducerFlow([
+
+    // importing single-line needs an existing thought
+    importText({ path: HOME_PATH, text }),
+
+    // manually change `b` to empty thought to not see 'b' end of the new value.
+    existingThoughtChange({
+      newValue: '',
+      oldValue: 'b',
+      context: ['a'],
+      path: [{ value: 'a', rank: 0 }, { value: 'b', rank: 0 }] as SimplePath
+    }),
+
+    importText({
+      path: [{ value: 'a', rank: 0 }, { value: '', rank: 0 }],
+      text: paste,
+    }),
+
+  ])(initialState())
+
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported)
+    .toBe(`- ${HOME_TOKEN}
+  - a
+    - <b><i>A</i></b>`)
+})
+
+it('import multi-line nested html tags', () => {
+  const paste = `
+  <li><i><b>A</b></i></li>
+  <li><i><b>B</b></i></li>
+  <li><i><b>C</b></i></li>
+  `
+  const actual = importExport(paste)
+  expect(actual)
+    .toBe(
+      `
+- <i><b>A</b></i>
+- <i><b>B</b></i>
+- <i><b>C</b></i>
+`
+    )
+})

--- a/src/util/convertHTMLtoJSON.ts
+++ b/src/util/convertHTMLtoJSON.ts
@@ -15,8 +15,14 @@ const isFormattingTag = (node: HimalayaNode) => node.type === 'element'
 
 /** Strip span and encode a <i> or <b> element as HTML. */
 const formattingNodeToHtml = (node: Element) => {
-  const content = (_.head(node.children) as Text).content
+  const content: string = node.children.reduce((acc, child) => {
+    return acc + (child.type === 'text' ? child.content
+      : child.type === 'comment' ? ''
+      : formattingNodeToHtml(child))
+  }, '')
+
   if (node.tagName === 'span') return content
+
   return `<${node.tagName}>${content}</${node.tagName}>`
 }
 


### PR DESCRIPTION
Fixes #1091 

Notes: This also solves the problem that causes the app to crash when a single space character is pasted.