### PR TITLE
Remove unwanted text selection after clipboard copy

### DIFF
--- a/src/components/ModalExport.tsx
+++ b/src/components/ModalExport.tsx
@@ -110,6 +110,9 @@ const ModalExport = () => {
 
     clipboard.on('success', () => {
 
+      // Note: clipboard leaves unwanted text selection after copy operation. so removing it to prevent issue with gesture handler
+      if (document.getSelection()?.toString()) document.getSelection()?.removeAllRanges()
+
       dispatch([
         modalRemindMeLater({ id: 'help' }),
         alert(`Copied ${exportThoughtsPhrase} to the clipboard`, { alertType: 'clipboard', clearTimeout: 3000 })


### PR DESCRIPTION
fixes #1077 

# Source of issue

After the clipboard copy in `ModalExport` there was an unwanted text selection, probably caused by `clipboard`. This was preventing the gesture handler to work as it only works when there is no text selection in the document.

# Solution

Removing the text selection after a successful clipboard copy operation solves the problem.