### PR TITLE
Fix rootSubthoughts conflicts to fix tutorial crashes

### DIFF
--- a/src/components/Tutorial/Tutorial2StepContext1.js
+++ b/src/components/Tutorial/Tutorial2StepContext1.js
@@ -14,29 +14,21 @@ import {
 } from '../../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Tutorial2StepContext1 = ({ cursor, tutorialChoice, rootSubthoughts }) => <Fragment>
+const Tutorial2StepContext1 = ({ cursor, tutorialChoice, rootChildren }) => <Fragment>
   <p>Let's say that {
     tutorialChoice === TUTORIAL_VERSION_TODO ? 'you want to make a list of things you have to do at home.' :
     tutorialChoice === TUTORIAL_VERSION_JOURNAL ? 'one of the themes in your journal is "Relationships".' :
     tutorialChoice === TUTORIAL_VERSION_BOOK ? `you hear a podcast on ${TUTORIAL_CONTEXT[tutorialChoice]}.` :
     null
   } Add a thought with the text "{TUTORIAL_CONTEXT[tutorialChoice]}" <i>within</i> “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}”.</p>
-  <p>Do you remember how to do it?
-    <TutorialHint>
-      <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
-    </TutorialHint>
-  </p>
+  {rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase())
+    ? <p>Do you remember how to do it?
+      <TutorialHint>
+        <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
+      </TutorialHint>
+    </p>
+    : <p>Oops, somehow “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}” was changed or deleted. Click the Prev button to go back.</p>
+  }
 </Fragment>
 
 export default Tutorial2StepContext1
-// eslint-disable
-/*
-{rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase())
-  ? <p>Do you remember how to do it?
-    <TutorialHint>
-      <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
-    </TutorialHint>
-  </p>
-  : <p>Oops, somehow “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}” was changed or deleted. Click the Prev button to go back.</p>
-}
-*/

--- a/src/components/Tutorial/Tutorial2StepContext1.js
+++ b/src/components/Tutorial/Tutorial2StepContext1.js
@@ -21,14 +21,22 @@ const Tutorial2StepContext1 = ({ cursor, tutorialChoice, rootSubthoughts }) => <
     tutorialChoice === TUTORIAL_VERSION_BOOK ? `you hear a podcast on ${TUTORIAL_CONTEXT[tutorialChoice]}.` :
     null
   } Add a thought with the text "{TUTORIAL_CONTEXT[tutorialChoice]}" <i>within</i> “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}”.</p>
-  {rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase())
-    ? <p>Do you remember how to do it?
-      <TutorialHint>
-        <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
-      </TutorialHint>
-    </p>
-    : <p>Oops, somehow “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}” was changed or deleted. Click the Prev button to go back.</p>
-  }
+  <p>Do you remember how to do it?
+    <TutorialHint>
+      <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
+    </TutorialHint>
+  </p>
 </Fragment>
 
 export default Tutorial2StepContext1
+// eslint-disable
+/*
+{rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase())
+  ? <p>Do you remember how to do it?
+    <TutorialHint>
+      <br /><br />{!cursor || headValue(cursor).toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase() ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". ` : null}{isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
+    </TutorialHint>
+  </p>
+  : <p>Oops, somehow “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}” was changed or deleted. Click the Prev button to go back.</p>
+}
+*/

--- a/src/components/Tutorial/Tutorial2StepContext1Parent.js
+++ b/src/components/Tutorial/Tutorial2StepContext1Parent.js
@@ -20,7 +20,7 @@ const Tutorial2StepContext1Parent = ({ cursor, tutorialChoice, rootSubthoughts }
   <p>You should create this thought at the top level, i.e. not <i>within</i> any other thoughts.
     <TutorialHint>
       <br /><br />{
-        rootSubthoughts.length > 0 && (!cursor || cursor.length > 1)
+        rootSubthoughts && rootSubthoughts.length > 0 && (!cursor || cursor.length > 1)
           ? <Fragment>Select {rootSubthoughts.length === 1 ? 'the top-level thought' : 'one of the top-level thoughts'} ({joinConjunction(rootSubthoughts.map(child => `"${ellipsize(child.value)}"`), 'or')}). </Fragment>
           : null
       }{isTouch ? 'Trace the line below with your finger' : `Hit the Enter key`} to create a new thought. Then type "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}".

--- a/src/components/Tutorial/Tutorial2StepContext1Parent.js
+++ b/src/components/Tutorial/Tutorial2StepContext1Parent.js
@@ -15,13 +15,13 @@ import {
 } from '../../constants'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Tutorial2StepContext1Parent = ({ cursor, tutorialChoice, rootSubthoughts }) => <Fragment>
+const Tutorial2StepContext1Parent = ({ cursor, tutorialChoice, rootChildren }) => <Fragment>
   <p>Let's begin! Create a new thought with the text “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}”{cursor && headValue(cursor).startsWith('"') ? ' (without quotes)' : null}.</p>
   <p>You should create this thought at the top level, i.e. not <i>within</i> any other thoughts.
     <TutorialHint>
       <br /><br />{
-        rootSubthoughts && rootSubthoughts.length > 0 && (!cursor || cursor.length > 1)
-          ? <Fragment>Select {rootSubthoughts.length === 1 ? 'the top-level thought' : 'one of the top-level thoughts'} ({joinConjunction(rootSubthoughts.map(child => `"${ellipsize(child.value)}"`), 'or')}). </Fragment>
+        rootChildren.length > 0 && (!cursor || cursor.length > 1)
+          ? <Fragment>Select {rootChildren.length === 1 ? 'the top-level thought' : 'one of the top-level thoughts'} ({joinConjunction(rootChildren.map(child => `"${ellipsize(child.value)}"`), 'or')}). </Fragment>
           : null
       }{isTouch ? 'Trace the line below with your finger' : `Hit the Enter key`} to create a new thought. Then type "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}".
     </TutorialHint>

--- a/src/components/Tutorial/Tutorial2StepContext1SubThought.js
+++ b/src/components/Tutorial/Tutorial2StepContext1SubThought.js
@@ -9,9 +9,9 @@ import TutorialHint from './TutorialHint'
 import { context1SubthoughtCreated } from './TutorialUtils'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootSubthoughts }) => {
+const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootChildren }) => {
 
-  const context1SubthoughtisCreated = context1SubthoughtCreated({ rootSubthoughts, tutorialChoice })
+  const context1SubthoughtisCreated = context1SubthoughtCreated({ rootChildren, tutorialChoice })
 
   if (context1SubthoughtisCreated) {
     return <Fragment>
@@ -28,8 +28,9 @@ const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootSubthough
     }</p>
     {
       // e.g. Home
-      // e.g. Home/To Do
-      getChildrenRanked(store.getState(), [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
+      rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
+        // e.g. Home/To Do
+        getChildrenRanked(store.getState(), [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
         ? <p>Do you remember how to do it?
           <TutorialHint>
             <br /><br />
@@ -42,6 +43,5 @@ const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootSubthough
     }
   </Fragment>
 }
-// rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
 
 export default Tutorial2StepContext1SubThought

--- a/src/components/Tutorial/Tutorial2StepContext1SubThought.js
+++ b/src/components/Tutorial/Tutorial2StepContext1SubThought.js
@@ -28,9 +28,8 @@ const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootSubthough
     }</p>
     {
       // e.g. Home
-      rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
-        // e.g. Home/To Do
-        getChildrenRanked(store.getState(), [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
+      // e.g. Home/To Do
+      getChildrenRanked(store.getState(), [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
         ? <p>Do you remember how to do it?
           <TutorialHint>
             <br /><br />
@@ -43,5 +42,6 @@ const Tutorial2StepContext1SubThought = ({ cursor, tutorialChoice, rootSubthough
     }
   </Fragment>
 }
+// rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
 
 export default Tutorial2StepContext1SubThought

--- a/src/components/Tutorial/Tutorial2StepContext2.js
+++ b/src/components/Tutorial/Tutorial2StepContext2.js
@@ -13,11 +13,11 @@ import {
 } from '../../util'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Tutorial2StepContext2 = ({ tutorialChoice, rootSubthoughts, cursor }) => <Fragment>
+const Tutorial2StepContext2 = ({ tutorialChoice, rootChildren, cursor }) => <Fragment>
   <p>Now add a thought with the text "{TUTORIAL_CONTEXT[tutorialChoice]}" <i>within</i> “{TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}”.</p>
   {
     // e.g. Work
-    rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase())
+    rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase())
       ? <p>Do you remember how to do it?
         <TutorialHint>
           <br /><br />{cursor && cursor.length === 2 && cursor[0].value === TUTORIAL_CONTEXT2_PARENT[tutorialChoice]

--- a/src/components/Tutorial/Tutorial2StepContext2Subthought.js
+++ b/src/components/Tutorial/Tutorial2StepContext2Subthought.js
@@ -27,10 +27,10 @@ import TutorialHint from './TutorialHint'
 import StaticSuperscript from '../StaticSuperscript'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const context2SubthoughtCreated = ({ rootSubthoughts, tutorialChoice }) => {
+const context2SubthoughtCreated = ({ rootChildren, tutorialChoice }) => {
   const state = store.getState()
   // e.g. Work
-  return rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
+  return rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do
   getChildrenRanked(state, [TUTORIAL_CONTEXT2_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do/y
@@ -38,14 +38,14 @@ const context2SubthoughtCreated = ({ rootSubthoughts, tutorialChoice }) => {
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const Tutorial2StepContext2Subthought = ({ tutorialChoice, rootSubthoughts, cursor }) => {
+const Tutorial2StepContext2Subthought = ({ tutorialChoice, rootChildren, cursor }) => {
 
   const state = store.getState()
   const value = TUTORIAL_CONTEXT[tutorialChoice] || ''
   const caseSensitiveValue = getContexts(state, value).length > 0 ? value : value.toLowerCase()
   const contexts = getContexts(state, caseSensitiveValue)
 
-  const isContext2SubthoughtCreated = context2SubthoughtCreated({ rootSubthoughts, tutorialChoice })
+  const isContext2SubthoughtCreated = context2SubthoughtCreated({ rootChildren, tutorialChoice })
 
   if (isContext2SubthoughtCreated) {
     return <Fragment>
@@ -67,7 +67,7 @@ const Tutorial2StepContext2Subthought = ({ tutorialChoice, rootSubthoughts, curs
     } Add it to this “{TUTORIAL_CONTEXT[tutorialChoice]}” list.</p>
     {
       // e.g. Work
-      rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
+      rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
         // e.g. Work/To Do
         getChildrenRanked(state, [TUTORIAL_CONTEXT2_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
         ? <p>Do you remember how to do it?

--- a/src/components/Tutorial/TutorialNavigationNext.js
+++ b/src/components/Tutorial/TutorialNavigationNext.js
@@ -25,8 +25,6 @@ import {
 // eslint-disable-next-line jsdoc/require-jsdoc
 const mapStateToProps = state => {
   const { thoughts: { contextIndex }, cursor, expanded = {} } = state
-  // console.log('state', state)
-  // console.log([HOME_TOKEN])
   return {
     contextIndex,
     cursor,

--- a/src/components/Tutorial/TutorialNavigationNext.js
+++ b/src/components/Tutorial/TutorialNavigationNext.js
@@ -29,7 +29,7 @@ const mapStateToProps = state => {
     contextIndex,
     cursor,
     expanded,
-    rootSubthoughts: getAllChildren(state, [HOME_TOKEN]),
+    rootChildren: getAllChildren(state, [HOME_TOKEN]),
     tutorialChoice: +getSetting(state, 'Tutorial Choice') || 0,
     tutorialStep: +getSetting(state, 'Tutorial Step') || 1,
   }
@@ -41,7 +41,7 @@ const TutorialNavigationNext = connect(mapStateToProps)(
     contextIndex,
     cursor,
     expanded,
-    rootSubthoughts,
+    rootChildren,
     tutorialChoice,
     tutorialStep,
     dispatch,
@@ -60,8 +60,8 @@ const TutorialNavigationNext = connect(mapStateToProps)(
         tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_ENTER ||
         tutorialStep === TUTORIAL_STEP_SUBTHOUGHT_ENTER
       ) && (!cursor || headValue(cursor).length > 0)) ||
-      (Math.floor(tutorialStep) === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT && context1SubthoughtCreated({ rootSubthoughts, tutorialChoice })) ||
-      (Math.floor(tutorialStep) === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT && context2SubthoughtCreated({ rootSubthoughts, tutorialChoice }))
+      (Math.floor(tutorialStep) === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT && context1SubthoughtCreated({ rootChildren, tutorialChoice })) ||
+      (Math.floor(tutorialStep) === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT && context2SubthoughtCreated({ rootChildren, tutorialChoice }))
       ? <TutorialNavigationButton clickHandler={() => dispatch(tutorialNext({}))} value={tutorialStep === TUTORIAL_STEP_SUCCESS || tutorialStep === TUTORIAL2_STEP_SUCCESS ? 'Finish' : 'Next'} />
       : <span className='tutorial-next-wait text-small'>Complete the instructions to continue</span>
   })

--- a/src/components/Tutorial/TutorialNavigationNext.js
+++ b/src/components/Tutorial/TutorialNavigationNext.js
@@ -25,6 +25,8 @@ import {
 // eslint-disable-next-line jsdoc/require-jsdoc
 const mapStateToProps = state => {
   const { thoughts: { contextIndex }, cursor, expanded = {} } = state
+  // console.log('state', state)
+  // console.log([HOME_TOKEN])
   return {
     contextIndex,
     cursor,

--- a/src/components/Tutorial/TutorialStepAutoExpand.js
+++ b/src/components/Tutorial/TutorialStepAutoExpand.js
@@ -20,7 +20,7 @@ import {
 } from '../../selectors'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const TutorialStepAutoExpand = ({ cursor, rootSubthoughts = [] } = {}) => {
+const TutorialStepAutoExpand = ({ cursor } = {}) => {
 
   const state = store.getState()
   const cursorContext = pathToContext(cursor || [])

--- a/src/components/Tutorial/TutorialStepAutoExpandExpand.js
+++ b/src/components/Tutorial/TutorialStepAutoExpandExpand.js
@@ -5,11 +5,11 @@ import { getChildrenRanked } from '../../selectors'
 import { ellipsize, pathToContext } from '../../util'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const TutorialStepAutoExpandExpand = ({ cursor, rootSubthoughts = [] }) => {
+const TutorialStepAutoExpandExpand = ({ cursor, rootChildren = [] }) => {
 
   /** A thought in the root that is not the cursor and has children. */
   const rootSubthoughtNotCursorWithSubthoughts = () =>
-    rootSubthoughts.find(child =>
+    rootChildren.find(child =>
       (!cursor || pathToContext(cursor).indexOf(child.value) === -1) &&
       getChildrenRanked(store.getState(), [child]).length > 0
     )

--- a/src/components/Tutorial/TutorialUtils.js
+++ b/src/components/Tutorial/TutorialUtils.js
@@ -2,13 +2,35 @@ import { store } from '../../store'
 import { TUTORIAL_CONTEXT, TUTORIAL_CONTEXT1_PARENT, TUTORIAL_CONTEXT2_PARENT } from '../../constants'
 import { getChildrenRanked } from '../../selectors'
 
+/** Kludgy workaround for undefined rootSubthoughts/rootChildren. */
+function getRootThing(rootSubthoughts, rootChildren) {
+  if (rootSubthoughts) {
+    // console.log('returning rootSubthoughts')
+    // if (rootChildren) {
+    //   console.log('  but have rootChildren also (WEIRD)')
+    // }
+    return rootSubthoughts
+  }
+  else {
+    if (rootChildren) {
+      // console.log('returning rootChildren')
+      return rootChildren
+    }
+    else {
+      // console.log('returning neither (FAIL)')
+      return undefined
+    }
+  }
+}
+
 /** Returns true if the first context thought has been created, e.g. /Home/To Do/x. */
-export const context1SubthoughtCreated = ({ rootSubthoughts, tutorialChoice }) => {
+export const context1SubthoughtCreated = ({ rootSubthoughts, rootChildren, tutorialChoice }) => {
+  const rootThing = getRootThing(rootSubthoughts, rootChildren)
 
   const state = store.getState()
 
   // e.g. Home
-  return rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
+  return rootThing.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
   // e.g. Home/To Do
   getChildrenRanked(state, [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) &&
   // e.g. Home/To Do/x
@@ -16,12 +38,13 @@ export const context1SubthoughtCreated = ({ rootSubthoughts, tutorialChoice }) =
 }
 
 /** Returns true if the first context thought has been created, e.g. /Work/To Do/y. */
-export const context2SubthoughtCreated = ({ rootSubthoughts, tutorialChoice }) => {
+export const context2SubthoughtCreated = ({ rootSubthoughts, rootChildren, tutorialChoice }) => {
+  const rootThing = getRootThing(rootSubthoughts, rootChildren)
 
   const state = store.getState()
 
   // e.g. Work
-  return rootSubthoughts.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
+  return rootThing.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do
   getChildrenRanked(state, [TUTORIAL_CONTEXT2_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do/y

--- a/src/components/Tutorial/TutorialUtils.js
+++ b/src/components/Tutorial/TutorialUtils.js
@@ -2,35 +2,13 @@ import { store } from '../../store'
 import { TUTORIAL_CONTEXT, TUTORIAL_CONTEXT1_PARENT, TUTORIAL_CONTEXT2_PARENT } from '../../constants'
 import { getChildrenRanked } from '../../selectors'
 
-/** Kludgy workaround for undefined rootSubthoughts/rootChildren. */
-function getRootThing(rootSubthoughts, rootChildren) {
-  if (rootSubthoughts) {
-    // console.log('returning rootSubthoughts')
-    // if (rootChildren) {
-    //   console.log('  but have rootChildren also (WEIRD)')
-    // }
-    return rootSubthoughts
-  }
-  else {
-    if (rootChildren) {
-      // console.log('returning rootChildren')
-      return rootChildren
-    }
-    else {
-      // console.log('returning neither (FAIL)')
-      return undefined
-    }
-  }
-}
-
 /** Returns true if the first context thought has been created, e.g. /Home/To Do/x. */
-export const context1SubthoughtCreated = ({ rootSubthoughts, rootChildren, tutorialChoice }) => {
-  const rootThing = getRootThing(rootSubthoughts, rootChildren)
+export const context1SubthoughtCreated = ({ rootChildren, tutorialChoice }) => {
 
   const state = store.getState()
 
   // e.g. Home
-  return rootThing.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
+  return rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) &&
   // e.g. Home/To Do
   getChildrenRanked(state, [TUTORIAL_CONTEXT1_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) &&
   // e.g. Home/To Do/x
@@ -38,13 +16,12 @@ export const context1SubthoughtCreated = ({ rootSubthoughts, rootChildren, tutor
 }
 
 /** Returns true if the first context thought has been created, e.g. /Work/To Do/y. */
-export const context2SubthoughtCreated = ({ rootSubthoughts, rootChildren, tutorialChoice }) => {
-  const rootThing = getRootThing(rootSubthoughts, rootChildren)
+export const context2SubthoughtCreated = ({ rootChildren, tutorialChoice }) => {
 
   const state = store.getState()
 
   // e.g. Work
-  return rootThing.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
+  return rootChildren.find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do
   getChildrenRanked(state, [TUTORIAL_CONTEXT2_PARENT[tutorialChoice]]).find(child => child.value.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) &&
   // e.g. Work/To Do/y

--- a/src/components/Tutorial/index.js
+++ b/src/components/Tutorial/index.js
@@ -84,29 +84,31 @@ const Tutorial = ({ contextViews, cursor, rootChildren, tutorialChoice, tutorial
       (tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT && cursor && headValue(cursor).toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) ||
       (tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT && cursor && headValue(cursor).toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
     )
+    /* eslint-disable */
       ? <div className='tutorial-trace-gesture'>
-        <GestureDiagram path={
-          tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
-            tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT
-            ? shortcutById('newThoughtOrOutdent').gesture
-            : tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
-              tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT ||
-              tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT ||
-              tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT ||
-              tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT
-              ? shortcutById('newSubthought').gesture
-              : tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE
-                ? shortcutById('toggleContextView').gesture
-                : null
-        }
-        size='160'
-        strokeWidth='10'
-        arrowSize='5'
-        className='animate-pulse'
-        />
-      </div>
+          <GestureDiagram path =
+            {
+              tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
+                tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
+                tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
+                tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT
+                ? shortcutById('newThoughtOrOutdent').gesture
+                : tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
+                  tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT ||
+                  tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT ||
+                  tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT ||
+                  tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT
+                  ? shortcutById('newSubthought').gesture
+                  : tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE
+                    ? shortcutById('toggleContextView').gesture
+                    : null
+            }
+            size='160'
+            strokeWidth='10'
+            arrowSize='5'
+            className='animate-pulse'
+          />
+        </div>
       : null
     }
 

--- a/src/components/Tutorial/index.js
+++ b/src/components/Tutorial/index.js
@@ -84,31 +84,29 @@ const Tutorial = ({ contextViews, cursor, rootChildren, tutorialChoice, tutorial
       (tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT && cursor && headValue(cursor).toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) ||
       (tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT && cursor && headValue(cursor).toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())
     )
-    /* eslint-disable */
       ? <div className='tutorial-trace-gesture'>
-          <GestureDiagram path =
-            {
-              tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
-                tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
-                tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
-                tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT
-                ? shortcutById('newThoughtOrOutdent').gesture
-                : tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
-                  tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT ||
-                  tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT ||
-                  tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT ||
-                  tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT
-                  ? shortcutById('newSubthought').gesture
-                  : tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE
-                    ? shortcutById('toggleContextView').gesture
-                    : null
-            }
-            size='160'
-            strokeWidth='10'
-            arrowSize='5'
-            className='animate-pulse'
-          />
-        </div>
+        <GestureDiagram path={
+          tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
+            tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
+            tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
+            tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT
+            ? shortcutById('newThoughtOrOutdent').gesture
+            : tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
+              tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT ||
+              tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT ||
+              tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT ||
+              tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT
+              ? shortcutById('newSubthought').gesture
+              : tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE
+                ? shortcutById('toggleContextView').gesture
+                : null
+        }
+        size='160'
+        strokeWidth='10'
+        arrowSize='5'
+        className='animate-pulse'
+        />
+      </div>
       : null
     }
 


### PR DESCRIPTION
Issue #1098 

@raineorshine

FYI the function checks for rootSubthoughts.length > 0, which of course crashes because rootSubthoughts is null, and doesn't have a length field or any field.

I added a test for rootSubthoughts (truthiness = false if null) which fixed this particular crash. But then it crashes on the next tutorial screen, not immediately, but after I follow its instructions, which are to type something.

That crash is taking place in Tutorial2StepContext1.js, where it is also using rootSubthoughts, without considering that it might be null.

We need to decide if the problem is
a) the fact that rootSubthoughts is null, and it shouldn't be
b) it is allowed to be null, but there has to be tests and handling for when it is.

Question: Where is the code that calls Tutorial2StepContext1Parent? This would be the code that could potentially pass it a rootSubthoughts that is not null. I can't find any code that is calling it directly. It gets there through React via the dispatch function, but nowhere else based on the repo files.

One thing that makes this time consuming is that every time I run the project to test it, or run it with some added console.log statements, I have to manually go through all the tutorial steps from the beginning of the first tutorial, after first manually clearing the IndexedDB.