### PR TITLE
Check if more than one child exist for empty thought sorting

### DIFF
--- a/src/selectors/getChildren.ts
+++ b/src/selectors/getChildren.ts
@@ -84,7 +84,7 @@ const rankDiff = (a: Child, b: Child) => Math.abs(a?.rank - b?.rank)
 const getChildrenSortedAlphabetical = (state: State, context: Context): Child[] => {
   const sorted = getChildrenSortedBy(state, context, compareThought)
   const emptyIndex = sorted.findIndex(child => !child.value)
-  return emptyIndex === -1 ? sorted : resortEmptyInPlace(sorted)
+  return emptyIndex === -1 || sorted.length === 1 ? sorted : resortEmptyInPlace(sorted)
 }
 
 /** Re-sorts empty thoughts in a sorted array to their point of creation. */

--- a/src/selectors/getChildren.ts
+++ b/src/selectors/getChildren.ts
@@ -84,11 +84,13 @@ const rankDiff = (a: Child, b: Child) => Math.abs(a?.rank - b?.rank)
 const getChildrenSortedAlphabetical = (state: State, context: Context): Child[] => {
   const sorted = getChildrenSortedBy(state, context, compareThought)
   const emptyIndex = sorted.findIndex(child => !child.value)
-  return emptyIndex === -1 || sorted.length === 1 ? sorted : resortEmptyInPlace(sorted)
+  return emptyIndex === -1 ? sorted : resortEmptyInPlace(sorted)
 }
 
 /** Re-sorts empty thoughts in a sorted array to their point of creation. */
 const resortEmptyInPlace = (sorted: Child[]): Child[] => {
+
+  if (sorted.length === 1) return sorted
 
   let emptyIndex = sorted.findIndex(child => !child.value)
 

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -399,6 +399,35 @@ describe('DOM', () => {
       expect(childrenString).toMatch('_a_bc_def_')
     })
 
+    it('only one empty subthought', async () => {
+      store.dispatch([
+        importText({
+          path: HOME_PATH,
+          text: `
+              - =sort
+                - Alphabetical
+              - d
+              - f
+              - a
+              - c
+              - e
+              - b
+          `
+        }),
+        setCursorFirstMatchActionCreator(['a']),
+        newThought({ value: '', insertNewSubthought: true }),
+      ])
+
+      const thought = await findThoughtByText('a')
+
+      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
+      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+      const childrenString = thoughtChildren.map((child: HTMLElement) => child.textContent)
+        .map(value => value || '_')
+        .join('')
+      expect(childrenString).toMatch('_')
+    })
+
     // TODO
     it.skip('multiple contiguous empty thoughts', async () => {
       store.dispatch([


### PR DESCRIPTION
In resortEmptyInPlace function If there is one empty child, the app will be crashed when Global Sort is Alphabetical. Because in this function we get nearestSibling which will be undefined when there is one empty child.

When you toggle sort a context you can not reproduce this issue because there will be two child in the context. 