### PR TITLE
Use global sort value as default sort instead of None

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { isTouch } from '../browser'
 import { cursorBack as cursorBackActionCreator, expandContextThought, modalRemindMeLater, toggleSidebar as toggleSidebarActionCreator } from '../action-creators'
 import { MODAL_CLOSE_DURATION, ABSOLUTE_PATH, HOME_PATH, TUTORIAL2_STEP_SUCCESS } from '../constants'
-import { attribute, getSetting, getAllChildren, isTutorial } from '../selectors'
+import { getSetting, getAllChildren, isTutorial, getSortPreference } from '../selectors'
 import { isAbsolute, publishMode } from '../util'
 import { State } from '../util/initialState'
 
@@ -55,7 +55,8 @@ const mapStateToProps = (state: State) => {
   const rootThoughtsLength = children.filter(childrenFilterPredicate(state, rankedRoot, [], false)).length
 
   // pass rootSort to allow root Subthoughts ro render on toggleSort
-  const rootSort = attribute(state, rootContext, '=sort') || 'None'
+
+  const rootSort = getSortPreference(state, rootContext)
 
   return {
     search,

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -624,7 +624,7 @@ const ThoughtContainer = ({
       isParentHovering={isAnyChildHovering}
       showContexts={allowSingleContext}
       simplePath={simplePath}
-      sort={attribute(store.getState(), pathToContext(simplePathLive!), '=sort') || 'None'}
+      sort={getSortPreference(store.getState(), pathToContext(simplePathLive!))}
     />
   </li>)) : null
 }

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -195,6 +195,91 @@ describe('DOM', () => {
     expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
   })
 
+  describe('sort with Global Sort settings', () => {
+    it('thoughts are sorted alphabetically when "Global Sort" settings is Alphabetical', async () => {
+      const thoughtValue = 'c'
+      store.dispatch([
+        newThought({ value: thoughtValue }),
+        newThought({ value: 'b' }),
+        newThought({ value: 'a' }),
+        setCursor({ path: null }),
+
+        ((dispatch, getState) => dispatch(existingThoughtChange({
+          context: [EM_TOKEN, 'Settings', 'Global Sort'],
+          oldValue: 'None',
+          newValue: 'Alphabetical',
+          path: rankThoughtsFirstMatch(getState(), [EM_TOKEN, 'Settings', 'Global Sort', 'None']) as SimplePath
+        }))) as Thunk,
+      ])
+
+      const thought = await findThoughtByText(thoughtValue)
+      expect(thought).toBeTruthy()
+
+      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
+      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+
+      expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['a', 'b', 'c'])
+    })
+
+    it('subthoughts are sorted alphabetically when "Global Sort" settings is Alphabetical', async () => {
+
+      const thoughtValue = 'a'
+      store.dispatch([
+        newThought({ value: thoughtValue }),
+        newThought({ value: '3', insertNewSubthought: true }),
+        newThought({ value: '1' }),
+        newThought({ value: '2' }),
+        setCursorFirstMatchActionCreator([thoughtValue]),
+        ((dispatch, getState) => dispatch(existingThoughtChange({
+          context: [EM_TOKEN, 'Settings', 'Global Sort'],
+          oldValue: 'None',
+          newValue: 'Alphabetical',
+          path: rankThoughtsFirstMatch(getState(), [EM_TOKEN, 'Settings', 'Global Sort', 'None']) as SimplePath
+        }))) as Thunk,
+      ])
+
+      const thought = await findThoughtByText(thoughtValue)
+      expect(thought).toBeTruthy()
+
+      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
+      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+
+      expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
+    })
+
+    it('subthoughts are not sorted alphabetically when toggling sort and "Global Sort" settings is Alphabetical', async () => {
+
+      const thoughtValue = 'a'
+      store.dispatch([
+        newThought({ value: thoughtValue }),
+        newThought({ value: '3', insertNewSubthought: true }),
+        newThought({ value: '1' }),
+        newThought({ value: '2' }),
+        setCursorFirstMatchActionCreator([thoughtValue]),
+        ((dispatch, getState) => dispatch(existingThoughtChange({
+          context: [EM_TOKEN, 'Settings', 'Global Sort'],
+          oldValue: 'None',
+          newValue: 'Alphabetical',
+          path: rankThoughtsFirstMatch(getState(), [EM_TOKEN, 'Settings', 'Global Sort', 'None']) as SimplePath
+        }))) as Thunk,
+      ])
+
+      store.dispatch(toggleAttribute({
+        context: ['a'],
+        key: '=sort',
+        value: 'None',
+      }))
+
+      const thought = await findThoughtByText(thoughtValue)
+      expect(thought).toBeTruthy()
+
+      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
+      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+
+      expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['3', '1', '2'])
+    })
+  })
+
   describe('empty thought ordering is preserved at the point of creation', () => {
 
     it('after first thought', async () => {

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -146,21 +146,20 @@ describe('DOM', () => {
   afterEach(cleanupTestApp)
 
   it('thoughts are sorted alphabetically', async () => {
-    const thoughtValue = 'c'
     store.dispatch([
-      newThought({ value: thoughtValue }),
+      newThought({ value: 'c' }),
       newThought({ value: 'a' }),
       newThought({ value: 'b' }),
       setCursor({ path: null }),
+
+      toggleAttribute({
+        context: ['__ROOT__'],
+        key: '=sort',
+        value: 'Alphabetical',
+      })
     ])
 
-    store.dispatch(toggleAttribute({
-      context: ['__ROOT__'],
-      key: '=sort',
-      value: 'Alphabetical',
-    }))
-
-    const thought = await findThoughtByText(thoughtValue)
+    const thought = await findThoughtByText('c')
     expect(thought).toBeTruthy()
 
     const thoughtsWrapper = thought!.closest('ul') as HTMLElement
@@ -171,22 +170,21 @@ describe('DOM', () => {
 
   it('subthoughts are sorted alphabetically', async () => {
 
-    const thoughtValue = 'a'
     store.dispatch([
-      newThought({ value: thoughtValue }),
+      newThought({ value: 'a' }),
       newThought({ value: '3', insertNewSubthought: true }),
       newThought({ value: '1' }),
       newThought({ value: '2' }),
-      setCursorFirstMatchActionCreator([thoughtValue])
+      setCursorFirstMatchActionCreator(['a']),
+
+      toggleAttribute({
+        context: ['a'],
+        key: '=sort',
+        value: 'Alphabetical',
+      })
     ])
 
-    store.dispatch(toggleAttribute({
-      context: ['a'],
-      key: '=sort',
-      value: 'Alphabetical',
-    }))
-
-    const thought = await findThoughtByText(thoughtValue)
+    const thought = await findThoughtByText('a')
     expect(thought).toBeTruthy()
 
     const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
@@ -197,9 +195,8 @@ describe('DOM', () => {
 
   describe('sort with Global Sort settings', () => {
     it('thoughts are sorted alphabetically when "Global Sort" settings is Alphabetical', async () => {
-      const thoughtValue = 'c'
       store.dispatch([
-        newThought({ value: thoughtValue }),
+        newThought({ value: 'c' }),
         newThought({ value: 'b' }),
         newThought({ value: 'a' }),
         setCursor({ path: null }),
@@ -212,7 +209,7 @@ describe('DOM', () => {
         }))) as Thunk,
       ])
 
-      const thought = await findThoughtByText(thoughtValue)
+      const thought = await findThoughtByText('c')
       expect(thought).toBeTruthy()
 
       const thoughtsWrapper = thought!.closest('ul') as HTMLElement
@@ -223,13 +220,12 @@ describe('DOM', () => {
 
     it('subthoughts are sorted alphabetically when "Global Sort" settings is Alphabetical', async () => {
 
-      const thoughtValue = 'a'
       store.dispatch([
-        newThought({ value: thoughtValue }),
+        newThought({ value: 'a' }),
         newThought({ value: '3', insertNewSubthought: true }),
         newThought({ value: '1' }),
         newThought({ value: '2' }),
-        setCursorFirstMatchActionCreator([thoughtValue]),
+        setCursorFirstMatchActionCreator(['a']),
         ((dispatch, getState) => dispatch(existingThoughtChange({
           context: [EM_TOKEN, 'Settings', 'Global Sort'],
           oldValue: 'None',
@@ -238,7 +234,7 @@ describe('DOM', () => {
         }))) as Thunk,
       ])
 
-      const thought = await findThoughtByText(thoughtValue)
+      const thought = await findThoughtByText('a')
       expect(thought).toBeTruthy()
 
       const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
@@ -247,30 +243,32 @@ describe('DOM', () => {
       expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
     })
 
-    it('subthoughts are not sorted alphabetically when toggling sort and "Global Sort" settings is Alphabetical', async () => {
+    it('subthoughts are not sorted alphabetically when context sort is None and "Global Sort" settings is Alphabetical', async () => {
 
-      const thoughtValue = 'a'
       store.dispatch([
-        newThought({ value: thoughtValue }),
+        newThought({ value: 'a' }),
         newThought({ value: '3', insertNewSubthought: true }),
         newThought({ value: '1' }),
         newThought({ value: '2' }),
-        setCursorFirstMatchActionCreator([thoughtValue]),
+
+        setCursorFirstMatchActionCreator(['a']),
+
         ((dispatch, getState) => dispatch(existingThoughtChange({
           context: [EM_TOKEN, 'Settings', 'Global Sort'],
           oldValue: 'None',
           newValue: 'Alphabetical',
           path: rankThoughtsFirstMatch(getState(), [EM_TOKEN, 'Settings', 'Global Sort', 'None']) as SimplePath
         }))) as Thunk,
+
+        toggleAttribute({
+          context: ['a'],
+          key: '=sort',
+          value: 'None',
+        })
+
       ])
 
-      store.dispatch(toggleAttribute({
-        context: ['a'],
-        key: '=sort',
-        value: 'None',
-      }))
-
-      const thought = await findThoughtByText(thoughtValue)
+      const thought = await findThoughtByText('a')
       expect(thought).toBeTruthy()
 
       const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement

--- a/src/shortcuts/toggleSort.tsx
+++ b/src/shortcuts/toggleSort.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { HOME_PATH } from '../constants'
-import { attributeEquals, getSetting, simplifyPath } from '../selectors'
+import { getSetting, getSortPreference, simplifyPath } from '../selectors'
 import { setCursor, toggleAttribute } from '../action-creators'
 import { pathToContext } from '../util'
 import { Icon as IconType, Shortcut } from '../types'
@@ -47,8 +47,7 @@ const toggleSortShortcut: Shortcut = {
     const { cursor } = state
 
     const context = pathToContext(cursor ? simplifyPath(state, cursor) : HOME_PATH)
-
-    return attributeEquals(state, context, '=sort', 'Alphabetical')
+    return getSortPreference(state, context) === 'Alphabetical'
   }
 }
 


### PR DESCRIPTION
This pr fixes the global sorting issue. When global sorting is Alphabetical, sorting is not working.

## Steps to Reproduce
Set global sorting to `Alphabetical`.

- b
- a
 
## Current Behavior
- b
- a
 

## Expected Behavior
- a
- b
 