### PR TITLE
Fix childrenFilterPredicate to work with forcedChildren

### DIFF
--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -375,7 +375,7 @@ export const SubthoughtsComponent = ({
     return cursor[depth] && cursor[depth].rank === child.rank
   }) : 0
 
-  const filteredChildren = children.filter(childrenFilterPredicate(state, resolvedPath, pathToContext(simplePath), !!childrenForced))
+  const filteredChildren = children.filter(childrenFilterPredicate(state, resolvedPath, pathToContext(simplePath), showContexts))
 
   const proposedPageSize = isRoot(simplePath)
     ? Infinity

--- a/src/search/__tests__/algoliaSearch.ts
+++ b/src/search/__tests__/algoliaSearch.ts
@@ -25,7 +25,11 @@ describe('remote search', () => {
   beforeEach(async () => {
     const mockStore = createMockStore()
     const store = mockStore(initialState())
-    await initAlgoliaSearch('userId', store)
+
+    await initAlgoliaSearch('userId', {
+      applicationId: 'test_application_id',
+      index: 'test_index'
+    }, store)
   })
 
   it('return context map from the remote search hits', async () => {

--- a/src/search/algoliaSearch.ts
+++ b/src/search/algoliaSearch.ts
@@ -1,6 +1,5 @@
 import AlgoliaClient, { SearchIndex } from 'algoliasearch'
 import { Store } from 'redux'
-import { ALGOLIA_CONFIG } from '../constants'
 import { setRemoteSearch } from '../action-creators'
 import { Context, Index } from '../types'
 import { getContextMap, getAlgoliaApiKey } from '../util'
@@ -29,13 +28,18 @@ export const getRemoteSearch = (remoteDataProvider: DataProvider) => {
   }
 }
 
+interface AlgoliaConfig {
+  applicationId: string,
+  index: string,
+}
+
 /**
  * Initialize algolia search client.
  */
-const initAlgoliaSearch = async (userId: string, store: Store) => {
+const initAlgoliaSearch = async (userId: string, algoliaConfig: AlgoliaConfig, store: Store) => {
   const apiKey = await getAlgoliaApiKey(userId)
-  const algoliaClient = AlgoliaClient(ALGOLIA_CONFIG.applicationId, apiKey)
-  searchIndex = algoliaClient.initIndex(ALGOLIA_CONFIG.index)
+  const algoliaClient = AlgoliaClient(algoliaConfig.applicationId, apiKey)
+  searchIndex = algoliaClient.initIndex(algoliaConfig.index)
   store.dispatch(setRemoteSearch({ value: true }))
 }
 

--- a/src/selectors/getChildren.ts
+++ b/src/selectors/getChildren.ts
@@ -173,11 +173,11 @@ const isDescendantOfMetaCursor = (state: State, context: Context): boolean => {
 }
 
 /** Checks if the child is visible or if the child lies within the cursor or is descendant of the meta cursor. */
-const isChildVisibleWithCursorCheck = _.curry((state: State, path: Path, context: Context, isForcedChildren = false, child: Child | ThoughtContext) => {
+const isChildVisibleWithCursorCheck = _.curry((state: State, path: Path, context: Context, showContexts = false, child: Child | ThoughtContext) => {
 
-  const showContexts = isContextViewActive(state, pathToContext(path))
+  showContexts = showContexts || isContextViewActive(state, pathToContext(path))
 
-  const value = pathHeadValue(state, path, child, showContexts || isForcedChildren)
+  const value = pathHeadValue(state, path, child, showContexts)
   const childContext = [...pathToContext(path), value]
 
   return state.showHiddenThoughts ||
@@ -198,7 +198,7 @@ const isCreatedAfterAbsoluteToggle = _.curry((state: State, child: Child | Thoug
  * 2. Checks if child is within cursor.
  * 3. Checks if child is created after latest absolute context toggle if starting context is absolute.
  */
-export const childrenFilterPredicate = _.curry((state: State, path: Path, context: Context, isForcedChildren = false, child: Child | ThoughtContext) => {
-  return isChildVisibleWithCursorCheck(state, path, context, isForcedChildren, child) &&
+export const childrenFilterPredicate = _.curry((state: State, path: Path, context: Context, showContexts = false, child: Child | ThoughtContext) => {
+  return isChildVisibleWithCursorCheck(state, path, context, showContexts, child) &&
   (!isAbsolute(state.rootContext) || isCreatedAfterAbsoluteToggle(state, child))
 }, 5)

--- a/src/util/initFirebase.ts
+++ b/src/util/initFirebase.ts
@@ -1,7 +1,7 @@
 import { Store } from 'redux'
 import globals from '../globals'
 import { authenticate, loadPublicThoughts, setRemoteSearch, status as statusActionCreator, userAuthenticated } from '../action-creators'
-import { FIREBASE_CONFIG, OFFLINE_TIMEOUT } from '../constants'
+import { ALGOLIA_CONFIG, FIREBASE_CONFIG, OFFLINE_TIMEOUT } from '../constants'
 import { owner } from '../util'
 import { State } from '../util/initialState'
 import { Snapshot, User } from '../types'
@@ -18,7 +18,12 @@ export const initFirebase = async ({ store }: { store: Store<State, any>}) => {
     firebase.auth().onAuthStateChanged((user: User) => {
       if (user) {
         store.dispatch(userAuthenticated(user))
-        initAlgoliaSearch(user.uid, store)
+
+        const { applicationId, index } = ALGOLIA_CONFIG
+        const hasRemoteConfig = applicationId && index
+
+        if (!hasRemoteConfig) console.warn('Algolia configs not found. Remote search is not enabled.')
+        else initAlgoliaSearch(user.uid, { applicationId, index }, store)
       }
       else {
         store.dispatch(authenticate({ value: false }))


### PR DESCRIPTION
fix #1092

# Changes
- Fix `childrenFilterPredicate` to use pass `showContexts` instead of `isForcedChildren`.
- Do not initialize remote search if required configs are not available.