### PR TITLE
Priortize plainText over hmtlText that is passed to importText

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -40,7 +40,6 @@ import {
   headValue,
   isDivider,
   isElementHiddenByAutoFocus,
-  isHTML,
   isURL,
   pathToContext,
   setSelection,
@@ -524,9 +523,8 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
 
       dispatch(importText({
         path,
-        text: isHTML(plainText)
-          ? plainText
-          : htmlText || plainText,
+        // Note: priortize plainText over htmlText as imporText itself checks if the given text is an html
+        text: plainText || htmlText,
         rawDestValue,
       }))
 


### PR DESCRIPTION
fixes #1049

# Cause of issue

In the `Editable`component, `plainText` was passed to `importText` function only if it is an HTML. Basically prioritizing `htmlText` over `plainText` made it more complicated. Even the indented text was passed as HTML. In chrome the `htmlText` has  a `meta` tag at the beginning. Since `importText` checks if the text is an HTML by the presence of a proper closing tag at the beginning, so in the Chrome it was not detected as an HTML and was parsed as blocks. That's why it was working properly. However, it is not the case for the Safari. So it was causing the inconsistent imports.

# Solution

We simply prioritize `plainText`. Rest is handled by already available logic in `importText`
