### PR TITLE
Don't set caret when user click an Editable

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { unescape } from 'html-escaper'
@@ -181,6 +181,7 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
   // store the old value so that we have a transcendental head when it is changed
   const oldValueRef = useRef(value)
   const editableNonceRef = useRef(state.editableNonce)
+  const [isTapped, setIsTapped] = useState(false)
 
   useEffect(() => {
     editableNonceRef.current = state.editableNonce
@@ -362,7 +363,6 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
     //     focusNode: !!focusNode,
     //   })
     // }
-
     // allow transient editable to have focus on render
     if (transient || (
       isEditing &&
@@ -370,7 +370,8 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
       !noteFocus &&
       contentRef.current &&
       (cursorWithoutSelection || isAtBeginning) &&
-      !dragHold
+      !dragHold &&
+      !isTapped
     )) {
       /*
         When a new thought is created, the Shift key should be on when Auto-Capitalization is enabled.
@@ -387,6 +388,8 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
         setSelectionToCursorOffset()
       }
     }
+
+    isTapped && setIsTapped(false)
 
     /** Flushes pending edits. */
     const flush = () => throttledChangeRef.current.flush()
@@ -611,6 +614,7 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
 
     const isHiddenByAutofocus = isElementHiddenByAutoFocus(e.target as HTMLElement)
     const editingOrOnCursor = state.editing || equalPath(path, state.cursor)
+    setIsTapped(true)
 
     if (disabled || (
       !globals.touching &&

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -389,7 +389,9 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
       }
     }
 
-    isTapped && setIsTapped(false)
+    if (isTapped) {
+      setIsTapped(false)
+    }
 
     /** Flushes pending edits. */
     const flush = () => throttledChangeRef.current.flush()
@@ -614,7 +616,6 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
 
     const isHiddenByAutofocus = isElementHiddenByAutoFocus(e.target as HTMLElement)
     const editingOrOnCursor = state.editing || equalPath(path, state.cursor)
-    setIsTapped(true)
 
     if (disabled || (
       !globals.touching &&
@@ -630,6 +631,10 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
         // prevent focus to allow navigation with mobile keyboard down
         setCursorOnThought()
       }
+    }
+    else {
+      // We need to know that user clicked the editable to not set caret programmatically, because caret will be already set by browser. Issue: #981
+      setIsTapped(true)
     }
   }
 


### PR DESCRIPTION
fixes: #981 
_____
> #### Why do we set the caret?
> 
> On events that don't contain user clicks, we should set the caret for editable elements. Because the user doesn't click anywhere but we want the caret to be on a thought. Here are some examples of this situation;
> 
> - When we refresh the page, the caret should be on the thought in the path.
> - When we delete a thought, the caret should be on the previous thought.
> - When we add a thought, the caret should be on the newly created thought.
> ....
> #### What should we do?
> 
> We should not set the caret if we want to see that the caret on the correct position where the user clicks. Because the browser already set the caret where the user clicks. The only thing we should know before setting caret is whether the user clicked or not.