### PR TITLE
Activate cursorBack when clicking the hidden thought

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, useMemo, useRef } from 'react'
+import React, { FC, MouseEvent, useMemo, useRef, useState } from 'react'
 import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
@@ -100,13 +100,15 @@ const isLeftSpaceClick = (e: MouseEvent, content?: HTMLElement) => {
 const Content: ContentComponent = props => {
   const { search, isTutorialLocal, tutorialStep, showModal, showRemindMeLaterModal, cursorBack: moveCursorBack, toggleSidebar, rootThoughtsLength, noteFocus, rootSort, isAbsoluteContext } = props
   const contentRef = useRef<HTMLDivElement>(null)
+  const [isPressed, setIsPressed] = useState<boolean | null>(null)
 
   /** Removes the cursor if the click goes all the way through to the content. Extends cursorBack with logic for closing modals. */
-  const clickOnEmptySpace = (e: any) => {
-    // Stop event bubbling. We need to handle this event if we click really on content element not other elements.
-    if (e.target.id !== 'content') {
+  const clickOnEmptySpace = () => {
+    // We need to make sure the user starts the action by pressing the Content element.
+    if (!isPressed) {
       return
     }
+    setIsPressed(false)
 
     // click event occured during text selection has focus node of type text unlike normal event which has node of type element
     // prevent text selection from calling cursorBack incorrectly
@@ -140,8 +142,8 @@ const Content: ContentComponent = props => {
       id='content'
       ref={contentRef}
       className={contentClassNames}
-      onTouchEnd={clickOnEmptySpace}
-      onMouseDown={clickOnEmptySpace}
+      onClick={clickOnEmptySpace}
+      onMouseDown={() => setIsPressed(true)}
     >
       {search != null
         ? <Search />

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -102,7 +102,12 @@ const Content: ContentComponent = props => {
   const contentRef = useRef<HTMLDivElement>(null)
 
   /** Removes the cursor if the click goes all the way through to the content. Extends cursorBack with logic for closing modals. */
-  const clickOnEmptySpace = () => {
+  const clickOnEmptySpace = (e: any) => {
+    // Stop event bubbling. We need to handle this event if we click really on content element not other elements.
+    if (e.target.id !== 'content') {
+      return
+    }
+
     // click event occured during text selection has focus node of type text unlike normal event which has node of type element
     // prevent text selection from calling cursorBack incorrectly
     const selection = window.getSelection()
@@ -135,7 +140,8 @@ const Content: ContentComponent = props => {
       id='content'
       ref={contentRef}
       className={contentClassNames}
-      onClick={clickOnEmptySpace}
+      onTouchEnd={clickOnEmptySpace}
+      onMouseDown={clickOnEmptySpace}
     >
       {search != null
         ? <Search />

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -100,14 +100,13 @@ const isLeftSpaceClick = (e: MouseEvent, content?: HTMLElement) => {
 const Content: ContentComponent = props => {
   const { search, isTutorialLocal, tutorialStep, showModal, showRemindMeLaterModal, cursorBack: moveCursorBack, toggleSidebar, rootThoughtsLength, noteFocus, rootSort, isAbsoluteContext } = props
   const contentRef = useRef<HTMLDivElement>(null)
-  const [isPressed, setIsPressed] = useState<boolean | null>(null)
+  const [isPressed, setIsPressed] = useState<boolean>(false)
 
   /** Removes the cursor if the click goes all the way through to the content. Extends cursorBack with logic for closing modals. */
   const clickOnEmptySpace = () => {
-    // We need to make sure the user starts the action by pressing the Content element.
-    if (!isPressed) {
-      return
-    }
+    // make sure the the actual Content element has been clicked
+    // otherwise it will incorrectly be called on mobile due to touch vs click ordering (#1029)
+    if (!isPressed) return
     setIsPressed(false)
 
     // click event occured during text selection has focus node of type text unlike normal event which has node of type element

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -612,7 +612,7 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
     const isHiddenByAutofocus = isElementHiddenByAutoFocus(e.target as HTMLElement)
     const editingOrOnCursor = state.editing || equalPath(path, state.cursor)
 
-    if (disabled || (
+    if (disabled || isHiddenByAutofocus || (
       !globals.touching &&
       // not sure if this can happen, but I observed some glitchy behavior with the cursor moving when a drag and drop is completed so check dragInProgress to be safe
       !state.dragInProgress &&

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -605,6 +605,8 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
 
   /** Sets the cursor on the thought on mousedown or tap. Handles hidden elements, drags, and editing mode. */
   const onTap = (e: React.MouseEvent | React.TouchEvent) => {
+    e.stopPropagation()
+
     const state = store.getState()
 
     showContexts = showContexts || isContextViewActive(state, pathToContext(simplePath))

--- a/src/e2e/__tests__/caret.ts
+++ b/src/e2e/__tests__/caret.ts
@@ -211,4 +211,22 @@ describe('caret testing for mobile platform', () => {
     expect(offset).toBe(0)
 
   })
+
+  it('on clicking the hidden thought, caret should be on the parent thought of editing thought', async () => {
+    const importText = `
+    - A
+      - B
+        -C
+    - D`
+
+    await page.keyboard.press('Enter')
+    await paste(page, [''], importText)
+
+    await clickThought(page, 'A')
+    await clickThought(page, 'C')
+    await clickThought(page, 'D')
+
+    const textContext = await page.evaluate(() => window.getSelection()?.focusNode?.textContent)
+    expect(textContext).toBe('B')
+  })
 })


### PR DESCRIPTION
fixes: #1029 

____

This issue occurs because we are clicking the editable area of hidden thoughts. I added border for .editable class to show you the boundaries of editable elements.

![image](https://user-images.githubusercontent.com/23136437/117495390-38e1e300-af7e-11eb-9683-b39eb99a73c7.png)

There is already a function written for handle this situation `isElementHiddenByAutoFocus` . But the problem was in tap handler, it was not entering the if block because `editingOrOnCursor` is true when we click the area of `d`

https://github.com/cybersemics/em/blob/e30375659d5d5ad98c5df5bbe88f3e9a7d92ff1d/src/components/Editable.tsx#L612-L630

I was thinking solve this issue with css `visible: hidden` property but this will cause other issues. For example, if we add  `.distance-from-cursor-3 > .child { visibility: hidden }`then we can not see the thoughts in `.distance-from-cursor-3` We were going to need to add other css properties for visible thughts in `.distance-from-cursor-3`