### PR TITLE
Add theme before react loads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,14 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>em</title>
+
+    <style>
+      body.dark {
+        color: white;
+        background-color: black;
+      }
+    </style>
+
   </head>
   <body>
     <noscript>
@@ -48,6 +56,10 @@
     <div id="debug"></div>
 
     <script src="https://www.gstatic.com/firebasejs/4.12.0/firebase.js"></script>
-
+    <script>
+      // Note: Initially theme needs to be set here before react loads. Else it causes white flash.
+      const theme = localStorage['Settings/Theme'] || 'dark'
+      document.body.classList.add(theme)
+    </script>
   </body>
 </html>

--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -118,7 +118,7 @@ const AppComponent: FC<Props> = props => {
       <Alert />
       <ErrorMessage />
 
-      {isDocumentEditable() && !tutorial && <>
+      {isDocumentEditable() && !tutorial && !showModal && <>
         <Sidebar />
         <HamburgerMenu />
       </>}


### PR DESCRIPTION
fixes #269 

# Cause of issue

Theme was only set up after the first load of the `AppComponent`. It momentarily causes `body` to have no theme class. This was causing initial white flash.

# Solution

Adding required style and js logic to set initial theme before react loads solves the problem.