### PR TITLE
stop propagation for MouseEvent of Editable

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -610,7 +610,10 @@ const Editable = ({ disabled, isEditing, simplePath, path, cursorOffset, showCon
 
   /** Sets the cursor on the thought on mousedown or tap. Handles hidden elements, drags, and editing mode. */
   const onTap = (e: React.MouseEvent | React.TouchEvent) => {
-    e.stopPropagation()
+    // Stop propagation to not trigger onMouseDown event of Content.
+    if (e.nativeEvent instanceof MouseEvent) {
+      e.stopPropagation()
+    }
 
     const state = store.getState()
 


### PR DESCRIPTION
Fixes for the case: https://github.com/cybersemics/em/issues/1029#issuecomment-839718995

_____

#### Reason
I had added e.stopPropagation() in onTap to block the triggering onMouseDown event of Content element(event bubbling). But this also blocks the calling onTouchEnd event in TouchMonitor.tsx 

#### Solution:
 In onTap function we need to stop propagation if event type is a MouseEvents. As I said before, for touch events e.stopPropagation() won't block the event bubbling for mouse events. It only blocks the event bubbling for touch events. So, it blocks the calling onTouchEnd event of TouchMonitor.  

There will be no problem for TouchEvents because this is an edge case scenario, and in this case the onTap gets onMouseDown event not onTouchEnd event, because touch is not ended on Editable element, touch is ended on Content. You can see the case at [https://github.com/cybersemics/em/pull/1128#issuecomment-837427219](https://github.com/cybersemics/em/pull/1128#issuecomment-837427219)