### PR TITLE
Cancel active gesture if dragInProgress

### DIFF
--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -68,11 +68,14 @@ const mapDispatchToProps = { updateSplitPos: updateSplitPosition }
 
 type Props = StateProps & DispatchProps
 
+/** Cancel gesture if there is an active text selection on active drag. */
+const shouldCancelGesture = () => !!window.getSelection()?.toString() || store.getState().dragInProgress
+
 /**
  * Wrap an element in the MultiGesture componentt if the user has a touch screen.
  */
 const MultiGestureIfTouch: FC = ({ children }) => isTouch
-  ? <MultiGesture onGesture={handleGestureSegment} onEnd={handleGestureEnd}>{children}</MultiGesture>
+  ? <MultiGesture onGesture={handleGestureSegment} onEnd={handleGestureEnd} shouldCancelGesture={shouldCancelGesture}>{children}</MultiGesture>
   : <>{children}</>
 
 /**


### PR DESCRIPTION
fixes #1129 

# Cause of issue

On dragging `b` to `a.b` as described in the linked issue, the `cursorBack` gesture was being activated right after `exisitingThoughtMove`. On active drag, gesture is not being canceled.

# Changes

- Added `shouldCancelGesture` to the `MultiGestureComponent`.
- Used `shouldCancelGesture` for `onMoveShouldSetPanResponder`, `onMoveShouldSetPanResponderCapture`. Also used it with `onPanResponderMove` to abandon active gesture.  It is because `onMoveShouldSetPanResponder` and `onMoveShouldSetPanResponderCapture` executes before `beginDrag`. 