### PR TITLE
Fix stale accum in existingThoughtChange recursive updates

### DIFF
--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -7,6 +7,7 @@ import { hashContext, hashThought, initEvents, initFirebase, owner, setSelection
 import { loadFromUrl, loadLocalState, preloadSources } from './action-creators'
 import importOnFirstMatchPathActionCreator from './test-helpers/importOnFirstMatchPath'
 import getLexemeFromDB from './test-helpers/e2e-helpers/getLexemeFromDB'
+import checkDataIntegrity from './test-helpers/checkDataIntegrity'
 import _ from 'lodash'
 
 /** Initilaize local db , firebase and window events. */
@@ -71,6 +72,7 @@ window.em = {
   hashContext,
   hashThought,
   isPending: withState(isPending),
+  checkDataIntegrity: withState(checkDataIntegrity)
 }
 
 /** Logs debugging information to a fixed position debug window. Useful for PWA debugging. */

--- a/src/reducers/__tests__/existingThoughtChange.ts
+++ b/src/reducers/__tests__/existingThoughtChange.ts
@@ -280,7 +280,51 @@ it('data integrity test', () => {
 
   // run steps through reducer flow and export as plaintext for readable test
   const stateNew = reducerFlow(steps)(initialState())
-  const noOfUpdates = Object.keys(checkDataIntegrity(stateNew)).length
+  const { thoughtIndexUpdates, contextIndexUpdates } = checkDataIntegrity(stateNew)
 
-  expect(noOfUpdates).toBe(0)
+  const thoughtUpdates = Object.keys(thoughtIndexUpdates).length
+  const contextUpdates = Object.keys(contextIndexUpdates).length
+
+  expect(thoughtUpdates).toBe(0)
+  expect(contextUpdates).toBe(0)
+})
+
+// Issue: https://github.com/cybersemics/em/issues/1144
+it('data integrity test after editing a parent with multiple descendants with same value and depth', () => {
+
+  const text = `
+  - ${' '}
+    - a
+      - m
+    - b
+      - m`
+
+  const steps = [
+    importText({
+      path: HOME_PATH,
+      text
+    }),
+    setCursor({
+      path: [{
+        value: '',
+        rank: 0
+      }]
+    }),
+    existingThoughtChange({
+      newValue: 'x',
+      oldValue: '',
+      context: [HOME_TOKEN],
+      path: [{ value: '', rank: 0 }] as SimplePath
+    })
+  ]
+
+  // run steps through reducer flow and export as plaintext for readable test
+  const stateNew = reducerFlow(steps)(initialState())
+  const { thoughtIndexUpdates, contextIndexUpdates } = checkDataIntegrity(stateNew)
+
+  const thoughtUpdates = Object.keys(thoughtIndexUpdates).length
+  const contextUpdates = Object.keys(contextIndexUpdates).length
+
+  expect(thoughtUpdates).toBe(0)
+  expect(contextUpdates).toBe(0)
 })

--- a/src/reducers/__tests__/existingThoughtMove.ts
+++ b/src/reducers/__tests__/existingThoughtMove.ts
@@ -584,9 +584,13 @@ it('data integrity test', () => {
 
   // run steps through reducer flow and export as plaintext for readable test
   const stateNew = reducerFlow(steps)(initialState())
-  const noOfUpdates = Object.keys(checkDataIntegrity(stateNew)).length
+  const { thoughtIndexUpdates, contextIndexUpdates } = checkDataIntegrity(stateNew)
 
-  expect(noOfUpdates).toBe(0)
+  const thoughtUpdates = Object.keys(thoughtIndexUpdates).length
+  const contextUpdates = Object.keys(contextIndexUpdates).length
+
+  expect(thoughtUpdates).toBe(0)
+  expect(contextUpdates).toBe(0)
 })
 
 it('consitent rank between thoughtIndex and contextIndex on duplicate merge', () => {


### PR DESCRIPTION
fixes #1144 

# Cause of issue.

https://github.com/cybersemics/em/blob/06dfe24874083b741a1aed0c9909d52a9742381e/src/reducers/existingThoughtChange.ts#L209-L210

I was accessing stale `accum` that had only updates of the current scope. Even though I had commented that I need to access updated `accum` 🤦 

# Solution

Updating it to use the updated `accum` that has all the updates of the previous recursions did the trick.

