### PR TITLE
Remove static server spin up inside puppeteer env configuration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,4 +33,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm run test:e2e
+        run: npm run test:e2e:prod

--- a/package-lock.json
+++ b/package-lock.json
@@ -12072,12 +12072,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -12089,17 +12083,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "requires": {
         "is-docker": "^2.0.0"
-      }
-    },
-    "is2": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.7.tgz",
-      "integrity": "sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==",
-      "dev": true,
-      "requires": {
-        "deep-is": "^0.1.3",
-        "ip-regex": "^4.1.0",
-        "is-url": "^1.2.4"
       }
     },
     "isarray": {
@@ -20526,16 +20509,6 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      }
-    },
-    "tcp-port-used": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
-      "dev": true,
-      "requires": {
-        "debug": "4.3.1",
-        "is2": "^2.0.6"
       }
     },
     "temp-dir": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint:package-lock": "node ./scripts/validate-package-lock.js",
     "servebuild": "serve -s build -l 3000",
     "test": "react-scripts test --testPathIgnorePatterns=./src/e2e",
-    "test:e2e": "react-scripts test ./src/e2e"
+    "test:e2e": "react-scripts test ./src/e2e",
+    "test:e2e:prod": "npm run servebuild & react-scripts test ./src/e2e; kill $!"
   },
   "dependencies": {
     "@bit/mui-org.material-ui.swipeable-drawer": "^4.9.10",
@@ -131,7 +132,6 @@
     "fake-indexeddb": "^3.1.2",
     "husky": "^6.0.0",
     "it-all": "^1.0.5",
-    "jest-dev-server": "^5.0.0",
     "jest-environment-puppeteer-jsdom": "^4.3.1",
     "jest-localstorage-mock": "^2.4.10",
     "jest-puppeteer": "^5.0.2",
@@ -141,7 +141,6 @@
     "react-dnd-test-utils": "^11.1.3",
     "redux-mock-store": "^1.5.4",
     "serve": "^11.3.2",
-    "tcp-port-used": "^1.0.2",
     "typedoc": "^0.17.8",
     "typedoc-plugin-exclude-references": "^1.0.0",
     "typedoc-plugin-external-module-name": "^4.0.6",

--- a/src/e2e/puppeteer-environment.js
+++ b/src/e2e/puppeteer-environment.js
@@ -4,11 +4,7 @@
 
 const chalk = require('chalk')
 const JsDomEnvironment = require('jest-environment-jsdom')
-const { setup: setupDevServer, teardown: teardownDevServer } = require('jest-dev-server')
-const fs = require('fs')
-const path = require('path')
 const puppeteer = require('puppeteer')
-const portUsed = require('tcp-port-used')
 
 /** Puppeteer Environment for jest. */
 class PuppeteerEnvironment extends JsDomEnvironment {
@@ -22,28 +18,6 @@ class PuppeteerEnvironment extends JsDomEnvironment {
 
     await super.setup()
 
-    // use existing app if already running
-    if (await portUsed.check(3000, 'localhost')) {
-      console.info(chalk.yellow('Using the currently running app on http://localhost:3000'))
-    }
-    // otherwise serve up the build folder
-    else {
-      const buildPath = path.join(__dirname, '..', '..', 'build')
-      const doesBuildExist = fs.existsSync(buildPath)
-
-      if (!doesBuildExist) {
-        console.error(chalk.red('App build not found.'))
-        throw new Error('App build not found.')
-      }
-
-      await setupDevServer({
-        command: 'npm run servebuild',
-        launchTimeout: 300000,
-        debug: true,
-        port: 3000
-      })
-    }
-
     this.global.browser = await puppeteer.launch({
       headless: true,
     })
@@ -53,7 +27,6 @@ class PuppeteerEnvironment extends JsDomEnvironment {
   async teardown() {
     console.info(chalk.yellow('Teardown Test Environment.'))
     await this.global.browser.close()
-    await teardownDevServer()
     await super.teardown()
   }
 }


### PR DESCRIPTION
fixes #1191

# Changes

- Remove static server spin up from `puppeteer-environment.js`
- Spin up and kill static server  from bash command  in `test:e2e` script.