### PR TITLE
Use pull_request_target for e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - dev
-  pull_request:
-    branches:
-      - "**"
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 env:
   CI: true
@@ -20,6 +19,9 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Set Node.js version
         uses: actions/setup-node@v1


### PR DESCRIPTION
As you know, we have made integration with BrowserStack for the ios e2e test. The new ios e2e tests are not working for now because the forked repos couldn't access the secrets that are required for BrowserStack integration.

After this PR, the e2e test workflow for ios will be run properly for every PR that is opened from the forked repository.