### PR TITLE
Refactor expandThoughts and allow supressExpansion to afftect only non pinned expansion path.

### DIFF
--- a/src/action-creators/__tests__/cursorPrev.ts
+++ b/src/action-creators/__tests__/cursorPrev.ts
@@ -2,6 +2,7 @@ import { HOME_PATH } from '../../constants'
 import { cursorPrev, importText, setCursor } from '../../action-creators'
 import { createTestStore } from '../../test-helpers/createTestStore'
 import setCursorFirstMatch, { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
+import globals from '../../globals'
 
 describe('normal view', () => {
 
@@ -123,4 +124,90 @@ describe('normal view', () => {
 
   })
 
+})
+
+describe('global suppress expansion', () => {
+
+  beforeEach(() => {
+    globals.suppressExpansion = false
+  })
+
+  it('suppress expansion path on cursor prev', async () => {
+    const text = `
+    - a
+      - c
+        - k
+      - d
+        - e
+        - f`
+
+    jest.useFakeTimers()
+    const store = createTestStore()
+
+    store.dispatch([
+      importText({
+        path: HOME_PATH,
+        text,
+      }),
+      setCursorFirstMatchActionCreator(['a', 'd']),
+      cursorPrev()
+    ])
+
+    expect(globals.suppressExpansion)
+      .toBe(true)
+  })
+
+  it('do not activate suppress expansion on cursorPrev if new cursor is pinned', async () => {
+    const text = `
+    - a
+      - c
+        - =pin
+          - true
+        - k
+      - d
+        - e
+        - f`
+
+    jest.useFakeTimers()
+    const store = createTestStore()
+
+    store.dispatch([
+      importText({
+        path: HOME_PATH,
+        text,
+      }),
+      setCursorFirstMatchActionCreator(['a', 'd']),
+      cursorPrev()
+    ])
+
+    expect(globals.suppressExpansion)
+      .toBe(false)
+  })
+
+  it('do not activate suppress expansion on cursorPrev if new cursor parent has pinned children', async () => {
+    const text = `
+    - a
+      - =pinChildren
+        - true
+      - c
+        - k
+      - d
+        - e
+        - f`
+
+    jest.useFakeTimers()
+    const store = createTestStore()
+
+    store.dispatch([
+      importText({
+        path: HOME_PATH,
+        text,
+      }),
+      setCursorFirstMatchActionCreator(['a', 'd']),
+      cursorPrev()
+    ])
+
+    expect(globals.suppressExpansion)
+      .toBe(false)
+  })
 })

--- a/src/action-creators/cursorNext.ts
+++ b/src/action-creators/cursorNext.ts
@@ -1,10 +1,10 @@
 import { HOME_TOKEN } from '../constants'
 import { scrollCursorIntoView, setCursor, suppressExpansion } from '../action-creators'
-import { parentOf } from '../util'
+import { parentOf, pathToContext } from '../util'
 import { Thunk } from '../types'
 
 // must be imported after util (???)
-import { getChildrenSorted, getThoughtAfter, simplifyPath } from '../selectors'
+import { attributeEquals, getChildrenSorted, getThoughtAfter, simplifyPath } from '../selectors'
 
 /** Moves the cursor to the next sibling, ignoring descendants. */
 const cursorNext = (): Thunk => (dispatch, getState) => {
@@ -23,10 +23,13 @@ const cursorNext = (): Thunk => (dispatch, getState) => {
   const next = getThoughtAfter(state, simplifyPath(state, cursor))
   if (!next) return
 
-  // just long enough to keep the expansion suppressed during cursor movement in rapid succession
-  dispatch(suppressExpansion({ duration: 100 }))
-
   const path = parentOf(cursor).concat(next)
+
+  const isCursorPinned = attributeEquals(state, pathToContext(path), '=pin', 'true') || attributeEquals(state, pathToContext(parentOf(path)), '=pinChildren', 'true')
+
+  // just long enough to keep the expansion suppressed during cursor movement in rapid succession
+  if (!isCursorPinned) dispatch(suppressExpansion({ duration: 100 }))
+
   dispatch(setCursor({ path }))
   dispatch(scrollCursorIntoView())
 }

--- a/src/action-creators/cursorPrev.ts
+++ b/src/action-creators/cursorPrev.ts
@@ -1,7 +1,7 @@
 import { HOME_TOKEN } from '../constants'
 import { scrollCursorIntoView, setCursor, suppressExpansion } from '../action-creators'
-import { getThoughtBefore, simplifyPath, getChildrenSorted } from '../selectors'
-import { parentOf } from '../util'
+import { getThoughtBefore, simplifyPath, getChildrenSorted, attributeEquals } from '../selectors'
+import { parentOf, pathToContext } from '../util'
 import { Thunk } from '../types'
 
 /** Moves the cursor to the previous sibling, ignoring descendants. */
@@ -21,10 +21,13 @@ const cursorPrev = (): Thunk => (dispatch, getState) => {
   const prev = getThoughtBefore(state, simplifyPath(state, cursor))
   if (!prev) return
 
-  // just long enough to keep the expansion suppressed during cursor movement in rapid succession
-  dispatch(suppressExpansion({ duration: 100 }))
-
   const path = [...parentOf(cursor), prev]
+
+  const isCursorPinned = attributeEquals(state, pathToContext(path), '=pin', 'true') || attributeEquals(state, pathToContext(parentOf(path)), '=pinChildren', 'true')
+
+  // just long enough to keep the expansion suppressed during cursor movement in rapid succession
+  if (!isCursorPinned) dispatch(suppressExpansion({ duration: 100 }))
+
   dispatch(setCursor({ path }))
   dispatch(scrollCursorIntoView())
 }

--- a/src/reducers/setCursor.ts
+++ b/src/reducers/setCursor.ts
@@ -5,6 +5,7 @@ import { equalPath, equalThoughtRanked, hashContext, headValue, isDescendant, pa
 import { render, settings } from '../reducers'
 import { State } from '../util/initialState'
 import { Index, Path, SimplePath, TutorialChoice } from '../types'
+import globals from '../globals'
 
 /**
  * Sets the cursor on a thought.
@@ -71,7 +72,7 @@ const setCursor = (state: State, {
   //   }
   // })
 
-  const expanded = expandThoughts({ ...state, contextViews: newContextViews }, thoughtsResolved)
+  const expanded = globals.suppressExpansion ? {} : expandThoughts({ ...state, contextViews: newContextViews }, thoughtsResolved)
 
   const tutorialChoice = +(getSetting(state, 'Tutorial Choice') || 0) as TutorialChoice
   const tutorialStep = +(getSetting(state, 'Tutorial Step') || 1)

--- a/src/reducers/toggleContextView.ts
+++ b/src/reducers/toggleContextView.ts
@@ -5,6 +5,7 @@ import { expandThoughts, getContexts, getSetting } from '../selectors'
 import { hashContext, headValue, pathToContext, reducerFlow } from '../util'
 import { State } from '../util/initialState'
 import { Context } from '../types'
+import globals from '../globals'
 
 /** Returns a new contextViews object with the given context toggled to the opposite of its previous value. */
 const toggleContext = (state: State, context: Context) => immer.produce(state.contextViews, draft => {
@@ -44,7 +45,7 @@ const toggleContextView = (state: State) => {
     // update context views and expanded
     state => ({
       ...state,
-      expanded: expandThoughts(state, state.cursor)
+      expanded: globals.suppressExpansion ? {} : expandThoughts(state, state.cursor)
     }),
 
     // advance tutorial from context view toggle step


### PR DESCRIPTION
fixes #1212 

# Changes
- Make `suppressExpansion` prevent the expansion of the given `path` if it is a non-pinned thought.
- Refactored `expandThoughts` to simplify it and prevent unnecessary recursions.
- Add tests for `expandThoughts` for the cases of `suppressExpansion`.