### PR TITLE
Fix the site crash issue during the step of "hiding the thought" on the Start Tutorial 

### DIFF
--- a/src/util/normalizeThought.ts
+++ b/src/util/normalizeThought.ts
@@ -16,7 +16,10 @@ export const stripEmojiFromText = (s: string) => {
 }
 
 /** Strips all html tags. */
-export const stripTags = (s: string) => s.replace(REGEXP_TAGS, '')
+export const stripTags = (s: string | {value: string, rank: number, id: string, lastUpdated: string}) => {
+  const str = typeof s === 'string' ? s : s.value
+  return str.replace(REGEXP_TAGS, '')
+}
 
 /**
  * Making character 's' will just become an empty value ''.


### PR DESCRIPTION
Fix Ticket #1227

Cause: the incoming data is not always a string, thus the String.replace  function won't work correctly.