### PR TITLE
Use an enum + a mapped type to improve mobile/gestures type

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -84,7 +84,7 @@ const GestureDiagram = ({ path, size = 50, flexibleSize, strokeWidth = 1.5, arro
   }
 
   // eslint-disable-next-line no-extra-parens
-  const pathSegments = (path.split('') as Direction[]).map(pathSegmentDelta)
+  const pathSegments = (Array.from(path) as Direction[]).map(pathSegmentDelta)
   const pathString = pathSegments.map(segment => `l ${segment.dx} ${segment.dy}`).join(' ')
   const sumWidth = Math.abs(pathSegments.reduce((accum, cur) => accum + cur.dx, 0))
   const sumHeight = Math.abs(pathSegments.reduce((accum, cur) => accum + cur.dy, 0))

--- a/src/e2e/helpers/constants.ts
+++ b/src/e2e/helpers/constants.ts
@@ -1,6 +1,12 @@
-import { Direction, Index } from '../../types'
+import { GesturePath } from '../../types'
 
-export const gestures: Index<Direction[]> = {
-  newSubThought: ['r', 'd', 'r'],
-  newThought: ['r', 'd'],
+enum gestureEnum {
+  newSubThought = 'rdr',
+  newThought = 'rd',
+}
+
+// widen the type of the gestureEnum values to GesturePath using a mapped type
+// https://www.typescriptlang.org/docs/handbook/2/mapped-types.html
+export const gestures = gestureEnum as {
+  [key in keyof typeof gestureEnum]: GesturePath
 }

--- a/src/e2e/helpers/mobile/gesture.ts
+++ b/src/e2e/helpers/mobile/gesture.ts
@@ -1,4 +1,4 @@
-import { Direction } from '../../../types'
+import { Direction, GesturePath } from '../../../types'
 import { Browser, TouchAction } from 'webdriverio'
 
 export interface GestureOptions {
@@ -11,9 +11,9 @@ export interface GestureOptions {
 const WAIT_ACTION = { action: 'wait', ms: 50 } as TouchAction
 
 /** Apply gesture action for the given path. */
-const gesture = async (browser: Browser<'async'>, path: Direction[], { xStart = 70, yStart = 300, segmentLength = 70 }: GestureOptions = {}) => {
+const gesture = async (browser: Browser<'async'>, path: GesturePath, { xStart = 70, yStart = 300, segmentLength = 70 }: GestureOptions = {}) => {
 
-  const moveActions = path.reduce<TouchAction[]>((acc, cur) => {
+  const moveActions = (Array.from(path) as Direction[]).reduce<TouchAction[]>((acc, cur) => {
     const { x: previousX, y: previousY } = acc.length > 0
       ? acc[acc.length - 1]
       : { x: xStart, y: yStart }

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,10 +249,7 @@ export type Direction = 'u' | 'd' | 'l' | 'r'
 export type DirectionMap<T> = (dir: Direction) => T
 
 // allow string explicitly since Typescript will not allow Direction[] to be specified as a string
-export type GesturePath = string | (Direction[] & {
-  map: DirectionMap<Direction>,
-  split: (s: string) => Direction[],
-})
+export type GesturePath = string | Direction[]
 
 export type Alert = {
   alertType?: string,


### PR DESCRIPTION
This makes the keys of `gestures` well-defined again. It also uses strings to represent the gestures for readability.

I also simplified the `GesturePath` type, though it is still quite loose since it is not based on an enum.