### PR TITLE
Factor out DragAndDropThought and StaticThought

### DIFF
--- a/src/components/DragAndDropThought.tsx
+++ b/src/components/DragAndDropThought.tsx
@@ -1,0 +1,191 @@
+import { FC } from 'react'
+import { DragSource, DragSourceConnector, DragSourceMonitor, DropTarget, DropTargetConnector, DropTargetMonitor } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
+import { isTouch } from '../browser'
+import { store } from '../store'
+import globals from '../globals'
+import { alert, dragHold, dragInProgress, error, existingThoughtMove, newThoughtSubmit } from '../action-creators'
+import { ConnectedThoughtContainerProps, ConnectedThoughtDispatchProps, ThoughtContainerProps } from './Thought'
+
+// util
+import {
+  parentOf,
+  ellipsize,
+  equalArrays,
+  equalPath,
+  headValue,
+  isDocumentEditable,
+  isEM,
+  pathToContext,
+  isDescendantPath,
+  isRoot,
+  unroot,
+} from '../util'
+
+// selectors
+import {
+  getNextRank,
+  getRankBefore,
+  getSortPreference,
+  hasChild,
+  isBefore,
+  rootedParentOf,
+  visibleDistanceAboveCursor,
+} from '../selectors'
+
+export type ConnectedDraggableThoughtContainerProps =
+  ConnectedThoughtContainerProps &
+  ReturnType<typeof dragCollect> &
+  ReturnType<typeof dropCollect> &
+  ConnectedThoughtDispatchProps
+
+/** Returns true if the thought can be dragged. */
+const canDrag = (props: ConnectedThoughtContainerProps) => {
+  const state = store.getState()
+  const thoughts = pathToContext(props.simplePathLive!)
+  const context = parentOf(pathToContext(props.simplePathLive!))
+  const isDraggable = props.isDraggable || props.isCursorParent
+
+  return isDocumentEditable() &&
+    !!isDraggable &&
+    (!isTouch || globals.touched) &&
+    !hasChild(state, thoughts, '=immovable') &&
+    !hasChild(state, thoughts, '=readonly') &&
+    !hasChild(state, context, '=immovable') &&
+    !hasChild(state, context, '=readonly')
+}
+
+/** Handles drag start. */
+const beginDrag = ({ simplePathLive }: ConnectedThoughtContainerProps) => {
+  store.dispatch(dragInProgress({
+    value: true,
+    draggingThought: simplePathLive,
+    offset: document.getSelection()?.focusOffset,
+  }))
+  return { simplePath: simplePathLive }
+}
+
+/** Handles drag end. */
+const endDrag = () => {
+  store.dispatch([
+    dragInProgress({ value: false }),
+    dragHold({ value: false }),
+    alert(null)
+  ])
+}
+
+/** Collects props from the DragSource. */
+const dragCollect = (connect: DragSourceConnector, monitor: DragSourceMonitor) => ({
+  dragSource: connect.dragSource(),
+  dragPreview: () => connect.dragPreview()(getEmptyImage()),
+  isDragging: monitor.isDragging()
+})
+
+/** Returns true if the ThoughtContainer can be dropped at the given DropTarget. */
+const canDrop = (props: ConnectedThoughtContainerProps, monitor: DropTargetMonitor) => {
+
+  const state = store.getState()
+  const { cursor, expandHoverTopPath } = state
+  const { path } = props
+  const { simplePath: thoughtsFrom } = monitor.getItem()
+  const thoughtsTo = props.simplePathLive!
+  const simpleThoughts = pathToContext(props.simplePathLive!)
+  const context = parentOf(simpleThoughts)
+  const isSorted = getSortPreference(state, context).type !== 'None'
+
+  const distance = cursor ? cursor?.length - thoughtsTo.length : 0
+
+  /** If the epxand hover top is active then all the descenendants of the current active expand hover top path should be droppable. */
+  const isExpandedTop = () => expandHoverTopPath && path.length > expandHoverTopPath.length && isDescendantPath(path, expandHoverTopPath)
+
+  const isHidden = distance >= visibleDistanceAboveCursor(state) && !isExpandedTop()
+
+  const isSelf = equalPath(thoughtsTo, thoughtsFrom)
+  const isDescendantOfFrom = isDescendantPath(thoughtsTo, thoughtsFrom) && !isSelf
+  const oldContext = rootedParentOf(state, thoughtsFrom)
+  const newContext = rootedParentOf(state, thoughtsTo)
+  const sameContext = equalArrays(oldContext, newContext)
+
+  // do not drop on descendants (exclusive) or thoughts hidden by autofocus
+  // allow drop on itself or after itself even  though it is a noop so that drop-hover appears consistently
+  // allow drop if thought is the nearest visible though to the root
+  // allow drop if the thought is the active expanded top context or it's direct children
+  return !isHidden && !isDescendantOfFrom && (!isSorted || !sameContext)
+}
+
+/** Handles dropping a thought on a DropTarget. */
+const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
+
+  // no bubbling
+  if (monitor.didDrop() || !monitor.isOver({ shallow: true })) return
+
+  const state = store.getState()
+
+  const { simplePath: thoughtsFrom } = monitor.getItem()
+  const thoughtsTo = props.simplePathLive!
+  const isRootOrEM = isRoot(thoughtsFrom) || isEM(thoughtsFrom)
+  const oldContext = rootedParentOf(state, thoughtsFrom)
+  const newContext = rootedParentOf(state, thoughtsTo)
+  const sameContext = equalArrays(oldContext, newContext)
+
+  // cannot move root or em context
+  if (isRootOrEM && !sameContext) {
+    store.dispatch(error({ value: `Cannot move the ${isRoot(thoughtsFrom) ? 'home' : 'em'} context to another context.` }))
+    return
+  }
+
+  // drop on itself or after itself is a noop
+  if (equalPath(thoughtsFrom, thoughtsTo) || isBefore(state, thoughtsFrom, thoughtsTo)) return
+
+  const newPath = unroot(parentOf(thoughtsTo)).concat({
+    value: headValue(thoughtsFrom),
+    rank: getRankBefore(state, thoughtsTo)
+  })
+
+  store.dispatch(props.showContexts
+    ? newThoughtSubmit({
+      value: headValue(thoughtsTo),
+      context: pathToContext(thoughtsFrom),
+      rank: getNextRank(state, thoughtsFrom)
+    })
+    : existingThoughtMove({
+      oldPath: thoughtsFrom,
+      newPath
+    })
+  )
+
+  // alert user of move to another context
+  if (!sameContext) {
+
+    // wait until after MultiGesture has cleared the error so this alert does not get cleared
+    setTimeout(() => {
+      const alertFrom = '"' + ellipsize(headValue(thoughtsFrom)) + '"'
+      const alertTo = isRoot(newContext)
+        ? 'home'
+        : '"' + ellipsize(headValue(parentOf(thoughtsTo))) + '"'
+
+      store.dispatch(alert(`${alertFrom} moved to ${alertTo} context.`))
+      clearTimeout(globals.errorTimer)
+      globals.errorTimer = window.setTimeout(() => store.dispatch(alert(null)), 5000)
+    }, 100)
+  }
+}
+
+/** Collects props from the DropTarget. */
+const dropCollect = (connect: DropTargetConnector, monitor: DropTargetMonitor) => ({
+  dropTarget: connect.dropTarget(),
+  isHovering: monitor.isOver({ shallow: true }) && monitor.canDrop(),
+  // is being hovered over current thought irrespective of whether the given item is droppable
+  isBeingHoveredOver: monitor.isOver({ shallow: true }),
+  isDeepHovering: monitor.isOver()
+})
+
+/** A draggable and droppable Thought component. */
+const DragAndDropThought = (thoughtContainer: FC<ConnectedDraggableThoughtContainerProps>) =>
+  DragSource('thought', { canDrag, beginDrag, endDrag }, dragCollect)(
+    DropTarget('thought', { canDrop, drop }, dropCollect)(
+      thoughtContainer
+    )
+  )
+
+export default DragAndDropThought

--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { isTouch } from '../browser'
+import { store } from '../store'
+import { rootedParentOf } from '../selectors'
+import { expandContextThought } from '../action-creators'
+import { headValue, isDivider, isDocumentEditable } from '../util'
+
+// components
+import BulletCursorOverlay from './BulletCursorOverlay'
+import ContextBreadcrumbs from './ContextBreadcrumbs'
+import Divider from './Divider'
+import Editable from './Editable'
+import HomeLink from './HomeLink'
+import Superscript from './Superscript'
+import { ConnectedThoughtProps } from './Thought'
+
+/** A static thought element with overlay bullet, context breadcrumbs, editable, and superscript. */
+const StaticThought = ({
+  cursorOffset,
+  env,
+  hideBullet,
+  homeContext,
+  isDragging,
+  isEditing,
+  isLeaf,
+  path,
+  publish,
+  rank,
+  showContextBreadcrumbs,
+  showContexts,
+  style,
+  simplePath,
+  toggleTopControlsAndBreadcrumbs
+}: ConnectedThoughtProps) => {
+  const isRoot = simplePath.length === 1
+  const isRootChildLeaf = simplePath.length === 2 && isLeaf
+
+  const state = store.getState()
+
+  return <div className='thought'>
+
+    {!(publish && (isRoot || isRootChildLeaf)) && !hideBullet && <BulletCursorOverlay simplePath={simplePath} isDragging={isDragging}/>}
+
+    {showContextBreadcrumbs && !isRoot ? <ContextBreadcrumbs path={rootedParentOf(state, rootedParentOf(state, simplePath))} homeContext={homeContext} />
+    : showContexts && simplePath.length > 2 ? <span className='ellipsis'><a tabIndex={-1}/* TODO: Add setting to enable tabIndex for accessibility */ onClick={() => {
+      store.dispatch(expandContextThought(path))
+    }}>... </a></span>
+    : null}
+
+    {homeContext ? <HomeLink />
+    : isDivider(headValue(simplePath)) ? <Divider path={simplePath} />
+    // cannot use simplePathLive here else Editable gets re-rendered during editing
+    : <Editable
+      path={path}
+      cursorOffset={cursorOffset}
+      disabled={!isDocumentEditable()}
+      isEditing={isEditing}
+      rank={rank}
+      showContexts={showContexts}
+      style={style}
+      simplePath={simplePath}
+      onKeyDownAction={isTouch ? undefined : toggleTopControlsAndBreadcrumbs}
+    />}
+
+    <Superscript simplePath={simplePath} showContexts={showContexts} superscript={false} />
+  </div>
+}
+
+export default StaticThought

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -7,22 +7,17 @@ import { getEmptyImage } from 'react-dnd-html5-backend'
 import { isTouch } from '../browser'
 import { store } from '../store'
 import globals from '../globals'
-import { alert, dragHold, dragInProgress, error, existingThoughtMove, expandContextThought, newThoughtSubmit, setCursor, toggleTopControlsAndBreadcrumbs } from '../action-creators'
+import { alert, dragHold, dragInProgress, error, existingThoughtMove, newThoughtSubmit, setCursor, toggleTopControlsAndBreadcrumbs } from '../action-creators'
 import { DROP_TARGET, MAX_DISTANCE_FROM_CURSOR, TIMEOUT_BEFORE_DRAG } from '../constants'
 import { State } from '../util/initialState'
 import { Child, Context, Index, Lexeme, Path, SimplePath, ThoughtContext } from '../types'
 
 // components
 import Bullet from './Bullet'
-import BulletCursorOverlay from './BulletCursorOverlay'
 import Byline from './Byline'
-import ContextBreadcrumbs from './ContextBreadcrumbs'
-import Divider from './Divider'
-import Editable from './Editable'
-import HomeLink from './HomeLink'
 import Note from './Note'
+import StaticThought from './StaticThought'
 import Subthoughts from './Subthoughts'
-import Superscript from './Superscript'
 import ThoughtAnnotation from './ThoughtAnnotation'
 import useLongPress from '../hooks/useLongPress'
 
@@ -353,7 +348,7 @@ const dropCollect = (connect: DropTargetConnector, monitor: DropTargetMonitor) =
   isDeepHovering: monitor.isOver()
 })
 
-type ConnectedThoughtProps = ThoughtProps &
+export type ConnectedThoughtProps = ThoughtProps &
   Pick<ReturnType<typeof mapDispatchToProps>, 'toggleTopControlsAndBreadcrumbs'>
 
 type ConnectedThoughtContainerProps =
@@ -369,58 +364,6 @@ type ConnectedDraggableThoughtContainerProps =
 /**********************************************************************
  * Components
  **********************************************************************/
-
-/** A single thought element with overlay bullet, context breadcrumbs, editable, and superscript. */
-const Thought = ({
-  cursorOffset,
-  env,
-  hideBullet,
-  homeContext,
-  isDragging,
-  isEditing,
-  isLeaf,
-  path,
-  publish,
-  rank,
-  showContextBreadcrumbs,
-  showContexts,
-  style,
-  simplePath,
-  toggleTopControlsAndBreadcrumbs
-}: ConnectedThoughtProps) => {
-  const isRoot = simplePath.length === 1
-  const isRootChildLeaf = simplePath.length === 2 && isLeaf
-
-  const state = store.getState()
-
-  return <div className='thought'>
-
-    {!(publish && (isRoot || isRootChildLeaf)) && !hideBullet && <BulletCursorOverlay simplePath={simplePath} isDragging={isDragging}/>}
-
-    {showContextBreadcrumbs && !isRoot ? <ContextBreadcrumbs path={rootedParentOf(state, rootedParentOf(state, simplePath))} homeContext={homeContext} />
-    : showContexts && simplePath.length > 2 ? <span className='ellipsis'><a tabIndex={-1}/* TODO: Add setting to enable tabIndex for accessibility */ onClick={() => {
-      store.dispatch(expandContextThought(path))
-    }}>... </a></span>
-    : null}
-
-    {homeContext ? <HomeLink />
-    : isDivider(headValue(simplePath)) ? <Divider path={simplePath} />
-    // cannot use simplePathLive here else Editable gets re-rendered during editing
-    : <Editable
-      path={path}
-      cursorOffset={cursorOffset}
-      disabled={!isDocumentEditable()}
-      isEditing={isEditing}
-      rank={rank}
-      showContexts={showContexts}
-      style={style}
-      simplePath={simplePath}
-      onKeyDownAction={isTouch ? undefined : toggleTopControlsAndBreadcrumbs}
-    />}
-
-    <Superscript simplePath={simplePath} showContexts={showContexts} superscript={false} />
-  </div>
-}
 
 /** A thought container with bullet, thought annotation, thought, and subthoughts.
  *
@@ -627,7 +570,7 @@ const ThoughtContainer = ({
         simplePath={simplePath}
       />
 
-      <Thought
+      <StaticThought
         env={env}
         path={path}
         cursorOffset={cursorOffset}


### PR DESCRIPTION
The Thought component is huge. This PR starts with some easy refactoring to split things up a bit. 

It factors out `StaticThought` which is a simple component that renders all of the thought-related elements within the `ThoughtContainer`: `BulletCursorOverlay`, `ContextBreadcrumbs`, `HomeLink`, `Divider`, `Editable`, and `Superscript`.

This also factor out a `DragAndDropThought` component which mostly encapsulates the react-dnd logic.

They are still tightly coupled and share props, but it's a start.