### PR TITLE
Remove alert components after dismiss alert by clicking the 'x'

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -29,7 +29,7 @@ const AlertWithTransition = ({ alert, close }: AlertComponentProps) => {
     close()
   }
 
-  // If dismissed, set timeout to 0 to remove alert component.
+  // if dismissed, set timeout to 0 to remove alert component immediately. Otherwise it will block toolbar interactions until the timeout completes.
   return <TransitionGroup childFactory={child => !isDismissed ? child : React.cloneElement(child, { timeout: 0 })}>
     {alert
       ? <CSSTransition key={0} timeout={800} classNames='fade' onEntering={() => setDismiss(false)}>

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
@@ -21,12 +21,20 @@ type AlertComponentProps = ReturnType<typeof mapStateToProps> & ReturnType<typeo
 
 /** An alert component with an optional closeLink that fades in and out. */
 const AlertWithTransition = ({ alert, close }: AlertComponentProps) => {
+  const [isDismissed, setDismiss] = useState(false)
 
-  return <TransitionGroup>
+  /** Handle alert close. */
+  const handleClose = () => {
+    setDismiss(true)
+    close()
+  }
+
+  // If dismissed, set timeout to 0 to remove alert component.
+  return <TransitionGroup childFactory={child => !isDismissed ? child : React.cloneElement(child, { timeout: 0 })}>
     {alert
-      ? <CSSTransition key={0} timeout={800} classNames='fade'>
+      ? <CSSTransition key={0} timeout={800} classNames='fade' onEntering={() => setDismiss(false)}>
         { /* Specify a key to force the component to re-render and thus recalculate useSwipeToDismissProps when the alert changes. Otherwise the alert gets stuck off screen in the dismiss state. */ }
-        <AlertComponent alert={alert} onClose={close} key={alert.value} />
+        <AlertComponent alert={alert} onClose={handleClose} key={alert.value} />
       </CSSTransition>
       : null}
   </TransitionGroup>


### PR DESCRIPTION
fixes: #1291  
____
CSSTransition apply *-enter, *-enter-active, *-exit and *-exit-active respectively. When we dismiss the alert, it will stick on *-exit-active class until the timeout ends. And the toolbar stays behind the alert component. So, that's why we can't click the items in the toolbar.
Now, we set the timeout to 0 after clicking the dismiss button to remove alert components from DOM.