### PR TITLE
Mark failed tests as failed on BrowserStack

### DIFF
--- a/src/e2e/webdriverio-environment.js
+++ b/src/e2e/webdriverio-environment.js
@@ -21,6 +21,13 @@ class WebdriverIOEnvironment extends JsDomEnvironment {
     super(config)
   }
 
+  handleTestEvent(event, state) {
+    if (event.name === 'test_fn_failure') {
+      this.global.browser.executeScript(`browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Failed"}}`)
+      console.log(event, state)
+    }
+  }
+
   async setup() {
     console.info(chalk.yellow('Setup Test Environment for webdriverio.'))
     await super.setup()


### PR DESCRIPTION
We can't see whether the test is failed on BrowserStack. And it is really hard to find the failed tests on BrowserStack. After this PR, we can see the test result on BrowserStack.
