### PR TITLE
Prevent moving some meta thoughts on subCategorizeAll

### DIFF
--- a/src/reducers/__tests__/subCategorizeAll.ts
+++ b/src/reducers/__tests__/subCategorizeAll.ts
@@ -1,4 +1,4 @@
-import { HOME_TOKEN } from '../../constants'
+import { HOME_PATH, HOME_TOKEN } from '../../constants'
 import { initialState, reducerFlow } from '../../util'
 import { exportContext } from '../../selectors'
 
@@ -7,7 +7,8 @@ import newSubthought from '../newSubthought'
 import newThought from '../newThought'
 import subCategorizeAll from '../subCategorizeAll'
 import setCursor from '../setCursor'
-import cursorBack from '../cursorBack'
+import importText from '../importText'
+import setCursorFirstMatch from '../../test-helpers/setCursorFirstMatch'
 
 it('subcategorize multiple thoughts', () => {
 
@@ -89,28 +90,50 @@ it('set cursor on new empty thought', () => {
 
 })
 
-it('move all visible and hidden thoughts into a new empty thought after subcategorizeAll', () => {
+it('move all non meta thoughts and only allowed meta thoughts into new empty thought after subCategorizeAll', () => {
+
+  const text = `
+  - a
+    - =archive
+    - =bullet
+    - =focus
+    - =label
+    - =note
+    - =pin
+    - =publish
+    - =style
+    - =view
+    - c
+    - d
+    - e`
 
   const steps = [
-    newThought('b'),
-    newSubthought('=archive'),
-    newThought('c'),
-    newSubthought('d'),
-    cursorBack,
-    subCategorizeAll
+    importText({
+      text,
+      path: HOME_PATH
+    }),
+    setCursorFirstMatch(['a', 'c']),
+    subCategorizeAll,
   ]
 
-  // run steps through reducer flow
+  // run steps through reducer flow and export as plaintext for readable test
   const stateNew = reducerFlow(steps)(initialState())
-
   const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
 
-  const expectedOutput = `- ${HOME_TOKEN}
-  - b
-    -${' '}
-      - =archive
-      - c
-        - d`
 
-  expect(exported).toEqual(expectedOutput)
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - ${''/* prevent trim_trailing_whitespace */}
+      - =style
+      - =view
+      - c
+      - d
+      - e
+    - =archive
+    - =bullet
+    - =focus
+    - =label
+    - =note
+    - =pin
+    - =publish`)
 })

--- a/src/reducers/subCategorizeAll.ts
+++ b/src/reducers/subCategorizeAll.ts
@@ -4,6 +4,16 @@ import { State } from '../util/initialState'
 import { parentOf, ellipsize, headValue, isEM, pathToContext, once, reducerFlow, isRoot } from '../util'
 import { getChildrenRanked, hasChild, lastThoughtsFromContextChain, simplifyPath, splitChain } from '../selectors'
 
+const SUBCATEGORIZE_ALL_META_EXCEPTIONS = [
+  '=archive',
+  '=bullet',
+  '=focus',
+  '=label',
+  '=note',
+  '=pin',
+  '=publish',
+]
+
 /** Inserts a new thought as a parent of all thoughts in the given context. */
 const subCategorizeAll = (state: State) => {
 
@@ -42,6 +52,9 @@ const subCategorizeAll = (state: State) => {
   const children = getChildrenRanked(state, pathToContext(simplifyPath(state, path)))
   const pathParent = cursor.length > 1 ? cursorParent : HOME_PATH
 
+  // filter out meta children that should not be moved
+  const filteredChildren = children.filter(child => !SUBCATEGORIZE_ALL_META_EXCEPTIONS.includes(child.value))
+
   // get newly created thought
   // use fresh state
   const getThoughtNew = once((state: State) => {
@@ -61,7 +74,7 @@ const subCategorizeAll = (state: State) => {
     }),
 
     // move children
-    ...children.map(child =>
+    ...filteredChildren.map(child =>
       (state: State) => moveThought(state, {
         oldPath: cursorParent.concat(child),
         newPath: cursorParent.concat(getThoughtNew(state), child)

--- a/src/reducers/subCategorizeAll.ts
+++ b/src/reducers/subCategorizeAll.ts
@@ -4,15 +4,16 @@ import { State } from '../util/initialState'
 import { parentOf, ellipsize, headValue, isEM, pathToContext, once, reducerFlow, isRoot } from '../util'
 import { getChildrenRanked, hasChild, lastThoughtsFromContextChain, simplifyPath, splitChain } from '../selectors'
 
-const SUBCATEGORIZE_ALL_META_EXCEPTIONS = [
-  '=archive',
-  '=bullet',
-  '=focus',
-  '=label',
-  '=note',
-  '=pin',
-  '=publish',
-]
+// attributes that apply to the parent and should not be moved with subCategorizeAll
+const stationaryMetaAttributes = {
+  '=archive': true,
+  '=bullet': true,
+  '=focus': true,
+  '=label': true,
+  '=note': true,
+  '=pin': true,
+  '=publish': true,
+}
 
 /** Inserts a new thought as a parent of all thoughts in the given context. */
 const subCategorizeAll = (state: State) => {
@@ -53,7 +54,7 @@ const subCategorizeAll = (state: State) => {
   const pathParent = cursor.length > 1 ? cursorParent : HOME_PATH
 
   // filter out meta children that should not be moved
-  const filteredChildren = children.filter(child => !SUBCATEGORIZE_ALL_META_EXCEPTIONS.includes(child.value))
+  const filteredChildren = children.filter(child => !(child.value in stationaryMetaAttributes))
 
   // get newly created thought
   // use fresh state


### PR DESCRIPTION
fixes #1244

# Changes

- Filter out meta exceptions on `subCategorizeAll`.
- Update tests.