### PR TITLE
fix: site crashes when no cursor detected but the splitSentence icon clicked

### DIFF
--- a/src/shortcuts/splitSentences.tsx
+++ b/src/shortcuts/splitSentences.tsx
@@ -24,6 +24,10 @@ const splitSentencesShortcut: Shortcut = {
   exec: (dispatch: Dispatch<Action | Thunk>, getState) => {
     const state = getState()
     const { cursor } = state
+    if (!cursor) {
+      dispatch(alert('Cannot split sentences: no cursor is found.', { alertType: 'splitSentencesErr1', clearTimeout: 3000 }))
+      return
+    }
     const value = headValue(cursor!)
     const sentences = splitSentence(value)
 


### PR DESCRIPTION
Immediately after the site is  loaded, click the split sentence icon. At that time the cursor doesn't point to any thought. The site will crash with the below error:
<img width="1528" alt="Screen Shot 2021-07-01 at 2 43 31 PM" src="https://user-images.githubusercontent.com/5419448/124203220-38f7ee00-daaa-11eb-9fc9-0ee112d60f05.png">

Fixed the above bug.