### PR TITLE
Prevent archived child from getting deleted on deleteEmptyThought

### DIFF
--- a/src/reducers/deleteEmptyThought.ts
+++ b/src/reducers/deleteEmptyThought.ts
@@ -47,6 +47,9 @@ const deleteEmptyThought = (state: State): State => {
   // archive an empty thought with hidden children
   else if (isEmpty && visibleChildren.length === 0) {
     return reducerFlow([
+      // trying to archive child =archive causes an error when it is no longer available to be moved
+      // filter out child =archive to avoid
+      // https://github.com/cybersemics/em/issues/1282
       ...allChildren.map(child => (child.value === '=archive' ? null : archiveThought({ path: [...cursor, child] }))),
       state => {
         const archivedChild = getChildrenRanked(state, context)[0]

--- a/src/reducers/deleteEmptyThought.ts
+++ b/src/reducers/deleteEmptyThought.ts
@@ -47,7 +47,7 @@ const deleteEmptyThought = (state: State): State => {
   // archive an empty thought with hidden children
   else if (isEmpty && visibleChildren.length === 0) {
     return reducerFlow([
-      ...allChildren.map(child => archiveThought({ path: [...cursor, child] })),
+      ...allChildren.map(child => (child.value === '=archive' ? null : archiveThought({ path: [...cursor, child] }))),
       state => {
         const archivedChild = getChildrenRanked(state, context)[0]
         return moveThought(state, {


### PR DESCRIPTION
fixes #1282 

# Cause of issue.

On deleting an empty thought all its hidden thoughts are archived which includes the `=archive` meta child too. Archiving the `=archive` thought will get deleted. So we cannot move already deleted thought to the new archived context.

# Solution
 
Just filtering out the `=archive` meta solves the problem. 

However, we don't get the following expected output as you described in the issue. 

```
- =archive
  - =archive
    - a
```

Since the logic is to copy the archived child to the context above it. Two duplicate `=archive` context will merge together to become this instead

```
=archive
  - a
```

Inorder to get the expected output as you mentioned we need to copy the nested `['', '=archive']` to `['=archive', '=archive']` instead of  `['=archive']` (current implementation).

I have not made this change. Please let me know if this is necessary.

