### PR TITLE
Prevent showing note if the parent is pending or not loaded

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -4,7 +4,7 @@ import { isTouch } from '../browser'
 import { store } from '../store'
 import { attribute, hasChild, isContextViewActive } from '../selectors'
 import { deleteAttribute, editing, setAttribute, setNoteFocus } from '../action-creators'
-import { asyncFocus, selectNextEditable, setSelection, strip } from '../util'
+import { asyncFocus, hashContext, selectNextEditable, setSelection, strip } from '../util'
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable'
 import { Context } from '../types'
 
@@ -27,7 +27,15 @@ const Note = ({ context, onFocus }: NoteProps) => {
   const [justPasted, setJustPasted] = useState(false)
 
   const hasNote = hasChild(state, context, '=note')
-  if (!hasNote || isContextViewActive(state, context)) return null
+
+  /** Check if the note thought is pending or not. */
+  const isNotePending = () => {
+    const hashedContext = hashContext([...context, '=note'])
+    const noteThought = state.thoughts.contextIndex[hashedContext]
+    return !noteThought || noteThought.pending
+  }
+
+  if (!hasNote || isNotePending() || isContextViewActive(state, context)) return null
 
   const note = attribute(state, context, '=note')
 

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -2,9 +2,9 @@ import React, { useRef, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { isTouch } from '../browser'
 import { store } from '../store'
-import { attribute, hasChild, isContextViewActive } from '../selectors'
+import { attribute, getParent, hasChild, isContextViewActive } from '../selectors'
 import { deleteAttribute, editing, setAttribute, setNoteFocus } from '../action-creators'
-import { asyncFocus, hashContext, selectNextEditable, setSelection, strip } from '../util'
+import { asyncFocus, selectNextEditable, setSelection, strip } from '../util'
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable'
 import { Context } from '../types'
 
@@ -30,8 +30,7 @@ const Note = ({ context, onFocus }: NoteProps) => {
 
   /** Check if the note thought is pending or not. */
   const isNotePending = () => {
-    const hashedContext = hashContext([...context, '=note'])
-    const noteThought = state.thoughts.contextIndex[hashedContext]
+    const noteThought = getParent(state, [...context, '=note'])
     return !noteThought || noteThought.pending
   }
 


### PR DESCRIPTION
fixes #1256 

# Changes
 - Add check to not show `Note` if the related `Parent` has not been loaded or if it is pending.

@raineorshine Should we write a test for this? We may need to mock `store.getState` to mimick the pending parent.