### PR TITLE
Prevent second onTap when gesture is below threshold

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -651,9 +651,15 @@ const Editable = ({
 
   /** Sets the cursor on the thought on mousedown or tap. Handles hidden elements, drags, and editing mode. */
   const onTap = (e: React.MouseEvent | React.TouchEvent) => {
-    // Stop propagation to not trigger onMouseDown event of Content.
+    // stop propagation to prevent clickOnEmptySpace onClick handler in Content component
     if (e.nativeEvent instanceof MouseEvent) {
       e.stopPropagation()
+    }
+    // when the MultiGesture is below the gesture threshold it is possible that onTap and onMouseDown are both triggered
+    // in this case, we need to prevent onTap from being called a second time via onMouseDown
+    // https://github.com/cybersemics/em/issues/1268
+    else if (globals.touching) {
+      e.preventDefault()
     }
 
     const state = store.getState()

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -187,10 +187,12 @@ class MultiGesture extends React.Component<MultiGestureProps> {
 
   static defaultProps: MultiGestureProps = {
     // the distance threshold for a single gesture
-    threshold: 12,
+    // if this is too high, there is an awkward distance between a click and a gesture where nothing happens
+    // related: https://github.com/cybersemics/em/issues/1268
+    threshold: 3,
 
     // the distance to allow scrolling before abandoning the gesture
-    scrollThreshold: 12,
+    scrollThreshold: 15,
 
     // fired at the start of a gesture
     // includes false starts


### PR DESCRIPTION
Fixes #1268