### PR TITLE
Fixes deleteEmptyThought for thoughts with archived children

### DIFF
--- a/src/reducers/__tests__/deleteEmptyThought.ts
+++ b/src/reducers/__tests__/deleteEmptyThought.ts
@@ -14,6 +14,7 @@ import newSubthought from '../newSubthought'
 import newThought from '../newThought'
 import setCursor from '../setCursor'
 import importTextReducer from '../importText'
+import archiveThought from '../archiveThought'
 
 it('delete empty thought', () => {
   const steps = [newThought('a'), newThought(''), deleteEmptyThought]
@@ -70,6 +71,33 @@ it("archive thought with hidden children - arvhive all children in cursor's pare
   - =archive
     - =a
     - =b`)
+})
+
+it("archive thought with archived and hidden children - arvhive all children in cursor's parent", () => {
+  const steps = [
+    importTextReducer({
+      text: `
+        -
+          - =a
+          - b
+          - =c`,
+    }),
+    setCursorFirstMatch(['', 'b']),
+    archiveThought({}),
+    setCursorFirstMatch(['']),
+    deleteEmptyThought,
+  ]
+
+  // run steps through reducer flow and export as plaintext for readable test
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - =archive
+    - =a
+    - b
+    - =c`)
 })
 
 it('do nothing if there is no cursor', () => {

--- a/src/reducers/deleteEmptyThought.ts
+++ b/src/reducers/deleteEmptyThought.ts
@@ -14,6 +14,7 @@ import {
   getNextRank,
   getChildren,
   getChildrenRanked,
+  getAllChildren,
   isContextViewActive,
   prevSibling,
   simplifyPath,
@@ -49,7 +50,7 @@ const deleteEmptyThought = (state: State): State => {
   else if (isEmpty && visibleChildren.length === 0) {
     return reducerFlow([
       // archive all children
-      // if a child is already archived, move it to the parent instead
+      // if a child is already archived, move it to the parent
       // https://github.com/cybersemics/em/issues/864
       // https://github.com/cybersemics/em/issues/1282
       ...allChildren.map(child => {
@@ -61,13 +62,13 @@ const deleteEmptyThought = (state: State): State => {
             })
       }),
 
-      // move the archive up a level so it does not get permanently deleted
+      // move the child archive up a level so it does not get permanently deleted
       state => {
-        const archivedChild = getChildrenRanked(state, context)[0]
-        return archivedChild
+        const childArchive = getAllChildren(state, context).find(child => child.value === '=archive')
+        return childArchive
           ? moveThought(state, {
-              oldPath: [...cursor, archivedChild],
-              newPath: [...parentOf(cursor), archivedChild],
+              oldPath: [...cursor, childArchive],
+              newPath: [...parentOf(cursor), childArchive],
             })
           : state
       },

--- a/src/util/isThoughtArchived.ts
+++ b/src/util/isThoughtArchived.ts
@@ -2,4 +2,4 @@ import { equalThoughtValue } from '../util'
 import { Path } from '../types'
 
 /** Determines whether a thought is archived or not. */
-export const isThoughtArchived = (path: Path) => path.some(equalThoughtValue('=archive')) || false
+export const isThoughtArchived = (path: Path) => path.some(equalThoughtValue('=archive'))


### PR DESCRIPTION
fixes #864 

As described in [this comment](https://github.com/cybersemics/em/issues/864#issuecomment-813031897), the deleteEmptyThought didn't work as expected for archived children. 

Problem - we were trying to [archive all hidden children](https://github.com/cybersemics/em/blob/139130d3595fac8358a2cc6746d8b0e89fe58f76/src/reducers/deleteEmptyThought.ts#L50) of the empty thought, but the `archiveThoughts` handles one type of hidden thoughts differently - the thoughts that are already archived. Such thoughts get deleted based on [this condition](https://github.com/cybersemics/em/blob/139130d3595fac8358a2cc6746d8b0e89fe58f76/src/reducers/archiveThought.ts#L135), which isn't what we intend to do here. 

Solution - Do not try to archive the already archived thoughts, and simply move them to the parent instead.