### PR TITLE
dragInProgress: Turn off globals.touching when drag ends

### DIFF
--- a/src/action-creators/dragInProgress.ts
+++ b/src/action-creators/dragInProgress.ts
@@ -2,6 +2,7 @@ import { Thunk, Path, SimplePath } from '../types'
 import { DROP_TARGET } from '../constants'
 import expandOnHoverTop from './expandOnHoverTop'
 import expandOnHoverBottom from './expandOnHoverBottom'
+import globals from '../globals'
 
 interface Payload {
   value: boolean
@@ -15,6 +16,11 @@ interface Payload {
 const dragInProgress =
   (payload: Payload): Thunk =>
   dispatch => {
+    // react-dnd stops propagation of the TouchMonitor's touchend event, so we need to turn off globals.touching here
+    if (!payload.value) {
+      globals.touching = false
+    }
+
     dispatch({
       type: 'dragInProgress',
       ...payload,


### PR DESCRIPTION
Fixes #1331

react-dnd stops propagation of the TouchMonitor's touchend event, so we need to turn off globals.touching manually.