### PR TITLE
Optimize and re-enable undo/redo

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "fp-and-or": "^0.1.3",
     "himalaya": "^1.1.0",
     "html-escaper": "^3.0.3",
-    "immer": "^9.0.3",
+    "immer": "^9.0.5",
     "indexeddbshim": "^7.1.0",
     "ipfs-http-client": "^43.0.1",
     "jex-block-parser": "^1.0.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -197,9 +197,8 @@ export const MAX_EXPAND_DEPTH = 5
 // shortcut ids of default buttons that appear in the toolbar
 // otherwise read from Settings thought
 export const TOOLBAR_DEFAULT_SHORTCUTS = [
-  // disable undo/redo until deepClone is optimized
-  // 'undo',
-  // 'redo',
+  'undo',
+  'redo',
   // 'search',
   'outdent',
   'indent',

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,9 +13,7 @@ import pullQueue from './redux-middleware/pullQueue'
 import updateUrlHistory from './redux-middleware/updateUrlHistory'
 import appReducer from './reducers/app'
 import cursorChangedEnhancer from './redux-enhancers/cursorChanged'
-
-// disabled until deepClone performance can be fixed
-// import undoRedoReducerEnhancer from './redux-enhancers/undoRedoReducerEnhancer'
+import undoRedoReducerEnhancer from './redux-enhancers/undoRedoReducerEnhancer'
 
 const composeEnhancers = composeWithDevTools({ trace: true })
 
@@ -27,6 +25,7 @@ export const store = createStore(
   appReducer,
   composeEnhancers(
     applyMiddleware(multi, thunk, pushQueue, pullQueue, updateUrlHistory),
-    /* undoRedoReducerEnhancer, */ cursorChangedEnhancer,
+    undoRedoReducerEnhancer,
+    cursorChangedEnhancer,
   ),
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9478,10 +9478,10 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
-immer@^9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.3.tgz#146e2ba8b84d4b1b15378143c2345559915097f4"
-  integrity sha512-mONgeNSMuyjIe0lkQPa9YhdmTv8P19IeHV0biYhcXhbd5dhdB9HSK93zBpyKjp6wersSUgT5QyU0skmejUVP2A==
+immer@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
+  integrity sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
fixes #1332 

Tried replacing [deepclone](https://github.com/Starcounter-Jack/JSON-Patch#jsonpatchdeepclonevalue-any-any) with immer's [produce](https://immerjs.github.io/immer/produce) for optimizing the undo/redo operations, and it seems to improve the performance by at least 5-6x. Further testing would be helpful for providing detailed insights.