### PR TITLE
[bug-fix]: fix touch start warning on dev

### DIFF
--- a/src/components/Superscript.native.tsx
+++ b/src/components/Superscript.native.tsx
@@ -4,6 +4,8 @@ import { hasLexeme, getContexts, rootedParentOf } from '../selectors'
 import { HOME_TOKEN } from '../constants'
 import { parentOf, equalArrays, head, headValue, pathToContext } from '../util'
 import { Child, Context, Index, SimplePath, State } from '../@types'
+import { Text } from './Text.native'
+import { commonStyles } from '../style/commonStyles'
 
 interface SuperscriptProps {
   contextViews?: Index<boolean>
@@ -63,19 +65,19 @@ const Superscript: FC<SuperscriptProps> = ({ empty, numContexts, showSingle, sup
   //   .reduce((charCount, child) => charCount + child.length, 0)
 
   return (
-    <span className='superscript-container'>
+    <Text style={commonStyles.whiteText}>
       {
         !empty && superscript && numContexts! > (showSingle ? 0 : 1) ? (
-          <span className='num-contexts'>
+          <Text>
             {' '}
             {/* Make the container position:relative so that the modal is positioned correctly */}
             {numContexts ? <sup>{numContexts}</sup> : null}
             {/* render the depth-bar inside the superscript so that it gets re-rendered with it */}
             {/* <DepthBar/> */}
-          </span>
+          </Text>
         ) : null /* <DepthBar/> */
       }
-    </span>
+    </Text>
   )
 }
 


### PR DESCRIPTION
This PR fixes the warning ⚠️ below on dev env.

```shell
Cannot record touch end without a touch start.
 Touch End: {"identifier":0,"pageX":336,"pageY":117,"timestamp":5076.699999928474}
 Touch Bank: []
```

This warning was caused by #1353 where we mistakenly added native code to the superscript web component. Solved by adding creating a native version of the superscript and reverted the web superscript to its original implementation. 