### PR TITLE
Set caret after applying bump thought down

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames'
 import {
   alert,
   cursorBack,
-  editing,
   error,
   editThought,
   importText,
@@ -16,6 +15,7 @@ import {
   setInvalidState,
   tutorialNext,
   newThought,
+  editing as editingAction,
 } from '../action-creators'
 import { isTouch, isSafari } from '../browser'
 import globals from '../globals'
@@ -135,6 +135,7 @@ interface EditableProps {
   */
   transient?: boolean
   onKeyDownAction?: () => void
+  editing?: boolean | null
 }
 
 interface Alert {
@@ -192,6 +193,7 @@ const Editable = ({
   onKeyDownAction,
   dispatch,
   transient,
+  editing,
 }: Connected<EditableProps>) => {
   const state = store.getState()
   const thoughts = pathToContext(simplePath)
@@ -432,7 +434,7 @@ const Editable = ({
       shortcutEmitter.off('shortcut', flush)
       showDuplicationAlert(false, dispatch)
     }
-  }, [isEditing, cursorOffset, state.dragInProgress])
+  }, [isEditing, cursorOffset, state.dragInProgress, editing])
 
   /** Performs meta validation and calls thoughtChangeHandler immediately or using throttled reference. */
   const onChangeHandler = (e: ContentEditableEvent) => {
@@ -618,7 +620,7 @@ const Editable = ({
           !window.getSelection()?.focusNode ||
           !window.getSelection()?.focusNode?.parentElement?.classList.contains('editable')
         ) {
-          dispatch(editing({ value: false }))
+          dispatch(editingAction({ value: false }))
         }
       }
     })

--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -31,6 +31,7 @@ const StaticThought = ({
   style,
   simplePath,
   toggleTopControlsAndBreadcrumbs,
+  editing,
 }: ConnectedThoughtProps) => {
   const isRoot = simplePath.length === 1
   const isRootChildLeaf = simplePath.length === 2 && isLeaf
@@ -70,6 +71,7 @@ const StaticThought = ({
         <Editable
           path={path}
           cursorOffset={cursorOffset}
+          editing={editing}
           disabled={!isDocumentEditable()}
           isEditing={isEditing}
           rank={rank}

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -106,6 +106,7 @@ interface ThoughtProps {
   style?: React.CSSProperties
   simplePath: SimplePath
   view?: string | null
+  editing?: boolean | null
 }
 
 export type ConnectedThoughtProps = ThoughtProps &
@@ -125,7 +126,7 @@ const getGlobalBullet = (key: string) => GLOBAL_STYLE_ENV[key as keyof typeof GL
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const mapStateToProps = (state: State, props: ThoughtContainerProps) => {
-  const { cursor, cursorOffset, expanded, expandedContextThought, search, expandHoverTopPath } = state
+  const { cursor, cursorOffset, expanded, expandedContextThought, search, expandHoverTopPath, editing } = state
 
   const { path, simplePath, showContexts, depth } = props
 
@@ -179,6 +180,7 @@ const mapStateToProps = (state: State, props: ThoughtContainerProps) => {
     publish: !search && publishMode(),
     simplePathLive,
     view: attribute(state, contextLive, '=view'),
+    editing,
   }
 }
 
@@ -244,6 +246,7 @@ const ThoughtContainer = ({
   simplePathLive,
   view,
   toggleTopControlsAndBreadcrumbs,
+  editing,
 }: ConnectedDraggableThoughtContainerProps) => {
   const state = store.getState()
 
@@ -477,6 +480,7 @@ const ThoughtContainer = ({
             simplePath={simplePath}
             toggleTopControlsAndBreadcrumbs={toggleTopControlsAndBreadcrumbs}
             view={view}
+            editing={editing}
           />
 
           <Note context={thoughtsLive} onFocus={setCursorOnNote({ path: path })} />

--- a/src/e2e/iOS/__tests__/caret.ts
+++ b/src/e2e/iOS/__tests__/caret.ts
@@ -230,3 +230,27 @@ it('Swipe over hidden thought', async () => {
 
   expect(previousSibling).toBe('y')
 })
+
+it('Bump Thought Down on a thought that has children', async () => {
+  await newThought('foo')
+  await newThought('bar', { insertNewSubthought: true })
+  await hideKeyboardByTappingDone()
+
+  const editableNodeHandle = await getEditable('foo')
+  await tap(editableNodeHandle)
+
+  await gesture(gestures.bumpThoughtDown)
+  const newThoughtEditable = await editThought('new')
+  const selectionTextContent = await getSelection().focusNode?.textContent
+
+  const childrenTexts = await ref().execute((newThoughtEditable: Element<'async'>) => {
+    const children = (newThoughtEditable as unknown as HTMLElement)
+      .closest('ul.children')
+      ?.firstElementChild?.getElementsByTagName('ul')[0]
+      ?.getElementsByClassName('editable') as HTMLCollection
+    return Array.from(children).map(x => (x as HTMLElement).innerText)
+  }, newThoughtEditable)
+
+  expect(selectionTextContent).toBe('new')
+  expect(childrenTexts).toEqual(['foo', 'bar'])
+})

--- a/src/e2e/iOS/helpers/editThought.ts
+++ b/src/e2e/iOS/helpers/editThought.ts
@@ -8,7 +8,7 @@ import waitForEditable from './waitForEditable'
  * */
 const editThought = async (browser: Browser<'async'>, value: string) => {
   await browser.sendKeys([value])
-  await waitForEditable(browser, value)
+  return await waitForEditable(browser, value)
 }
 
 export default editThought

--- a/src/reducers/bumpThoughtDown.ts
+++ b/src/reducers/bumpThoughtDown.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import _ from 'lodash'
 import { editThought, moveThought, createThought, setCursor, subCategorizeOne, editableRender } from '../reducers'
 import { getPrevRank, getRankBefore, getAllChildren, simplifyPath, rootedParentOf } from '../selectors'
@@ -60,6 +61,8 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
     // set cursor
     setCursor({
       path: simplePathWithNewRankAndValue,
+      offset: state.cursorOffset === 0 ? state.cursorOffset + 1 : 0, //trigger useEffect callback on Editable component
+      editing: true,
     }),
     editableRender,
   ])(state)

--- a/src/reducers/bumpThoughtDown.ts
+++ b/src/reducers/bumpThoughtDown.ts
@@ -62,6 +62,7 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
     setCursor({
       path: simplePathWithNewRankAndValue,
       editing: true,
+      offset: 0,
     }),
     editableRender,
   ])(state)

--- a/src/reducers/bumpThoughtDown.ts
+++ b/src/reducers/bumpThoughtDown.ts
@@ -61,7 +61,6 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
     // set cursor
     setCursor({
       path: simplePathWithNewRankAndValue,
-      offset: state.cursorOffset === 0 ? state.cursorOffset + 1 : 0, //trigger useEffect callback on Editable component
       editing: true,
     }),
     editableRender,

--- a/src/shortcuts/bumpThoughtDown.ts
+++ b/src/shortcuts/bumpThoughtDown.ts
@@ -1,5 +1,5 @@
 import { asyncFocus, isDocumentEditable } from '../util'
-import { bumpThoughtDown, setCursor } from '../action-creators'
+import { bumpThoughtDown } from '../action-creators'
 import { Shortcut } from '../@types'
 
 const bumpThoughtDownShortcut: Shortcut = {
@@ -9,24 +9,12 @@ const bumpThoughtDownShortcut: Shortcut = {
   gesture: 'rld',
   keyboard: { key: 'd', meta: true, alt: true },
   canExecute: getState => !!getState().cursor && isDocumentEditable(),
-  exec: (dispatch, getState) => {
-    asyncFocus()
+  exec: dispatch => {
+    // If there is already active selection, no need to focus to the hidden input.
+    if (!window.getSelection()?.focusNode) {
+      asyncFocus()
+    }
     dispatch(bumpThoughtDown())
-
-    // trigger useEffect callback on Editable component by causing a change on isEditing props
-    const cursor = getState().cursor
-    dispatch(
-      setCursor({
-        path: null,
-      }),
-    )
-    dispatch(
-      setCursor({
-        path: cursor,
-        offset: 0,
-        editing: true,
-      }),
-    )
   },
 }
 

--- a/src/shortcuts/bumpThoughtDown.ts
+++ b/src/shortcuts/bumpThoughtDown.ts
@@ -1,5 +1,5 @@
 import { asyncFocus, isDocumentEditable } from '../util'
-import { bumpThoughtDown } from '../action-creators'
+import { bumpThoughtDown, setCursor } from '../action-creators'
 import { Shortcut } from '../@types'
 
 const bumpThoughtDownShortcut: Shortcut = {
@@ -9,9 +9,24 @@ const bumpThoughtDownShortcut: Shortcut = {
   gesture: 'rld',
   keyboard: { key: 'd', meta: true, alt: true },
   canExecute: getState => !!getState().cursor && isDocumentEditable(),
-  exec: dispatch => {
+  exec: (dispatch, getState) => {
     asyncFocus()
     dispatch(bumpThoughtDown())
+
+    // trigger useEffect callback on Editable component by causing a change on isEditing props
+    const cursor = getState().cursor
+    dispatch(
+      setCursor({
+        path: null,
+      }),
+    )
+    dispatch(
+      setCursor({
+        path: cursor,
+        offset: 0,
+        editing: true,
+      }),
+    )
   },
 }
 

--- a/src/test-helpers/constants.ts
+++ b/src/test-helpers/constants.ts
@@ -3,6 +3,7 @@ import { GesturePath } from '../@types'
 enum gestureEnum {
   newSubThought = 'rdr',
   newThought = 'rd',
+  bumpThoughtDown = 'rld',
 }
 
 // widen the type of the gestureEnum values to GesturePath using a mapped type


### PR DESCRIPTION
fixes: #1354 

-------

We are changing the value of the current thought in bumpThoughtDown.ts and the `useEffect` callback that is related to setSelection logic is not triggered in the `Editable` component.

https://github.com/cybersemics/em/blob/4db13c0b6d84b3531684b6c65e51d4f86b42c409/src/components/Editable.tsx#L360

The useEffect callback is triggered only if the following value change: `isEditing, cursorOffset, state.dragInProgress`

As a solution, I changed the `cursorOffset` in bumpThoughtDown.ts and also set the 'editing' state to true to be able to set caret. I don't want to broke stuff that is related to caret logic and Editable so, that's why I choose this way.  If you have a better idea we can change this logic.