### PR TITLE
set editing state to false on Editable on-unmount

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -360,6 +360,16 @@ const Editable = ({
   }
 
   useEffect(() => {
+    // Set editing to false after unmount
+    return () => {
+      const { cursor, editing } = store.getState()
+      if (editing && equalPath(cursor, path)) {
+        dispatch(editingAction({ value: false }))
+      }
+    }
+  }, [])
+
+  useEffect(() => {
     const { editing, noteFocus, dragHold } = state
 
     // focus on the ContentEditable element if editing os on desktop

--- a/src/e2e/puppeteer/__tests__/caret.ts
+++ b/src/e2e/puppeteer/__tests__/caret.ts
@@ -3,6 +3,7 @@
  */
 import { devices } from 'puppeteer'
 import helpers from '../helpers'
+import { WindowEm } from '../../../initialize'
 
 jest.setTimeout(20000)
 
@@ -188,6 +189,7 @@ describe('mobile only', () => {
     waitForHiddenEditable,
     waitForState,
     clickThought,
+    ref,
   } = helpers({ emulatedDevice: devices['iPhone 11'] })
 
   it('when subCategorizeOne, caret should be on new thought', async () => {
@@ -232,5 +234,26 @@ describe('mobile only', () => {
 
     const cursorText = await getEditingText()
     expect(cursorText).toBe('B')
+  })
+
+  it('while editing true, after opening modal the editing should be false', async () => {
+    const importText = `
+    - A
+      - B`
+
+    await paste(importText)
+
+    const editableNodeHandle = await waitForEditable('B')
+    await click(editableNodeHandle, { horizontalClickLine: 'left' })
+    await click(editableNodeHandle, { horizontalClickLine: 'left' })
+
+    await waitForState('editing', true)
+
+    await click('#exportContext')
+    await click('.popup-close-x')
+
+    await waitForState('editing', false)
+    const editingValue = await ref().evaluate(() => (window.em as WindowEm).testHelpers.getState().editing)
+    expect(editingValue).toBe(false)
   })
 })


### PR DESCRIPTION
fixes: #1347 

I didn't write iOS test as iOS tests take a long time to run. But good news, this issue was producible on mobile-view and I wrote puppeteer test 🐣 