### PR TITLE
Refactor toolbar re-rendering.

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "redux": "^4.1.0",
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "sanitize-html": "^2.4.0",
     "truncate-html": "^1.0.3",
     "ts-key-enum": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15781,6 +15781,11 @@ reselect@^3.0.1:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
   integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-alpn@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.1.2.tgz#30b60cfbb0c0b8dc897940fe13fe255afcdd4d28"


### PR DESCRIPTION
fixes #1396

# Change

- Separate toolbar icons into separate component `ToolbarIcon`
- Add `reselect` memoized selectors to re-render only when active or exec status of toolbar icons are changed.
- Remove `thoughts` and `cursor` from `mapStateToProps` in `Toolbar`.