### PR TITLE
Remove tags from thoughts instead of whole exported content

### DIFF
--- a/src/selectors/__tests__/exportContext.ts
+++ b/src/selectors/__tests__/exportContext.ts
@@ -173,3 +173,25 @@ it('export as markdown without escaping metaprogramming attributes', () => {
   expect(exported).toBe(`- Hello **wor*ld***
   - =readonly`)
 })
+
+it('export as plain text replacing html tags only from thoughts and not from the whole exported content.', () => {
+  const text = `
+  - a
+  - <
+  - b
+  - />
+  - c
+  `
+
+  const steps = [importText({ text }), setCursorFirstMatch([text])]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+  - <
+  - b
+  - />
+  - c`)
+})

--- a/src/selectors/__tests__/exportContext.ts
+++ b/src/selectors/__tests__/exportContext.ts
@@ -174,7 +174,7 @@ it('export as markdown without escaping metaprogramming attributes', () => {
   - =readonly`)
 })
 
-it('export as plain text replacing html tags only from thoughts and not from the whole exported content.', () => {
+it('export as plain and markdown text replacing html tags only from thoughts and not from the whole exported content.', () => {
   const text = `
   - a
   - <
@@ -186,9 +186,18 @@ it('export as plain text replacing html tags only from thoughts and not from the
   const steps = [importText({ text }), setCursorFirstMatch([text])]
 
   const stateNew = reducerFlow(steps)(initialState())
-  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+  const exportedPlain = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
 
-  expect(exported).toBe(`- ${HOME_TOKEN}
+  expect(exportedPlain).toBe(`- ${HOME_TOKEN}
+  - a
+  - <
+  - b
+  - />
+  - c`)
+
+  const exportedMarkdown = exportContext(stateNew, [HOME_TOKEN], 'text/markdown')
+
+  expect(exportedMarkdown).toBe(`- ${HOME_TOKEN}
   - a
   - <
   - b

--- a/src/selectors/exportContext.ts
+++ b/src/selectors/exportContext.ts
@@ -85,10 +85,12 @@ export const exportContext = (
   // Get the thought under process
   // If it is root, then do not convert it to markdown
   const currentThought = head(context)
+  const value = format === 'text/plain' ? currentThought.replace(REGEXP_TAGS, '') : currentThought
+
   const markdownText: string =
     format === 'text/markdown' && !isHome([currentThought]) && !currentThought.includes('=')
       ? turndownService.turndown(currentThought)
-      : currentThought
+      : value
 
   // Handle newlines in thoughts.
   // This should never happen (newlines are converted to separate thoughts on import) but guard against newlines just in case.
@@ -103,9 +105,7 @@ export const exportContext = (
     exportedChildren && format === 'text/html' ? tab1 : ''
   }${exportedChildren}${linePostfix}`
 
-  const textFinal = format === 'text/plain' ? textWithChildren.replace(REGEXP_TAGS, '') : textWithChildren
-
-  const output = indent === 0 && format === 'text/html' ? `<ul>\n  ${textFinal}\n</ul>` : textFinal
+  const output = indent === 0 && format === 'text/html' ? `<ul>\n  ${textWithChildren}\n</ul>` : textWithChildren
 
   /** Replaces the title of the output. */
   const outputReplaceTitle = (output: string) => (title ? replaceTitle(output, title, format) : output)


### PR DESCRIPTION
fixes #1446 

# Cause of the issue

`exportContext` used regex to remove HTML tags from the whole exported content. So for the given content below

```
- a
- <
- b
- />
- c
```
This part gets removed.

```
<
- b
- />
```

resulting in the final content 

```
- a
- 
- c
```

# Solution

Removed the tags from the individual thought value instead.