### PR TITLE
Fix =focus zoom edit mode issue

### DIFF
--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -728,6 +728,8 @@ export const SubthoughtsComponent = ({
               (attribute(state, [...childContext, '=focus', 'Zoom'], '=bullet') === 'None' ||
                 (!!childContextEnvZoom() && attribute(state, childContextEnvZoom()!, '=bullet') === 'None'))
 
+            const appendedChildPath = appendChildPath(state, childPath, path)
+            const isChildCursor = cursor && equalPath(appendedChildPath, state.cursor)
             /*
             simply using index i as key will result in very sophisticated rerendering when new Empty thoughts are added.
             The main problem is that when a new Thought is added it will get key (index) of the previous thought,
@@ -747,12 +749,15 @@ export const SubthoughtsComponent = ({
                 // @MIGRATION_TODO: Child.id changes based on context due to intermediate migration steps. So we cannot use child.id as key. Fix this after migration is complete.
                 key={`${child.rank}${child.id ? '-context' : ''}`}
                 rank={child.rank}
-                isVisible={actualDistance() < 2 || (distance === 2 && isEditingChildPath())}
+                isVisible={
+                  // if thought is a zoomed cursor then it is visible
+                  (isChildCursor && !!zoomCursor) || actualDistance() < 2 || (distance === 2 && isEditingChildPath())
+                }
                 showContexts={showContexts}
                 prevChild={filteredChildren[i - 1]}
                 isParentHovering={isParentHovering}
                 style={Object.keys(style).length > 0 ? style : undefined}
-                path={appendChildPath(state, childPath, path)}
+                path={appendedChildPath}
                 simplePath={childPath}
               />
             ) : null

--- a/src/e2e/puppeteer/__tests__/focusZoom.ts
+++ b/src/e2e/puppeteer/__tests__/focusZoom.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment ./src/e2e/puppeteer-environment.js
+ */
+
+import { delay } from '../../../test-helpers/delay'
+import helpers from '../helpers'
+
+jest.setTimeout(20000)
+
+const { paste, getEditable, waitForEditable, clickBullet, getComputedColor, clickThought } = helpers()
+
+/**
+ * Get alpha value from the rgba string.
+ */
+const parseAlphaFromRGBA = (value: string) => {
+  const regex = /rgba\(\d{1,3},\d{1,3},\d{1,3},(.{1,})\)/
+  const matches = regex.exec(value.replace(/ /g, ''))
+  return matches && matches[1]
+}
+
+it('Hide siblings when curor has focus zoom.', async () => {
+  const importText = `
+  - a
+  - b
+    - =focus
+      - Zoom`
+
+  await paste(importText)
+  await waitForEditable('b')
+  await clickThought('b')
+
+  await waitForEditable('a')
+
+  // TODO: Create a waitForTransitionEnd helper
+  // wait for animation to complete
+  await delay(700)
+  const editableNodeA = (await getEditable('a')).asElement()
+  expect(editableNodeA).toBeDefined()
+
+  const color = await getComputedColor(editableNodeA!)
+
+  expect(parseAlphaFromRGBA(color)).toBe('0')
+})
+
+it('Allow edit mode when cursor has focus zoom.', async () => {
+  // Related issue: https://github.com/cybersemics/em/issues/1448
+  const importText = `
+  - a
+  - b
+    - =focus
+      - Zoom`
+
+  await paste(importText)
+  await waitForEditable('b')
+  await waitForEditable('a')
+
+  await clickThought('a')
+  await clickBullet('b')
+
+  // TODO: Create a waitForTransitionEnd helper
+  // wait for animation to complete
+  await delay(700)
+
+  const editableNodeA = (await getEditable('a')).asElement()
+  expect(editableNodeA).toBeDefined()
+
+  const color = await getComputedColor(editableNodeA!)
+  expect(parseAlphaFromRGBA(color)).toBe('0')
+
+  await clickThought('b')
+
+  // wait for animation to complete
+  await delay(700)
+
+  const editableNodeAUpdated = (await getEditable('a')).asElement()
+  expect(editableNodeAUpdated).toBeDefined()
+
+  const colorUpdated = await getComputedColor(editableNodeAUpdated!)
+  expect(parseAlphaFromRGBA(colorUpdated)).toBe('0')
+})

--- a/src/e2e/puppeteer/helpers/getComputedColor.ts
+++ b/src/e2e/puppeteer/helpers/getComputedColor.ts
@@ -1,0 +1,16 @@
+/* eslint-disable fp/no-loops */
+import { ElementHandle, Page } from 'puppeteer'
+
+/**
+ * Get computed color.
+ */
+const getComputedColor = async (page: Page, element: ElementHandle) => {
+  const styleHandle = await page.evaluateHandle(elementHandle => {
+    const cssDeclarationObject = window.getComputedStyle(elementHandle)
+    return cssDeclarationObject.color
+  }, element)
+  const color = await styleHandle.jsonValue()
+  return color as string
+}
+
+export default getComputedColor

--- a/src/e2e/puppeteer/helpers/index.ts
+++ b/src/e2e/puppeteer/helpers/index.ts
@@ -6,6 +6,7 @@ import $ from './$'
 import click from './click'
 import clickBullet from './clickBullet'
 import clickThought from './clickThought'
+import getComputedColor from './getComputedColor'
 import getEditable from './getEditable'
 import getEditingText from './getEditingText'
 import getSelection from './getSelection'
@@ -35,6 +36,7 @@ const helpers = {
   click,
   clickBullet,
   clickThought,
+  getComputedColor,
   getEditable,
   getEditingText,
   getSelection,


### PR DESCRIPTION
fixes #1448 

# Cause of the issue.

This regression seems to be  introduced in this commit https://github.com/cybersemics/em/commit/e348617679eeb35479b9452a01f135802b3541d5 

When `isHiddenByAutofocus ` was replaced by `isVisible`. Strangely we cannot see the changes in this commit that removed the use of `isHiddenByAutofocus `. But `isHiddenByAutofocus ` is still available on a commit before it. So I assume this was the point of regression.

Since `isVisible` is based on `actualDistance` it doesn't properly determine if the thought is visible or not. Especially in the case of the focus zoom. A cursor that is focused zoomed will always be visible . However, the logic that calculated `isVisible` didn't include it . So this was causing the `cursorBack` issue.

# Solution

I added the necessary logic to make sure that the focus zoomed cursor has `isVisible` true. I also wrote some puppeteer tests for focus zoom.
