### PR TITLE
Added markdown formatting to thoughts for bold and italics.

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -249,7 +249,7 @@ const Editable = ({
 
   // side effect to set old value ref to head value from updated simplePath.
   useEffect(() => {
-    oldValueRef.current = value
+    oldValueRef.current = isEditing ? removeMarkdownFormatting(value) : formatMarkdown(value)
   }, [value])
 
   /** Set or reset invalid state. */
@@ -768,10 +768,10 @@ const Editable = ({
           isCursorCleared
           ? ''
           : isEditing
-          ? value
+          ? removeMarkdownFormatting(value)
           : childrenLabel.length > 0
           ? childrenLabel[0].value
-          : ellipsizeUrl(value)
+          : ellipsizeUrl(formatMarkdown(value))
       }
       placeholder={
         isCursorCleared
@@ -796,6 +796,18 @@ const Editable = ({
       style={style || {}}
     />
   )
+}
+
+/** Replaces markdown features like bold and italics via double asterisks and single asterisks with <b> and <i> tags respectively. */
+const formatMarkdown = (value: string) => {
+  return value
+    .replace(/\*\*(.*)\*\*/g, `<b class="md-bold">$1</b>`)
+    .replace(/\*(.*)\*/g, `<i class="md-italics">$1</i>`)
+}
+
+/** Replaces converted bold and italic tags from the html to double asterisks and single asterisks respectivtively. */
+const removeMarkdownFormatting = (value: string) => {
+  return value.replace(/<b class="md-bold">(.*)<\/b>/g, `**$1**`).replace(/<i class="md-italics">(.*)<\/i>/g, `*$1*`)
 }
 
 export default connect(mapStateToProps)(Editable)

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -249,7 +249,7 @@ const Editable = ({
 
   // side effect to set old value ref to head value from updated simplePath.
   useEffect(() => {
-    oldValueRef.current = isEditing ? removeMarkdownFormatting(value) : formatMarkdown(value)
+    oldValueRef.current = value
   }, [value])
 
   /** Set or reset invalid state. */
@@ -610,8 +610,9 @@ const Editable = ({
     const { invalidState } = state
     throttledChangeRef.current.flush()
 
-    // if there was an ephemeral duplicate state, reset the rendered value to previous non-duplicate
-    if (contentRef.current?.innerHTML !== oldValueRef.current) {
+    // if there was an ephemeral duplicate state, reset the rendered value to previous non-duplicate.
+    // There can be markdown formatted html, so it needs removing before checking with the previous value.
+    if (removeMarkdownFormatting(contentRef.current?.innerHTML ?? '') !== oldValueRef.current) {
       contentRef.current!.innerHTML = oldValueRef.current
       contentRef.current!.style.opacity = '1.0'
       showDuplicationAlert(false, dispatch)
@@ -759,6 +760,7 @@ const Editable = ({
         ['editable-' + headId(path)]: true,
         empty: value.length === 0,
       })}
+      isEditing={isEditing && selection.isThought()}
       forceUpdate={editableNonceRef.current !== state.editableNonce}
       html={
         value === EM_TOKEN
@@ -768,10 +770,10 @@ const Editable = ({
           isCursorCleared
           ? ''
           : isEditing
-          ? removeMarkdownFormatting(value)
+          ? value
           : childrenLabel.length > 0
           ? childrenLabel[0].value
-          : ellipsizeUrl(formatMarkdown(value))
+          : ellipsizeUrl(value)
       }
       placeholder={
         isCursorCleared
@@ -796,13 +798,6 @@ const Editable = ({
       style={style || {}}
     />
   )
-}
-
-/** Replaces markdown features like bold and italics via double asterisks and single asterisks with <b> and <i> tags respectively. */
-const formatMarkdown = (value: string) => {
-  return value
-    .replace(/\*\*(.*)\*\*/g, `<b class="md-bold">$1</b>`)
-    .replace(/\*(.*)\*/g, `<i class="md-italics">$1</i>`)
 }
 
 /** Replaces converted bold and italic tags from the html to double asterisks and single asterisks respectivtively. */


### PR DESCRIPTION
Fixes #1382

## Changes
- Created two functions
> - `formatMarkdown`: Takes a string and uses regex to replace and convert `**` and `*` to `<b>` and `<i>` respectively.
> - `removeMarkdownFormatting`: Takes a string and uses regex to invert the change done by `formatMarkdown` function.
- Changed the conditional rendering inside of `Editable` component to use above functions based on `isEditing` current value.
- Set `oldValueRef.current` to values with markdown formatting, since the formatting started to break when moving from active thought to the thought below it.