### PR TITLE
Fix for column 2 not initially visible while toggling hidden thoughts

### DIFF
--- a/src/reducers/toggleHiddenThoughts.ts
+++ b/src/reducers/toggleHiddenThoughts.ts
@@ -1,9 +1,16 @@
 import { State } from '../@types'
+import { expandThoughts } from '../selectors'
 
 /** Shows or hides all hidden and metaprogramming thoughts. */
-const toggleHiddenThoughts = (state: State) => ({
-  ...state,
-  showHiddenThoughts: !state.showHiddenThoughts,
-})
+const toggleHiddenThoughts = (state: State) => {
+  const toggledState = {
+    ...state,
+    showHiddenThoughts: !state.showHiddenThoughts,
+  }
+  return {
+    ...toggledState,
+    expanded: expandThoughts(toggledState, toggledState.cursor),
+  }
+}
 
 export default toggleHiddenThoughts

--- a/src/reducers/toggleHiddenThoughts.ts
+++ b/src/reducers/toggleHiddenThoughts.ts
@@ -1,17 +1,16 @@
-import { reducerFlow } from './../util/reducerFlow'
+import { State } from '../@types'
 import { expandThoughts } from '../selectors'
 
 /** Shows or hides all hidden and metaprogramming thoughts. */
-const toggleHiddenThoughts = reducerFlow([
-  state => ({
+const toggleHiddenThoughts = (state: State) => {
+  const toggledState = {
     ...state,
     showHiddenThoughts: !state.showHiddenThoughts,
-  }),
-  // calculate expanded with the toggled showHiddenThoughts
-  state => ({
-    ...state,
-    expanded: expandThoughts(state, state.cursor),
-  }),
-])
+  }
+  return {
+    ...toggledState,
+    expanded: expandThoughts(toggledState, toggledState.cursor),
+  }
+}
 
 export default toggleHiddenThoughts

--- a/src/reducers/toggleHiddenThoughts.ts
+++ b/src/reducers/toggleHiddenThoughts.ts
@@ -1,16 +1,17 @@
-import { State } from '../@types'
+import { reducerFlow } from './../util/reducerFlow'
 import { expandThoughts } from '../selectors'
 
 /** Shows or hides all hidden and metaprogramming thoughts. */
-const toggleHiddenThoughts = (state: State) => {
-  const toggledState = {
+const toggleHiddenThoughts = reducerFlow([
+  state => ({
     ...state,
     showHiddenThoughts: !state.showHiddenThoughts,
-  }
-  return {
-    ...toggledState,
-    expanded: expandThoughts(toggledState, toggledState.cursor),
-  }
-}
+  }),
+  // calculate expanded with the toggled showHiddenThoughts
+  state => ({
+    ...state,
+    expanded: expandThoughts(state, state.cursor),
+  }),
+])
 
 export default toggleHiddenThoughts


### PR DESCRIPTION
Fixes #1474 

## Preface
Rendering thought depends on `state.expanded` which in-turn depends on `state.showHiddenThoughts`. 
## The problem
`expanded` is not re-computed when toggling hidden thoughts.
## The solution
Recompute the `expanded` object when toggling hidden thoughts.
