### PR TITLE
Support =pin/false in thoughts irrespective of =pinChildren/true in ancestor

### DIFF
--- a/src/selectors/__tests__/expandThoughts.ts
+++ b/src/selectors/__tests__/expandThoughts.ts
@@ -261,6 +261,26 @@ describe('=pin', () => {
     expect(isContextExpanded(stateNew, ['a', 'b'])).toBeFalsy()
     expect(isContextExpanded(stateNew, ['a', 'b', 'c'])).toBeFalsy()
   })
+  it('thoughts with =pin/false is not expanded even if ancestor has =pinChildren/true', () => {
+    const text = `
+    - a
+      - =pinChildren
+        - true
+      - b
+        - =pin
+          - false
+        - c
+      - d
+    `
+
+    const steps = [importText({ text }), setCursorFirstMatch(['a'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeFalsy()
+    expect(isContextExpanded(stateNew, ['a', 'd'])).toBeTruthy()
+  })
 })
 
 describe('=pinChildren', () => {

--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -146,11 +146,12 @@ function expandThoughtsRecursive(
         const isAncestor = () => isDescendant(childContext, expansionBasePathContext)
 
         /** Check if the path is equal to the expansion path. */
-        const isExpansionBasePath = equalArrays(childContext, expansionBasePathContext)
+        const isExpansionBasePath = () => equalArrays(childContext, expansionBasePathContext)
 
-        if (!isExpansionBasePath && isPinClosed(child.id)) return false
-
-        return !isFunction(value) || isExpansionBasePath || isAncestor()
+        return (
+          (!isFunction(value) || isExpansionBasePath() || isAncestor()) &&
+          (!isPinClosed(child.id) || isExpansionBasePath())
+        )
       })
 
   // expand if child is only child and its child is not url

--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -115,6 +115,9 @@ function expandThoughtsRecursive(
     return attribute(state, context, '=pin')
   }
 
+  /** Returns true if the child should be pinned closed. */
+  const isPinClosed = (child: ThoughtId | ThoughtContext) => isPinned(child) === 'false'
+
   const simpleContext = pathToContext(state, simplePath)
   const context = pathToContext(state, path)
 
@@ -143,9 +146,11 @@ function expandThoughtsRecursive(
         const isAncestor = () => isDescendant(childContext, expansionBasePathContext)
 
         /** Check if the path is equal to the expansion path. */
-        const isExpansionBasePath = () => equalArrays(childContext, expansionBasePathContext)
+        const isExpansionBasePath = equalArrays(childContext, expansionBasePathContext)
 
-        return !isFunction(value) || isExpansionBasePath() || isAncestor()
+        if (!isExpansionBasePath && isPinClosed(child.id)) return false
+
+        return !isFunction(value) || isExpansionBasePath || isAncestor()
       })
 
   // expand if child is only child and its child is not url


### PR DESCRIPTION
Fixes #1243 

## Overview
In case of thoughts where children are pinned `i.e. =pinChildren/true` , its descendant's `=pin/false` is not respected.

## The solution
Check for =pin/false while filtering visible children.