### PR TITLE
Bullet turns into leaf when parent is edited

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -1,7 +1,7 @@
 import React, { MouseEvent } from 'react'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
-import { getLexeme, hasChildren, isContextViewActive, isPending } from '../selectors'
+import { getLexeme, isContextViewActive, isPending } from '../selectors'
 import { head } from '../util'
 import { Context, State } from '../@types'
 
@@ -24,8 +24,6 @@ const mapStateToProps = (state: State, props: BulletProps) => {
   return {
     // if being edited and meta validation error has occured
     invalid: !!props.isEditing && invalidState,
-    // re-render when leaf status changes
-    isLeaf: props.leaf && !hasChildren(state, props.context),
     missing: !lexeme,
     pending: isPending(state, props.context),
     showContexts: isContextViewActive(state, props.context),
@@ -37,7 +35,7 @@ const Bullet = ({
   showContexts,
   glyph,
   invalid,
-  isLeaf,
+  leaf,
   missing,
   onClick,
   pending,
@@ -55,7 +53,7 @@ const Bullet = ({
     })}
   >
     <span className='glyph' onClick={onClick}>
-      {glyph || (showContexts ? (isLeaf ? '◦' : '▹') : isLeaf ? '•' : '▸')}
+      {glyph || (showContexts ? (leaf ? '◦' : '▹') : leaf ? '•' : '▸')}
     </span>
   </span>
 )

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: State, props: BulletProps) => {
     // if being edited and meta validation error has occured
     invalid: !!props.isEditing && invalidState,
     // re-render when leaf status changes
-    isLeaf: !hasChildren(state, props.context),
+    isLeaf: props.leaf && !hasChildren(state, props.context),
     missing: !lexeme,
     pending: isPending(state, props.context),
     showContexts: isContextViewActive(state, props.context),


### PR DESCRIPTION
Fixes #1462 

## Overview
- All the successive descendants children's bullet were turning into leaf when it's ancestor context was edited even though they had children

## Solution
- In bullet.tsx , `leaf` is passed down as a prop but it was never used. This `leaf` was responsible for tracking whether current thought should be bullet or leaf. But here in mapStateToProps same logic is being used again of finding out the children (which seems redundant to me but I have left it as it is) and just used props.leaf to keep the track.