### PR TITLE
Fixed archived counts being counted in superscript.

### DIFF
--- a/src/components/ThoughtAnnotation.native.tsx
+++ b/src/components/ThoughtAnnotation.native.tsx
@@ -150,7 +150,7 @@ const ThoughtAnnotation = ({
   /** Returns true if the thought is not archived. */
   const isNotArchive = (thoughtContext: ThoughtContext) =>
     // thoughtContext.context should never be undefined, but unfortunately I have personal thoughts in production with no context. I am not sure whether this was old data, or if it's still possible to encounter, so guard against undefined context for now.
-    showHiddenThoughts || !getAncestorByValue(state, thoughtContext, '=archieve')
+    showHiddenThoughts || !getAncestorByValue(state, thoughtContext, '=archive')
 
   const numContexts = contexts.filter(isNotArchive).length + (isRealTimeContextUpdate ? 1 : 0)
 

--- a/src/components/__tests__/Superscript.ts
+++ b/src/components/__tests__/Superscript.ts
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/dom'
+import { importText } from '../../action-creators'
+import { store } from '../../store'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createRtlTestApp'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('Superscript should count all the contexts in which it is defined.', async () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+        - b
+          - c
+        - d
+          - c
+        - e
+          - f
+            - c
+      `,
+    }),
+  ])
+
+  const element = screen.getByText('3')
+  expect(element.nodeName).toBe('SUP')
+})
+
+it('Superscript should not count archived contexts', async () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+        - =archive
+          - b
+            - c
+        - d
+          - c
+        - e
+          - f
+            - c
+      `,
+    }),
+  ])
+
+  const element = screen.getByText('2')
+  expect(element.nodeName).toBe('SUP')
+})

--- a/src/selectors/getAncestorBy.ts
+++ b/src/selectors/getAncestorBy.ts
@@ -1,6 +1,5 @@
 import { getThoughtById } from './index'
 import { Index, Parent, State, ThoughtId } from '../@types'
-import { normalizeThought } from '../util'
 
 /**
  * Traverses the thought tree upwards from the given thought and returns the first ancestor that passes the check function.
@@ -37,6 +36,6 @@ const getAncestorBy = (
  * Get ancestor by normalized value.
  */
 export const getAncestorByValue = (state: State, thoughtId: ThoughtId, normalizedValue: string) =>
-  getAncestorBy(state, thoughtId, thought => normalizeThought(thought.value) === normalizedValue)
+  getAncestorBy(state, thoughtId, thought => thought.value === normalizedValue)
 
 export default getAncestorBy

--- a/src/selectors/getAncestorBy.ts
+++ b/src/selectors/getAncestorBy.ts
@@ -33,9 +33,9 @@ const getAncestorBy = (
 }
 
 /**
- * Get ancestor by normalized value.
+ * Get ancestor by value.
  */
-export const getAncestorByValue = (state: State, thoughtId: ThoughtId, normalizedValue: string) =>
-  getAncestorBy(state, thoughtId, thought => thought.value === normalizedValue)
+export const getAncestorByValue = (state: State, thoughtId: ThoughtId, value: string) =>
+  getAncestorBy(state, thoughtId, thought => thought.value === value)
 
 export default getAncestorBy


### PR DESCRIPTION
Fixes #1459

## Changes
- Removed `normalizeThought` function from `getAncesstorByValue` utility, since it removed the `=` from `=archive`, resulting in all archived thoughts being counted in the superscript.
- Fixed a typo `=archive` to `=archive` in `ThoughtAnnotation.native.tsx`

I checked all the use-cases of `getAncesstorByValue` and it seems to be used only to find meta values like `=archive`, so it seemed safe to remove the `normalizeThought` from the function.

