### PR TITLE
Style attributes not stripped after <br>

### DIFF
--- a/src/util/__tests__/importText.ts
+++ b/src/util/__tests__/importText.ts
@@ -1129,6 +1129,21 @@ it('import single line with style attributes', () => {
 </ul>`)
 })
 
+it('import single line with style attributes and a single br tag', () => {
+  const text = `<br><span style="color: pink;">Marcel Duchamp: The Art of the Possible</span>`
+
+  const stateNew = importText(initialState(), { text })
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/html')
+
+  expect(exported).toBe(`<ul>
+  <li>__ROOT__${EMPTY_SPACE}
+    <ul>
+      <li>Marcel Duchamp: The Art of the Possible</li>
+    </ul>
+  </li>
+</ul>`)
+})
+
 it('import raw state', () => {
   // raw thought state with two thoughts: a/b
   // most of this is settings, but keep them for completeness

--- a/src/util/strip.ts
+++ b/src/util/strip.ts
@@ -15,11 +15,7 @@ const regexSpanTagOnlyContainsWhitespaces = /<span[^>]*>([\s]+)<\/span>/gim
 /** Strip HTML tags, close incomplete html tags, convert nbsp to normal spaces, and trim. */
 export const strip = (
   html: string,
-  { preserveFormatting, preventTrim, stripAttributes }: StripOptions = {
-    preserveFormatting: false,
-    preventTrim: false,
-    stripAttributes: true,
-  },
+  { preserveFormatting = false, preventTrim = false, stripAttributes = true }: StripOptions = {},
 ) => {
   const replacedHtml = html
     .replace(/<\/p><p/g, '</p>\n<p') // <p> is a block element, if there is no newline between <p> tags add newline.


### PR DESCRIPTION
Fixes #1486 

## Problem

- In strip.ts file, there were no default args provided technically although it seemed like the object provided for strip options was default. However this won't work as it will return `undefined` if the parameter is not provided.

## Solution
- Provided default params values for all strip options properties to support stripAttributes logic by default