### PR TITLE
Remove false positive in for multi column mode

### DIFF
--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -278,11 +278,11 @@ const mapStateToProps = (state: State, props: SubthoughtsProps) => {
       return grandchildren
     })
 
-    const isMultiColumn = otherChildren.every(
-      children => children.filter(child => child.value in columnMap).length >= 2,
-    )
+    const isMultiColumn =
+      otherChildren.length > 0 &&
+      otherChildren.every(children => children.filter(child => child.value in columnMap).length >= 2)
 
-    return otherChildren.length > 0 && isMultiColumn
+    return isMultiColumn
   }
 
   return {

--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -282,7 +282,7 @@ const mapStateToProps = (state: State, props: SubthoughtsProps) => {
       children => children.filter(child => child.value in columnMap).length >= 2,
     )
 
-    return isMultiColumn
+    return otherChildren.length > 0 && isMultiColumn
   }
 
   return {

--- a/src/components/__tests__/Subthoughts.ts
+++ b/src/components/__tests__/Subthoughts.ts
@@ -9,6 +9,7 @@ import Subthoughts from '../Subthoughts'
 import { Context, Path, SimplePath, State } from '../../@types'
 import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
 import { getAllChildren } from '../../selectors'
+import { screen } from '@testing-library/dom'
 
 // type for Thoughts or Subthoughts component that has a simplePath prop
 interface ThoughtOrSubthoughtsComponent {
@@ -591,5 +592,55 @@ describe('expand thoughts', () => {
 
     // on change of isExpanded the Subthought should re-render and render it's children
     expect(thoughtB()).toHaveLength(1)
+  })
+})
+
+describe('multi-column mode', () => {
+  it('Multi-column mode must not be active on single nested thought', () => {
+    // import thoughts
+    store.dispatch([
+      importText({
+        text: `- a
+        - =view
+          - Table
+        - b
+          - c
+            - e`,
+      }),
+    ])
+
+    const thoughtB = screen.getAllByText('b').filter(element => element.classList.contains('editable'))[0]
+
+    expect(thoughtB.closest('.is-multi-column')).toBeFalsy()
+  })
+
+  it('Multi-column mode must be active on muliple levels of nested thought', () => {
+    // import thoughts
+    store.dispatch([
+      importText({
+        text: `- Fruit
+        - =view
+          - Table
+        - Apple
+          - Color
+            - Red
+          - Type
+            - Seed
+        - Banana
+          - Color
+            - Yellow
+          - Type
+            - Tropical
+        - Tangerine
+          - Color
+            - Orange
+          - Type
+            - Citrus`,
+      }),
+    ])
+
+    const thoughtRed = screen.getAllByText('Color').filter(element => element.classList.contains('editable'))[0]
+
+    expect(thoughtRed.closest('.is-multi-column')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Fixes #1488 

## Changes
- Returned false from `isMultiColumnTable` if `otherChildren` is empty.

## Cause of issue
`otherChildren.every` always returns true if the array is empty. This is most probably why we were getting a false positive from `isMultiColumn()` function.
