### PR TITLE
clearThought + Paste

### DIFF
--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -109,7 +109,8 @@ const importText = (
     // insert the textNormalized into the destValue in the correct place
     // trim after concatenating in case destValue has whitespace
     const left = (destValue.slice(0, replaceStart ?? 0) + textNormalized).trimLeft()
-    const right = destValue.slice(replaceEnd ?? 0).trimRight()
+    // if cursorCleared is true i.e. clearThought is enabled we don't have to use existing thought to be appended
+    const right = state.cursorCleared ? '' : destValue.slice(replaceEnd ?? 0).trimRight()
     const newValue = left + right
 
     const offset = getTextContentFromHTML(left).length


### PR DESCRIPTION
Fixes #1395 

## Overview:
- The imported value used to get prepended to the existing thought value whilst clearThought is activated.

## Solution
 - Looking at the code in importText.ts, we are normally just prepending the new imported values to the existing thought. So just checked for the condition where cursorCleared is true. If true make `right` as an empty string, else same as previous.

## Some issues I have seen with import text feature.
## Issue 1
- Create any thought 'xyz'.
- Move the cursor to the end of string.
- Paste a certain string from the clipboard (e.g 'a' )
- Imported value gets prepended instead of being appended. Don't think this is an expected behavior, right?

## Issue 2
- Create any thought 'xyz'.
- Delete the text you just created completely but make sure you are still in edit mode
- Paste a random string
- Cursor position doesn't go to end of string rather stays at front. (Potential Issue)
- Now try to delete the string you just pasted either by navigating the cursor to the end and hitting `backspace` or just press `delete` from where the cursor initially is.
- Error is shown  as `Cannot read properties of undefined (reading 'lastUpdated')` 

Let me know your thought on these isssues. If it is valid I will convert them into actual issue in github.