### PR TITLE
Fixed undo button being active although no undo action is available

### DIFF
--- a/src/redux-enhancers/undoRedoReducerEnhancer.ts
+++ b/src/redux-enhancers/undoRedoReducerEnhancer.ts
@@ -16,8 +16,8 @@ const stateSectionsToOmit = ['alert', 'pushQueue', 'user']
 const restorePushQueueFromPatches = (state: State, oldState: State, patch: Patch) => {
   const thoughtIndexPath = '/thoughts/thoughtIndex/'
   const contextIndexPath = '/thoughts/contextIndex/'
-  const thoughtIndexChanges = patch.filter(p => p.path.indexOf(thoughtIndexPath) === 0)
-  const contextIndexChanges = patch.filter(p => p.path.indexOf(contextIndexPath) === 0)
+  const thoughtIndexChanges = patch.filter(p => p?.path.indexOf(thoughtIndexPath) === 0)
+  const contextIndexChanges = patch.filter(p => p?.path.indexOf(contextIndexPath) === 0)
 
   const thoughtIndexUpdates = thoughtIndexChanges.reduce((acc, { path }) => {
     const [thoughtId] = path.slice(thoughtIndexPath.length).split('/')
@@ -72,7 +72,7 @@ const addActionsToPatch = (patch: Patch, actions: string[]) => patch.map(operati
 /**
  * Gets the first action from a patch.
  */
-const getPatchAction = (patch: Patch) => patch[0].actions[0]
+const getPatchAction = (patch: Patch) => patch[0]?.actions[0]
 
 /**
  * Gets the nth item from the end of an array.

--- a/src/selectors/isUndoEnabled.ts
+++ b/src/selectors/isUndoEnabled.ts
@@ -2,4 +2,4 @@ import { State } from '../@types'
 import { getLatestActionType } from '../util/getLastActionType'
 
 /** Determines if undo is enabled. */
-export const isUndoEnabled = (state: State) => getLatestActionType(state.inversePatches) !== undefined
+export const isUndoEnabled = (state: State) => !!getLatestActionType(state.inversePatches)

--- a/src/selectors/isUndoEnabled.ts
+++ b/src/selectors/isUndoEnabled.ts
@@ -1,4 +1,5 @@
 import { State } from '../@types'
+import { getLatestActionType } from '../util/getLastActionType'
 
 /** Determines if undo is enabled. */
-export const isUndoEnabled = (state: State) => !!state.inversePatches.length
+export const isUndoEnabled = (state: State) => getLatestActionType(state.inversePatches) !== undefined

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -20,7 +20,7 @@ describe('undo shortcut', () => {
 
   it('dispatches undo action on shortcut if undo is enabled', () => {
     // enable undo
-    isUndoEnabled.mockImplementationOnce(() => true)
+    isUndoEnabled.mockReturnValue(true)
 
     const mockStore = createMockStore()
     const store = mockStore(initialState())

--- a/src/shortcuts/redo.ts
+++ b/src/shortcuts/redo.ts
@@ -1,18 +1,9 @@
 import RedoIcon from '../components/RedoIcon'
-import { Patch, Shortcut } from '../@types'
+import { Shortcut } from '../@types'
 import { isRedoEnabled } from '../selectors/isRedoEnabled'
 import { alert as alertAction } from '../action-creators'
-import { NAVIGATION_ACTIONS } from '../constants'
 import { startCase } from 'lodash'
-
-/**
- * Recursively calculates last action type from patches history if it is one of the navigation actions and finally returns the action.
- */
-const getLatestActionType = (patches: Patch[], n = 1): string => {
-  const lastActionType = patches[patches.length - n]?.[0]?.actions[0]
-  if (NAVIGATION_ACTIONS[lastActionType]) return getLatestActionType(patches, n + 1)
-  return lastActionType
-}
+import { getLatestActionType } from '../util/getLastActionType'
 
 const redoShortcut: Shortcut = {
   id: 'redo',

--- a/src/shortcuts/redo.ts
+++ b/src/shortcuts/redo.ts
@@ -23,7 +23,7 @@ const redoShortcut: Shortcut = {
       alertAction(`Redo: ${startCase(lastActionType)}`, { isInline: true, clearDelay: 3000, showCloseLink: false }),
     )
   },
-  isActive: getState => isRedoEnabled(getState()),
+  canExecute: getState => isRedoEnabled(getState()),
 }
 
 export default redoShortcut

--- a/src/shortcuts/undo.ts
+++ b/src/shortcuts/undo.ts
@@ -23,7 +23,7 @@ const undoShortcut: Shortcut = {
       alertAction(`Undo: ${startCase(lastActionType)}`, { isInline: true, clearDelay: 3000, showCloseLink: false }),
     )
   },
-  isActive: getState => isUndoEnabled(getState()),
+  canExecute: getState => isUndoEnabled(getState()),
 }
 
 export default undoShortcut

--- a/src/shortcuts/undo.ts
+++ b/src/shortcuts/undo.ts
@@ -1,18 +1,9 @@
 import UndoIcon from '../components/UndoIcon'
-import { Patch, Shortcut } from '../@types'
+import { Shortcut } from '../@types'
 import { isUndoEnabled } from '../selectors/isUndoEnabled'
 import { alert as alertAction } from '../action-creators'
-import { NAVIGATION_ACTIONS } from '../constants'
 import { startCase } from 'lodash'
-
-/**
- * Recursively calculates last action type from inversePatches history if it is one of the navigation actions and finally returns the action.
- */
-const getLatestActionType = (inversePatches: Patch[], n = 1): string => {
-  const lastActionType = inversePatches[inversePatches.length - n]?.[0]?.actions[0]
-  if (NAVIGATION_ACTIONS[lastActionType]) return getLatestActionType(inversePatches, n + 1)
-  return lastActionType
-}
+import { getLatestActionType } from '../util/getLastActionType'
 
 const undoShortcut: Shortcut = {
   id: 'undo',

--- a/src/util/getLastActionType.ts
+++ b/src/util/getLastActionType.ts
@@ -1,0 +1,12 @@
+import { Patch } from '../@types'
+import { NAVIGATION_ACTIONS } from '../constants'
+
+/**
+ * Recursively calculates last action type from inversePatches history if it is one of the navigation actions and finally returns the action.
+ * Returns undefined if there is no navigation actions in inversePatches.
+ */
+export const getLatestActionType = (inversePatches: Patch[], n = 1): string | undefined => {
+  const lastActionType = inversePatches[inversePatches.length - n]?.[0]?.actions[0]
+  if (NAVIGATION_ACTIONS[lastActionType]) return getLatestActionType(inversePatches, n + 1)
+  return lastActionType
+}

--- a/src/util/getLastActionType.ts
+++ b/src/util/getLastActionType.ts
@@ -2,11 +2,11 @@ import { Patch } from '../@types'
 import { NAVIGATION_ACTIONS } from '../constants'
 
 /**
- * Recursively calculates last action type from inversePatches history if it is one of the navigation actions and finally returns the action.
- * Returns undefined if there is no navigation actions in inversePatches.
+ * Recursively calculates last action type from patches/inversePatches history if it is one of the navigation actions and finally returns the action.
+ * Returns undefined if there is no navigation actions in patches/inversePatches.
  */
-export const getLatestActionType = (inversePatches: Patch[], n = 1): string | undefined => {
-  const lastActionType = inversePatches[inversePatches.length - n]?.[0]?.actions[0]
-  if (NAVIGATION_ACTIONS[lastActionType]) return getLatestActionType(inversePatches, n + 1)
+export const getLatestActionType = (patchArr: Patch[], n = 1): string | undefined => {
+  const lastActionType = patchArr[patchArr.length - n]?.[0]?.actions[0]
+  if (NAVIGATION_ACTIONS[lastActionType]) return getLatestActionType(patchArr, n + 1)
   return lastActionType
 }


### PR DESCRIPTION
fixes #1495 

## Changes
1. Updated the `isUndoEnabled` selector to return true only if there is some undo-able action in `inversePatches`.
2. Added optional chaining for functions in `undoRedoReducerEnhancer`.
3. Segregated `getLastActionType` function to utils.