### PR TITLE
Thoughts without = should not count as metaprogramming attributes 

### DIFF
--- a/src/util/getThoughtIdByContext.ts
+++ b/src/util/getThoughtIdByContext.ts
@@ -8,7 +8,6 @@ import { Context, Parent, State, ThoughtId } from '../@types'
 // import { normalizeThought } from './normalizeThought'
 // import { getAllChildren } from '../selectors'
 import { isRoot } from './isRoot'
-import { normalizeThought } from './normalizeThought'
 import { childIdsToThoughts, getThoughtById } from '../selectors'
 
 // const SEPARATOR_TOKEN = '__SEP__'
@@ -60,7 +59,7 @@ const recursiveParentFinder = (
 
   const child = children.find(child => {
     const targetValue = target[targetIndex]
-    return targetValue !== undefined && normalizeThought(target[targetIndex]) === normalizeThought(child.value)
+    return targetValue !== undefined && target[targetIndex] === child.value
   })
 
   if (!child) return null

--- a/src/util/isFunction.ts
+++ b/src/util/isFunction.ts
@@ -1,2 +1,2 @@
 /** Returns true if the given value starts `=`, indicating a metaprogramming attribute i.e =view, =note etc while also considering spaces and word characters. */
-export const isFunction = (s: string) => !!s.match(/^= *\w+ *$/g)
+export const isFunction = (s: string) => !!s.match(/^=[A-Za-z]+$/g)

--- a/src/util/isFunction.ts
+++ b/src/util/isFunction.ts
@@ -1,2 +1,2 @@
-/** Returns true if the given value starts `=`, indicating a metaprogramming attribute. */
-export const isFunction = (s: string) => s.startsWith('=')
+/** Returns true if the given value starts `=`, indicating a metaprogramming attribute i.e =view, =note etc while also considering spaces and word characters. */
+export const isFunction = (s: string) => !!s.match(/^= *\w+ *$/g)

--- a/src/util/isFunction.ts
+++ b/src/util/isFunction.ts
@@ -1,2 +1,2 @@
 /** Returns true if the given value starts `=`, indicating a metaprogramming attribute i.e =view, =note etc while also considering spaces and word characters. */
-export const isFunction = (s: string) => !!s.match(/^=[A-Za-z]+$/g)
+export const isFunction = (s: string) => !!s.match(/^=\w+$/g)

--- a/src/util/normalizeThought.ts
+++ b/src/util/normalizeThought.ts
@@ -2,9 +2,11 @@ import _ from 'lodash'
 import * as pluralize from 'pluralize'
 import { REGEXP_TAGS } from '../constants'
 import emojiStrip from 'emoji-strip'
+import { isFunction } from '.'
 
 /** Trims a string. */
-export const trim = (s: string) => s.replace(s.length > 0 && s.replace(/\W/g, '').length > 0 ? /\W/g : /s/g, '')
+export const trim = (s: string) =>
+  isFunction(s) ? s.replace(/ /g, '') : s.replace(s.length > 0 && s.replace(/\W/g, '').length > 0 ? /\W/g : /s/g, '')
 
 /** Strips emoji from text. Preserves emoji on its own. */
 export const stripEmojiFromText = (s: string) => {

--- a/src/util/normalizeThought.ts
+++ b/src/util/normalizeThought.ts
@@ -2,11 +2,9 @@ import _ from 'lodash'
 import * as pluralize from 'pluralize'
 import { REGEXP_TAGS } from '../constants'
 import emojiStrip from 'emoji-strip'
-import { isFunction } from '.'
 
 /** Trims a string. */
-export const trim = (s: string) =>
-  isFunction(s) ? s.replace(/ /g, '') : s.replace(s.length > 0 && s.replace(/\W/g, '').length > 0 ? /\W/g : /s/g, '')
+export const trim = (s: string) => s.replace(s.length > 0 && s.replace(/\W/g, '').length > 0 ? /\W/g : /s/g, '')
 
 /** Strips emoji from text. Preserves emoji on its own. */
 export const stripEmojiFromText = (s: string) => {


### PR DESCRIPTION
fixes #1507 

## Overview
- Thoughts without = were  counted as metaprogramming attributes

## Problem
-  In `normalizeThought.ts`, while trimming we are excluding all the characters that are non-word including `=`. Due to this the function returns back a normal string with `=`. Thus even if we passed in `=view` in `attribute.ts` ,normalizedThought would treat `=view` as `view` and hence would work as metaprogramming attribute.

## Solution
- Initially I thought to just omit the use of normalizeThought in `getThoughtByContext.ts` file line no: 63 to be exact, but later thought that this is a function that is used extensively and it might have possible regressions. So I applied a regex expression in `isFunction.ts` to check for possible metaprogramming attribute and then used that function in `normalizedThought.ts` in `trim` function to avoid replacing `=`.
    