### PR TITLE
Fixed thoughts not spliting after paste.

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -250,7 +250,7 @@ const Editable = ({
   // side effect to set old value ref to head value from updated simplePath. Also update editing value, if it is different from current value.
   useEffect(() => {
     oldValueRef.current = value
-    if (state.editingValue !== value) {
+    if (isEditing && selection.isThought() && state.editingValue !== value) {
       dispatch(setEditingValue(value))
     }
   }, [value])

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -247,9 +247,12 @@ const Editable = ({
   const setContentInvalidState = (value: boolean) =>
     contentRef.current && contentRef.current.classList[value ? 'add' : 'remove']('invalid-option')
 
-  // side effect to set old value ref to head value from updated simplePath.
+  // side effect to set old value ref to head value from updated simplePath. Also update editing value, if it is different from current value.
   useEffect(() => {
     oldValueRef.current = value
+    if (state.editingValue !== value) {
+      dispatch(setEditingValue(value))
+    }
   }, [value])
 
   /** Set or reset invalid state. */


### PR DESCRIPTION
Fixes #1461

## Problem
`editingValue` was not updated on paste.

## Changes
On the side-effect of updated head-value, we dispatch `setEditingValue` to current value, if the value is different and `isEditing` is active.
