### PR TITLE
Alert flashes and disappears after move

### DIFF
--- a/src/components/DragAndDropThought.tsx
+++ b/src/components/DragAndDropThought.tsx
@@ -82,7 +82,7 @@ const beginDrag = ({ simplePathLive }: ConnectedThoughtContainerProps) => {
 
 /** Handles drag end. */
 const endDrag = () => {
-  store.dispatch([dragInProgress({ value: false }), dragHold({ value: false }), alert(null)])
+  store.dispatch([dragInProgress({ value: false }), dragHold({ value: false })])
 }
 
 /** Collects props from the DragSource. */
@@ -178,9 +178,7 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
       const alertFrom = '"' + ellipsize(fromThought.value) + '"'
       const alertTo = isRoot(newContext) ? 'home' : '"' + ellipsize(parentThought.value) + '"'
 
-      store.dispatch(alert(`${alertFrom} moved to ${alertTo} context.`))
-      globals.errorTimer && clearTimeout(globals.errorTimer)
-      globals.errorTimer = window.setTimeout(() => store.dispatch(alert(null)), 5000)
+      store.dispatch(alert(`${alertFrom} moved to ${alertTo} context.`, { alertType: 'moveThought', clearDelay: 5000 }))
     }, 100)
   }
 }

--- a/src/components/Subthoughts.tsx
+++ b/src/components/Subthoughts.tsx
@@ -399,9 +399,7 @@ const drop = (props: SubthoughtsProps, monitor: DropTargetMonitor) => {
       const alertFrom = '"' + ellipsize(fromThought.value) + '"'
       const alertTo = isRoot(newContext) ? 'home' : '"' + ellipsize(toThought.value) + '"'
 
-      store.dispatch(alert(`${alertFrom} moved to ${alertTo}.`))
-      clearTimeout(globals.errorTimer)
-      globals.errorTimer = window.setTimeout(() => store.dispatch(alert(null)), 5000)
+      store.dispatch(alert(`${alertFrom} moved to ${alertTo}.`, { alertType: 'moveThought', clearDelay: 5000 }))
     }, 100)
   }
 }


### PR DESCRIPTION
Fixes #1510 

## Problem
- `endDrag` handler function in  `DragAndDropThought.tsx` was dispatching a redudant `alert(null)` action.

## Solution
- Removed the `alert(null)` action from endDrag handler function
- Removed the use of manual clearance of alert using `window.setTimeout()`. I'm pretty sure after the latest fix of alert action 
   creator these conditions gets handled automatically.