### PR TITLE
Empty thought with formatting tags breaks caret

### DIFF
--- a/src/util/__tests__/strip.ts
+++ b/src/util/__tests__/strip.ts
@@ -45,6 +45,34 @@ it('preserve bold with attribute', () => {
   )
 })
 
+it('empty formatting tags', () => {
+  expect(strip('<b></b>', { preserveFormatting: true })).toBe('')
+})
+
+it('empty formatting tags multiline', () => {
+  expect(
+    strip(
+      `<b>
+  
+      </b>`,
+      { preserveFormatting: true },
+    ),
+  ).toBe('')
+})
+
+it('leading and trailing whitespaces in multiline formatting tags', () => {
+  expect(
+    strip(
+      `<b>
+      
+      Hello
+
+      </b>`,
+      { preserveFormatting: true },
+    ),
+  ).toBe('<b> Hello </b>')
+})
+
 // This fails here, but succeeds on regex101.com (???)
 it.skip('preserve bold with newlines in attribute', () => {
   expect(

--- a/src/util/__tests__/strip.ts
+++ b/src/util/__tests__/strip.ts
@@ -60,19 +60,6 @@ it('empty formatting tags multiline', () => {
   ).toBe('')
 })
 
-it('leading and trailing whitespaces in multiline formatting tags', () => {
-  expect(
-    strip(
-      `<b>
-      
-      Hello
-
-      </b>`,
-      { preserveFormatting: true },
-    ),
-  ).toBe('<b> Hello </b>')
-})
-
 // This fails here, but succeeds on regex101.com (???)
 it.skip('preserve bold with newlines in attribute', () => {
   expect(

--- a/src/util/strip.ts
+++ b/src/util/strip.ts
@@ -12,7 +12,9 @@ type StripOptions = { preserveFormatting?: boolean; preventTrim?: boolean; strip
 
 const regexSpanTagOnlyContainsWhitespaces = /<span[^>]*>([\s]+)<\/span>/gim
 
-const regexExpForEmptyFormattingTags = /<[^/>][^>]*> *<\/[^>]+>/gim
+const regexExpForEmptyFormattingTags = /<[^/>][^>]*>\s*<\/[^>]+>/gim
+
+const regexExpForWhiteSpacesInTags = /[\s]+/gm
 
 /** Strip HTML tags, close incomplete html tags, convert nbsp to normal spaces, and trim. */
 export const strip = (
@@ -25,7 +27,8 @@ export const strip = (
     .replace(regexSpanTagOnlyContainsWhitespaces, '$1') // Replace span tags contain whitespaces
     .replace(regexNbsp, ' ')
     .replace(regexDecimalSpace, ' ') // Some text editors use decimal code for space character
-    .replace(regexExpForEmptyFormattingTags, '') // Replace empty formatting tags with space
+    .replace(regexExpForEmptyFormattingTags, '') // Remove empty formatting tags
+    .replace(regexExpForWhiteSpacesInTags, ' ') // Replace whitespaces (leading and trailing) from formatting tags
 
   const sanitizedHtml = unescape(
     sanitize(replacedHtml, {

--- a/src/util/strip.ts
+++ b/src/util/strip.ts
@@ -12,6 +12,8 @@ type StripOptions = { preserveFormatting?: boolean; preventTrim?: boolean; strip
 
 const regexSpanTagOnlyContainsWhitespaces = /<span[^>]*>([\s]+)<\/span>/gim
 
+const regexExpForEmptyFormattingTags = /<[^/>][^>]*> *<\/[^>]+>/gim
+
 /** Strip HTML tags, close incomplete html tags, convert nbsp to normal spaces, and trim. */
 export const strip = (
   html: string,
@@ -23,6 +25,7 @@ export const strip = (
     .replace(regexSpanTagOnlyContainsWhitespaces, '$1') // Replace span tags contain whitespaces
     .replace(regexNbsp, ' ')
     .replace(regexDecimalSpace, ' ') // Some text editors use decimal code for space character
+    .replace(regexExpForEmptyFormattingTags, '') // Replace empty formatting tags with space
 
   const sanitizedHtml = unescape(
     sanitize(replacedHtml, {

--- a/src/util/strip.ts
+++ b/src/util/strip.ts
@@ -14,8 +14,6 @@ const regexSpanTagOnlyContainsWhitespaces = /<span[^>]*>([\s]+)<\/span>/gim
 
 const regexExpForEmptyFormattingTags = /<[^/>][^>]*>\s*<\/[^>]+>/gim
 
-const regexExpForWhiteSpacesInTags = /[\s]+/gm
-
 /** Strip HTML tags, close incomplete html tags, convert nbsp to normal spaces, and trim. */
 export const strip = (
   html: string,
@@ -28,7 +26,6 @@ export const strip = (
     .replace(regexNbsp, ' ')
     .replace(regexDecimalSpace, ' ') // Some text editors use decimal code for space character
     .replace(regexExpForEmptyFormattingTags, '') // Remove empty formatting tags
-    .replace(regexExpForWhiteSpacesInTags, ' ') // Replace whitespaces (leading and trailing) from formatting tags
 
   const sanitizedHtml = unescape(
     sanitize(replacedHtml, {


### PR DESCRIPTION
Fixes #1503 

## Problem
- Empty formatting tags such as `<b></b>`, `<i></i>` when pasted were resolved even when there is no content.

## Solution
- Used regex expression to replace empty formatting tags with space which will restrict from pasting empty formatting tag ultimately resolving the caret issue.