### PR TITLE
Alert flashes and disappears after gesture

### DIFF
--- a/src/action-creators/alert.ts
+++ b/src/action-creators/alert.ts
@@ -24,7 +24,7 @@ const alert =
     const { alert } = getState()
 
     // if clearDelay is not provided i.e undefined alert should not dismiss.
-    if (clearTimeout && clearDelay) {
+    if (clearDelay) {
       // if clearAlertTimeoutId !== null, it means that previous alert hasn't been cleared yet. In this case cancel previous timeout and start new.
       clearAlertTimeoutId && clearTimeout(clearAlertTimeoutId)
       clearAlertTimeoutId = setTimeout(() => {

--- a/src/action-creators/alert.ts
+++ b/src/action-creators/alert.ts
@@ -23,7 +23,8 @@ const alert =
   (dispatch, getState) => {
     const { alert } = getState()
 
-    if (clearTimeout) {
+    // if clearDelay is not provided i.e undefined alert should not dismiss.
+    if (clearTimeout && clearDelay) {
       // if clearAlertTimeoutId !== null, it means that previous alert hasn't been cleared yet. In this case cancel previous timeout and start new.
       clearAlertTimeoutId && clearTimeout(clearAlertTimeoutId)
       clearAlertTimeoutId = setTimeout(() => {


### PR DESCRIPTION
Fixes #1513 

## Problem

- The main problem lied in the main alert logic i.e `alert.ts` (action-creator). Default behavior of alert should be that if the value for `clearDelay` is not provided explicitly `alert` component shouldn't dismiss at all. But since we are not checking the logic `alert` dismisses soon if `clearDelay` is not provided.

## Solution

- Checked for whether `clearDelay` param has been provided or not. If not then don't dispatch `alert(null)`