### PR TITLE
Simplify rankThoughtsFirstMatch

### DIFF
--- a/src/selectors/__tests__/expandThoughts.ts
+++ b/src/selectors/__tests__/expandThoughts.ts
@@ -360,7 +360,7 @@ describe('expand with : char', () => {
     const stateNew = reducerFlow(steps)(initialState())
 
     expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['b:'])).toBeTruthy()
     expect(isContextExpanded(stateNew, ['a', 'x'])).toBeFalsy()
     expect(isContextExpanded(stateNew, ['x'])).toBeFalsy()
   })
@@ -381,9 +381,9 @@ describe('expand with : char', () => {
     const stateNew = reducerFlow(steps)(initialState())
 
     expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b', 'c'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b', 'c', 'x'])).toBeFalsy()
+    expect(isContextExpanded(stateNew, ['b:'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['b:', 'c:'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['b', 'c:', 'x'])).toBeFalsy()
   })
 
   it('thougts that contain html and end with ":" are expanded', () => {
@@ -400,8 +400,8 @@ describe('expand with : char', () => {
     const stateNew = reducerFlow(steps)(initialState())
 
     expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b'])).toBeTruthy()
-    expect(isContextExpanded(stateNew, ['b', 'c'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['<b>b:</b>'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['<b>b:</b>', '<b><i>c:</i></b>'])).toBeTruthy()
   })
 })
 

--- a/src/selectors/__tests__/exportContext.ts
+++ b/src/selectors/__tests__/exportContext.ts
@@ -137,7 +137,7 @@ it('export multi-line thoughts as separate thoughts', () => {
     editThoughtAtFirstMatch({
       oldValue: 'Hello',
       newValue: 'Hello\nworld',
-      at: ['a', 'b', 'hello'],
+      at: ['a', 'b', 'Hello'],
     }),
   ]
   const stateNew = reducerFlow(steps)(initialState())

--- a/src/shortcuts/__tests__/redo.ts
+++ b/src/shortcuts/__tests__/redo.ts
@@ -117,7 +117,7 @@ it('redo contiguous changes', () => {
     editThoughtAtFirstMatchActionCreator({
       newValue: 'Atlantic City',
       oldValue: 'Atlantic ',
-      at: ['Atlantic'],
+      at: ['Atlantic '],
     }),
     { type: 'undoAction' },
   ])

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -303,7 +303,7 @@ it('state.alert is omitted from the undo patch', () => {
           - A
           - B`,
     }),
-    setCursorFirstMatchActionCreator(['a']),
+    setCursorFirstMatchActionCreator(['A']),
     { type: 'archiveThought' },
   ])
   const { inversePatches } = store.getState()


### PR DESCRIPTION
`rankThoughtsFirstMatch` used to rely on `Lexemes` to get the rank of each thought. Now that a `Path` only consists of ids, we can traverse the `contextIndex` directly.

As a side effect, this fixes the issue where `toggleAttribute` was failing (#1464). It relied on `rankThoughtsFirstMatch`, but didn't work when some `Lexeme` contexts were pending.