### PR TITLE
Invalid "Duplicate Thoughts" alert after import

### DIFF
--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -16,7 +16,7 @@ import {
   unroot,
   validateRoam,
 } from '../util'
-import { editThought, setCursor, updateThoughts } from '../reducers'
+import { editThought, setCursor, updateThoughts, editingValue } from '../reducers'
 import { getAllChildren, simplifyPath, rootedParentOf, getThoughtById } from '../selectors'
 import { Path, SimplePath, State, Timestamp } from '../@types'
 import newThought from './newThought'
@@ -121,6 +121,10 @@ const importText = (
         newValue,
         context: rootedParentOf(state, pathToContext(state, path)),
         path: simplePath,
+      }),
+
+      editingValue({
+        value: newValue,
       }),
 
       !preventSetCursor && path


### PR DESCRIPTION
Fixes #1541 

## Problem

- Duplication alert was shown when a text is imported/pasted initially and then hit enter

## Solution
- There was this particular logic in (https://github.com/cybersemics/em/blob/dev/src/shortcuts/newThoughtOrOutdent.tsx#L36-L40) where it was checking `cursorHeadThought.value !== editingValue`. So previously `editingValue` was only being set in `Editable.tsx` component but we should also update the editingValue when it is imported/pasted. Hence `editingValue` reducer is used in `importText` reducer to fix this particular issue.