### PR TITLE
importJSON: Error importing nested list

### DIFF
--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -150,10 +150,7 @@ const importText = (
       }),
     )
 
-    // flatten is necessary because htmlToJson can return array within array which in turns causes block.scope to be undefined in importJSON.ts L123
-    const json = isRoam
-      ? _.flatten(roamJsonToBlocks(JSON.parse(sanitizedConvertedText)))
-      : _.flatten(htmlToJson(sanitizedConvertedText))
+    const json = isRoam ? roamJsonToBlocks(JSON.parse(sanitizedConvertedText)) : htmlToJson(sanitizedConvertedText)
 
     const uuid = createId()
 

--- a/src/reducers/importText.ts
+++ b/src/reducers/importText.ts
@@ -150,7 +150,10 @@ const importText = (
       }),
     )
 
-    const json = isRoam ? roamJsonToBlocks(JSON.parse(sanitizedConvertedText)) : htmlToJson(sanitizedConvertedText)
+    // flatten is necessary because htmlToJson can return array within array which in turns causes block.scope to be undefined in importJSON.ts L123
+    const json = isRoam
+      ? _.flatten(roamJsonToBlocks(JSON.parse(sanitizedConvertedText)))
+      : _.flatten(htmlToJson(sanitizedConvertedText))
 
     const uuid = createId()
 

--- a/src/util/htmlToJson.ts
+++ b/src/util/htmlToJson.ts
@@ -133,7 +133,7 @@ const joinChildren = (nodes: Block[]) => {
     }),
   )
 
-  return parentsWithChildren.length === 1 ? parentsWithChildren[0] : parentsWithChildren
+  return parentsWithChildren.length === 1 ? parentsWithChildren[0] : parentsWithChildren.flat()
 }
 
 /** Converts an <li> element to a Block. */
@@ -195,7 +195,10 @@ const himalayaToBlock = (nodes: HimalayaNode[]): Block | Block[] => {
 
   // retrieve first chunk, if the first element is Block and the second is Block[], join children (Block[]) with parent (Block), else return blocks as is.
   const [first, rest] = blocks
+  console.log('rest :', rest)
+  console.log('first :', first)
   const result = !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks as Block[]) : (blocks as Block[])
+  console.log('result :', result)
 
   return result
 }

--- a/src/util/htmlToJson.ts
+++ b/src/util/htmlToJson.ts
@@ -120,9 +120,9 @@ const handleBr = (nodes: HimalayaNode[], brIndex: number): HimalayaNode[] => {
 }
 
 /** Append children to parent as children property if it's necessary. */
-const joinChildren = (nodes: Block[]) => {
+const joinChildren = (nodes: Block[] | Block[][]) => {
   // split by chunk with size of 2, first element in chunk is Block - parent, the second is Block[] - children
-  const chunks = _.chunk(nodes, 2)
+  const chunks = _.chunk(nodes as Block[], 2)
   const parentsWithChildren = chunks.map(chunk =>
     chunk.reduce((accum, node, index) => {
       if (index === 0) return node
@@ -195,7 +195,8 @@ const himalayaToBlock = (nodes: HimalayaNode[]): Block | Block[] => {
 
   // retrieve first chunk, if the first element is Block and the second is Block[], join children (Block[]) with parent (Block), else return blocks as is.
   const [first, rest] = blocks
-  const result = !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks as Block[]) : (blocks as Block[])
+  const result =
+    !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks as Block[] | Block[][]) : (blocks as Block[])
 
   return result
 }

--- a/src/util/htmlToJson.ts
+++ b/src/util/htmlToJson.ts
@@ -195,10 +195,7 @@ const himalayaToBlock = (nodes: HimalayaNode[]): Block | Block[] => {
 
   // retrieve first chunk, if the first element is Block and the second is Block[], join children (Block[]) with parent (Block), else return blocks as is.
   const [first, rest] = blocks
-  console.log('rest :', rest)
-  console.log('first :', first)
   const result = !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks as Block[]) : (blocks as Block[])
-  console.log('result :', result)
 
   return result
 }

--- a/src/util/htmlToJson.ts
+++ b/src/util/htmlToJson.ts
@@ -120,11 +120,11 @@ const handleBr = (nodes: HimalayaNode[], brIndex: number): HimalayaNode[] => {
 }
 
 /** Append children to parent as children property if it's necessary. */
-const joinChildren = (nodes: Block[] | Block[][]) => {
+const joinChildren = (nodes: (Block | Block[])[]) => {
   // split by chunk with size of 2, first element in chunk is Block - parent, the second is Block[] - children
-  const chunks = _.chunk(nodes as Block[], 2)
+  const chunks = _.chunk(nodes, 2)
   const parentsWithChildren = chunks.map(chunk =>
-    chunk.reduce((accum, node, index) => {
+    chunk.flat().reduce((accum, node, index) => {
       if (index === 0) return node
       return {
         ...accum,
@@ -133,7 +133,7 @@ const joinChildren = (nodes: Block[] | Block[][]) => {
     }),
   )
 
-  return parentsWithChildren.length === 1 ? parentsWithChildren[0] : parentsWithChildren.flat()
+  return parentsWithChildren.length === 1 ? parentsWithChildren[0] : parentsWithChildren
 }
 
 /** Converts an <li> element to a Block. */
@@ -195,8 +195,7 @@ const himalayaToBlock = (nodes: HimalayaNode[]): Block | Block[] => {
 
   // retrieve first chunk, if the first element is Block and the second is Block[], join children (Block[]) with parent (Block), else return blocks as is.
   const [first, rest] = blocks
-  const result =
-    !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks as Block[] | Block[][]) : (blocks as Block[])
+  const result = !Array.isArray(first) && Array.isArray(rest) ? joinChildren(blocks) : (blocks as Block[])
 
   return result
 }


### PR DESCRIPTION
Fixes #1547 

## Problem

- while importing nested list, `htmlToJson` would normally return a single dimensional array. However in some cases, it can return two dimensional array as well, which causes a problem in (https://github.com/cybersemics/em/blob/dev/src/util/importJSON.ts#L123) as it is attempting to trim `undefined`

## Preliminary solution
- The solution is to flatten the array obtained from `htmlToJson` so that `block.scope` is not `undefined`. However this solution doesn't fix the expected formatting of the thoughts as discussed in the issue #1547 