### PR TITLE
Add feature that shows user last action on undo shortcut description

### DIFF
--- a/src/@types/Shortcut.ts
+++ b/src/@types/Shortcut.ts
@@ -18,7 +18,7 @@ export interface Shortcut {
   conflicts?: string[]
 
   // a description of what the shortcut does that is shown in the Help modal
-  description?: string
+  description?: string | ((getState: () => State) => string)
 
   // executes the shortcut
   exec: (

--- a/src/components/ModalHelp.tsx
+++ b/src/components/ModalHelp.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { isTouch } from '../browser'
+import { store } from '../store'
 import { formatKeyboardShortcut, globalShortcuts } from '../shortcuts'
 import * as db from '../data-providers/dexie'
 import { makeCompareByProp, sort } from '../util'
@@ -30,7 +31,7 @@ const ShortcutRows = (shortcut: Shortcut, i: number) => (
   <tr key={i}>
     <th>
       <b>{shortcut.label}</b>
-      <p>{shortcut.description}</p>
+      <p>{typeof shortcut.description === 'function' ? shortcut.description(store.getState) : shortcut.description}</p>
     </th>
     <td>
       {isTouch && shortcut.gesture ? (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -303,7 +303,11 @@ const Toolbar = ({
                       <Shortcut {...shortcut} />
                     </div>
                   ) : null}
-                  <div className='overlay-body'>{shortcut.description}</div>
+                  <div className='overlay-body'>
+                    {typeof shortcut.description === 'function'
+                      ? shortcut.description(store.getState)
+                      : shortcut.description}
+                  </div>
                 </div>
               </CSSTransition>
             ) : null}

--- a/src/shortcuts/redo.ts
+++ b/src/shortcuts/redo.ts
@@ -8,7 +8,15 @@ import { getLatestActionType } from '../util/getLastActionType'
 const redoShortcut: Shortcut = {
   id: 'redo',
   label: 'Redo',
-  description: 'Redo',
+  description: getState => {
+    const lastActionType = getLatestActionType(getState().patches)
+
+    if (lastActionType) {
+      return `Redo ${startCase(lastActionType)}`
+    }
+
+    return 'Redo'
+  },
   svg: RedoIcon,
   exec: (dispatch, getState) => {
     if (!isRedoEnabled(getState())) return

--- a/src/shortcuts/undo.ts
+++ b/src/shortcuts/undo.ts
@@ -8,7 +8,15 @@ import { getLatestActionType } from '../util/getLastActionType'
 const undoShortcut: Shortcut = {
   id: 'undo',
   label: 'Undo',
-  description: 'Undo.',
+  description: getState => {
+    const lastActionType = getLatestActionType(getState().inversePatches)
+
+    if (lastActionType) {
+      return `Undo ${startCase(lastActionType)}`
+    }
+
+    return 'Undo.'
+  },
   svg: UndoIcon,
   exec: (dispatch, getState) => {
     if (!isUndoEnabled(getState())) return


### PR DESCRIPTION
Fixes #1557

<img width="670" alt="Screen Shot 2022-04-24 at 09 58 57" src="https://user-images.githubusercontent.com/39818428/164955112-52812a7a-5b65-4e1c-96dc-3e57647219b4.png">

Changes:
- Change undo's message into the function to enable dynamic description based on the last user action
- Add function type declaration for shortcut's message
- Change usage how to display shortcut message


