### PR TITLE
Split thought duplicates lexeme

### DIFF
--- a/src/reducers/splitThought.ts
+++ b/src/reducers/splitThought.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { HOME_TOKEN } from '../constants'
 import { appendToPath, parentOf, pathToContext, reducerFlow, strip, head } from '../util'
 import { getChildrenRanked, simplifyPath, getThoughtById } from '../selectors'
-import { editableRender, editThought, moveThought, newThought } from '../reducers'
+import { editableRender, editThought, moveThought, newThought, deleteData } from '../reducers'
 import { Path, SplitResult, State } from '../@types'
 
 /** Splits a thought into two thoughts.
@@ -28,6 +28,10 @@ const splitThought = (state: State, { path, splitResult }: { path?: Path; splitR
   const pathLeft = path
 
   return reducerFlow([
+    // always delete current lexeme value as we don't want any lexeme value duplication after split
+    deleteData({
+      value,
+    }),
     // set the thought's text to the left of the selection
     editThought({
       oldValue: value,

--- a/src/shortcuts/__tests__/splitThought.ts
+++ b/src/shortcuts/__tests__/splitThought.ts
@@ -1,0 +1,40 @@
+import { store } from '../../store'
+import { newThought } from '../../action-creators'
+import testTimer from '../../test-helpers/testTimer'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import { screen } from '@testing-library/dom'
+
+const fakeTimer = testTimer()
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('Splitting thought right after non word character', async () => {
+  fakeTimer.useFakeTimer()
+
+  store.dispatch([
+    newThought({
+      value: '*test',
+    }),
+  ])
+
+  await fakeTimer.runAllAsync()
+
+  await fakeTimer.useRealTimer()
+
+  fakeTimer.useFakeTimer()
+
+  store.dispatch({
+    type: 'splitThought',
+    splitResult: {
+      left: '*',
+      right: 'test',
+    },
+  })
+
+  await fakeTimer.runAllAsync()
+
+  await fakeTimer.useRealTimer()
+
+  expect(() => screen.getByText('2')).toThrow('Unable to find an element')
+})

--- a/src/shortcuts/__tests__/splitThought.ts
+++ b/src/shortcuts/__tests__/splitThought.ts
@@ -9,7 +9,7 @@ const fakeTimer = testTimer()
 beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 
-it('Splitting thought right after non word character', async () => {
+it('split thought after non-word character', async () => {
   fakeTimer.useFakeTimer()
 
   store.dispatch([
@@ -19,10 +19,6 @@ it('Splitting thought right after non word character', async () => {
   ])
 
   await fakeTimer.runAllAsync()
-
-  await fakeTimer.useRealTimer()
-
-  fakeTimer.useFakeTimer()
 
   store.dispatch({
     type: 'splitThought',
@@ -36,5 +32,6 @@ it('Splitting thought right after non word character', async () => {
 
   await fakeTimer.useRealTimer()
 
+  // ensure that the Lexeme is not duplicated since it is the same as the source thought
   expect(() => screen.getByText('2')).toThrow('Unable to find an element')
 })


### PR DESCRIPTION
Fixes #1559 

## Problem

- Everytime a thought is created/edited it gets pushed to IndexedDB. This is handled by `pushQueue` middleware.

- When a normal thought (pure word characters value) is splitted, `pushQueue` middleware runs and it first dispatched `pullPendingLexemes` where it tries to retrieve pending lexemes from IndexedDB if exists. The splitted thought values in this case always produce a unique lexeme value hash hence no pending lexemes are pulled.

- However when a thought (value with non-word + word characters) is splitted in such a way that the caret position is after a non-word character it creates duplication in lexemeValue as `hashThought` provides same hash value for *test, test, ^*test## etc. So in this case when `pullPendingLexemes` is called it returns a pending lexeme from IndexedDB that ultimately gets merged by `mergeConflictingLexemeIndexUpdates`. This is the actual reason that when splitting a certain lexeme can have multiple contexts.

## Solution

When splitting a thought, always remove the current lexeme value (thought to be splitted) from IndexedDB as splitting should always result in creation of new unique lexeme values of the thought.