### PR TITLE
Caret moves to offset 1 after outdent 

### DIFF
--- a/src/e2e/browserEnvironment/helpers/getSelection.ts
+++ b/src/e2e/browserEnvironment/helpers/getSelection.ts
@@ -7,6 +7,7 @@ import { BrowserEnvironment } from '../types'
  * await getSelection().focusOffset
  * await getSelection().focusNode
  * await getSelection().focusNode?.textContent
+ * await getSelection().focusNode?.nodeType
  *
  **/
 const getSelection = (browser: BrowserEnvironment) => {
@@ -33,11 +34,21 @@ const getSelection = (browser: BrowserEnvironment) => {
         },
       })
 
+      // eslint-disable-next-line fp/no-mutating-methods
+      Object.defineProperty(focusNodePromise, 'nodeType', {
+        get: function (): Promise<number | undefined> {
+          // short-circuit the focusNodePromise since we are accessing a property
+          propertyAccessed = true
+          return browser.execute(() => window.getSelection()?.focusNode?.nodeType)
+        },
+      })
+
       // add the textContent property
       // add undefined to match the native browser api
       return focusNodePromise as
         | (typeof focusNodePromise & {
             textContent: Promise<string | null | undefined>
+            nodeType: Promise<number | undefined>
           })
         | undefined
     },

--- a/src/e2e/puppeteer/__tests__/caret.ts
+++ b/src/e2e/puppeteer/__tests__/caret.ts
@@ -12,6 +12,7 @@ describe('all platforms', () => {
     click,
     clickBullet,
     clickThought,
+    down,
     getSelection,
     paste,
     press,
@@ -148,6 +149,26 @@ describe('all platforms', () => {
 
     const textContext = await getSelection().focusNode?.textContent
     expect(textContext).toBe('b')
+  })
+
+  // https://github.com/cybersemics/em/issues/1568
+  it('caret at the end of a thought should be preserved on indent and outdent', async () => {
+    const importText = `
+    - a
+    - chicago`
+    await paste(importText)
+    await clickThought('chicago')
+
+    // await press('Enter')
+    await press('End')
+    await press('Tab')
+    await down('Shift')
+    await press('Tab')
+
+    const nodeType = await getSelection().focusNode?.nodeType
+    expect(nodeType).toBe(Node.ELEMENT_NODE)
+    const offset = await getSelection().focusOffset
+    expect(offset).toBe(1)
   })
 })
 

--- a/src/e2e/puppeteer/helpers/down.ts
+++ b/src/e2e/puppeteer/helpers/down.ts
@@ -1,0 +1,8 @@
+import { KeyInput, Keyboard, Page } from 'puppeteer'
+
+type Options = Parameters<Keyboard['down']>[1]
+
+/** Holds down a key on the keyboad. */
+const down = (page: Page, key: KeyInput, options?: Options) => page.keyboard.down(key, options)
+
+export default down

--- a/src/e2e/puppeteer/helpers/index.ts
+++ b/src/e2e/puppeteer/helpers/index.ts
@@ -6,6 +6,7 @@ import $ from './$'
 import click from './click'
 import clickBullet from './clickBullet'
 import clickThought from './clickThought'
+import down from './down'
 import getComputedColor from './getComputedColor'
 import getEditable from './getEditable'
 import getEditingText from './getEditingText'
@@ -36,6 +37,7 @@ const helpers = {
   click,
   clickBullet,
   clickThought,
+  down,
   getComputedColor,
   getEditable,
   getEditingText,

--- a/src/reducers/indent.ts
+++ b/src/reducers/indent.ts
@@ -38,8 +38,8 @@ const indent = (state: State) => {
     })
   }
 
-  // store selection offset before moveThought is dispatched
-  const offset = selection.offset()
+  // calculate offset value based upon selection node before moveThought is dispatched
+  const offset = (selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
 
   const cursorNew = appendToPath(parentOf(cursor), prev.id, head(cursor))
 

--- a/src/reducers/outdent.ts
+++ b/src/reducers/outdent.ts
@@ -32,8 +32,8 @@ const outdent = (state: State) => {
     })
   }
 
-  // store selection offset before moveThought is dispatched
-  const offset = selection.offset()
+  // calculate offset value based upon selection node before moveThought is dispatched
+  const offset = (selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
 
   const cursorNew: Path = [...unroot(rootedParentOf(state, parentOf(cursor))), head(cursor)]
 


### PR DESCRIPTION
Fixes #1568 

## Problem
- When we are calculating offset, we are not considering selection node type which is actually necessary to track accurate caret position.

## Solution

- When calculating cursor offset, check whether the active caret is on which node. Then accordingly apply logic to either take the value from `selection.offset()` or `state.cursorOffset`