### PR TITLE
Merge Databases

### DIFF
--- a/scripts/merge-dbs/.gitignore
+++ b/scripts/merge-dbs/.gitignore
@@ -1,3 +1,2 @@
 build
 sample
-output

--- a/scripts/merge-dbs/.gitignore
+++ b/scripts/merge-dbs/.gitignore
@@ -1,0 +1,3 @@
+build
+sample
+output

--- a/scripts/merge-dbs/README.md
+++ b/scripts/merge-dbs/README.md
@@ -1,4 +1,6 @@
-Imports one em database into another.
+Merges **em** databases.
+
+Handles old schema and reconstructs all thoughts.
 
 ## Build
 
@@ -6,15 +8,18 @@ Imports one em database into another.
 npm run build
 ```
 
+## Setup
+
+1. Place backup dbs in a new directory.
+2. Save a db with schema v5 as `db.json` in the same directory to serve as the base db. All backups will be merged into the base.
+
 ## Usage
 
-- `node index.js [BASE_DB] [BACKUP_DB]`
-
 ```
-node build/scripts/merge-dbs/index.js ~/em-backups/2022-05-16.json  ~/em-backups/backups\ 2021-01-01\ -\ 2021-01-31
+node build/scripts/merge-dbs/index.js ~/em-backups/backups
 ```
 
-Outputs two files:
-
-- `em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-contextIndex.json`
-- `em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-thoughtIndex.json`
+- Reads all backup files in the specified directory.
+- Reads the base db from `db.json`.
+- Overwrites `db.json` with the merged db.
+- Saves progress to `progress.json` after each backup is merged to enable resume.

--- a/scripts/merge-dbs/README.md
+++ b/scripts/merge-dbs/README.md
@@ -1,0 +1,16 @@
+Imports one em database into another.
+
+## Build
+
+```sh
+npm run build
+```
+
+## Usage
+
+`node build/scripts/merge/index.js sample/em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export.json sample/backups`
+
+Outputs two files:
+
+- `em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-contextIndex.json`
+- 'em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-thoughtIndex.json`

--- a/scripts/merge-dbs/README.md
+++ b/scripts/merge-dbs/README.md
@@ -8,7 +8,11 @@ npm run build
 
 ## Usage
 
-`node build/scripts/merge/index.js sample/em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export.json sample/backups`
+- `node index.js [BASE_DB] [BACKUP_DB]`
+
+```
+node build/scripts/merge-dbs/index.js ~/em-backups/2022-05-16.json  ~/em-backups/backups\ 2021-01-01\ -\ 2021-01-31
+```
 
 Outputs two files:
 

--- a/scripts/merge-dbs/README.md
+++ b/scripts/merge-dbs/README.md
@@ -17,4 +17,4 @@ node build/scripts/merge-dbs/index.js ~/em-backups/2022-05-16.json  ~/em-backups
 Outputs two files:
 
 - `em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-contextIndex.json`
-- 'em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-thoughtIndex.json`
+- `em-proto-wWpM1PlkbFSbPTXzOvRwFwaHf052-export-thoughtIndex.json`

--- a/scripts/merge-dbs/blank-db.json
+++ b/scripts/merge-dbs/blank-db.json
@@ -1,0 +1,750 @@
+{
+  "thoughtIndex": {
+    "__ROOT__": {
+      "id": "__ROOT__",
+      "value": "__ROOT__",
+      "parentId": "__ROOT_PARENT_ID__",
+      "children": [
+        "V77ckoU9aPjFD1uoe6pZC"
+      ],
+      "pending": false,
+      "lastUpdated": "2022-05-21T18:31:43.783Z",
+      "rank": 0,
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "__ABSOLUTE__": {
+      "id": "__ABSOLUTE__",
+      "value": "__ABSOLUTE__",
+      "parentId": "__ROOT_PARENT_ID__",
+      "children": [],
+      "pending": true,
+      "lastUpdated": "",
+      "rank": 0,
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "__EM__": {
+      "id": "__EM__",
+      "value": "__EM__",
+      "parentId": "__ROOT_PARENT_ID__",
+      "rank": 0,
+      "children": [
+        "VuvLgfcm09jzZNfIBTcm_"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "VuvLgfcm09jzZNfIBTcm_": {
+      "id": "VuvLgfcm09jzZNfIBTcm_",
+      "value": "Settings",
+      "parentId": "__EM__",
+      "rank": 0,
+      "children": [
+        "sFDNrxMO3Xs4PSwoKF8JD",
+        "FDXl3lK4R7aMYZ_Bvq3pN",
+        "_Hi_dCIjuql-uiDjoJa8f",
+        "RNPxjmuYIrLMx4cz6oSCO",
+        "c8fPBFeZAUq6U1fSk1BSP",
+        "c3wWqliFq90kCCmaIZUU9",
+        "InLtaisXNqgnRTBuffcN9"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "sFDNrxMO3Xs4PSwoKF8JD": {
+      "id": "sFDNrxMO3Xs4PSwoKF8JD",
+      "value": "=readonly",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "FDXl3lK4R7aMYZ_Bvq3pN": {
+      "id": "FDXl3lK4R7aMYZ_Bvq3pN",
+      "value": "Theme",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 1,
+      "children": [
+        "1t808B73IwY0Q6hEeki05",
+        "qvKKXVvoZGV5sqrIEGBPG",
+        "phHTAJgsveLyqLsV-o0a4"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "_Hi_dCIjuql-uiDjoJa8f": {
+      "id": "_Hi_dCIjuql-uiDjoJa8f",
+      "value": "Global Sort",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 2,
+      "children": [
+        "QJc5L2VOyxeyPREeI4dYN",
+        "sVKesYeoTmEzhw3XxDCeG",
+        "lZlrpW0_2sme4-YZ724jQ"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "RNPxjmuYIrLMx4cz6oSCO": {
+      "id": "RNPxjmuYIrLMx4cz6oSCO",
+      "value": "Data Integrity Check",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 3,
+      "children": [
+        "T49ACGNmH_DsdwjIzzze2",
+        "-PHif1bAbgO7-kml36isW",
+        "kc9725IFGB3n1D7wcUi1L"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "c8fPBFeZAUq6U1fSk1BSP": {
+      "id": "c8fPBFeZAUq6U1fSk1BSP",
+      "value": "Tutorial",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 4,
+      "children": [
+        "5HvtAANnPZAJxXdJLbFge",
+        "cZWUdpdein6Djne75NjNg",
+        "e8BvqNaajABRcX5mlknYB"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": "2022-05-21T18:31:41.474Z"
+    },
+    "c3wWqliFq90kCCmaIZUU9": {
+      "id": "c3wWqliFq90kCCmaIZUU9",
+      "value": "Tutorial Choice",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 5,
+      "children": [
+        "VvIyBbMg9wri9NLYkMTFR",
+        "aERdZ1wsYg5KhSMvwXrsd",
+        "Z8jyT3QoWcpOXDpZgLAeg"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "InLtaisXNqgnRTBuffcN9": {
+      "id": "InLtaisXNqgnRTBuffcN9",
+      "value": "Tutorial Step",
+      "parentId": "VuvLgfcm09jzZNfIBTcm_",
+      "rank": 6,
+      "children": [
+        "7hCFWmpypU4GF1d3-n_ju",
+        "uK6V_Q_nUwwfEVX_E4yub",
+        "huvLeOt7-uIF-xMsAHfG5"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "1t808B73IwY0Q6hEeki05": {
+      "id": "1t808B73IwY0Q6hEeki05",
+      "value": "=readonly",
+      "parentId": "FDXl3lK4R7aMYZ_Bvq3pN",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "qvKKXVvoZGV5sqrIEGBPG": {
+      "id": "qvKKXVvoZGV5sqrIEGBPG",
+      "value": "=options",
+      "parentId": "FDXl3lK4R7aMYZ_Bvq3pN",
+      "rank": 1,
+      "children": [
+        "MQp7LIePxP_qifgob0KSW",
+        "ga1aVl8qUDX_PD2b4MBrc"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "phHTAJgsveLyqLsV-o0a4": {
+      "id": "phHTAJgsveLyqLsV-o0a4",
+      "value": "Dark",
+      "parentId": "FDXl3lK4R7aMYZ_Bvq3pN",
+      "rank": 2,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "QJc5L2VOyxeyPREeI4dYN": {
+      "id": "QJc5L2VOyxeyPREeI4dYN",
+      "value": "=readonly",
+      "parentId": "_Hi_dCIjuql-uiDjoJa8f",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "sVKesYeoTmEzhw3XxDCeG": {
+      "id": "sVKesYeoTmEzhw3XxDCeG",
+      "value": "=options",
+      "parentId": "_Hi_dCIjuql-uiDjoJa8f",
+      "rank": 1,
+      "children": [
+        "UkQuzNrINyLjRofEtjfmt",
+        "EnXqY3Irxys-sgibqu0xK"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "lZlrpW0_2sme4-YZ724jQ": {
+      "id": "lZlrpW0_2sme4-YZ724jQ",
+      "value": "None",
+      "parentId": "_Hi_dCIjuql-uiDjoJa8f",
+      "rank": 2,
+      "children": [
+        "HX7_86XZR6y6hfDREKRjL"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "T49ACGNmH_DsdwjIzzze2": {
+      "id": "T49ACGNmH_DsdwjIzzze2",
+      "value": "=readonly",
+      "parentId": "RNPxjmuYIrLMx4cz6oSCO",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "-PHif1bAbgO7-kml36isW": {
+      "id": "-PHif1bAbgO7-kml36isW",
+      "value": "=options",
+      "parentId": "RNPxjmuYIrLMx4cz6oSCO",
+      "rank": 1,
+      "children": [
+        "vEJ40WmgIhOTZtc-0OaQC",
+        "e_UAxRX6Hwxnj3HF5zFB6"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "kc9725IFGB3n1D7wcUi1L": {
+      "id": "kc9725IFGB3n1D7wcUi1L",
+      "value": "Off",
+      "parentId": "RNPxjmuYIrLMx4cz6oSCO",
+      "rank": 2,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "5HvtAANnPZAJxXdJLbFge": {
+      "id": "5HvtAANnPZAJxXdJLbFge",
+      "value": "=readonly",
+      "parentId": "c8fPBFeZAUq6U1fSk1BSP",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "cZWUdpdein6Djne75NjNg": {
+      "id": "cZWUdpdein6Djne75NjNg",
+      "value": "=options",
+      "parentId": "c8fPBFeZAUq6U1fSk1BSP",
+      "rank": 1,
+      "children": [
+        "JUNFyk8CNNwfyxqRhOjue",
+        "z_mPMHZ2L60OZf_z83P7C"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "e8BvqNaajABRcX5mlknYB": {
+      "id": "e8BvqNaajABRcX5mlknYB",
+      "value": "Off",
+      "parentId": "c8fPBFeZAUq6U1fSk1BSP",
+      "rank": 2,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": "2022-05-21T18:31:41.474Z",
+      "sortValue": "Off"
+    },
+    "VvIyBbMg9wri9NLYkMTFR": {
+      "id": "VvIyBbMg9wri9NLYkMTFR",
+      "value": "=readonly",
+      "parentId": "c3wWqliFq90kCCmaIZUU9",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "aERdZ1wsYg5KhSMvwXrsd": {
+      "id": "aERdZ1wsYg5KhSMvwXrsd",
+      "value": "=type",
+      "parentId": "c3wWqliFq90kCCmaIZUU9",
+      "rank": 1,
+      "children": [
+        "xM0fe5Rq4yRgkeuqnj2hQ"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "Z8jyT3QoWcpOXDpZgLAeg": {
+      "id": "Z8jyT3QoWcpOXDpZgLAeg",
+      "value": "0",
+      "parentId": "c3wWqliFq90kCCmaIZUU9",
+      "rank": 2,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "7hCFWmpypU4GF1d3-n_ju": {
+      "id": "7hCFWmpypU4GF1d3-n_ju",
+      "value": "=readonly",
+      "parentId": "InLtaisXNqgnRTBuffcN9",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "uK6V_Q_nUwwfEVX_E4yub": {
+      "id": "uK6V_Q_nUwwfEVX_E4yub",
+      "value": "=type",
+      "parentId": "InLtaisXNqgnRTBuffcN9",
+      "rank": 1,
+      "children": [
+        "xamE0ZOiC0aKQtvjTAqMt"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "huvLeOt7-uIF-xMsAHfG5": {
+      "id": "huvLeOt7-uIF-xMsAHfG5",
+      "value": "1",
+      "parentId": "InLtaisXNqgnRTBuffcN9",
+      "rank": 2,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "MQp7LIePxP_qifgob0KSW": {
+      "id": "MQp7LIePxP_qifgob0KSW",
+      "value": "Dark",
+      "parentId": "qvKKXVvoZGV5sqrIEGBPG",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "ga1aVl8qUDX_PD2b4MBrc": {
+      "id": "ga1aVl8qUDX_PD2b4MBrc",
+      "value": "Light",
+      "parentId": "qvKKXVvoZGV5sqrIEGBPG",
+      "rank": 1,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "UkQuzNrINyLjRofEtjfmt": {
+      "id": "UkQuzNrINyLjRofEtjfmt",
+      "value": "None",
+      "parentId": "sVKesYeoTmEzhw3XxDCeG",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "EnXqY3Irxys-sgibqu0xK": {
+      "id": "EnXqY3Irxys-sgibqu0xK",
+      "value": "Alphabetical",
+      "parentId": "sVKesYeoTmEzhw3XxDCeG",
+      "rank": 1,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "HX7_86XZR6y6hfDREKRjL": {
+      "id": "HX7_86XZR6y6hfDREKRjL",
+      "value": "=options",
+      "parentId": "lZlrpW0_2sme4-YZ724jQ",
+      "rank": 0,
+      "children": [
+        "WYYKaEAZ9D8G-y_hRvEO_",
+        "IFGBBTToS3W3aQfTSBsXd"
+      ],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "vEJ40WmgIhOTZtc-0OaQC": {
+      "id": "vEJ40WmgIhOTZtc-0OaQC",
+      "value": "On",
+      "parentId": "-PHif1bAbgO7-kml36isW",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "e_UAxRX6Hwxnj3HF5zFB6": {
+      "id": "e_UAxRX6Hwxnj3HF5zFB6",
+      "value": "Off",
+      "parentId": "-PHif1bAbgO7-kml36isW",
+      "rank": 1,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "JUNFyk8CNNwfyxqRhOjue": {
+      "id": "JUNFyk8CNNwfyxqRhOjue",
+      "value": "On",
+      "parentId": "cZWUdpdein6Djne75NjNg",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "z_mPMHZ2L60OZf_z83P7C": {
+      "id": "z_mPMHZ2L60OZf_z83P7C",
+      "value": "Off",
+      "parentId": "cZWUdpdein6Djne75NjNg",
+      "rank": 1,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "xM0fe5Rq4yRgkeuqnj2hQ": {
+      "id": "xM0fe5Rq4yRgkeuqnj2hQ",
+      "value": "Number",
+      "parentId": "aERdZ1wsYg5KhSMvwXrsd",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "xamE0ZOiC0aKQtvjTAqMt": {
+      "id": "xamE0ZOiC0aKQtvjTAqMt",
+      "value": "Number",
+      "parentId": "uK6V_Q_nUwwfEVX_E4yub",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "WYYKaEAZ9D8G-y_hRvEO_": {
+      "id": "WYYKaEAZ9D8G-y_hRvEO_",
+      "value": "Desc",
+      "parentId": "HX7_86XZR6y6hfDREKRjL",
+      "rank": 0,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "IFGBBTToS3W3aQfTSBsXd": {
+      "id": "IFGBBTToS3W3aQfTSBsXd",
+      "value": "Asc",
+      "parentId": "HX7_86XZR6y6hfDREKRjL",
+      "rank": 1,
+      "children": [],
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523",
+      "lastUpdated": ""
+    },
+    "V77ckoU9aPjFD1uoe6pZC": {
+      "id": "V77ckoU9aPjFD1uoe6pZC",
+      "parentId": "__ROOT__",
+      "children": [],
+      "lastUpdated": "2022-05-21T18:31:43.783Z",
+      "rank": 0,
+      "value": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    }
+  },
+  "lexemeIndex": {
+    "323720a6648d6a2272003af034bc823a": {
+      "value": "__ROOT__",
+      "contexts": [],
+      "created": "2022-05-19T10:58:38.820Z",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "36e16b2e5cf62e55e5a97fb45b85f030": {
+      "value": "__ABSOLUTE__",
+      "contexts": [],
+      "created": "2022-05-19T10:58:38.820Z",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "27f1123ea6a031cea0b59c63d4be848f": {
+      "value": "__EM__",
+      "contexts": [],
+      "created": "2022-05-19T10:58:38.820Z",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "5f91c388edbaa147a3faf14281100291": {
+      "id": "5f91c388edbaa147a3faf14281100291",
+      "value": "Settings",
+      "contexts": [
+        "RlqvrXUt3bIdFCR_kSEEf",
+        "VuvLgfcm09jzZNfIBTcm_"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "a86ababb5c309af90099d9e84425159a": {
+      "id": "a86ababb5c309af90099d9e84425159a",
+      "value": "=readonly",
+      "contexts": [
+        "7CdC75lCW61Jd9WqQujy4",
+        "3AVfFj9iRDghiiNROyYCb",
+        "VdFmG1kzR7TdEevmxKXQO",
+        "q9g7WgGi_y0J4yXmrBggu",
+        "XDY5uvN-04-mDFszD5Eaq",
+        "e855HgckTYKuanG3cFDvg",
+        "Xa8FHbJtz3BrGR806XTGa",
+        "sFDNrxMO3Xs4PSwoKF8JD",
+        "1t808B73IwY0Q6hEeki05",
+        "QJc5L2VOyxeyPREeI4dYN",
+        "T49ACGNmH_DsdwjIzzze2",
+        "5HvtAANnPZAJxXdJLbFge",
+        "VvIyBbMg9wri9NLYkMTFR",
+        "7hCFWmpypU4GF1d3-n_ju"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "ea8c71e4d5e7af3b546fff23c72e4869": {
+      "id": "ea8c71e4d5e7af3b546fff23c72e4869",
+      "value": "Theme",
+      "contexts": [
+        "wZAJ9tWAA0qJ0jUxiQbZj",
+        "FDXl3lK4R7aMYZ_Bvq3pN"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "6619061e339875751a22095681333fc1": {
+      "id": "6619061e339875751a22095681333fc1",
+      "value": "Global Sort",
+      "contexts": [
+        "dItoG2o4tSkf-ZcyNCJW2",
+        "_Hi_dCIjuql-uiDjoJa8f"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "736ddc5e944b66af77bc3e3278667e5e": {
+      "id": "736ddc5e944b66af77bc3e3278667e5e",
+      "value": "Data Integrity Check",
+      "contexts": [
+        "JxNiu49mAiEc3GIJ1D3OI",
+        "RNPxjmuYIrLMx4cz6oSCO"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "cdbc8c25ca68d96971e57db3f38298ad": {
+      "id": "cdbc8c25ca68d96971e57db3f38298ad",
+      "value": "Tutorial",
+      "contexts": [
+        "oU7u-UAxWvmALkLCJMC5a",
+        "c8fPBFeZAUq6U1fSk1BSP"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "52b83f8c68fc29f0f7e3589f260a996a": {
+      "id": "52b83f8c68fc29f0f7e3589f260a996a",
+      "value": "Tutorial Choice",
+      "contexts": [
+        "Y0c64hEuUbqsnE1GkVoWu",
+        "c3wWqliFq90kCCmaIZUU9"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "95fa1f512ce6a54e390f385cdb5f6d0e": {
+      "id": "95fa1f512ce6a54e390f385cdb5f6d0e",
+      "value": "Tutorial Step",
+      "contexts": [
+        "rApRf23vNDDptxL4DHMkP",
+        "InLtaisXNqgnRTBuffcN9"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "8ced970148bbcecd81a4da922f0ae557": {
+      "id": "8ced970148bbcecd81a4da922f0ae557",
+      "value": "=options",
+      "contexts": [
+        "DViXRJ942IkNr269V29Qx",
+        "HWxW7eU9gPhbha2AgXHnc",
+        "mVmGd86TDnju5hXXoUNwc",
+        "sp24kMHAdrQk3xdCMF_Ra",
+        "D1XHKumdMnKnLlX92ehX1",
+        "qvKKXVvoZGV5sqrIEGBPG",
+        "sVKesYeoTmEzhw3XxDCeG",
+        "HX7_86XZR6y6hfDREKRjL",
+        "-PHif1bAbgO7-kml36isW",
+        "cZWUdpdein6Djne75NjNg"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "81140ebed7fd304f58ceeb52c57ebf72": {
+      "id": "81140ebed7fd304f58ceeb52c57ebf72",
+      "value": "Dark",
+      "contexts": [
+        "K-J_9Nz7cgt0ANFVZZPVa",
+        "cmslYlLtc8J7m6m63_Ogx",
+        "MQp7LIePxP_qifgob0KSW",
+        "phHTAJgsveLyqLsV-o0a4"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "9bda129680fad936823e86f4a5287da0": {
+      "id": "9bda129680fad936823e86f4a5287da0",
+      "value": "None",
+      "contexts": [
+        "llMQUHKXJvwC7C9ofz0ct",
+        "8_cIuqW2GKnxdXRAKa0zd",
+        "UkQuzNrINyLjRofEtjfmt",
+        "lZlrpW0_2sme4-YZ724jQ"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "674313aceb22ee1d8fc128bf141df88d": {
+      "id": "674313aceb22ee1d8fc128bf141df88d",
+      "value": "Off",
+      "contexts": [
+        "0ZXh5CAv6gbujKp49fEuX",
+        "X2C8gN9khqeR9pGQuw8w1",
+        "f13vDccnaCn8UgaP8nope",
+        "e_UAxRX6Hwxnj3HF5zFB6",
+        "kc9725IFGB3n1D7wcUi1L",
+        "z_mPMHZ2L60OZf_z83P7C",
+        "e8BvqNaajABRcX5mlknYB"
+      ],
+      "created": "2022-05-21T18:31:41.474Z",
+      "lastUpdated": "2022-05-21T18:31:41.474Z",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "2dc975ff398a1ab9ff9f676829b78130": {
+      "id": "2dc975ff398a1ab9ff9f676829b78130",
+      "value": "On",
+      "contexts": [
+        "JtGvr7Qidg7aPi3d2hWgC",
+        "YXXQXsaOPDzguimG3R9gt",
+        "VpOdB_vIiyfnDdLdJkcbP",
+        "vEJ40WmgIhOTZtc-0OaQC",
+        "JUNFyk8CNNwfyxqRhOjue"
+      ],
+      "created": "2022-05-21T18:31:41.474Z",
+      "lastUpdated": "2022-05-21T18:31:41.474Z",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "1b857164b8d95cb930abf5b8d276d6b9": {
+      "id": "1b857164b8d95cb930abf5b8d276d6b9",
+      "value": "=type",
+      "contexts": [
+        "JuFdk_a_60sOFXpa9bx0S",
+        "Qbot1X40Gn2yc8Jt01iK5",
+        "aERdZ1wsYg5KhSMvwXrsd",
+        "uK6V_Q_nUwwfEVX_E4yub"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "2ac9debed546a3803a8de9e53c875e09": {
+      "id": "2ac9debed546a3803a8de9e53c875e09",
+      "value": "0",
+      "contexts": [
+        "ar2kwGtb5vf2Oo6Mbg-ZS",
+        "Z8jyT3QoWcpOXDpZgLAeg"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "71fbbbfe8a7b7c71942aeb9bf9f0f637": {
+      "id": "71fbbbfe8a7b7c71942aeb9bf9f0f637",
+      "value": "1",
+      "contexts": [
+        "TcphbTCMzkGOWBOf6v80r",
+        "huvLeOt7-uIF-xMsAHfG5"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "f57c77c0ad312328ed297bbdd58ca38a": {
+      "id": "f57c77c0ad312328ed297bbdd58ca38a",
+      "value": "Light",
+      "contexts": [
+        "L26wMO9-AuizF-pCwdKk2",
+        "ga1aVl8qUDX_PD2b4MBrc"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "0b5b6691cc9684b976ae3d686f6d4204": {
+      "id": "0b5b6691cc9684b976ae3d686f6d4204",
+      "value": "Alphabetical",
+      "contexts": [
+        "a-LyodwOlv1TzBdu-wP5c",
+        "EnXqY3Irxys-sgibqu0xK"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "70a876cf710921490472a2cd90e1f1bc": {
+      "id": "70a876cf710921490472a2cd90e1f1bc",
+      "value": "Number",
+      "contexts": [
+        "IzklVx8cb4Gm8L1MepHgE",
+        "XBfGHaDzElb-LVY9MgaXd",
+        "xM0fe5Rq4yRgkeuqnj2hQ",
+        "xamE0ZOiC0aKQtvjTAqMt"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "1bcabc75221ed756889df851c593c49a": {
+      "id": "1bcabc75221ed756889df851c593c49a",
+      "value": "Desc",
+      "contexts": [
+        "7C44ytpW7hYIslrj-TYNZ",
+        "WYYKaEAZ9D8G-y_hRvEO_"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "1f07439ec567055c76d3b069214e50a8": {
+      "id": "1f07439ec567055c76d3b069214e50a8",
+      "value": "Asc",
+      "contexts": [
+        "cLhS3o76LNXcsLcpUPOCX",
+        "IFGBBTToS3W3aQfTSBsXd"
+      ],
+      "created": "",
+      "lastUpdated": "",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    },
+    "00000000000000000000000000000000": {
+      "value": "",
+      "contexts": [
+        "V77ckoU9aPjFD1uoe6pZC"
+      ],
+      "created": "2022-05-21T18:31:43.783Z",
+      "lastUpdated": "2022-05-21T18:31:43.783Z",
+      "updatedBy": "04f1ce85-e532-45e3-96b4-9917b1d3a523"
+    }
+  }
+}

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -1,0 +1,357 @@
+/*************************************************************************
+ * MODULE IMPORTS
+ ************************************************************************/
+
+import fs from 'fs'
+import path from 'path'
+import chalk from 'chalk'
+import _ from 'lodash'
+import { v4 as uid } from 'uuid'
+import memoryStore from './memoryStore'
+
+/*************************************************************************
+ * MOCK BROWSER
+ ************************************************************************/
+
+global.addEventListener = () => {}
+global.self = {} as any
+global.document = {
+  createElement: () => {
+    return {
+      innerHTML: '',
+      get textContent() {
+        return this.innerHTML
+      },
+    }
+  },
+  hasFocus: () => false,
+} as any
+global.sessionStorage = memoryStore()
+global.localStorage = memoryStore()
+
+/*************************************************************************
+ * EM IMPORTS
+ ************************************************************************/
+
+import { HOME_TOKEN } from '../../src/constants'
+import { hashContext, hashThought, head, initialState, isRoot, timestamp, unroot } from '../../src/util'
+import { exportContext, getAllChildren, hasLexeme } from '../../src/selectors'
+import { importText } from '../../src/reducers'
+import {
+  Child,
+  Context,
+  Index,
+  Lexeme,
+  Parent,
+  State,
+  Timestamp,
+  ThoughtContext,
+  ThoughtIndices,
+} from '../../src/@types'
+
+/*************************************************************************
+ * TYPES
+ ************************************************************************/
+
+interface Database {
+  users: Index<RawThoughts>
+}
+
+interface FirebaseParent {
+  id?: string
+  // firebase stores arrays as objects
+  children: Index<Child>
+  context: Context
+  lastUpdated: Timestamp
+  pending?: boolean
+  updatedBy: string
+}
+
+interface FirebaseThoughts {
+  contextIndex: Index<FirebaseParent>
+  // Firebase thoughtIndex is actually a FirebaseLexeme, but exportContext doesn't use it so we can quiet the type checker
+  thoughtIndex: Index<Lexeme>
+}
+
+type RawThoughts = FirebaseThoughts | ThoughtIndices
+
+interface ErrorLog {
+  e: Error
+  file: string
+  message: string
+}
+
+/*************************************************************************
+ * CONSTANTS
+ ************************************************************************/
+
+const userId = 'm9S244ovF7fVrwpAoqoWxcz08s52'
+
+const helpText = `Usage: node build/scripts/merge/index.js em-proto-current.json em-proto-backup.json`
+
+let prevContext: Context = []
+
+const stateStart = initialState()
+
+/*****************************************************************
+ * SCRIPT
+ *****************************************************************/
+
+/** Gets the number of Lexemes in the State or Thoughts. */
+const numLexemes = (stateOrThoughts: State | ThoughtIndices | FirebaseThoughts) =>
+  Object.keys(((stateOrThoughts as State).thoughts || (stateOrThoughts as ThoughtIndices)).thoughtIndex).length
+
+/** Gets the number of Parents in the State or Thoughts. */
+const numParents = (stateOrThoughts: State | ThoughtIndices | FirebaseThoughts) =>
+  Object.keys(((stateOrThoughts as State).thoughts || (stateOrThoughts as ThoughtIndices)).contextIndex).length
+
+/** Checks if the contextIndex uses the most up-to-date hash function by checking the existence of the root context hash. This is NOT sufficient to determine if all Parents have a context property, which was added incrementally without a schemaVersion change. */
+const isModernHash = (thoughts: RawThoughts) => '6f94eccb7b23a8040cd73b60ba7c5abf' in thoughts.contextIndex
+
+/** Read a thought database from file. Normalizes contextIndex and thoughtIndex property names. */
+const readThoughts = (file: string): FirebaseThoughts => {
+  const input = fs.readFileSync(file, 'utf-8')
+  const db = JSON.parse(input)
+  const state = db.users?.[userId] || db
+
+  // rename contextChildren -> contextIndex
+  if (state.contextChildren) {
+    state.contextIndex = state.contextChildren
+    delete state.contextChildren
+  }
+
+  // rename data -> thoughtIndex
+  if (state.data) {
+    state.thoughtIndex = state.data
+    delete state.data
+  }
+
+  console.info(`${chalk.blue(numParents(state))} Parents read`)
+
+  return state
+}
+
+/** Since the legacy contextIndex has no context property, it is impossible traverse the tree without the original hash function. Instead, recreate the contextIndex with new hashes from the thoughtIndex, which does have the context. Converts Firebase "arrays" to proper arrays. Leaves thoughtIndex as-is since it is not used to merge thoughts. */
+const recreateParents = (thoughts: FirebaseThoughts | ThoughtIndices): ThoughtIndices => {
+  const lexemes = Object.values(thoughts.thoughtIndex)
+  console.info(`Recalculating context hash from ${chalk.blue(lexemes.length)} Lexemes`)
+
+  const updatedBy = uid()
+
+  // build a new contextIndex by iterating through each legacy Lexeme
+  const contextIndex = lexemes.reduce<Index<Parent>>((accum, lexeme) => {
+    // invalid Lexeme
+    if (lexeme.value == null) return accum
+
+    // read legacy memberOf property as contexts
+    const contexts: ThoughtContext[] = Object.values((lexeme as any).memberOf || lexeme.contexts || {})
+
+    // skip missing contexts
+    if (!contexts) return accum
+
+    // add each legacy ThoughtContext as a Child to a Parent
+    contexts.forEach(cx => {
+      // skip ThoughtContext without context property
+      if (!cx.context) return
+
+      const context = Object.values(cx.context)
+      const key = hashContext(context)
+      const parentOld = accum[key]
+      const childrenOld = Object.values(parentOld?.children || {})
+      accum[key] = {
+        ...parentOld,
+        id: key,
+        children: [...childrenOld, { value: lexeme.value, rank: cx.rank || Math.random() * 10e8 }],
+        context,
+        lastUpdated: cx.lastUpdated || timestamp(),
+        updatedBy,
+      }
+    })
+
+    return accum
+  }, {})
+
+  const thoughtsNew: ThoughtIndices & { isContextIndexRehashed: boolean } = {
+    contextIndex,
+    thoughtIndex: thoughts.thoughtIndex,
+    // track recalculated contexthash to avoid recalculating again in mergeThoughts
+    isContextIndexRehashed: true,
+  }
+
+  return thoughtsNew
+}
+
+/** Normalizes the contextIndex by converting Firebase "arrays" to proper arrays and recalculating context hashes if needed. Skips hash recalculation if isContextIndexRehashed is true. */
+// const normalizeFirebaseArrays = (thoughts: FirebaseThoughts | ThoughtIndices): ThoughtIndices => {
+//   // if the contextIndex already has proper arrays, return it as-is to avoid NOOP iteration
+//   // assume the first Parent is representative
+//   const firstParent = Object.values(thoughts.contextIndex)[0] as Parent | FirebaseParent
+//   if (Array.isArray(firstParent.context) && Array.isArray(firstParent.children)) return thoughts as ThoughtIndices
+
+//   console.info(`Normalizing ${chalk.blue(numParents(thoughts))} Parents`)
+
+//   // track how many parents do not have a context property
+//   // a few are okay, but they are skipped so en masse is a problem
+//   let missingContexts = 0
+
+//   // convert Firebase "arrays" to proper arrays
+//   // thoughtIndex is not used, so we don't have to normalize it
+//   const contextIndexNew = Object.keys(thoughts.contextIndex as Index<FirebaseParent>).reduce((accum, key) => {
+//     const parent = thoughts.contextIndex[key]
+
+//     // there are some invalid Parents with missing context field
+//     if (!parent.context) {
+//       missingContexts++
+//       return {}
+//     }
+
+//     // convert Parent.children Firebase "array"
+//     const children = Object.values(parent.children || {})
+//     const context = Object.values(parent.context || {})
+
+//     return {
+//       ...accum,
+//       [key]: {
+//         ...parent,
+//         children,
+//         context,
+//       },
+//     }
+//   }, {})
+
+//   if (missingContexts > 10) {
+//     console.warn('More than 10 Parents with missing context property:', missingContexts)
+//   }
+
+//   return {
+//     ...thoughts,
+//     contextIndex: contextIndexNew,
+//   }
+// }
+
+/** Merges thoughts into current state using importText to handle duplicates and merged descendants. */
+const mergeThoughts = (state: State, thoughts: ThoughtIndices) => {
+  console.info(`Exporting ${chalk.blue(numParents(thoughts))} Parents to HTML`)
+  const stateBackup: State = {
+    ...stateStart,
+    thoughts: {
+      ...stateStart.thoughts,
+      ...thoughts,
+    },
+  }
+
+  // import each child individually to reduce memory usage
+  const stateNew = getAllChildren(stateBackup, [HOME_TOKEN]).reduce((stateAccum, child) => {
+    console.info(`Exporting ${child.value}`)
+    const html = exportContext(stateBackup, [child.value])
+    console.info(`Importing ${child.value}`)
+    const stateNew = importText(stateAccum, { text: html })
+    console.info(
+      `New state has ${chalk.blue(numParents(stateNew))} Parents and ${chalk.blue(numLexemes(stateNew))} Lexemes`,
+    )
+
+    return stateNew
+  }, state)
+
+  return stateNew
+}
+
+const main = () => {
+  const [, , file1, file2] = process.argv
+
+  // check args
+  if (process.argv.length < 4) {
+    console.info(helpText)
+    process.exit(0)
+  }
+
+  const basename = path.basename(file1)
+  const indexExt = basename.lastIndexOf('.')
+  const file1Base = basename.slice(0, indexExt)
+  const file1Ext = basename.slice(indexExt)
+
+  // read base thoughts
+  // assume that they are completely valid, with modern hashes and proper context fields
+  console.info(`Reading current thoughts: ${file1}`)
+  const thoughtsCurrent = readThoughts(file1) as unknown as ThoughtIndices
+
+  // read thoughts to be imported
+  // this can be a directory or a file
+  const filesToImport = fs.lstatSync(file2).isDirectory()
+    ? fs.readdirSync(file2).map(file => `${file2}/${file}`)
+    : [file2]
+
+  // accumulate the new state by importing each input
+  let stateNew: State = { ...stateStart, thoughts: thoughtsCurrent }
+  const errors: ErrorLog[] = []
+  const success: string[] = []
+
+  filesToImport.forEach(file => {
+    // skip hidden files including .DS_Store
+    if (path.basename(file).startsWith('.')) return
+
+    let thoughtsImported: ThoughtIndices
+
+    try {
+      console.info(`Reading thoughts: ${file}`)
+      thoughtsImported = recreateParents(readThoughts(file))
+    } catch (e) {
+      console.error('Error reading')
+      errors.push({ e: e as Error, file, message: 'Error reading' })
+      console.info('')
+      return
+    }
+
+    try {
+      stateNew = mergeThoughts(stateNew, thoughtsImported)
+
+      // if we made it this far, there was no error
+      success.push(file)
+    } catch (e) {
+      console.error('Error merging')
+      errors.push({ e: e as Error, file, message: 'Error merging' })
+      console.info('')
+      return
+    }
+
+    console.info('')
+  })
+
+  // write new state to output directory
+  fs.mkdirSync('output', { recursive: true })
+
+  // merge updated thoughts back into firebase db
+  const dbNew = {
+    ...thoughtsCurrent,
+    contextIndex: stateNew.thoughts.contextIndex,
+    thoughtIndex: stateNew.thoughts.thoughtIndex,
+  }
+  const fileNew = `output/${file1Base}-merged${file1Ext}`
+  console.info(`Writing new database with ${chalk.blue(numParents(stateNew))} Parents to output`)
+  fs.writeFileSync(fileNew, JSON.stringify(dbNew, null, 2))
+
+  if (errors.length === 0) {
+    console.info(chalk.green('SUCCESS'))
+  } else {
+    console.info('Writing error log')
+    const debugOutput = errors.map(error => `${error.file}\n${error.message}\n${error.e.stack}`).join('\n')
+    fs.writeFileSync('output/debug.log', debugOutput)
+
+    if (success.length > 0) {
+      console.info('')
+      console.info('Files that did get merged:')
+      success.forEach(file => console.error(file))
+    }
+
+    console.info('Files that did not get merged:')
+    errors.forEach(error => console.error(error.file))
+
+    console.info(
+      `${chalk.red(
+        success.length > 0 ? 'PARTIAL SUCCESS' : 'FAIL',
+      )}! See output/debug.log for error messages and stack trace.`,
+    )
+  }
+}
+
+main()

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -402,7 +402,7 @@ const mergeThoughts = (state: State, thoughts: RawThoughts): MergeResult => {
     }
     Object.values(contexts).forEach(cx => {
       // very old schemas can contain a bare array of contexts
-      const thoughtContext = Array.isArray(cx) ? (cx as Context) : cx.context
+      const thoughtContext = Array.isArray(cx) ? (cx as Context) : cx?.context
       if (!thoughtContext) {
         missingContexts++
         return

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -151,11 +151,10 @@ interface ProgressReport {
   schema: number
   size: number
   lexemesBase: number
-  lexemesRead: number
   lexemesSaved: number
   thoughtsBase: number
-  thoughtsRead: number
   thoughtsSaved: number
+  thoughtsAdded: number
   time: number
 }
 
@@ -585,6 +584,8 @@ const main = () => {
 
       console.info(`Thoughts written ${timeWriteFile.print()}`)
 
+      const thoughtsSaved = numThoughts(dbNew)
+
       const progressReport: ProgressReport = {
         checksum: backupChecksum,
         date: new Date().toString(),
@@ -595,11 +596,10 @@ const main = () => {
         size: fs.statSync(`${dir}/db.json`).size / 1024000, // MB
         time: timeStart.measure(),
         lexemesBase: numLexemesCurrent,
-        lexemesRead: numLexemes(thoughtsBackup),
         lexemesSaved: numLexemes(dbNew),
         thoughtsBase: numThoughtsCurrent,
-        thoughtsRead: numThoughts(thoughtsBackup),
-        thoughtsSaved: numThoughts(dbNew),
+        thoughtsSaved,
+        thoughtsAdded: thoughtsSaved - numThoughtsCurrent,
       }
 
       progress.add(progressReport)

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -8,6 +8,7 @@ import chalk from 'chalk'
 import _ from 'lodash'
 import { v4 as uid } from 'uuid'
 import memoryStore from './memoryStore'
+import time from './time'
 
 /*************************************************************************
  * MOCK BROWSER
@@ -119,6 +120,7 @@ const stateStart = initialState()
 
 /** Read a thought database from file. Normalizes contextIndex and thoughtIndex property names. */
 const readThoughts = (file: string): RawThoughts => {
+  const t = time()
   const input = fs.readFileSync(file, 'utf-8')
   const db = JSON.parse(input)
   const state = db.users?.[userId] || db
@@ -137,6 +139,8 @@ const readThoughts = (file: string): RawThoughts => {
 
   // console.info(`${chalk.blue(numParents(state))} Parents read`)
   // console.info('Done reading')
+
+  console.info(`Thoughts read (${t.measure()}s)`)
 
   return state
 }
@@ -320,6 +324,8 @@ const mergeThoughts = (state: State, thoughts: RawThoughts) => {
   /** Checks if the contextIndex uses the most up-to-date hashing function by checking the existence of the root context hash. This is NOT sufficient to determine if all Parents have a context property, which was added incrementally without a schemaVersion change. */
   // const isModernHash = (thoughts: FirebaseThoughts) => '6f94eccb7b23a8040cd73b60ba7c5abf' in thoughts.contextIndex
 
+  const t = time()
+
   // schema v5
   if ('lexemeIndex' in thoughts) {
     console.log('Schema: v5')
@@ -382,6 +388,8 @@ const mergeThoughts = (state: State, thoughts: RawThoughts) => {
 
   //   return stateNew
   // }, state)
+
+  console.info(`Thoughts merged (${t.measure()}s)`)
 
   return state
 }
@@ -464,8 +472,13 @@ const main = () => {
     lexemeIndex: state.thoughts.lexemeIndex,
   }
   const fileNew = `output/${file1Base}-merged${file1Ext}`
+
+  const t = time()
+
   // console.info(`Writing new database with ${chalk.blue(numParents(state))} Parents to output`)
   fs.writeFileSync(fileNew, JSON.stringify(dbNew, null, 2))
+
+  console.info(`Thoughts written (${t.measure()}s)`)
 
   if (errors.length === 0) {
     console.info(chalk.green('SUCCESS'))

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -500,7 +500,8 @@ const main = () => {
     console.info(helpText)
     process.exit(0)
   } else if (!fs.existsSync(`${dir}/db.json`)) {
-    console.error('Missing db.json. Please save a base db with schema v5 to [DIR]/db.json.')
+    console.error(chalk.red('Missing db.json. Please save a base db with schema v5 to [DIR]/db.json.'))
+    process.exit(1)
   }
 
   // read base thoughts

--- a/scripts/merge-dbs/index.ts
+++ b/scripts/merge-dbs/index.ts
@@ -10,6 +10,7 @@ import { v4 as uid } from 'uuid'
 import memoryStore from './memoryStore'
 import time from './time'
 import crypto from 'crypto'
+import blankdb from './blank-db.json'
 
 /*************************************************************************
  * MOCK BROWSER
@@ -498,15 +499,23 @@ const main = () => {
   // check args
   if (process.argv.length < 3) {
     console.info(helpText)
-    process.exit(0)
-  } else if (!fs.existsSync(`${dir}/db.json`)) {
-    console.error(chalk.red('Missing db.json. Please save a base db with schema v5 to [DIR]/db.json.'))
     process.exit(1)
+  }
+
+  const hasBaseDb = fs.existsSync(`${dir}/db.json`)
+
+  if (!hasBaseDb) {
+    console.warn(chalk.yellow('Missing db.json. Merging into blank database.'))
   }
 
   // read base thoughts
   // assume that they use schema v5
-  const { lastUpdated, rawThoughts: thoughtsCurrent } = readThoughts(`${dir}/db.json`)
+  const { lastUpdated, rawThoughts: thoughtsCurrent } = hasBaseDb
+    ? readThoughts(`${dir}/db.json`)
+    : {
+        lastUpdated: Date.now(),
+        rawThoughts: blankdb as unknown as RawThoughts,
+      }
 
   console.info(`Thoughts read: ${chalk.cyan(numThoughts(thoughtsCurrent))}`)
   console.info(`Lexemes read: ${chalk.cyan(numLexemes(thoughtsCurrent))}`)

--- a/scripts/merge-dbs/memoryStore.ts
+++ b/scripts/merge-dbs/memoryStore.ts
@@ -1,0 +1,29 @@
+/** A simple in-memory localStorage/sessionStorage shim. */
+const memoryStore = () => {
+  let store = {} as any
+  let length = 0
+  return {
+    get length() {
+      return length
+    },
+    clear: () => (store = {}),
+    key: (index: number) => {
+      throw new Error('Not implemented in mock')
+    },
+    getItem: (key: string) => store[key],
+    setItem: (key: string, value: any) => {
+      if (!(key in store)) {
+        length++
+      }
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      if (key in store) {
+        length--
+      }
+      delete store[key]
+    },
+  }
+}
+
+export default memoryStore

--- a/scripts/merge-dbs/package-lock.json
+++ b/scripts/merge-dbs/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "merge-dbs",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/merge-dbs/package.json
+++ b/scripts/merge-dbs/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "tsc ; npm run notify",
+    "notify": "/usr/bin/osascript -e \"display notification \\\"Build complete\\\"\"",
+    "watch": "nodemon -w index.ts -x \"npm run build\""
+  }
+}

--- a/scripts/merge-dbs/time.ts
+++ b/scripts/merge-dbs/time.ts
@@ -1,0 +1,11 @@
+/** Starts a timer. Returns an object with a measure method to return the formatted number of seconds elapsed. */
+const time = () => {
+  const t = Date.now()
+  return {
+    measure: () => {
+      return (Date.now() - t) / 1000
+    },
+  }
+}
+
+export default time

--- a/scripts/merge-dbs/time.ts
+++ b/scripts/merge-dbs/time.ts
@@ -1,10 +1,16 @@
-/** Starts a timer. Returns an object with a measure method to return the formatted number of seconds elapsed. */
+import chalk from 'chalk'
+
+/** Starts a timer. Returns an object with a measure method to return the formatted number of seconds elapsed and a print method. */
 const time = () => {
   const t = Date.now()
+
+  // API
+  const measure = () => (Date.now() - t) / 1000
+  const print = () => `(${chalk.yellow(measure() + 's')})`
+
   return {
-    measure: () => {
-      return (Date.now() - t) / 1000
-    },
+    measure,
+    print,
   }
 }
 

--- a/scripts/merge-dbs/tsconfig.json
+++ b/scripts/merge-dbs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["../../src/**/*.ts", "../../src/**/*.tsx", "../../src/**/*.js", "index.ts"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "noEmit": false,
+    "outDir": "build"
+  }
+}

--- a/scripts/split-db.js
+++ b/scripts/split-db.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+
+/** Splits the thoughtIndex and lexemeIndex of a large db into two files. */
+const file = process.argv[2]
+if (!file) {
+  console.error('Usage: node split-db.js db.json')
+  process.exit(1)
+}
+
+const thoughts = JSON.parse(fs.readFileSync(file, 'utf8'))
+const base = path.basename(file).slice(0, -5)
+fs.writeFileSync(`${path.dirname(file)}/${base}-thoughtIndex.json`, JSON.stringify(thoughts.thoughtIndex))
+fs.writeFileSync(`${path.dirname(file)}/${base}-lexemeIndex.json`, JSON.stringify(thoughts.lexemeIndex))

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,7 @@
+// disabled for merge-dbs script
+// import 'react-native-get-random-values'
+
 /** Defines client/browser-specific variables that do not change over the course of a session. */
-import 'react-native-get-random-values'
 import { v4 as uuid } from 'uuid'
 
 /** Returns true if the user's device is touch screen. */

--- a/src/device/router.ts
+++ b/src/device/router.ts
@@ -1,16 +1,18 @@
-export const baseUrl = window.location.origin
+export const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'
 
 /** Returns true if a link is to a thought within the user's thoughtspace. */
 export const isInternalLink = (url: string) => typeof window === 'undefined' || url.startsWith(window.location.origin)
 
 /** True if the current app is hosted on the same machine. */
-export const isLocalNetwork = Boolean(
-  window.location.hostname === 'localhost' ||
-    window.location.hostname === 'bs-local.com' || // required for browserstack
-    // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
-    // 193.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.startsWith('127.168.1.'),
-)
+export const isLocalNetwork =
+  typeof window === 'undefined' ||
+  Boolean(
+    window.location.hostname === 'localhost' ||
+      window.location.hostname === 'bs-local.com' || // required for browserstack
+      // [::1] is the IPv6 localhost address.
+      window.location.hostname === '[::1]' ||
+      // 127.0.0.1/8 is considered localhost for IPv4.
+      window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) ||
+      // 193.0.0.1/8 is considered localhost for IPv4.
+      window.location.hostname.startsWith('127.168.1.'),
+  )

--- a/src/reducers/__tests__/importText.ts
+++ b/src/reducers/__tests__/importText.ts
@@ -1,4 +1,5 @@
-import 'react-native-get-random-values'
+// disabled for merge-dbs script
+// import 'react-native-get-random-values'
 import { ABSOLUTE_TOKEN, EM_TOKEN, HOME_PATH, HOME_TOKEN, EMPTY_SPACE } from '../../constants'
 import { contextToThoughtId, hashThought, never, reducerFlow, timestamp, removeHome } from '../../util'
 import { initialState } from '../../util/initialState'

--- a/src/util/createId.ts
+++ b/src/util/createId.ts
@@ -1,4 +1,5 @@
-import 'react-native-get-random-values'
+// disabled for merge-dbs script
+// import 'react-native-get-random-values'
 import { nanoid } from 'nanoid'
 import { ThoughtId } from '../@types'
 import globals from '../globals'

--- a/src/util/isMobile.ts
+++ b/src/util/isMobile.ts
@@ -1,4 +1,5 @@
-import { Platform } from 'react-native'
+// disabled for merge-db
+// import { Platform } from 'react-native'
 
 /** Checks if app is running on mobile env. */
-export const isMobile = () => Platform.OS !== 'web'
+export const isMobile = () => false // Platform.OS !== 'web'


### PR DESCRIPTION
Merges two or more **em** databases together by converting them into a modern schema and importing one into the other, which will merge duplicates.

See `scripts/merge-dbs/README.md` for usage.

## Approach

Loop through each `Parent` and `Lexeme` directly:

- Low memory consumption
- Linear and resumable
  - Script should save as it goes, so that it can be run continuously and interrupted at any point without losing progress.
- Single pass architecture
- No need to export and then import
  - Import is meant to handle unpredictable user data, whereas old databases are highly predictable 
- preserves lastUpdated
- Loop through both `contextIndex` and `lexemeIndex`
  - Looping through `contextIndex` gives accurate `value` and `lastUpdated`, but does not work for legacy `Parents` without a `context` property
  - Looping through `thoughtIndex` [renamed to `lexemeIndex` in latest schema] conflates `value` and `lastUpdated` of hash-matched thoughts, but sometimes exists when a `Parent` lacks `context`.
  - Even modern schemas appear to have both, e.g. `export 2021-12-05.json`
- Requires backfilling ancestors
  - But merges duplicates "for free"

## Running on Node

The em codebase is expected to be run in the browser, so there are some hacks needed to get selectors and util functions to run in node. Also, all react native functionality must be deleted. 

These changes cannot be merged into `dev` without more advanced shimming. Therefore, it's probably be easier to maintain a separate branch. They are simple enough changes that it shouldn't be hard to rebase.

- local storage shim
- remove native components
- remove GestureResponderEvent
- remove react-native-get-random-values

## To Do

- [x] Identify the dev-friendly changes and apply them individually to dev
- [x] Create a new merge-dbs branch
- [x] Improve README documentation
  - usage
  - supported schemas
- [x] Get it to compile
  - Update for unique id schema
  - Erase old import/export/conversion logic
- [x] Loop through each `Parent`
- [x] Loop through each `Lexeme`
- [x] Handle older schemas
- [x] Recreate ancestors
- [x] Save to disk after each file
- [x] Merge TXT
- [x] ~Merge HTML~ (small enough to paste manually)
- [ ] If process grows too long, save to disk every minute and save to `state`: `MIGRATE_LAST_PARENT` or `MIGRATE_LAST_LEXEME` representing the index of the last successfully processed `Parent` or `Lexeme`.