### PR TITLE
Missing thought error after quick deletion

### DIFF
--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -63,54 +63,40 @@ export const ContextBreadcrumbs = ({
           .concat({ isOverflow: true } as OverflowChild, charLimitedArray.slice(charLimitedArray.length - 1))
       : charLimitedArray
 
-  /** Function to properly animate in and out (handled rapid deletion animating process). */
-  const renderBreadcrumbs = () => {
-    /** Renders BreadCrumbs that has access to isDeleting prop. */
-    const BreadCrumbs: FC<{
-      isOverflow?: boolean
-      subthoughts: SimplePath
-      label?: string
-      isDeleting?: boolean
-      id: string
-      index: number
-    }> = ({ isOverflow, subthoughts, label, isDeleting, id, index }) => {
-      return !isOverflow ? (
-        <span>
-          {index > 0 ? <span className='breadcrumb-divider'> • </span> : null}
-          {subthoughts && !isDeleting && <Link simplePath={subthoughts} label={label} />}
-          {subthoughts && !isDeleting && <Superscript simplePath={subthoughts} />}
+  /** Renders BreadCrumbs that has access to isDeleting prop. */
+  const BreadCrumbs: FC<{
+    isOverflow?: boolean
+    subthoughts: SimplePath
+    label?: string
+    isDeleting?: boolean
+    id: string
+    index: number
+  }> = ({ isOverflow, subthoughts, label, isDeleting, id, index }) => {
+    return !isOverflow ? (
+      <span>
+        {index > 0 ? <span className='breadcrumb-divider'> • </span> : null}
+        {subthoughts && !isDeleting && <Link simplePath={subthoughts} label={label} />}
+        {subthoughts && !isDeleting && <Superscript simplePath={subthoughts} />}
+      </span>
+    ) : (
+      <span>
+        <span className='breadcrumb-divider'> • </span>
+        <span onClick={() => setEllipsize(false)} style={{ cursor: 'pointer' }}>
+          {' '}
+          ...{' '}
         </span>
-      ) : (
-        <span>
-          <span className='breadcrumb-divider'> • </span>
-          <span onClick={() => setEllipsize(false)} style={{ cursor: 'pointer' }}>
-            {' '}
-            ...{' '}
-          </span>
-        </span>
-      )
-    }
+      </span>
+    )
+  }
 
-    const children = overflowArray.map(({ isOverflow, id, label }, i) => {
-      const subthoughts = ancestors(simplePath, id) as SimplePath
-
-      return (
-        <CSSTransition key={i} timeout={600} classNames='fade-600'>
-          <BreadCrumbs isOverflow={isOverflow} subthoughts={subthoughts} label={label} id={id} index={i} />
-        </CSSTransition>
-      )
+  /** Note: This function clones the direct breadcrumb children to inject isDeleting animation state. */
+  const factoryManager = (child: React.ReactElement) => {
+    const updatedGrandChild = React.cloneElement(child.props.children, {
+      ...child.props.children.props,
+      isDeleting: !child.props.in,
     })
 
-    /** Note: This function clones the direct breadcrumb children to inject isDeleting animation state. */
-    const factoryManager = (child: React.ReactElement) => {
-      const updatedGrandChild = React.cloneElement(child.props.children, {
-        ...child.props.children.props,
-        isDeleting: !child.props.in,
-      })
-
-      return React.cloneElement(child, { ...child.props }, updatedGrandChild)
-    }
-    return <TransitionGroup childFactory={factoryManager}>{children}</TransitionGroup>
+    return React.cloneElement(child, { ...child.props }, updatedGrandChild)
   }
 
   return (
@@ -143,7 +129,17 @@ export const ContextBreadcrumbs = ({
           <HomeLink color='gray' size={16} style={{ position: 'relative', left: -5, top: 2 }} />
         ) : null
       ) : (
-        renderBreadcrumbs()
+        <TransitionGroup childFactory={factoryManager}>
+          {overflowArray.map(({ isOverflow, id, label }, i) => {
+            const subthoughts = ancestors(simplePath, id) as SimplePath
+
+            return (
+              <CSSTransition key={i} timeout={600} classNames='fade-600'>
+                <BreadCrumbs isOverflow={isOverflow} subthoughts={subthoughts} label={label} id={id} index={i} />
+              </CSSTransition>
+            )
+          })}
+        </TransitionGroup>
       )}
     </div>
   )

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -102,8 +102,7 @@ export const ContextBreadcrumbs = ({
                   <span>
                     {i > 0 ? <span className='breadcrumb-divider'> • </span> : null}
                     {subthoughts && <Link simplePath={subthoughts} label={label} />}
-                    {/* Render when there are subthoughts and only when contextView is enabled */}
-                    {Object.keys(state.contextViews).length && subthoughts && <Superscript simplePath={subthoughts} />}
+                    {subthoughts && <Superscript simplePath={subthoughts} />}
                   </span>
                 ) : (
                   <span>

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -102,7 +102,8 @@ export const ContextBreadcrumbs = ({
                   <span>
                     {i > 0 ? <span className='breadcrumb-divider'> • </span> : null}
                     {subthoughts && <Link simplePath={subthoughts} label={label} />}
-                    {subthoughts && <Superscript simplePath={subthoughts} />}
+                    {/* Render when there are subthoughts and only when contextView is enabled */}
+                    {Object.keys(state.contextViews).length && subthoughts && <Superscript simplePath={subthoughts} />}
                   </span>
                 ) : (
                   <span>

--- a/src/util/ancestors.ts
+++ b/src/util/ancestors.ts
@@ -2,6 +2,9 @@ import { ThoughtId, Path } from '../@types'
 
 /** Returns a subpath of ancestor children up to the given thought (inclusive). */
 export const ancestors = (path: Path, child: ThoughtId): Path | null => {
-  const subPath = path.slice(0, path.findIndex(currentChild => currentChild === child) + 1) as Path
+  const subPath = path.slice(
+    0,
+    path.findIndex(currentChild => currentChild === child),
+  ) as Path
   return subPath.length > 0 ? subPath : null
 }

--- a/src/util/ancestors.ts
+++ b/src/util/ancestors.ts
@@ -2,9 +2,6 @@ import { ThoughtId, Path } from '../@types'
 
 /** Returns a subpath of ancestor children up to the given thought (inclusive). */
 export const ancestors = (path: Path, child: ThoughtId): Path | null => {
-  const subPath = path.slice(
-    0,
-    path.findIndex(currentChild => currentChild === child),
-  ) as Path
+  const subPath = path.slice(0, path.findIndex(currentChild => currentChild === child) + 1) as Path
   return subPath.length > 0 ? subPath : null
 }


### PR DESCRIPTION
Fixes #1562 

## Problem

Upon investigating thoroughly , the issue doesn't persist only when the app is refreshed but it also persists whenever a mouse has been moved (implying `showBreadCrumbs` and `showTopControls` to be true ). This creates a re-render of `Superscript` component slightly different than we would normally expect under working condition that being passing of undefined for prop `showContext` in `Superscript.tsx`.  (Re-render happens from `ContextBreadcrumbs` component.) So what happens is on quick deletion when `Superscript` re-renders due to above condition instead of getting rooted thought , the `simplePath` calculated is stale i.e still persists with same thought id that is deleted. Hence error is thrown.

## Solutution

- Avoid re rendering of `Superscript` component from `ContextBreadcrumbs` unless context view is activated!