### PR TITLE
Arrow up not working correctly for formatted thoughts

### DIFF
--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -15,7 +15,7 @@ interface NodeOffset {
 
 /** Gets the padding of an element as an array of numbers. */
 const getElementPaddings = (element: HTMLElement): number[] =>
-  window.getComputedStyle(element, null).getPropertyValue('padding').split('px ').map(Number)
+  window.getComputedStyle(element, null).getPropertyValue('padding').split('px').map(Number)
 
 /** Clears the selection. */
 export const clear = (): void => {
@@ -55,7 +55,7 @@ export const isThought = (): boolean => {
   return isEditable(focusNode) || isEditable(focusNode.parentNode)
 }
 
-/** Returns true if the selection is not on the first line of a multi-line text node. Returns true if there is no selection or if the text node is only a single line. */
+/** Returns true if the selection is  on the first line of a multi-line text node. Returns true if there is no selection or if the text node is only a single line. */
 export const isOnFirstLine = (): boolean => {
   const selection = window.getSelection()
   if (!selection) return true


### PR DESCRIPTION
Fixes #1490 

## Problem

-  In `selection.ts` -> `getElementPaddings` function we were splitting computedStyle property value of padding as `px `, which I don't believe is intentional. For formatted text, `getElementPaddings`, the property value of padding was computed as `0px`. The splitting via `px ` was unable to return a desired array.  Due to this when mapping to a Number it returned `NaN` hence the function `isOnFirstLine` returned false as it was unable to perform arithmetic operation due to `NaN` value. Hence `cursorUp` shortcut was not executed on formatted thoughts.

## Solution

- Just removed extra space from `px ` -> `px` while splitting