### PR TITLE
Importing mixed HTML with whitespace causes newline

### DIFF
--- a/src/util/textToHtml.ts
+++ b/src/util/textToHtml.ts
@@ -7,8 +7,6 @@ export const REGEXP_CONTAINS_META_TAG = /<meta\s*.*?>/
 // a list item tag
 const regexpListItem = /<li(?:\s|>)/gim
 
-const multilineRegex = /\n/gim
-
 const regexpLeadingSpacesAndBullet = /^\s*(?:[-—▪◦•]|\*\s)?/
 
 // regex that checks if the value starts with closed html tag
@@ -97,7 +95,7 @@ const moveLeadingSpacesToBeginning = (line: string) => {
 const parseBodyContent = (html: string) => {
   const content = bodyContent(html)
   // If content has <li> tags more than 1, don't convert content to blocks and then again html.
-  if (regexpListItem.test(content) && (content.match(multilineRegex) || []).length > 1) {
+  if (regexpListItem.test(content) && (content.match(regexpListItem) || []).length > 1) {
     return content
   }
   const stripped = strip(content, { preserveFormatting: true, stripAttributes: true })

--- a/src/util/textToHtml.ts
+++ b/src/util/textToHtml.ts
@@ -7,6 +7,8 @@ export const REGEXP_CONTAINS_META_TAG = /<meta\s*.*?>/
 // a list item tag
 const regexpListItem = /<li(?:\s|>)/gim
 
+const multilineRegex = /\n/gim
+
 const regexpLeadingSpacesAndBullet = /^\s*(?:[-—▪◦•]|\*\s)?/
 
 // regex that checks if the value starts with closed html tag
@@ -94,8 +96,8 @@ const moveLeadingSpacesToBeginning = (line: string) => {
  */
 const parseBodyContent = (html: string) => {
   const content = bodyContent(html)
-  // If content has <li> tags, don't convert content to blocks and then again html.
-  if (regexpListItem.test(content)) {
+  // If content has <li> tags more than 1, don't convert content to blocks and then again html.
+  if (regexpListItem.test(content) && (content.match(multilineRegex) || []).length > 1) {
     return content
   }
   const stripped = strip(content, { preserveFormatting: true, stripAttributes: true })


### PR DESCRIPTION
## Problem

There is a function called `parseBodyContent` in `textToHtml.ts` which checks for a regex expression for a `li` tag. From the reference I have found this:
> If the regex has the global flag set, test() will advance the [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) of the regex. A subsequent use of test() will start the search at the substring of str specified by [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) ([exec()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) will also advance the [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property). It is worth noting that the [lastIndex](https://developer.mozilla.org/en-US/docs/) will not reset when testing a different string.

Due to this alternating behavior is seen when pasted and deleted the particular html string. When regex expression test is true,  simply `content` is returned without stripping, hence a single thought is created as multi line.

## Solution

- Check for number of li tags before returning the content.