### PR TITLE
Do not split single line paragraph into multiple thoughts

### DIFF
--- a/src/reducers/__tests__/importText.ts
+++ b/src/reducers/__tests__/importText.ts
@@ -2,7 +2,7 @@ import 'react-native-get-random-values'
 import { ABSOLUTE_TOKEN, EM_TOKEN, HOME_PATH, HOME_TOKEN, EMPTY_SPACE } from '../../constants'
 import { contextToThoughtId, hashThought, never, reducerFlow, timestamp, removeHome } from '../../util'
 import { initialState } from '../../util/initialState'
-import { exportContext, getLexeme, contextToThought, contextToPath } from '../../selectors'
+import { exportContext, getLexeme, contextToThought, contextToPath, getAllChildren } from '../../selectors'
 import { importText, newThought } from '../../reducers'
 import { State } from '../../@types'
 import editThoughtAtFirstMatch from '../../test-helpers/editThoughtAtFirstMatch'
@@ -1104,6 +1104,20 @@ it('import multiple thoughts to end of home context with other thoughts', () => 
   - c
     - d
   - e`)
+})
+
+it('imported single line paragraph should be treated as a single thought, it shoud not be splitted.', () => {
+  const text = `<ul>
+  <li><i><b>The New Criterion</b></i><span style="font-weight: 400;"> is a </span>New York<span style="font-weight: 400;">–based monthly </span>literary magazine<span style="font-weight: 400;"> and journal of artistic and </span>cultural criticism<span style="font-weight: 400;">, 
+edited by </span>Roger Kimball<span style="font-weight: 400;"> (editor and publisher) and </span>James Panero<span style="font-weight: 400;"> (executive editor). 
+It has sections for criticism of poetry, theater, art, music, the media, and books. It was founded in 1982 by </span>Hilton Kramer<span style="font-weight: 400;">, former art critic for </span><i>The New York Times</i><span style="font-weight: 400;">, and Samuel Lipman, a pianist and music critic.</span>  </li>
+</ul>`
+
+  const stateNew = importText(initialState(), { text })
+
+  const rootChildren = getAllChildren(stateNew, [HOME_TOKEN])
+
+  expect(rootChildren.length).toBe(1)
 })
 
 it('import single line with style attributes', () => {

--- a/src/reducers/__tests__/importText.ts
+++ b/src/reducers/__tests__/importText.ts
@@ -1108,9 +1108,9 @@ it('import multiple thoughts to end of home context with other thoughts', () => 
 
 it('imported single line paragraph should be treated as a single thought, it shoud not be splitted.', () => {
   const text = `<ul>
-  <li><i><b>The New Criterion</b></i><span style="font-weight: 400;"> is a </span>New York<span style="font-weight: 400;">–based monthly </span>literary magazine<span style="font-weight: 400;"> and journal of artistic and </span>cultural criticism<span style="font-weight: 400;">, 
-edited by </span>Roger Kimball<span style="font-weight: 400;"> (editor and publisher) and </span>James Panero<span style="font-weight: 400;"> (executive editor). 
-It has sections for criticism of poetry, theater, art, music, the media, and books. It was founded in 1982 by </span>Hilton Kramer<span style="font-weight: 400;">, former art critic for </span><i>The New York Times</i><span style="font-weight: 400;">, and Samuel Lipman, a pianist and music critic.</span>  </li>
+  <li><i><b>The New Criterion</b></i><span style="font-weight: 400;">is a</span>New York<span style="font-weight: 400;">-based monthly</span>literary magazine<span style="font-weight: 400;">and journal of artistic and</span>cultural criticism<span style="font-weight: 400;">, 
+edited by</span>Roger Kimball<span style="font-weight: 400;">(editor and publisher) and</span>James Panero<span style="font-weight: 400;">(executive editor). 
+It has sections for criticism of poetry, theater, art, music, the media, and books. It was founded in 1982 by</span>Hilton Kramer<span style="font-weight: 400;">, former art critic for</span><i>The New York Times</i><span style="font-weight: 400;">, and Samuel Lipman, a pianist and music critic.</span>  </li>
 </ul>`
 
   const stateNew = importText(initialState(), { text })

--- a/src/util/textToHtml.ts
+++ b/src/util/textToHtml.ts
@@ -94,8 +94,8 @@ const moveLeadingSpacesToBeginning = (line: string) => {
  */
 const parseBodyContent = (html: string) => {
   const content = bodyContent(html)
-  // If content has <li> tags more than 1, don't convert content to blocks and then again html.
-  if (regexpListItem.test(content) && (content.match(regexpListItem) || []).length > 1) {
+  // If content has <li> and more than 1 multiline whitespace, don't convert content to blocks and then again html.
+  if (regexpListItem.test(content) && (content.match(/\n/gim) || []).length > 1) {
     // A RegExp object with the g flag keeps track of the lastIndex where a match occurred, so on subsequent matches it will start from the last used index, instead of 0. This ensures we reset last used index everytime the test is executed that prevents falsy alternating behavior
     regexpListItem.lastIndex = 0
     return content


### PR DESCRIPTION
original issue #1573
fix for pr (https://github.com/cybersemics/em/pull/1577)
## Overview

The PR ((https://github.com/cybersemics/em/pull/1577)) that was merged for  issue (#1573 )  caused an issue where when we import text such as
`<ul>
  <li><i><b>The New Criterion</b></i><span style="font-weight: 400;"> is a </span>New York<span style="font-weight: 400;">–based monthly </span>literary magazine<span style="font-weight: 400;"> and journal of artistic and </span>cultural criticism<span style="font-weight: 400;">, 
edited by </span>Roger Kimball<span style="font-weight: 400;"> (editor and publisher) and </span>James Panero<span style="font-weight: 400;"> (executive editor). 
It has sections for criticism of poetry, theater, art, music, the media, and books. It was founded in 1982 by </span>Hilton Kramer<span style="font-weight: 400;">, former art critic for </span><i>The New York Times</i><span style="font-weight: 400;">, and Samuel Lipman, a pianist and music critic.</span>  </li>
</ul>` which is intended to be a single paragraph caused creation of multiple thoughts by splitting the sentences. This PR fixes that particular issue and now treats the paragraph as a single thought like it used to be previously