### PR TITLE
Insert space when merging recently split thoughts 

### DIFF
--- a/src/@types/Thought.ts
+++ b/src/@types/Thought.ts
@@ -15,4 +15,6 @@ export interface Thought {
   // takes precedence over value for sorting purposes
   // used to preserve the sort order of thoughts that are edited to empty instead of moving them back to their insertion point
   sortValue?: string
+  // used to track if a space is required when merging two siblings/thoughts
+  splitSource?: ThoughtId
 }

--- a/src/reducers/__tests__/deleteEmptyThought.ts
+++ b/src/reducers/__tests__/deleteEmptyThought.ts
@@ -15,6 +15,7 @@ import newThought from '../newThought'
 import setCursor from '../setCursor'
 import importTextReducer from '../importText'
 import archiveThought from '../archiveThought'
+import splitThought from '../splitThought'
 
 it('delete empty thought', () => {
   const steps = [newThought('a'), newThought(''), deleteEmptyThought]
@@ -252,4 +253,24 @@ describe('mount', () => {
     expect(window.getSelection()?.focusNode?.textContent).toBe('applebanana')
     expect(window.getSelection()?.focusOffset).toBe('apple'.length)
   })
+})
+
+it('merge thought should respect space if any', () => {
+  const steps = [
+    newThought('hello world'),
+    splitThought({
+      splitResult: {
+        left: 'hello ',
+        right: 'world',
+      },
+    }),
+    deleteEmptyThought,
+  ]
+
+  // run steps through reducer flow and export as plaintext for readable test
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - hello world`)
 })

--- a/src/reducers/__tests__/deleteEmptyThought.ts
+++ b/src/reducers/__tests__/deleteEmptyThought.ts
@@ -255,13 +255,33 @@ describe('mount', () => {
   })
 })
 
-it('merge thought should respect space if any', () => {
+it('merge thought should respect space if any (whitespace at end of left splitted value)', () => {
   const steps = [
     newThought('hello world'),
     splitThought({
       splitResult: {
         left: 'hello ',
         right: 'world',
+      },
+    }),
+    deleteEmptyThought,
+  ]
+
+  // run steps through reducer flow and export as plaintext for readable test
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - hello world`)
+})
+
+it('merge thought should respect space if any (whitespace at front of right splitted value)', () => {
+  const steps = [
+    newThought('hello world'),
+    splitThought({
+      splitResult: {
+        left: 'hello',
+        right: ' world',
       },
     }),
     deleteEmptyThought,

--- a/src/reducers/createThought.ts
+++ b/src/reducers/createThought.ts
@@ -11,13 +11,14 @@ interface Payload {
   rank: number
   id?: ThoughtId
   addAsContext?: boolean
+  splitSource?: ThoughtId
 }
 /**
  * Creates a new thought with a known context and rank. Does not update the cursor. Use the newThought reducer for a higher level function.
  *
  * @param addAsContext Adds the given context to the new thought.
  */
-const createThought = (state: State, { context, value, rank, addAsContext, id }: Payload) => {
+const createThought = (state: State, { context, value, rank, addAsContext, id, splitSource }: Payload) => {
   // create thought if non-existent
   const lexeme: Lexeme = {
     ...(getLexeme(state, value) || {
@@ -64,6 +65,7 @@ const createThought = (state: State, { context, value, rank, addAsContext, id }:
       rank: addAsContext ? getNextRank(state, [value]) : rank,
       value: newValue,
       updatedBy: getSessionId(),
+      splitSource,
     }
   }
 

--- a/src/reducers/deleteEmptyThought.ts
+++ b/src/reducers/deleteEmptyThought.ts
@@ -81,13 +81,14 @@ const deleteEmptyThought = (state: State): State => {
   }
   // delete from beginning and merge with previous sibling
   else if (offset === 0 && !showContexts) {
-    const { value, rank } = cursorThought
+    const { value, rank, splitSource } = cursorThought
     const parentContext = context.length > 1 ? parentOf(context) : [HOME_TOKEN]
     const prev = prevSibling(state, value, pathToContext(state, rootedParentOf(state, cursor)), rank)
 
     // only if there is a previous sibling
     if (prev) {
-      const valueNew = prev.value + value
+      // if splitSource equals prev sibling thought id, then add an intervening space to preserve the original space while splitting from the source thought
+      const valueNew = splitSource === prev.id ? prev.value + ' ' + value : prev.value + value
       const pathPrevNew = appendToPath(parentOf(simplePath), prev.id)
 
       return reducerFlow([

--- a/src/reducers/newThought.ts
+++ b/src/reducers/newThought.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { Path, SimplePath, State } from '../@types'
+import { Path, SimplePath, State, ThoughtId } from '../@types'
 
 // constants
 import {
@@ -62,6 +62,7 @@ export interface NewThoughtPayload {
   offset?: number
   aboveMeta?: boolean
   preventSetCursor?: boolean
+  splitSource?: ThoughtId
 }
 
 /** Adds a new thought to the cursor. Calculates the rank to add the new thought above, below, or within a thought.
@@ -82,6 +83,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
     offset,
     preventSetCursor,
     aboveMeta,
+    splitSource,
   }: NewThoughtPayload = payload
 
   const tutorialStep = +(getSetting(state, 'Tutorial Step') || 0)
@@ -160,6 +162,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
       rank: newRank,
       value,
       id: newThoughtId,
+      splitSource,
     }),
     (newState: State) => {
       const parentPath = !preventSetCursor ? unroot(insertNewSubthought ? path : parentOf(path)) : null

--- a/src/reducers/splitThought.ts
+++ b/src/reducers/splitThought.ts
@@ -48,6 +48,8 @@ const splitThought = (state: State, { path, splitResult }: { path?: Path; splitR
       offset: 0,
       // must allow the cursor to be set since it is used as the destination for the children
       preventSetCursor: false,
+      // pass splitSource as prop if the left splitted value has whitespace at the end
+      ...(/\s+$/g.test(splitResult.left) ? { splitSource: headThought.id } : {}),
     }),
 
     // move children

--- a/src/reducers/splitThought.ts
+++ b/src/reducers/splitThought.ts
@@ -48,8 +48,8 @@ const splitThought = (state: State, { path, splitResult }: { path?: Path; splitR
       offset: 0,
       // must allow the cursor to be set since it is used as the destination for the children
       preventSetCursor: false,
-      // pass splitSource as prop if the left splitted value has whitespace at the end
-      ...(/\s+$/g.test(splitResult.left) ? { splitSource: headThought.id } : {}),
+      // pass splitSource as prop if the left splitted value has whitespace at the end or right splitted value has whitespace at the front
+      ...(/\s+$/g.test(splitResult.left) || /^\s+/g.test(splitResult.right) ? { splitSource: headThought.id } : {}),
     }),
 
     // move children


### PR DESCRIPTION
Fix #1576 

## Solution

- Added `splitSource` property in `Thought` type to store in thought id of the one that is going to be splitted.
- `splitSource` property is only passed if when splitting space is needed to be respected.