### PR TITLE
deleteThought: Thought not found for id

### DIFF
--- a/src/reducers/deleteThought.ts
+++ b/src/reducers/deleteThought.ts
@@ -155,11 +155,11 @@ const deleteThought = (state: State, { context, thoughtId, orphaned }: Payload) 
 
         return {
           ...accum,
-          pendingDeletes: [
+          pendingDeletes: _.uniq([
             ...(accum.pendingDeletes || []),
             ...(accumRecursive.pendingDeletes || []),
             ...(recursiveResults.pendingDeletes || []),
-          ],
+          ]),
           lexemeIndex: {
             ...accum.lexemeIndex,
             ...recursiveResults.lexemeIndex,


### PR DESCRIPTION
fixes #1521 

## Problem

- While creating `pendingDeletes`, there was a duplication for thoughts with metaprogramming attributes. Due to this, when descendant thoughts are recursively deleted, thought id is not found for second time for the duplicated `pendingDelete`.

## Solution

- Ensuring to uniquify  accummulated pending deletes before pushing to `pushQueue` state. 