### PR TITLE
Type meta attribute to move cursor

### DIFF
--- a/src/reducers/__tests__/editThought.ts
+++ b/src/reducers/__tests__/editThought.ts
@@ -8,7 +8,7 @@ import {
   contextToThought,
   parentOfThought,
 } from '../../selectors'
-import { newThought, importText } from '../../reducers'
+import { newThought, importText, newSubthought } from '../../reducers'
 import checkDataIntegrity from '../../test-helpers/checkDataIntegrity'
 import editThoughtByContext from '../../test-helpers/editThoughtByContext'
 import getAllChildrenByContext from '../../test-helpers/getAllChildrenByContext'
@@ -194,6 +194,35 @@ it('edit a thought existing in mutliple contexts', () => {
       id: thoughtABC.id,
     },
   ])
+})
+
+it('if meta programming attribute like =style exists in a context, there should not be duplication if new subthought with same attribute is created', () => {
+  const text = `
+- a
+  - =style
+    - color
+      - lightblue`
+
+  const steps = [
+    importText({
+      text,
+    }),
+    setCursorFirstMatch(['a']),
+    newSubthought({ value: '' }),
+    editThoughtByContext({
+      newValue: '=style',
+      oldValue: '',
+      at: ['a', ''],
+    }),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =style
+      - color
+        - lightblue`)
 })
 
 it('edit a thought that exists in another context', () => {

--- a/src/reducers/__tests__/editThought.ts
+++ b/src/reducers/__tests__/editThought.ts
@@ -7,6 +7,7 @@ import {
   getLexeme,
   contextToThought,
   parentOfThought,
+  childIdsToThoughts,
 } from '../../selectors'
 import { newThought, importText, newSubthought } from '../../reducers'
 import checkDataIntegrity from '../../test-helpers/checkDataIntegrity'
@@ -196,7 +197,7 @@ it('edit a thought existing in mutliple contexts', () => {
   ])
 })
 
-it('if meta programming attribute like =style exists in a context, there should not be duplication if new subthought with same attribute is created', () => {
+it('move cursor to existing meta programming thought if any', () => {
   const text = `
 - a
   - =style
@@ -223,6 +224,15 @@ it('if meta programming attribute like =style exists in a context, there should 
     - =style
       - color
         - lightblue`)
+
+  const expectedCursor = [
+    { value: 'a', rank: 0 },
+    { value: '=style', rank: 0 },
+  ]
+
+  const cursorThoughts = childIdsToThoughts(stateNew, stateNew.cursor!)
+
+  expect(cursorThoughts).toMatchObject(expectedCursor)
 })
 
 it('edit a thought that exists in another context', () => {

--- a/src/reducers/editThought.ts
+++ b/src/reducers/editThought.ts
@@ -6,8 +6,8 @@ import { Context, Lexeme, SimplePath, State, ThoughtId, Timestamp } from '../@ty
 import {
   addContext,
   createChildrenMap,
-  equalArrays,
   hashThought,
+  head,
   headId,
   isDivider,
   isFunction,
@@ -66,7 +66,8 @@ const editThought = (
   // only calculate decendant thought when current edited thought is a metaprogramming attribute
   const thoughtIdForExistingMetaProgrammingThought =
     isFunction(newValue) &&
-    equalArrays(state.cursor || [], thoughtToPath(state, editedThought.id)) &&
+    state.cursor &&
+    head(state.cursor) === editedThought.id &&
     findDescendant(state, editedThought.parentId, newValue)
 
   // We do not want to create a duplicate metaprogramming thought within the same context. Instead this logic ensures we delete the current cursor thought and move the cursor to the existing one


### PR DESCRIPTION
Fix #1578

## Problem
- Duplicate meta programming thought is created if the similar attribute exists within a context

## Solution

- Check for such condition within context where duplication is found for meta programming attributes
- Delete current cursor thought
- Set cursor to the already existing attribute within a context