### PR TITLE
Cursor triangle is tilted in table column 1

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2749,6 +2749,7 @@ code,
   margin-left: -1em;
   color: #838283;
   content: '▸';
+  font-style: normal;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Fixes #1522 

## Problem
-  `font-style: italic` was being applied  which is generally meant for empty thought with placeholder

## Solution

- override `font-style` to normal when thought is empty with no placeholder (specifically in table view)