### PR TITLE
Bullet fades on edit

### DIFF
--- a/src/components/Bullet.native.tsx
+++ b/src/components/Bullet.native.tsx
@@ -1,5 +1,4 @@
 import State from '../@types/State'
-import Thought from '../@types/Thought'
 import React from 'react'
 import { connect } from 'react-redux'
 import getLexeme from '../selectors/getLexeme'
@@ -8,6 +7,8 @@ import isPending from '../selectors/isPending'
 import { isContextViewActiveById } from '../selectors/isContextViewActive'
 import { TouchableOpacity, Text, StyleSheet } from 'react-native'
 import { commonStyles } from '../style/commonStyles'
+import ThoughtId from '../@types/ThoughtId'
+import getThoughtById from '../selectors/getThoughtById'
 
 // other bullets
 // •◦◂◄◀︎ ➤▹▸►◥
@@ -18,20 +19,21 @@ interface BulletProps {
   leaf?: boolean
   onClick: (event: any) => void
   showContexts?: boolean
-  thought: Thought
+  thoughtId: ThoughtId
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const mapStateToProps = (state: State, props: BulletProps) => {
   const { invalidState } = state
-  const lexeme = getLexeme(state, props.thought.value)
+  const thought = getThoughtById(state, props.thoughtId)
+  const lexeme = getLexeme(state, thought.value)
   return {
     // if being edited and meta validation error has occured
     invalid: !lexeme || (!!props.isEditing && invalidState),
     // re-render when leaf status changes
-    isLeaf: !hasChildren(state, props.thought.id),
-    pending: isPending(state, props.thought),
-    showContexts: isContextViewActiveById(state, props.thought.id),
+    isLeaf: !hasChildren(state, thought.id),
+    pending: isPending(state, thought),
+    showContexts: isContextViewActiveById(state, thought.id),
   }
 }
 

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -1,6 +1,5 @@
 import State from '../@types/State'
 import SimplePath from '../@types/SimplePath'
-import Thought from '../@types/Thought'
 import React, { useRef } from 'react'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
@@ -9,6 +8,8 @@ import getLexeme from '../selectors/getLexeme'
 import isPending from '../selectors/isPending'
 import { isContextViewActiveById } from '../selectors/isContextViewActive'
 import { isTouch, isMac, isSafari, isiPhone } from '../browser'
+import getThoughtById from '../selectors/getThoughtById'
+import ThoughtId from '../@types/ThoughtId'
 
 // other bullets
 // •◦◂◄◀︎ ➤▹▸►◥
@@ -18,7 +19,7 @@ interface BulletProps {
   leaf?: boolean
   onClick: (event: React.MouseEvent) => void
   showContexts?: boolean
-  thought: Thought
+  thoughtId: ThoughtId
   publish?: boolean
   simplePath: SimplePath
   hideBullet?: boolean
@@ -28,14 +29,15 @@ interface BulletProps {
 // eslint-disable-next-line jsdoc/require-jsdoc
 const mapStateToProps = (state: State, props: BulletProps) => {
   const { invalidState } = state
-  const lexeme = getLexeme(state, props.thought.value)
+  const thought = getThoughtById(state, props.thoughtId)
+  const lexeme = getLexeme(state, thought.value)
   return {
     // if being edited and meta validation error has occured
     invalid: !!props.isEditing && invalidState,
     missing: !lexeme,
     fontSize: state.fontSize,
-    pending: isPending(state, props.thought),
-    showContexts: isContextViewActiveById(state, props.thought.id),
+    pending: isPending(state, thought),
+    showContexts: isContextViewActiveById(state, thought.id),
     dark: theme(state) !== 'Light',
   }
 }

--- a/src/components/Thought.native.tsx
+++ b/src/components/Thought.native.tsx
@@ -377,7 +377,7 @@ const ThoughtContainer = ({
         {!(publish && context.length === 0) && (!isLeaf || !isPublishChild) && !hideBullet && (
           <Bullet
             isEditing={isEditing}
-            thought={getThoughtById(state, thoughtId)}
+            thoughtId={thoughtId}
             leaf={isLeaf}
             onClick={() => {
               if (!isEditing || children.length === 0) {

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -463,7 +463,7 @@ const ThoughtContainer = ({
                 }
               }}
               simplePath={simplePath}
-              thought={getThoughtById(state, thoughtId)}
+              thoughtId={thoughtId}
               hideBullet={hideBullet}
               publish={publish}
               isDragging={isDragging}

--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -1,0 +1,31 @@
+import { ReactWrapper } from 'enzyme'
+import windowEvent from '../../test-helpers/windowEvent'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import testTimer from '../../test-helpers/testTimer'
+
+let wrapper: ReactWrapper<unknown, unknown> // eslint-disable-line fp/no-let
+
+beforeEach(async () => {
+  wrapper = await createTestApp()
+})
+
+afterEach(cleanupTestApp)
+
+const fakeTimer = testTimer()
+
+it('bullet should not fade on edit, should only fade i.e color to gray when thought is missing', async () => {
+  // create thought
+
+  fakeTimer.useFakeTimer()
+
+  windowEvent('keydown', { key: 'Enter' })
+  wrapper.update()
+  const editable = wrapper.find('div.editable')
+  await editable.simulate('change', { target: { value: 'a' } })
+
+  await fakeTimer.runAllAsync()
+  await fakeTimer.useRealTimer()
+  wrapper.update()
+  const bulletEllipsis = document.querySelector('.bullet .glyph .glyph-fg.gray')
+  expect(bulletEllipsis).toBeNull()
+})


### PR DESCRIPTION
Fixes #1594 

## Problem

- `getThoughtById` was being used in `Thought` component level to find recently edited thought.
- however `Bullet` component won't re-render when thought value is being edited hence no recent thought is fetched thus causing `getLexeme` to return undefined.
-  When lexeme is undefined, thought is marked as missing and hence `gray` className is applied to bullet ellipsis.

## Solution

- use `getThoughtById` in `Bullet` component itself to always get recently edited thought with editing value