### PR TITLE
Undo/Redo: Cursor restored incorrectly after undo archive

### DIFF
--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -126,7 +126,9 @@ const undoReducer = (state: State, undoPatches: Patch[]) => {
     penultimateUndoPatch &&
     !!(
       (lastAction && NAVIGATION_ACTIONS[lastAction]) ||
-      (penultimateAction && (NAVIGATION_ACTIONS[penultimateAction] || penultimateAction === 'newThought'))
+      (penultimateAction &&
+        ((NAVIGATION_ACTIONS[penultimateAction] && NAVIGATION_ACTIONS[penultimateAction] !== 'setCursor') ||
+          penultimateAction === 'newThought'))
     )
 
   const poppedUndoPatches = undoTwice ? [penultimateUndoPatch, lastUndoPatch] : [lastUndoPatch]

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -374,3 +374,32 @@ it('undo redo importText action', () => {
 
   expect(exportedAfterRedo).toEqual(expectedOutputAfterRedo)
 })
+
+it('cursor should restore correctly after undo archive', async () => {
+  timer.useFakeTimer()
+  initialize()
+  await timer.runAllAsync()
+
+  appStore.dispatch([newThought({ value: 'a' }), setCursor({ path: null })])
+  await timer.runAllAsync()
+
+  timer.useFakeTimer()
+  // clear and call initialize again to reload from local db (simulating page refresh)
+  appStore.dispatch(clear())
+  await timer.runAllAsync()
+
+  initialize()
+
+  await timer.runAllAsync()
+
+  appStore.dispatch([setCursorFirstMatchActionCreator(['a']), { type: 'archiveThought' }, { type: 'undoAction' }])
+  await timer.runAllAsync()
+
+  timer.useRealTimer()
+
+  const expectedCursor = [{ value: 'a', rank: 0 }]
+
+  const cursorThoughts = childIdsToThoughts(appStore.getState(), appStore.getState().cursor!)
+
+  expect(cursorThoughts).toMatchObject(expectedCursor)
+})


### PR DESCRIPTION
Fixes #1389 

## Problem

- Refreshing a page generates a new set of undo patches which is different from when we see it normally, i,e without refreshing.  In `undoRedoEnhancer` -> `undoReducer` function has a variable called `undoTwice`. This is used to undo action again if the penultimate  action is of navigation type or `newThought`.  When refreshing a page, there exists a set of penultimate patch due to which `undoTwice` becomes true thus causing undo action to enable two times ultimately causing `setCursor` to be undoed.

## Solution 

- adding a condition to avoid two times undo action when page is refreshed.

## Note
- This may not be a solution you would want because it is just skipping that particular issue. Another possible thing that can be done is to fix the undo patches itself so that it can ressemble the normal condition (i.e without refreshing) but the problem is that as far as I know, patches are generally generated by `compare` (diffState function) which just compares the difference between newState and oldState. So fixing patches means to cleary understand what state is ideal depending upon the situation. Happy to discuss with you regarding this context.