### PR TITLE
Cursor restored incorrectly after editThought 

### DIFF
--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -175,12 +175,9 @@ const undoReducer = (state: State, undoPatches: Patch[]) => {
 
   if (!undoPatches.length) return state
 
-  const undoTwice =
-    penultimateUndoPatch &&
-    !!(
-      (lastAction && NAVIGATION_ACTIONS[lastAction]) ||
-      (penultimateAction && (NAVIGATION_ACTIONS[penultimateAction] || penultimateAction === 'newThought'))
-    )
+  const undoTwice = NAVIGATION_ACTIONS[lastAction]
+    ? penultimateUndoPatch && (penultimateAction ? UNDOABLE_ACTIONS[penultimateAction] : false)
+    : penultimateUndoPatch && penultimateAction === 'newThought'
 
   const poppedUndoPatches = undoTwice ? [penultimateUndoPatch, lastUndoPatch] : [lastUndoPatch]
 

--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -176,8 +176,8 @@ const undoReducer = (state: State, undoPatches: Patch[]) => {
   if (!undoPatches.length) return state
 
   const undoTwice = NAVIGATION_ACTIONS[lastAction]
-    ? penultimateUndoPatch && (penultimateAction ? UNDOABLE_ACTIONS[penultimateAction] : false)
-    : penultimateUndoPatch && penultimateAction === 'newThought'
+    ? UNDOABLE_ACTIONS[penultimateAction]
+    : penultimateAction === 'newThought'
 
   const poppedUndoPatches = undoTwice ? [penultimateUndoPatch, lastUndoPatch] : [lastUndoPatch]
 

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -386,3 +386,50 @@ it('undo redo importText action', () => {
 
   expect(exportedAfterRedo).toEqual(expectedOutputAfterRedo)
 })
+
+it('cursor should restore to same thought if the thought has been edited after undo', () => {
+  const store = createTestStore()
+
+  store.dispatch([
+    newThought({ value: 'a' }),
+    newThought({ value: 'b' }),
+    setCursorFirstMatchActionCreator(['a']),
+    editThoughtByContextActionCreator({ newValue: 'aa', oldValue: 'a', at: ['a'] }),
+    { type: 'undoAction' },
+  ])
+
+  const expectedCursor = [{ value: 'a', rank: 0 }]
+
+  const cursorThoughts = childIdsToThoughts(store.getState(), store.getState().cursor!)
+
+  expect(cursorThoughts).toMatchObject(expectedCursor)
+})
+
+it('cursor should restore correctly after undo archive', async () => {
+  timer.useFakeTimer()
+  initialize()
+  await timer.runAllAsync()
+
+  appStore.dispatch([newThought({ value: 'a' }), setCursor({ path: null })])
+  await timer.runAllAsync()
+
+  timer.useFakeTimer()
+  // clear and call initialize again to reload from local db (simulating page refresh)
+  appStore.dispatch(clear())
+  await timer.runAllAsync()
+
+  initialize()
+
+  await timer.runAllAsync()
+
+  appStore.dispatch([setCursorFirstMatchActionCreator(['a']), { type: 'archiveThought' }, { type: 'undoAction' }])
+  await timer.runAllAsync()
+
+  timer.useRealTimer()
+
+  const expectedCursor = [{ value: 'a', rank: 0 }]
+
+  const cursorThoughts = childIdsToThoughts(appStore.getState(), appStore.getState().cursor!)
+
+  expect(cursorThoughts).toMatchObject(expectedCursor)
+})

--- a/src/shortcuts/__tests__/undo.ts
+++ b/src/shortcuts/__tests__/undo.ts
@@ -391,8 +391,12 @@ it('cursor should restore to same thought if the thought has been edited after u
   const store = createTestStore()
 
   store.dispatch([
-    newThought({ value: 'a' }),
-    newThought({ value: 'b' }),
+    newThought({}),
+    setCursorFirstMatchActionCreator(['']),
+    editThoughtByContextActionCreator({ newValue: 'a', oldValue: '', at: [''] }),
+    newThought({}),
+    setCursorFirstMatchActionCreator(['']),
+    editThoughtByContextActionCreator({ newValue: 'b', oldValue: '', at: [''] }),
     setCursorFirstMatchActionCreator(['a']),
     editThoughtByContextActionCreator({ newValue: 'aa', oldValue: 'a', at: ['a'] }),
     { type: 'undoAction' },


### PR DESCRIPTION
Fixes #1389 , #1618 

## Problem

- Navigation actions right after undoable action were not grouped properly and undone with them

## Solution

- Modified `undoTwice` logic to properly handle mentioned notes in #1618 