### PR TITLE
Puppeteer + MacOS

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -14,7 +14,10 @@ env:
 jobs:
   run:
     name: Puppeteer
-    runs-on: ubuntu-latest
+    # Run on Mac since Puppeteer snapshots were generated on a Mac.
+    # Otherwise snapshot tests will fail.
+    # https://github.com/cybersemics/em/pull/1836
+    runs-on: macos-latest
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Run on Mac since Puppeteer snapshots were generated on a Mac.
Otherwise snapshot tests will fail.

Related: https://github.com/cybersemics/em/pull/1836