### PR TITLE
fix(footer): Adjust bottom margin based on scroll position to preserve safe area 2063

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -105,8 +105,10 @@ const Footer = () => {
     useEffect(() => {
     // Handle scroll position
     const handleScroll = () => {
-      const bottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight;
-      setIsScrolledToBottom(bottom);
+      const distance = document.documentElement.scrollHeight - window.innerHeight - window.scrollY;
+      setIsScrolledToBottom(distance);
+      document.documentElement.style.setProperty('--dynamic-bottom-margin', `${Math.min(distance, 20)}px`);
+
     };
 
     window.addEventListener('scroll', handleScroll);
@@ -121,9 +123,7 @@ const Footer = () => {
   if (isTutorialOn && tutorialStep !== TUTORIAL2_STEP_SUCCESS) return null
 
   return (
-    <ul aria-label='footer' className='footer list-none'  style={{
-        marginBottom: isScrolledToBottom ? 0 : 'env(safe-area-inset-bottom)',
-      }}>
+    <ul aria-label='footer' className='footer list-none'>
       <li>
         <div style={{ float: 'left', lineHeight: 1 }}>
           <a className='increase-font expand-click-area-left no-select' {...fastClick(() => dispatch(scaleFontUp()))}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -89,6 +89,7 @@ const Footer = () => {
   // })
 
   const firstUpdate = useRef(true)
+  const [isScrolledToBottom, setIsScrolledToBottom] = useState(false);
 
   // alert when font size changes
   useEffect(() => {
@@ -99,7 +100,20 @@ const Footer = () => {
     } else {
       firstUpdate.current = false
     }
-  }, [dispatch, fontSize])
+  }, [dispatch, fontSize]);
+
+    useEffect(() => {
+    // Handle scroll position
+    const handleScroll = () => {
+      const bottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight;
+      setIsScrolledToBottom(bottom);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    handleScroll(); // Initial check
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   // hide footer during tutorial
   // except for the last step that directs them to the Help link in the footer
@@ -107,7 +121,9 @@ const Footer = () => {
   if (isTutorialOn && tutorialStep !== TUTORIAL2_STEP_SUCCESS) return null
 
   return (
-    <ul aria-label='footer' className='footer list-none'>
+    <ul aria-label='footer' className='footer list-none'  style={{
+        marginBottom: isScrolledToBottom ? 0 : 'env(safe-area-inset-bottom)',
+      }}>
       <li>
         <div style={{ float: 'left', lineHeight: 1 }}>
           <a className='increase-font expand-click-area-left no-select' {...fastClick(() => dispatch(scaleFontUp()))}>


### PR DESCRIPTION

This commit fixes the issue of incorrect _bottom margin_ for the footer breadcrumbs during scrolling (#2063). The Footer component now _dynamically_ _adjusts the bottom margin based on the user's scroll position_. A new state variable isScrolledToBottom was introduced to track the scroll position, and a useEffect hook handles scroll events to update this state. The bottom margin is conditionally applied to ensure it's only present when needed