### PR TITLE
Delay multiline calculations until changes have been applied to the DOM

### DIFF
--- a/src/components/Editable/useMultiline.ts
+++ b/src/components/Editable/useMultiline.ts
@@ -13,17 +13,21 @@ const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: Simp
   const splitPosition = useSelector(state => state.splitPosition)
 
   const updateMultiline = useCallback(() => {
-    if (!contentRef.current) return
+    // useSelectorEffect fires _before_ the DOM updates, so we need to
+    // schedule the measurement using requestAnimationFrame.
+    requestAnimationFrame(() => {
+      if (!contentRef.current) return
 
-    const height = contentRef.current.getBoundingClientRect().height
-    // 1.72 must match line-height as defined in .thought-container
-    const singleLineHeight = fontSize * 1.72
-    // .editable.multiline gets 5px of padding-top to offset the collapsed line-height
-    // we need to account for padding-top, otherwise it can cause a false positive
-    const paddingTop = parseInt(window.getComputedStyle(contentRef.current).paddingTop)
-    // The element is multiline if its height is twice the single line height.
-    // (Actually we just check if it is over 1.5x the single line height for a more forgiving condition.)
-    setMultiline(height - paddingTop > singleLineHeight * 1.5)
+      const height = contentRef.current.getBoundingClientRect().height
+      // 1.72 must match line-height as defined in .thought-container
+      const singleLineHeight = fontSize * 1.72
+      // .editable.multiline gets 5px of padding-top to offset the collapsed line-height
+      // we need to account for padding-top, otherwise it can cause a false positive
+      const paddingTop = parseInt(window.getComputedStyle(contentRef.current).paddingTop)
+      // The element is multiline if its height is twice the single line height.
+      // (Actually we just check if it is over 1.5x the single line height for a more forgiving condition.)
+      setMultiline(height - paddingTop > singleLineHeight * 1.5)
+    })
   }, [contentRef, fontSize])
 
   // Recalculate multiline when the cursor changes.


### PR DESCRIPTION
Fixes #2041, #2049.

This PR fixes `useMultiline` not returning the correct value on initial render or paste. The problem lies in the fact that the DOM measurements are executed _right after_ the store changes, _but before_ the changes have been flushed to the DOM. We circumvent this by delaying the measurements until after the layout has been applied in the next frame.