### PR TITLE
Fix useMultiline store race condition

### DIFF
--- a/src/components/Editable/useMultiline.ts
+++ b/src/components/Editable/useMultiline.ts
@@ -1,23 +1,18 @@
 import { useCallback, useLayoutEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import SimplePath from '../../@types/SimplePath'
-import equalPath from '../../util/equalPath'
+import editingValueStore from '../../stores/editingValue'
 
 /** Returns true if the element has more than one line of text. */
-const useMultiline = (
-  contentRef: React.RefObject<HTMLElement>,
-  simplePath: SimplePath,
-  value: string,
-  isEditing?: boolean,
-) => {
+const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: SimplePath, isEditing?: boolean) => {
   const [multiline, setMultiline] = useState(false)
   const fontSize = useSelector(state => state.fontSize)
   const showSplitView = useSelector(state => state.showSplitView)
   const splitPosition = useSelector(state => state.splitPosition)
+  const cursor = useSelector(state => state.cursor)
 
-  // Check if the cursor is active.
-  // NOTE: We don't want to select the entire cursor path to skip invoking the layout effect too often.
-  const cursorActive = useSelector(state => equalPath(state.cursor, simplePath))
+  // While editing, watch the current Value and trigger the layout effect
+  const editingValue = editingValueStore.useSelector(state => (isEditing ? state : null))
 
   const updateMultiline = useCallback(() => {
     if (!contentRef.current) return
@@ -37,7 +32,7 @@ const useMultiline = (
   // cursor changes to or from the element.
   useLayoutEffect(() => {
     updateMultiline()
-  }, [contentRef, fontSize, isEditing, showSplitView, simplePath, splitPosition, value, cursorActive, updateMultiline])
+  }, [contentRef, fontSize, isEditing, showSplitView, simplePath, splitPosition, editingValue, cursor, updateMultiline])
 
   return multiline
 }

--- a/src/components/Editable/useMultiline.ts
+++ b/src/components/Editable/useMultiline.ts
@@ -1,7 +1,12 @@
 import { useCallback, useLayoutEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { shallowEqual, useSelector } from 'react-redux'
 import SimplePath from '../../@types/SimplePath'
+import State from '../../@types/State'
+import useSelectorEffect from '../../hooks/useSelectorEffect'
 import editingValueStore from '../../stores/editingValue'
+
+/** Selects the cursor from the state. */
+const selectCursor = (state: State) => state.cursor
 
 /** Returns true if the element has more than one line of text. */
 const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: SimplePath, isEditing?: boolean) => {
@@ -9,7 +14,6 @@ const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: Simp
   const fontSize = useSelector(state => state.fontSize)
   const showSplitView = useSelector(state => state.showSplitView)
   const splitPosition = useSelector(state => state.splitPosition)
-  const cursor = useSelector(state => state.cursor)
 
   // While editing, watch the current Value and trigger the layout effect
   const editingValue = editingValueStore.useSelector(state => (isEditing ? state : null))
@@ -32,7 +36,12 @@ const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: Simp
   // cursor changes to or from the element.
   useLayoutEffect(() => {
     updateMultiline()
-  }, [contentRef, fontSize, isEditing, showSplitView, simplePath, splitPosition, editingValue, cursor, updateMultiline])
+  }, [contentRef, fontSize, isEditing, showSplitView, simplePath, splitPosition, editingValue, updateMultiline])
+
+  // Recalculate multiline when the cursor changes.
+  // This is necessary because the width of thoughts change as the autofocus indent changes.
+  // (do not re-render component unless multiline changes)
+  useSelectorEffect(updateMultiline, selectCursor, shallowEqual)
 
   return multiline
 }

--- a/src/components/Editable/useMultiline.ts
+++ b/src/components/Editable/useMultiline.ts
@@ -34,9 +34,16 @@ const useMultiline = (contentRef: React.RefObject<HTMLElement>, simplePath: Simp
 
   // Recalculate multiline on mount, when the font size changes, edit, split view resize, value changes, and when the
   // cursor changes to or from the element.
-  useLayoutEffect(() => {
-    updateMultiline()
-  }, [contentRef, fontSize, isEditing, showSplitView, simplePath, splitPosition, editingValue, updateMultiline])
+  useLayoutEffect(updateMultiline, [
+    contentRef,
+    fontSize,
+    isEditing,
+    showSplitView,
+    simplePath,
+    splitPosition,
+    editingValue,
+    updateMultiline,
+  ])
 
   // Recalculate multiline when the cursor changes.
   // This is necessary because the width of thoughts change as the autofocus indent changes.

--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React, { useEffect } from 'react'
+import React, { useLayoutEffect } from 'react'
 import { useSelector } from 'react-redux'
 import LazyEnv from '../@types/LazyEnv'
 import Path from '../@types/Path'
@@ -76,9 +76,9 @@ const StaticThought = ({
   const value = useSelector(state => getThoughtById(state, head(simplePath)).value)
   // store ContentEditable ref to update DOM without re-rendering the Editable during editing
   const editableRef = React.useRef<HTMLInputElement>(null)
-  const multiline = useMultiline(editableRef, simplePath, value, isEditing)
+  const multiline = useMultiline(editableRef, simplePath, isEditing)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateSize?.()
   }, [multiline, updateSize])
 

--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -76,7 +76,7 @@ const StaticThought = ({
   const value = useSelector(state => getThoughtById(state, head(simplePath)).value)
   // store ContentEditable ref to update DOM without re-rendering the Editable during editing
   const editableRef = React.useRef<HTMLInputElement>(null)
-  const multiline = useMultiline(editableRef, simplePath, isEditing)
+  const multiline = useMultiline(editableRef, simplePath, value, isEditing)
 
   useEffect(() => {
     updateSize?.()

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -12,6 +12,7 @@ import calculateAutofocus from '../selectors/calculateAutofocus'
 import findDescendant from '../selectors/findDescendant'
 import { findAnyChild, hasChildren } from '../selectors/getChildren'
 import getThoughtById from '../selectors/getThoughtById'
+import isContextViewActive from '../selectors/isContextViewActive'
 import store from '../stores/app'
 import editingValueStore from '../stores/editingValue'
 import equalPath from '../util/equalPath'
@@ -37,6 +38,9 @@ export type OnResize = (args: {
 
 /** Selects the cursor. */
 const selectCursor = (state: State) => state.cursor
+
+/** Selects whether the context view is active for this thought. */
+const selectShowContexts = (path: SimplePath) => (state: State) => isContextViewActive(state, path)
 
 /** Finds the the first env entry with =focus/Zoom. O(children). */
 export const findFirstEnvContextWithZoom = (
@@ -94,6 +98,7 @@ const VirtualThought = ({
   const [height, setHeight] = useState<number | null>(singleLineHeight)
   const thought = useSelector(state => getThoughtById(state, head(simplePath)), shallowEqual)
   const isEditing = useSelector(state => equalPath(state.cursor, simplePath))
+  const isContextViewActive = useSelector(selectShowContexts(simplePath))
   const cursorLeaf = useSelector(state => !!state.cursor && !hasChildren(state, head(state.cursor)))
   const cursorDepth = useSelector(state => (state.cursor ? state.cursor.length : 0))
   const fontSize = useSelector(state => state.fontSize)
@@ -161,7 +166,18 @@ const VirtualThought = ({
 
   // Recalculate height when anything changes that could indirectly affect the height of the thought. (Height observers are slow.)
   // Autofocus changes when the cursor changes depth or moves between a leaf and non-leaf. This changes the left margin and can cause thoughts to wrap or unwrap.
-  useEffect(updateSize, [cursorDepth, cursorLeaf, fontSize, isVisible, leaf, note, simplePath, style, updateSize])
+  useEffect(updateSize, [
+    cursorDepth,
+    cursorLeaf,
+    fontSize,
+    isVisible,
+    leaf,
+    note,
+    simplePath,
+    style,
+    isContextViewActive,
+    updateSize,
+  ])
 
   // Recalculate height immediately as the editing value changes, otherwise there will be a delay between the text wrapping and the LayoutTree moving everything below the thought down.
   useEffect(() => {

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -6,6 +6,7 @@ import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
 import useDelayedAutofocus from '../hooks/useDelayedAutofocus'
+import useSelectorEffect from '../hooks/useSelectorEffect'
 import attributeEquals from '../selectors/attributeEquals'
 import calculateAutofocus from '../selectors/calculateAutofocus'
 import findDescendant from '../selectors/findDescendant'
@@ -37,6 +38,9 @@ export type OnResize = (args: {
 
 /** Selects whether the context view is active for this thought. */
 const selectShowContexts = (path: SimplePath) => (state: State) => isContextViewActive(state, path)
+
+/** Selects the cursor. */
+const selectCursor = (state: State) => state.cursor
 
 /** Finds the the first env entry with =focus/Zoom. O(children). */
 export const findFirstEnvContextWithZoom = (
@@ -172,6 +176,10 @@ const VirtualThought = ({
     editingValue,
     updateSize,
   ])
+
+  // Read the element's height from the DOM on cursor change and re-render with new height
+  // shimHiddenThought will re-render as needed.
+  useSelectorEffect(updateSize, selectCursor, shallowEqual)
 
   // trigger onResize with null on unmount to allow subscribers to clean up
   useEffect(


### PR DESCRIPTION
Alternative implementation of #2077.

Fixes #2041, #2049.

This PR fixes multiline calculation by making sure useLayoutEffect is not executed out-of-sync with React's scheduler and instead only triggered by hook dependencies. The performance seems to not be effected by this change.