### PR TITLE
#1842 divider alignment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2395,7 +2395,7 @@ code,
 }
 
 .child-divider {
-  margin-left: -125px;
+  margin-left: -12px;
 }
 
 .child-divider .drop-hover {

--- a/src/App.css
+++ b/src/App.css
@@ -2395,7 +2395,7 @@ code,
 }
 
 .child-divider {
-  margin-left: -12px;
+  margin-left: -16px;
 }
 
 .child-divider .drop-hover {


### PR DESCRIPTION
Fixes divider alignment: #1842 

A proper fix including the correct width should come with #543 

<img width="406" alt="image" src="https://github.com/cybersemics/em/assets/6959733/d484f043-e187-4a4c-906c-c173897f4930">

<img width="406" alt="image" src="https://github.com/cybersemics/em/assets/6959733/1eb16a2e-743a-4fe9-a5c1-1295fd42e29c">
