### PR TITLE
Fix table heights incorrect on initial render

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -558,6 +558,8 @@ a.text-link {
   white-space: pre-wrap;
 }
 
+/* Need to override max-width for table cols since they are rendered within the calculated width, instead of a whole line.
+This prevents table cols being rendered as multiline content, which causes inaacurate initial render */
 .table-col1 .thought,
 .table-col1 .thought-annotation {
   max-width: 100%;

--- a/src/App.css
+++ b/src/App.css
@@ -558,6 +558,11 @@ a.text-link {
   white-space: pre-wrap;
 }
 
+.table-col .thought,
+.table-col .thought-annotation {
+  max-width: 100%;
+}
+
 .thought-annotation {
   position: absolute;
   pointer-events: none;

--- a/src/App.css
+++ b/src/App.css
@@ -558,8 +558,8 @@ a.text-link {
   white-space: pre-wrap;
 }
 
-.table-col .thought,
-.table-col .thought-annotation {
+.table-col1 .thought,
+.table-col1 .thought-annotation {
   max-width: 100%;
 }
 

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -660,6 +661,7 @@ const LayoutTree = () => {
                 // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
+                className={classNames({ 'table-col': isTableCol1 })}
                 style={{
                   position: 'absolute',
                   // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -661,7 +661,7 @@ const LayoutTree = () => {
                 // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
-                className={classNames({ 'table-col': isTableCol1 })}
+                className={classNames({ 'table-col1': isTableCol1 })}
                 style={{
                   position: 'absolute',
                   // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.


### PR DESCRIPTION
#1889

Root Cause:
Unlike other `Thoughts` `table thoughts` are rendered within a fixed width container. And to expand click area we have style max-width: calc(100% - 1em) Due to this 1em the table cell rendered in 2 lines, and later the width is updated along with other cols. But since the initial render was 2 lines it gets assigned with multiline classname which gives additional padding. <- shows extra space After user selects item or any other render action the multiline class name gets removed causing the cell back to normal height

Solution:
assign max-width 100% instead of calc(100% - 1em) on table col specific cells