### PR TITLE
Fix #1842; divider rendering/alignment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2395,7 +2395,7 @@ code,
 }
 
 .child-divider {
-  margin-left: -125px;
+  margin-left: -16px;
 }
 
 .child-divider .drop-hover {


### PR DESCRIPTION
This PR fixes #1842 causing dividers to be rendered correctly by adjusting the divider's left margin.