### PR TITLE
Fix #543; divider width should match largest sibling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2395,7 +2395,7 @@ code,
 }
 
 .child-divider {
-  margin-left: -125px;
+  margin-left: -16px;
 }
 
 .child-divider .drop-hover {

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -3,12 +3,11 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import Path from '../@types/Path'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
-import rootedParentOf from '../selectors/rootedParentOf'
-import store from '../stores/app'
 import editingValueStore from '../stores/editingValue'
 import fastClick from '../util/fastClick'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
+import parentOf from '../util/parentOf'
 
 const DIVIDER_PLUS_PX = 20
 const DIVIDER_MIN_WIDTH = 85
@@ -28,8 +27,7 @@ const Divider = ({ path }: { path: Path }) => {
   /** Get the max width of nearby elements, add DIVIDER_PLUS_PX and set this width for divider. */
   const setStyle = () => {
     if (dividerRef.current) {
-      const state = store.getState()
-      const parentPath = rootedParentOf(state, path)
+      const parentPath = parentOf(path)
 
       const treeNode = dividerRef.current.closest('div.tree-node') as HTMLElement
       if (!treeNode) throw new Error('Divider tree node not found')
@@ -41,7 +39,7 @@ const Divider = ({ path }: { path: Path }) => {
 
       if (elements.length === 1) {
         /** If this divider is an only child in a table, find the widest col2. */
-        const grandparentPath = rootedParentOf(state, parentPath)
+        const grandparentPath = parentOf(parentPath)
         if (!grandparentPath) throw new Error('Divider grandparent not found')
 
         elements = document.querySelectorAll(

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -61,7 +61,10 @@ const Divider = ({ path }: { path: Path }) => {
     }
   }
 
-  useEffect(setStyle, [path, thoughtIndex]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Suppress the exhaustive-deps linter rule so that we can ignore dividerRef. Refs do not work in useEffect dependencies, as mutations do not trigger a re-render.
+  // We could use a callback ref to trigger setStyle every time the DOM node changes, but subscribing to the thoughtIndex (which is included for other thought updates) seems to cover all cases.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(setStyle, [path, thoughtIndex])
   editingValueStore.useEffect(setStyle)
 
   return (

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -36,9 +36,7 @@ const Divider = ({ path }: { path: Path }) => {
       const thoughtPath = treeNode.dataset.path?.split(',')
       if (!thoughtPath) throw new Error('Divider path not found on tree node')
 
-      let elements = document.querySelectorAll(
-        `.tree-node[data-path^="${parentPath}"]:not(.thought-divider)`,
-      ) as NodeListOf<HTMLElement>
+      let elements = document.querySelectorAll(`.tree-node[data-path^="${parentPath}"]:not(.thought-divider)`)
 
       if (elements.length === 1) {
         /** If this divider is an only child in a table, find the widest col2. */
@@ -47,7 +45,7 @@ const Divider = ({ path }: { path: Path }) => {
 
         elements = document.querySelectorAll(
           `.tree-node.table-col2[data-path^="${grandparentPath}"]:not(.thought-divider)`,
-        ) as NodeListOf<HTMLElement>
+        )
       } else if (!elements.length) {
         /** This is a top-level divider, use its siblings instead. */
         elements = document.querySelectorAll('.tree-node.top-level:not(.thought-divider)')

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -52,12 +52,10 @@ const Divider = ({ path }: { path: Path }) => {
 
       /** Find and set the max width of our selected elements. */
       const maxWidth = Math.max(
-        ...Array.from(elements).map(
-          element => (element.querySelector('.thought') as HTMLElement).offsetWidth + DIVIDER_PLUS_PX,
-        ),
+        ...Array.from(elements).map(element => (element.querySelector('.thought') as HTMLElement).offsetWidth),
       )
 
-      setWidth(maxWidth)
+      setWidth(maxWidth + DIVIDER_PLUS_PX)
     }
   }
 

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -61,7 +61,7 @@ const Divider = ({ path }: { path: Path }) => {
     }
   }
 
-  useEffect(setStyle, [dividerRef, path, thoughtIndex])
+  useEffect(setStyle, [path, thoughtIndex]) // eslint-disable-line react-hooks/exhaustive-deps
   editingValueStore.useEffect(setStyle)
 
   return (

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -36,8 +36,8 @@ const Divider = ({ path }: { path: Path }) => {
         ...siblingNodes
           .filter(node => !node.querySelector('.divider'))
           .map(node => {
-            const subs = node.querySelector('.thought') as HTMLElement
-            return subs ? subs.offsetWidth + DIVIDER_PLUS_PX : DIVIDER_PLUS_PX
+            const subthought = node.querySelector('.thought') as HTMLElement
+            return subthought ? subthought.offsetWidth + DIVIDER_PLUS_PX : DIVIDER_PLUS_PX
           }),
       )
 

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -61,7 +61,7 @@ const Divider = ({ path }: { path: Path }) => {
     }
   }
 
-  useEffect(setStyle, [setStyle, thoughtIndex])
+  useEffect(setStyle, [dividerRef, path, thoughtIndex])
   editingValueStore.useEffect(setStyle)
 
   return (

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -3,9 +3,11 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import Path from '../@types/Path'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
-import { DIVIDER_MIN_WIDTH, DIVIDER_PLUS_PX } from '../constants'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
+
+const DIVIDER_PLUS_PX = 20
+const DIVIDER_MIN_WIDTH = 85
 
 /** A custom horizontal rule. */
 const Divider = ({ path }: { path: Path }) => {

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -64,7 +64,7 @@ const Divider = ({ path }: { path: Path }) => {
   }
 
   useEffect(setStyle, []) // eslint-disable-line react-hooks/exhaustive-deps
-  editingValueStore.useEffect(setStyle)
+  editingValueStore.useEffect(() => setTimeout(setStyle, 0))
 
   return (
     <div

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,10 +1,10 @@
 import classNames from 'classnames'
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import Path from '../@types/Path'
-import State from '../@types/State'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import rootedParentOf from '../selectors/rootedParentOf'
+import store from '../stores/app'
 import editingValueStore from '../stores/editingValue'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
@@ -16,7 +16,6 @@ const DIVIDER_MIN_WIDTH = 85
 const Divider = ({ path }: { path: Path }) => {
   const dividerRef = React.createRef<HTMLInputElement>()
   const dispatch = useDispatch()
-  const state = useSelector((state: State) => state)
   const [width, setWidth] = useState(DIVIDER_MIN_WIDTH)
 
   /** Sets the cursor to the divider. */
@@ -28,6 +27,7 @@ const Divider = ({ path }: { path: Path }) => {
   /** Get the max width of nearby elements, add DIVIDER_PLUS_PX and set this width for divider. */
   const setStyle = () => {
     if (dividerRef.current) {
+      const state = store.getState()
       const parentPath = rootedParentOf(state, path)
 
       const treeNode = dividerRef.current.closest('div.tree-node') as HTMLElement

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,8 +1,11 @@
 import classNames from 'classnames'
 import React, { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import Path from '../@types/Path'
+import State from '../@types/State'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
+import rootedParentOf from '../selectors/rootedParentOf'
+import editingValueStore from '../stores/editingValue'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
 
@@ -13,6 +16,7 @@ const DIVIDER_MIN_WIDTH = 85
 const Divider = ({ path }: { path: Path }) => {
   const dividerRef = React.createRef<HTMLInputElement>()
   const dispatch = useDispatch()
+  const state = useSelector((state: State) => state)
   const [width, setWidth] = useState(DIVIDER_MIN_WIDTH)
 
   /** Sets the cursor to the divider. */
@@ -21,29 +25,47 @@ const Divider = ({ path }: { path: Path }) => {
     dispatch(setCursor({ path }))
   }
 
-  /** Get the max width of nearby for divider list child elements, add DIVIDER_PLUS_PX and set this width for divider. */
+  /** Get the max width of nearby elements, add DIVIDER_PLUS_PX and set this width for divider. */
   const setStyle = () => {
     if (dividerRef.current) {
-      const parentNode = dividerRef.current.closest('div.tree-node')
-      if (!parentNode) throw new Error('Parent node not found')
+      const parentPath = rootedParentOf(state, path)
 
-      /** Get the depth of this thought's node. */
-      const parentDepth = parentNode ? parseInt(parentNode.getAttribute('data-depth') || '0') : 0
-      const siblingNodes = Array.from(document.querySelectorAll(`.tree-node[data-depth="${parentDepth}"]`))
+      const treeNode = dividerRef.current.closest('div.tree-node') as HTMLElement
+      if (!treeNode) throw new Error('Divider tree node not found')
 
-      /** Find the largest child node and set the width of the divider to its width plus DIVIDER_PLUS_PX. */
+      const thoughtPath = treeNode.dataset.path?.split(',')
+      if (!thoughtPath) throw new Error('Divider path not found on tree node')
+
+      let elements = document.querySelectorAll(
+        `.tree-node[data-path^="${parentPath}"]:not(.thought-divider)`,
+      ) as NodeListOf<HTMLElement>
+
+      if (elements.length === 1) {
+        /** If this divider is an only child in a table, find the widest col2. */
+        const grandparentPath = rootedParentOf(state, parentPath)
+        if (!grandparentPath) throw new Error('Divider grandparent not found')
+
+        elements = document.querySelectorAll(
+          `.tree-node.table-col2[data-path^="${grandparentPath}"]:not(.thought-divider)`,
+        ) as NodeListOf<HTMLElement>
+      } else if (!elements.length) {
+        /** This is a top-level divider, use its siblings instead. */
+        elements = document.querySelectorAll('.tree-node.top-level:not(.thought-divider)')
+      }
+
+      /** Find and set the max width of our selected elements. */
       const maxWidth = Math.max(
-        ...siblingNodes.map(node => {
-          const subthought = node.querySelector('.thought:not(.thought-divider)') as HTMLElement
-          return subthought ? subthought.offsetWidth + DIVIDER_PLUS_PX : DIVIDER_PLUS_PX
-        }),
+        ...Array.from(elements).map(
+          element => (element.querySelector('.thought') as HTMLElement).offsetWidth + DIVIDER_PLUS_PX,
+        ),
       )
 
       setWidth(maxWidth)
     }
   }
 
-  useEffect(setStyle)
+  useEffect(setStyle, [dividerRef, state, path])
+  editingValueStore.subscribe(setStyle)
 
   return (
     <div

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -64,8 +64,9 @@ const Divider = ({ path }: { path: Path }) => {
     }
   }
 
-  useEffect(setStyle, [dividerRef, state, path])
-  editingValueStore.subscribe(setStyle)
+  useEffect(setStyle, []) // eslint-disable-line react-hooks/exhaustive-deps
+  const unsubscribe = editingValueStore.subscribe(setStyle)
+  useEffect(() => () => unsubscribe(), [unsubscribe])
 
   return (
     <div

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -25,6 +25,7 @@ const Divider = ({ path }: { path: Path }) => {
   const setStyle = () => {
     if (dividerRef.current) {
       const parentNode = dividerRef.current.closest('div.tree-node')
+      if (!parentNode) throw new Error('Parent node not found')
 
       /** Get the depth of this thought's node. */
       const parentDepth = parentNode ? parseInt(parentNode.getAttribute('data-depth') || '0') : 0

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -7,6 +7,7 @@ import rootedParentOf from '../selectors/rootedParentOf'
 import store from '../stores/app'
 import editingValueStore from '../stores/editingValue'
 import fastClick from '../util/fastClick'
+import hashPath from '../util/hashPath'
 import head from '../util/head'
 
 const DIVIDER_PLUS_PX = 20
@@ -33,10 +34,10 @@ const Divider = ({ path }: { path: Path }) => {
       const treeNode = dividerRef.current.closest('div.tree-node') as HTMLElement
       if (!treeNode) throw new Error('Divider tree node not found')
 
-      const thoughtPath = treeNode.dataset.path?.split(',')
-      if (!thoughtPath) throw new Error('Divider path not found on tree node')
+      const thoughtPath = treeNode.dataset.path
+      if (!thoughtPath || thoughtPath === '') throw new Error('Divider path not found on tree node')
 
-      let elements = document.querySelectorAll(`.tree-node[data-path^="${parentPath}"]:not(.thought-divider)`)
+      let elements = document.querySelectorAll(`.tree-node[data-path^="${hashPath(parentPath)}"]:not(.thought-divider)`)
 
       if (elements.length === 1) {
         /** If this divider is an only child in a table, find the widest col2. */
@@ -44,7 +45,7 @@ const Divider = ({ path }: { path: Path }) => {
         if (!grandparentPath) throw new Error('Divider grandparent not found')
 
         elements = document.querySelectorAll(
-          `.tree-node.table-col2[data-path^="${grandparentPath}"]:not(.thought-divider)`,
+          `.tree-node.table-col2[data-path^="${hashPath(grandparentPath)}"]:not(.thought-divider)`,
         )
       } else if (!elements.length) {
         /** This is a top-level divider, use its siblings instead. */

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -33,12 +33,10 @@ const Divider = ({ path }: { path: Path }) => {
 
       /** Find the largest child node and set the width of the divider to its width plus DIVIDER_PLUS_PX. */
       const maxWidth = Math.max(
-        ...siblingNodes
-          .filter(node => !node.querySelector('.divider'))
-          .map(node => {
-            const subthought = node.querySelector('.thought') as HTMLElement
-            return subthought ? subthought.offsetWidth + DIVIDER_PLUS_PX : DIVIDER_PLUS_PX
-          }),
+        ...siblingNodes.map(node => {
+          const subthought = node.querySelector('.thought:not(.thought-divider)') as HTMLElement
+          return subthought ? subthought.offsetWidth + DIVIDER_PLUS_PX : DIVIDER_PLUS_PX
+        }),
       )
 
       setWidth(maxWidth)

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames'
-import React, { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
+import React, { createRef, useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import Path from '../@types/Path'
+import State from '../@types/State'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import editingValueStore from '../stores/editingValue'
 import fastClick from '../util/fastClick'
@@ -14,8 +15,9 @@ const DIVIDER_MIN_WIDTH = 85
 
 /** A custom horizontal rule. */
 const Divider = ({ path }: { path: Path }) => {
-  const dividerRef = React.createRef<HTMLInputElement>()
   const dispatch = useDispatch()
+  const dividerRef = createRef<HTMLDivElement>()
+  const isCursor = useSelector((state: State) => hashPath(state.cursor) === hashPath(path))
   const [width, setWidth] = useState(DIVIDER_MIN_WIDTH)
 
   /** Sets the cursor to the divider. */
@@ -38,12 +40,12 @@ const Divider = ({ path }: { path: Path }) => {
       let elements = document.querySelectorAll(`.tree-node[data-path^="${hashPath(parentPath)}"]:not(.thought-divider)`)
 
       if (elements.length === 1) {
-        /** If this divider is an only child in a table, find the widest col2. */
+        /** If this divider is an only child, search further up the tree. */
         const grandparentPath = parentOf(parentPath)
         if (!grandparentPath) throw new Error('Divider grandparent not found')
 
         elements = document.querySelectorAll(
-          `.tree-node.table-col2[data-path^="${hashPath(grandparentPath)}"]:not(.thought-divider)`,
+          `.tree-node[data-path^="${hashPath(grandparentPath)}"]:not(.thought-divider)`,
         )
       } else if (!elements.length) {
         /** This is a top-level divider, use its siblings instead. */
@@ -61,6 +63,7 @@ const Divider = ({ path }: { path: Path }) => {
 
   useEffect(setStyle, []) // eslint-disable-line react-hooks/exhaustive-deps
   editingValueStore.useEffect(() => setTimeout(setStyle, 0))
+  if (isCursor) setTimeout(setStyle, 100)
 
   return (
     <div

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -17,7 +17,7 @@ const DIVIDER_MIN_WIDTH = 85
 const Divider = ({ path }: { path: Path }) => {
   const dispatch = useDispatch()
   const dividerRef = createRef<HTMLDivElement>()
-  const isCursor = useSelector((state: State) => hashPath(state.cursor) === hashPath(path))
+  const thoughtIndex = useSelector((state: State) => state.thoughts.thoughtIndex)
   const [width, setWidth] = useState(DIVIDER_MIN_WIDTH)
 
   /** Sets the cursor to the divider. */
@@ -61,9 +61,8 @@ const Divider = ({ path }: { path: Path }) => {
     }
   }
 
-  useEffect(setStyle, []) // eslint-disable-line react-hooks/exhaustive-deps
-  editingValueStore.useEffect(() => setTimeout(setStyle, 0))
-  if (isCursor) setTimeout(setStyle, 100)
+  useEffect(setStyle, [setStyle, thoughtIndex])
+  editingValueStore.useEffect(setStyle)
 
   return (
     <div

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -63,8 +63,7 @@ const Divider = ({ path }: { path: Path }) => {
   }
 
   useEffect(setStyle, []) // eslint-disable-line react-hooks/exhaustive-deps
-  const unsubscribe = editingValueStore.subscribe(setStyle)
-  useEffect(() => () => unsubscribe(), [unsubscribe])
+  editingValueStore.useEffect(setStyle)
 
   return (
     <div

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -660,6 +660,8 @@ const LayoutTree = () => {
                 // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
+                data-depth={depth}
+                className='tree-node'
                 style={{
                   position: 'absolute',
                   // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import classnames from 'classnames'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -663,7 +663,7 @@ const LayoutTree = () => {
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
                 data-path={hashPath(path)}
-                className={classNames({
+                className={classnames({
                   'tree-node': true,
                   'top-level': simplePath.length === 1,
                   'table-col1': isTableCol1,

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -1,4 +1,4 @@
-import classnames from 'classnames'
+import classNames from 'classnames'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -663,7 +663,7 @@ const LayoutTree = () => {
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
                 data-path={hashPath(path)}
-                className={classnames({
+                className={classNames({
                   'tree-node': true,
                   'top-level': simplePath.length === 1,
                   'table-col1': isTableCol1,

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -662,7 +662,7 @@ const LayoutTree = () => {
                 // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
-                data-path={path}
+                data-path={hashPath(path)}
                 className={classNames({
                   'tree-node': true,
                   'top-level': simplePath.length === 1,

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -27,6 +28,7 @@ import { appendToPathMemo } from '../util/appendToPath'
 import equalPath from '../util/equalPath'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
+import isDivider from '../util/isDivider'
 import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
 import parseLet from '../util/parseLet'
@@ -660,8 +662,14 @@ const LayoutTree = () => {
                 // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
                 // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
                 key={key}
-                data-depth={depth}
-                className='tree-node'
+                data-path={path}
+                className={classNames({
+                  'tree-node': true,
+                  'top-level': simplePath.length === 1,
+                  'table-col1': isTableCol1,
+                  'table-col2': isTableCol2,
+                  'thought-divider': isDivider(thought.value),
+                })}
                 style={{
                   position: 'absolute',
                   // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const MODAL_NEWCHILD_DELAY = 1200
 // export const MODAL_SUPERSCRIPT_DELAY = 800
 
 // divider plus px from max width of list items
-export const DIVIDER_PLUS_PX = 30
+export const DIVIDER_PLUS_PX = 20
 export const DIVIDER_MIN_WIDTH = 85
 
 export const LATEST_SHORTCUT_DIAGRAM_DURATION = 800

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,10 +24,6 @@ export const MODAL_NEWCHILD_DELAY = 1200
 // export const MODAL_SUPERSCRIPT_SUGGESTOR_DELAY = 1000 * 30
 // export const MODAL_SUPERSCRIPT_DELAY = 800
 
-// divider plus px from max width of list items
-export const DIVIDER_PLUS_PX = 20
-export const DIVIDER_MIN_WIDTH = 85
-
 export const LATEST_SHORTCUT_DIAGRAM_DURATION = 800
 
 // number of latest shorrcuts to show at a time


### PR DESCRIPTION
This PR fixes #543 causing the divider to now be the same width as the largest sibling.