### PR TITLE
fixed double drop target issue in context view

### DIFF
--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -54,9 +54,7 @@ const DropChildIfCollapsed = ({
   path,
   simplePath,
 }: DropChildProps & { dropTarget: ConnectDropTarget }) => {
-  const isExpanded = useSelector(
-    state => hasChildren(state, head(simplePath)) && !!state.expanded[hashPath(simplePath)],
-  )
+  const isExpanded = useSelector(state => hasChildren(state, head(simplePath)) && !!state.expanded[hashPath(path)])
   const draggingThought = useSelector(state => state.draggingThought, shallowEqual)
 
   // Do not render DropChild on expanded thoughts or on the dragging thought.


### PR DESCRIPTION
#1951 

The issue was happening because the drop-end was not unmounting upon the expanding of the thought 'b', it was not picking up the expansion of the thought, had to give it `path` instead of `simplepath` for it work.