### PR TITLE
adjusted position of drop target on to prevent user finger obscuring …

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2128,7 +2128,7 @@ code,
   position: absolute;
   height: 0.5em;
   /* margin to offset bullet width */
-  margin-left: -1em;
+  margin-left: 1em;
   /* Add additional click area to position the drop target more evenly between siblings (vertically).
      Unfortunately, due to the HTML hierarchy stacking order, multiple drop-ends at the same y position (e.g. after /a/b/c below) will always be obscured by their previous siblings descendants.
      This is still better than nothing.
@@ -2160,7 +2160,7 @@ code,
 
 /* Last drop-end in Subthoughts */
 .drop-end .drop-hover {
-  margin-left: calc(0.6em - 13px);
+  margin-left: calc(-1.4em - 13px);
   width: calc(100% - 3em);
 }
 

--- a/src/components/DropEnd.tsx
+++ b/src/components/DropEnd.tsx
@@ -98,7 +98,7 @@ const DropEnd = ({
         display: 'list-item',
         backgroundColor: testFlags.simulateDrop ? `hsl(170, 50%, ${20 + 5 * (depth % 2)}%)` : undefined,
         height: isRootPath ? '8em' : '1.9em',
-        marginLeft: isRootPath ? '-4em' : last ? '-2em' : undefined,
+        marginLeft: isRootPath ? '-2em' : undefined,
         // offset marginLeft, minus 1em for bullet
         // otherwise drop-hover will be too far left
         paddingLeft: isRootPath ? '3em' : last ? (isTouch ? '6em' : '1em') : undefined,


### PR DESCRIPTION
#1952 

Adjusted css to shift the drag zone towards right, so users finger do not obscure the DropHover on mobile