### PR TITLE
Maintain sort preference on bumpThoughtDown

### DIFF
--- a/src/actions/__tests__/bumpThoughtDown.ts
+++ b/src/actions/__tests__/bumpThoughtDown.ts
@@ -1,10 +1,12 @@
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import setCursor from '../../test-helpers/setCursorFirstMatch'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 import bumpThoughtDown from '../bumpThoughtDown'
 import cursorBack from '../cursorBack'
+import importText from '../importText'
 import newSubthought from '../newSubthought'
 import newThought from '../newThought'
 
@@ -86,4 +88,32 @@ it('bump root thought with children', () => {
   - ${''}
     - a
     - b`)
+})
+it('should maintain sort order when bumping down in a sorted context', () => {
+  const steps = [
+    importText({
+      text: `
+        - C
+          - =sort
+            - Alphabetical
+              - Asc
+          - A
+          - B
+      `,
+    }),
+    setCursor(['C']),
+    bumpThoughtDown({}),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - ${''}
+    - =sort
+      - Alphabetical
+        - Asc
+    - A
+    - B
+    - C`)
 })

--- a/src/actions/bumpThoughtDown.ts
+++ b/src/actions/bumpThoughtDown.ts
@@ -9,7 +9,9 @@ import editThought from '../actions/editThought'
 import editableRender from '../actions/editableRender'
 import moveThought from '../actions/moveThought'
 import setCursor from '../actions/setCursor'
+import sort from '../actions/sort'
 import subCategorizeOne from '../actions/subCategorizeOne'
+import findDescendant from '../selectors/findDescendant'
 import { getAllChildren } from '../selectors/getChildren'
 import getPrevRank from '../selectors/getPrevRank'
 import getRankBefore from '../selectors/getRankBefore'
@@ -40,6 +42,9 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
   // Need to store the full simplePath of each simplePath segment in the simplePath
   const parentPath = parentOf(simplePath)
 
+  // Find the sort preference, if any
+  const sortId = findDescendant(state, head(simplePath), ['=sort'])
+
   // modify the rank to get the thought to re-render (via the Subthoughts child key)
   // this should be fixed
   const simplePathWithNewRank: SimplePath = appendToPath(parentPath, head(simplePath))
@@ -61,6 +66,14 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
         rank: getPrevRank(state, head(simplePath!)),
         value,
       })
+    },
+
+    state => {
+      // sort the new thought if there is a sort preference
+      if (sortId) return sort(state, head(simplePath))
+
+      // otherwise, return the state
+      return state
     },
 
     // clear text

--- a/src/actions/bumpThoughtDown.ts
+++ b/src/actions/bumpThoughtDown.ts
@@ -9,12 +9,12 @@ import editThought from '../actions/editThought'
 import editableRender from '../actions/editableRender'
 import moveThought from '../actions/moveThought'
 import setCursor from '../actions/setCursor'
-import sort from '../actions/sort'
 import subCategorizeOne from '../actions/subCategorizeOne'
 import findDescendant from '../selectors/findDescendant'
 import { getAllChildren } from '../selectors/getChildren'
 import getPrevRank from '../selectors/getPrevRank'
 import getRankBefore from '../selectors/getRankBefore'
+import getSortedRank from '../selectors/getSortedRank'
 import getThoughtById from '../selectors/getThoughtById'
 import simplifyPath from '../selectors/simplifyPath'
 import appendToPath from '../util/appendToPath'
@@ -63,17 +63,10 @@ const bumpThoughtDown = (state: State, { simplePath }: { simplePath?: SimplePath
       // the context of the new empty thought
       return createThought(state, {
         path: simplePath as Path,
-        rank: getPrevRank(state, head(simplePath!)),
+        // If there is a sort preference, use it. Otherwise, insert at the top.
+        rank: sortId ? getSortedRank(state, head(simplePath), value) : getPrevRank(state, head(simplePath)),
         value,
       })
-    },
-
-    state => {
-      // sort the new thought if there is a sort preference
-      if (sortId) return sort(state, head(simplePath))
-
-      // otherwise, return the state
-      return state
     },
 
     // clear text


### PR DESCRIPTION
Fixes #1990.

This PR re-applies the sort preference (if any exists) on `bumpThoughtDown` to maintain the sort order after the child thought has been created.