### PR TITLE
Maintain sort order after collapsing a context

### DIFF
--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -231,7 +231,7 @@ describe('normal view', () => {
     expect(ranks.size).toEqual(6)
   })
 
-  it('should resort parent context when collapsing a thought with sort attribute', () => {
+  it('should re-sort parent context when collapsing a thought with sort attribute', () => {
     const steps = [
       importText({
         text: `
@@ -257,6 +257,33 @@ describe('normal view', () => {
       - Asc
   - a
   - c`)
+  })
+
+  it('should not re-sort parent context when collapsing a thought with sort set to None', () => {
+    const steps = [
+      importText({
+        text: `
+          - c
+          - b
+            - =sort
+              - None
+            - a
+        `,
+      }),
+      setCursor(['b']),
+      collapseContext({}),
+      setCursor(null),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    // TODO: =sort should be above all non-meta attributes.
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - c
+  - =sort
+    - None
+  - a`)
   })
 
   it('prevents switching to manual sort order when collapsing', () => {

--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -230,6 +230,34 @@ describe('normal view', () => {
     const ranks = new Set([a2.rank, b2.rank, c2.rank, d2.rank, e2.rank, f2.rank])
     expect(ranks.size).toEqual(6)
   })
+
+  it('should resort parent context when collapsing a thought with sort attribute', () => {
+    const steps = [
+      importText({
+        text: `
+          - c
+          - b
+            - =sort
+              - Alphabetical
+                - Asc
+            - a
+        `,
+      }),
+      setCursor(['b']),
+      collapseContext({}),
+      setCursor(null),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - =sort
+    - Alphabetical
+      - Asc
+  - a
+  - c`)
+  })
 })
 
 describe('context view', () => {

--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -258,6 +258,41 @@ describe('normal view', () => {
   - a
   - c`)
   })
+
+  it('prevents switching to manual sort order when collapsing', () => {
+    const steps = [
+      importText({
+        text: `
+        - d
+        - c
+        - b
+          - =sort
+            - Alphabetical
+              - Asc
+          - a
+          - e
+          - g
+        - f
+        `,
+      }),
+      setCursor(['b']),
+      collapseContext({}),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - =sort
+    - Alphabetical
+      - Asc
+  - a
+  - c
+  - d
+  - e
+  - f
+  - g`)
+  })
 })
 
 describe('context view', () => {

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -80,7 +80,8 @@ const collapseContext = (state: State, { at }: Options) => {
       path: simplePath,
     }),
 
-    // Move context sort up and sort parent context if sort preference exists and parent does not have a sort preference
+    // Sort parent context if sort preference exists and parent does not have a sort preference
+    // Sort preference must be moved up before sort to prevent conversion to manual sort.
     contextHasSortPreference && !parentHasSortPreference
       ? reducerFlow([
           moveThought({
@@ -94,7 +95,7 @@ const collapseContext = (state: State, { at }: Options) => {
 
     // outdent each child
     ...children.map((child, i) => (state: State) => {
-      // Skip sort since it has already been moved to the parent, if necessary
+      // Skip =sort since it has already been moved to the parent.
       if (child.value === '=sort') return state
 
       return moveThought(state, {

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -8,6 +8,7 @@ import setCursor from '../actions/setCursor'
 import findDescendant from '../selectors/findDescendant'
 import { getChildren, getChildrenRanked, isVisible } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
+import getSortedRank from '../selectors/getSortedRank'
 import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
 import rootedParentOf from '../selectors/rootedParentOf'
@@ -75,13 +76,16 @@ const collapseContext = (state: State, { at }: Options) => {
       newValue: createId(), // unique value
       path: simplePath,
     }),
+    // Sort parent context if sort preference exists
+    sortId ? sort(parentId) : null,
     // outdent each child
-    ...children.map((child, i) =>
-      moveThought({
-        oldPath: appendToPath(simplePath, child.id),
-        newPath: appendToPath(parentOf(simplePath), child.id),
-        newRank: rankStart + rankIncrement * i,
-      }),
+    ...children.map(
+      (child, i) => (state: State) =>
+        moveThought(state, {
+          oldPath: appendToPath(simplePath, child.id),
+          newPath: appendToPath(parentOf(simplePath), child.id),
+          newRank: sortId ? getSortedRank(state, parentId, child.value) : rankStart + rankIncrement * i,
+        }),
     ),
     // delete the original cursor
     deleteThought({
@@ -95,12 +99,6 @@ const collapseContext = (state: State, { at }: Options) => {
         editing: state.editing,
         offset: 0,
       }),
-    // sort the parent context if there is a sort preference
-    state => {
-      if (sortId) return sort(state, parentId)
-
-      return state
-    },
   ])(state)
 }
 

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -5,6 +5,7 @@ import Thunk from '../@types/Thunk'
 import alert from '../actions/alert'
 import moveThought from '../actions/moveThought'
 import setCursor from '../actions/setCursor'
+import findDescendant from '../selectors/findDescendant'
 import { getChildren, getChildrenRanked, isVisible } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
 import getThoughtById from '../selectors/getThoughtById'
@@ -18,6 +19,7 @@ import parentOf from '../util/parentOf'
 import reducerFlow from '../util/reducerFlow'
 import deleteThought from './deleteThought'
 import editThought from './editThought'
+import sort from './sort'
 
 interface Options {
   at?: Path | null
@@ -61,6 +63,10 @@ const collapseContext = (state: State, { at }: Options) => {
   const rankStart = getRankBefore(state, simplePath)
   const rankIncrement = (thought.rank - rankStart) / children.length
 
+  // Find the sort preference, if any
+  const parentId = head(rootedParentOf(state, simplePath))
+  const sortId = findDescendant(state, head(simplePath), ['=sort'])
+
   return reducerFlow([
     // first edit the collapsing thought to a unique value
     // otherwise, it could get merged when children are outdented in the next step
@@ -89,6 +95,12 @@ const collapseContext = (state: State, { at }: Options) => {
         editing: state.editing,
         offset: 0,
       }),
+    // sort the parent context if there is a sort preference
+    state => {
+      if (sortId) return sort(state, parentId)
+
+      return state
+    },
   ])(state)
 }
 

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -69,7 +69,7 @@ const collapseContext = (state: State, { at }: Options) => {
   const parentId = head(rootedParentOf(state, simplePath))
   const parentHasSortPreference = getSortPreference(state, parentId).type !== 'None'
   const contextSortId = findDescendant(state, head(simplePath), ['=sort'])
-  const contextHasSortPreference = !!contextSortId
+  const contextHasSortPreference = getSortPreference(state, head(simplePath)).type !== 'None'
 
   return reducerFlow([
     // first edit the collapsing thought to a unique value
@@ -85,8 +85,9 @@ const collapseContext = (state: State, { at }: Options) => {
     contextHasSortPreference && !parentHasSortPreference
       ? reducerFlow([
           moveThought({
-            oldPath: appendToPath(simplePath, contextSortId),
-            newPath: appendToPath(parentOf(simplePath), contextSortId),
+            // contextSortId must exist since contextHasSortPreference is true
+            oldPath: appendToPath(simplePath, contextSortId!),
+            newPath: appendToPath(parentOf(simplePath), contextSortId!),
             newRank: getRankBefore(state, simplePath),
           }),
           sort(parentId),
@@ -96,7 +97,7 @@ const collapseContext = (state: State, { at }: Options) => {
     // outdent each child
     ...children.map((child, i) => (state: State) => {
       // Skip =sort since it has already been moved to the parent.
-      if (child.value === '=sort') return state
+      if (contextHasSortPreference && child.value === '=sort') return state
 
       return moveThought(state, {
         oldPath: appendToPath(simplePath, child.id),


### PR DESCRIPTION
Fixes #2091.

This PR re-applies the sort preference (if any exists) on collapseContext after it has moved to the parent context.