### PR TITLE
Remove =pin and =children/=pin on collapseContext, preserve order

### DIFF
--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -438,34 +438,6 @@ describe('collapsing contexts with meta attributes', () => {
   - e`)
   })
 
-  it('should delete =children if it has no remaining children after collapsing', () => {
-    const steps = [
-      importText({
-        text: `
-          - a
-            - b
-              - =children
-                - =pin
-                  - true
-              - c
-            - d
-          - e
-        `,
-      }),
-      setCursor(['a', 'b']),
-      collapseContext({}),
-    ]
-
-    const stateNew = reducerFlow(steps)(initialState())
-    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
-
-    expect(exported).toBe(`- ${HOME_TOKEN}
-  - a
-    - c
-    - d
-  - e`)
-  })
-
   it('should keep =children if it has remaining children after collapsing', () => {
     const steps = [
       importText({

--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -504,4 +504,31 @@ describe('collapsing contexts with special attributes', () => {
     - d
   - e`)
   })
+
+  it('should move meta attributes to the top when collapsing a context', () => {
+    const steps = [
+      importText({
+        text: `
+          - =x
+          - a
+          - b
+            - =y
+            - c
+        `,
+      }),
+      toggleHiddenThoughts,
+      setCursor(['b']),
+      collapseContext({}),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - =x
+  - =y
+  - a
+  - c`)
+  })
 })

--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -279,11 +279,10 @@ describe('normal view', () => {
     const stateNew = reducerFlow(steps)(initialState())
     const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
 
-    // TODO: =sort should be above all non-meta attributes.
     expect(exported).toBe(`- ${HOME_TOKEN}
-  - c
   - =sort
     - None
+  - c
   - a`)
   })
 
@@ -384,7 +383,7 @@ describe('context view', () => {
   })
 })
 
-describe('collapsing contexts with special attributes', () => {
+describe('collapsing contexts with meta attributes', () => {
   it('should delete =pin when collapsing a context', () => {
     const steps = [
       importText({

--- a/src/actions/__tests__/collapseContext.ts
+++ b/src/actions/__tests__/collapseContext.ts
@@ -5,7 +5,6 @@ import importText from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
 import toggleContextView from '../../actions/toggleContextView'
-import toggleHiddenThoughts from '../../actions/toggleHiddenThoughts'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
 import contextToThought from '../../test-helpers/contextToThought'
@@ -397,7 +396,6 @@ describe('collapsing contexts with meta attributes', () => {
           - e
         `,
       }),
-      toggleHiddenThoughts,
       setCursor(['a', 'b']),
       collapseContext({}),
     ]
@@ -426,7 +424,6 @@ describe('collapsing contexts with meta attributes', () => {
           - e
         `,
       }),
-      toggleHiddenThoughts,
       setCursor(['a', 'b']),
       collapseContext({}),
     ]
@@ -455,7 +452,6 @@ describe('collapsing contexts with meta attributes', () => {
           - e
         `,
       }),
-      toggleHiddenThoughts,
       setCursor(['a', 'b']),
       collapseContext({}),
     ]
@@ -486,7 +482,6 @@ describe('collapsing contexts with meta attributes', () => {
           - e
         `,
       }),
-      toggleHiddenThoughts,
       setCursor(['a', 'b']),
       collapseContext({}),
     ]
@@ -515,7 +510,6 @@ describe('collapsing contexts with meta attributes', () => {
             - c
         `,
       }),
-      toggleHiddenThoughts,
       setCursor(['b']),
       collapseContext({}),
     ]

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -121,12 +121,6 @@ const collapseContext = (state: State, { at }: Options) => {
         editing: state.editing,
         offset: 0,
       }),
-    // sort the parent context if there is a sort preference
-    state => {
-      if (sortId) return sort(state, parentId)
-
-      return state
-    },
   ])(state)
 }
 

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -6,7 +6,7 @@ import alert from '../actions/alert'
 import moveThought from '../actions/moveThought'
 import setCursor from '../actions/setCursor'
 import findDescendant from '../selectors/findDescendant'
-import { getChildren, getChildrenRanked, isVisible } from '../selectors/getChildren'
+import { findAnyChild, getChildren, getChildrenRanked, isVisible } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
 import getSortPreference from '../selectors/getSortPreference'
 import getSortedRank from '../selectors/getSortedRank'
@@ -107,8 +107,7 @@ const collapseContext = (state: State, { at }: Options) => {
   const childrenAttributeId = findDescendant(state, head(simplePath), '=children')
   const childrenPinAttributeId = childrenAttributeId ? findDescendant(state, childrenAttributeId, '=pin') : null
   const shouldDeleteChildrenAttribute =
-    childrenAttributeId &&
-    getChildren(state, childrenAttributeId).filter(thought => thought.value !== '=pin').length === 0
+    childrenAttributeId && !findAnyChild(state, childrenAttributeId, thought => thought.value !== '=pin')
 
   return reducerFlow([
     // first edit the collapsing thought to a unique value

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -67,9 +67,9 @@ const collapseContext = (state: State, { at }: Options) => {
 
   // Find the sort preference, if any
   const parentId = head(rootedParentOf(state, simplePath))
-  const parentHasSortPreference = getSortPreference(state, parentId).type !== 'None'
-  const contextSortId = findDescendant(state, head(simplePath), ['=sort'])
   const contextHasSortPreference = getSortPreference(state, head(simplePath)).type !== 'None'
+  const parentHasSortPreference = getSortPreference(state, parentId).type !== 'None'
+  const sortId = findDescendant(state, head(simplePath), ['=sort'])
 
   return reducerFlow([
     // first edit the collapsing thought to a unique value
@@ -85,9 +85,9 @@ const collapseContext = (state: State, { at }: Options) => {
     contextHasSortPreference && !parentHasSortPreference
       ? reducerFlow([
           moveThought({
-            // contextSortId must exist since contextHasSortPreference is true
-            oldPath: appendToPath(simplePath, contextSortId!),
-            newPath: appendToPath(parentOf(simplePath), contextSortId!),
+            // sortId must exist since contextHasSortPreference is true
+            oldPath: appendToPath(simplePath, sortId!),
+            newPath: appendToPath(parentOf(simplePath), sortId!),
             newRank: getRankBefore(state, simplePath),
           }),
           sort(parentId),
@@ -121,6 +121,12 @@ const collapseContext = (state: State, { at }: Options) => {
         editing: state.editing,
         offset: 0,
       }),
+    // sort the parent context if there is a sort preference
+    state => {
+      if (sortId) return sort(state, parentId)
+
+      return state
+    },
   ])(state)
 }
 

--- a/src/actions/collapseContext.ts
+++ b/src/actions/collapseContext.ts
@@ -85,7 +85,6 @@ const collapseContext = (state: State, { at }: Options) => {
     contextHasSortPreference && !parentHasSortPreference
       ? reducerFlow([
           moveThought({
-            // sortId must exist since contextHasSortPreference is true
             oldPath: appendToPath(simplePath, sortId!),
             newPath: appendToPath(parentOf(simplePath), sortId!),
             newRank: getRankBefore(state, simplePath),


### PR DESCRIPTION
Fixes #1730, #2092.

This PR handles removing `=pin` and `=children/=pin` attributes on `collapseContext`. If `=children` has no other children after collapsing, it is removed as well.

Additionally, it preserves the proper ordering of meta attributes after collapsing according to #2092.