### PR TITLE
Fix tutorial step accumulation issue #2087

### DIFF
--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -42,7 +42,7 @@ const WithCSSTransition = ({ component, ...props }: { component: FC<any>; [props
 
   const Component = component
   return (
-    <CSSTransition nodeRef={nodeRef} in={true} key={Math.floor(props.step)} timeout={400} classNames='slide'>
+    <CSSTransition nodeRef={nodeRef} in={true} key={Math.floor(props.transitionKey)} timeout={400} classNames='slide'>
       <div ref={nodeRef}>
         <Component {...props} />
       </div>
@@ -79,7 +79,7 @@ const Tutorial: FC = () => {
     rootChildren,
     contextViews,
     dispatch,
-    key: Math.floor(tutorialStep),
+    transitionKey: Math.floor(tutorialStep),
   }
 
   const tutorialStepComponent =
@@ -104,6 +104,7 @@ const Tutorial: FC = () => {
   )
 
   const cursorHeadValue = useSelector(state => state.cursor && headValue(state, state.cursor))
+
   return (
     <div className='tutorial'>
       <div className='tutorial-inner'>


### PR DESCRIPTION
This fixes the issue #2087 

Solution: by renaming the key prop to transitionKey, we ensure that the prop is correctly passed and accessible. Since "key" is a special property in React, it could not keep track of each element being mapped and thus caused the accumulation.

Please review the changes and let me know if further adjustments are needed.