### PR TITLE
Fix stuck toolbar button

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -173,6 +173,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
                   onTapCancel={onTapCancel}
                   selected={selected === id}
                   shortcutId={id}
+                  setPressingToolbarId={setPressingToolbarId}
                 />
               )
             })}

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MutableRefObject, useCallback, useMemo } from 'react'
+import React, { Dispatch, FC, MutableRefObject, SetStateAction, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import DragShortcutZone from '../@types/DragShortcutZone'
 import Icon from '../@types/Icon'
@@ -23,6 +23,7 @@ export interface ToolbarButtonProps {
   onTapUp?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
   selected?: boolean
   shortcutId: ShortcutId
+  setPressingToolbarId: Dispatch<SetStateAction<string | null>>
 }
 
 /** A single button in the Toolbar. */
@@ -41,6 +42,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
   onTapUp,
   selected,
   shortcutId,
+  setPressingToolbarId,
 }) => {
   const colors = useSelector(themeColors)
   const shortcut = shortcutById(shortcutId)
@@ -174,6 +176,11 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
           paddingBottom: isDraggingAny ? '7em' : 0,
         }}
         className='toolbar-icon'
+        onMouseLeave={e => {
+          if (!customize) {
+            setPressingToolbarId(null)
+          }
+        }}
         {...fastClick(tapUp, tapDown, onTapCancel ? e => onTapCancel(shortcutId, e) : undefined, touchMove)}
       >
         {


### PR DESCRIPTION
This is a simple fix to issue #2088 

It passes the preexisting state setter setPressingToolbarId to the ToolbarButton component, then calls it when onMouseLeave is triggered AND customize is not true

From a quick glance, it appears your code was attempting to use the drag and drop handlers to essentially do the same thing, but these are actually not called in this edge case (perhaps because customize is false, which disables drag all together)

Please let me know if you have any questions. Would love to have a chance to discuss contract work with you. 

If you need any adjustments here, please let me know.

Thanks!
Michael