### PR TITLE
Fixed bug that kept the toolbar icon pressed when it was dragged

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -95,7 +95,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
   }, [isDraggingAny, setPressingToolbarId])
 
   /**
-   * update isPressed when the drag is released outside of the toolbar
+   * Udate isPressed when the drag is released outside of the toolbar
    * */
   useEffect(() => {
     const handleMouseUp = event => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -94,10 +94,10 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
     }
   }, [isDraggingAny, setPressingToolbarId])
 
-  /**
-   * Udate isPressed when the drag is released outside of the toolbar
-   * */
   useEffect(() => {
+    /**
+     * Update isPressed when the drag is released outside of the toolbar.
+     * */
     const handleMouseUp = event => {
       if (handleMouseUp) {
         setPressingToolbarId(null)

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -94,7 +94,9 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
     }
   }, [isDraggingAny, setPressingToolbarId])
 
-  // set is pressed to false when the drag is released outside of the toolbar
+  /**
+   * update isPressed when the drag is released outside of the toolbar
+   * */
   useEffect(() => {
     const handleMouseUp = event => {
       if (handleMouseUp) {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -30,7 +30,7 @@ interface ToolbarProps {
 }
 
 /** Toolbar component. */
-const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
+const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseUp }) => {
   // track scrollLeft after each touchend
   // this is used to reset pressingToolbarId when the user has scrolled at least 5px
   const lastScrollLeft = useRef<number>(0)
@@ -93,6 +93,23 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
       setPressingToolbarId(null)
     }
   }, [isDraggingAny, setPressingToolbarId])
+
+  // set is pressed to false when the drag is released outside of the toolbar. 
+  useEffect(() => {
+    const handleMouseUp = (event) => {
+      if (handleMouseUp) {
+        setPressingToolbarId(null)
+      }
+    }
+
+    // Add mouseup event listener to the document
+    document.addEventListener('mouseup', handleMouseUp);
+
+    // Cleanup mouseup event listener on component unmount
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp);
+    }
+  }, [handleMouseUp]);
 
   /**********************************************************************
    * Render

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -99,9 +99,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
      * Update isPressed when the drag is released outside of the toolbar.
      * */
     const handleMouseUp = event => {
-      if (handleMouseUp) {
-        setPressingToolbarId(null)
-      }
+      setPressingToolbarId(null)
     }
 
     // Add mouseup event listener to the document

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -30,7 +30,7 @@ interface ToolbarProps {
 }
 
 /** Toolbar component. */
-const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseUp }) => {
+const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
   // track scrollLeft after each touchend
   // this is used to reset pressingToolbarId when the user has scrolled at least 5px
   const lastScrollLeft = useRef<number>(0)
@@ -109,7 +109,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
     return () => {
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [handleMouseUp])
+  }, [])
 
   /**********************************************************************
    * Render

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -96,7 +96,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
 
   // set is pressed to false when the drag is released outside of the toolbar
   useEffect(() => {
-    const handleMouseUp = (event) => {
+    const handleMouseUp = event => {
       if (handleMouseUp) {
         setPressingToolbarId(null)
       }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -94,7 +94,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
     }
   }, [isDraggingAny, setPressingToolbarId])
 
-  // set is pressed to false when the drag is released outside of the toolbar. 
+  // set is pressed to false when the drag is released outside of the toolbar
   useEffect(() => {
     const handleMouseUp = (event) => {
       if (handleMouseUp) {
@@ -103,13 +103,13 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected, handleMouseU
     }
 
     // Add mouseup event listener to the document
-    document.addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('mouseup', handleMouseUp)
 
     // Cleanup mouseup event listener on component unmount
     return () => {
-      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [handleMouseUp]);
+  }, [handleMouseUp])
 
   /**********************************************************************
    * Render


### PR DESCRIPTION
This fixes the problem of bug #2088. Added a method to reset the isPressed value in the toolbar button when the user drags the toolbar button outside of the toolbar. 