### PR TITLE
fix: deselect toolbar button when dragging the cursor out of the toolbar (fixes #2088)

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -107,8 +107,8 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
   }, [updateArrows])
 
   // deselect button when moving the cursor out of the toolbar
-  const toolbarContainer = toolbarContainerRef.current
   useEffect(() => {
+    const toolbarContainer = toolbarContainerRef.current
     if (toolbarContainer) {
       /** Handler to deselect the button when the cursor leaves the toolbar. */
       const onMouseLeave = () => {
@@ -117,7 +117,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
       toolbarContainer.addEventListener('mouseleave', onMouseLeave)
       return () => toolbarContainer.removeEventListener('mouseleave', onMouseLeave)
     }
-  }, [toolbarContainer])
+  }, [toolbarContainerRef])
 
   // disable pressing on drag
   useEffect(() => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -106,19 +106,6 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
     }
   }, [updateArrows])
 
-  // deselect button when moving the cursor out of the toolbar
-  useEffect(() => {
-    const toolbarContainer = toolbarContainerRef.current
-    if (toolbarContainer) {
-      /** Handler to deselect the button when the cursor leaves the toolbar. */
-      const onMouseLeave = () => {
-        setPressingToolbarId(null)
-      }
-      toolbarContainer.addEventListener('mouseleave', onMouseLeave)
-      return () => toolbarContainer.removeEventListener('mouseleave', onMouseLeave)
-    }
-  }, [toolbarContainerRef])
-
   // disable pressing on drag
   useEffect(() => {
     if (isDraggingAny) {
@@ -198,6 +185,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
                   lastScrollLeft={lastScrollLeft}
                   onTapDown={selectPressingToolbarId}
                   onTapUp={onTapUp}
+                  onMouseLeave={deselectPressingToolbarId}
                   selected={selected === id}
                   shortcutId={id}
                 />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -93,6 +93,11 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
     [updateArrows, deselectPressingToolbarId],
   )
 
+  /** Handles mouse leave event. */
+  const onMouseLeave = useCallback(() => {
+    setPressingToolbarId(null)
+  }, [])
+
   /**********************************************************************
    * Effects
    **********************************************************************/
@@ -105,6 +110,15 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
       window.removeEventListener('resize', updateArrows)
     }
   }, [updateArrows])
+
+  // deselect button when moving the cursor out of the toolbar
+  const toolbarContainer = toolbarContainerRef.current
+  useEffect(() => {
+    if (toolbarContainer) {
+      toolbarContainer.addEventListener('mouseleave', onMouseLeave)
+      return () => toolbarContainer.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [onMouseLeave, toolbarContainer])
 
   // disable pressing on drag
   useEffect(() => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -93,11 +93,6 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
     [updateArrows, deselectPressingToolbarId],
   )
 
-  /** Handles mouse leave event. */
-  const onMouseLeave = useCallback(() => {
-    setPressingToolbarId(null)
-  }, [])
-
   /**********************************************************************
    * Effects
    **********************************************************************/
@@ -115,10 +110,14 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
   const toolbarContainer = toolbarContainerRef.current
   useEffect(() => {
     if (toolbarContainer) {
+      /** Handler to deselect the button when the cursor leaves the toolbar. */
+      const onMouseLeave = () => {
+        setPressingToolbarId(null)
+      }
       toolbarContainer.addEventListener('mouseleave', onMouseLeave)
       return () => toolbarContainer.removeEventListener('mouseleave', onMouseLeave)
     }
-  }, [onMouseLeave, toolbarContainer])
+  }, [toolbarContainer])
 
   // disable pressing on drag
   useEffect(() => {

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { FC, MutableRefObject, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import DragShortcutZone from '../@types/DragShortcutZone'
 import Icon from '../@types/Icon'
@@ -43,7 +43,6 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
   selected,
   shortcutId,
 }) => {
-  const toolbarButtonRef = useRef<HTMLDivElement>(null)
   const colors = useSelector(themeColors)
   const shortcut = shortcutById(shortcutId)
   if (!shortcut) {
@@ -145,20 +144,11 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
     [buttonError, colors, dropToRemove, fontSize, isButtonActive, isButtonExecutable, isDragging, longPress.isPressed],
   )
 
-  // deselect button when moving the cursor off the button
-  useEffect(() => {
-    const toolbarButton = toolbarButtonRef.current
-    if (toolbarButton && onMouseLeave) {
-      toolbarButton.addEventListener('mouseleave', onMouseLeave)
-      return () => toolbarButton.removeEventListener('mouseleave', onMouseLeave)
-    }
-  }, [toolbarButtonRef, onMouseLeave])
-
   return dropTarget(
     dragSource(
       <div
         {...longPress.props}
-        ref={toolbarButtonRef}
+        onMouseLeave={onMouseLeave}
         aria-label={shortcut.label}
         key={shortcutId}
         title={`${shortcut.label}${buttonError ? '\nError: ' + buttonError : ''}`}

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MutableRefObject, useCallback, useMemo } from 'react'
+import React, { FC, MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import DragShortcutZone from '../@types/DragShortcutZone'
 import Icon from '../@types/Icon'
@@ -21,6 +21,7 @@ export interface ToolbarButtonProps {
   lastScrollLeft: MutableRefObject<number>
   onTapDown?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
   onTapUp?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
+  onMouseLeave?: () => void
   selected?: boolean
   shortcutId: ShortcutId
 }
@@ -38,9 +39,11 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
   lastScrollLeft,
   onTapDown,
   onTapUp,
+  onMouseLeave,
   selected,
   shortcutId,
 }) => {
+  const toolbarButtonRef = useRef<HTMLDivElement>(null)
   const colors = useSelector(themeColors)
   const shortcut = shortcutById(shortcutId)
   if (!shortcut) {
@@ -142,10 +145,20 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
     [buttonError, colors, dropToRemove, fontSize, isButtonActive, isButtonExecutable, isDragging, longPress.isPressed],
   )
 
+  // deselect button when moving the cursor off the button
+  useEffect(() => {
+    const toolbarButton = toolbarButtonRef.current
+    if (toolbarButton && onMouseLeave) {
+      toolbarButton.addEventListener('mouseleave', onMouseLeave)
+      return () => toolbarButton.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [toolbarButtonRef, onMouseLeave])
+
   return dropTarget(
     dragSource(
       <div
         {...longPress.props}
+        ref={toolbarButtonRef}
         aria-label={shortcut.label}
         key={shortcutId}
         title={`${shortcut.label}${buttonError ? '\nError: ' + buttonError : ''}`}

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -80,8 +80,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
       const iconEl = e.target as HTMLElement
       const toolbarEl = iconEl.closest('.toolbar')!
       const scrolled = isTouch && Math.abs(lastScrollLeft.current - toolbarEl.scrollLeft) >= 5
-
-      if (!customize && isButtonExecutable && !disabled && !scrolled) {
+      if (!customize && isButtonExecutable && !disabled && !scrolled && isPressing) {
         exec(store.dispatch, store.getState, e, { type: 'toolbar' })
 
         // prevent Editable blur
@@ -97,7 +96,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [longPressTapUp, customize, isButtonExecutable, disabled, onTapUp],
+    [longPressTapUp, customize, isButtonExecutable, disabled, isPressing, onTapUp],
   )
 
   /** Handles the onMouseDown/onTouchEnd event. Updates lastScrollPosition for tapUp. */

--- a/src/test-helpers/click.ts
+++ b/src/test-helpers/click.ts
@@ -1,11 +1,13 @@
-import { act } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { act, fireEvent } from '@testing-library/react'
 
-/** Clicks an element within an act block. */
+/** Clicks an element within an act block, simulating mousedown and mouseup separately. */
 const click = async (selector: string) => {
   const el = document.querySelector(selector)!
   await act(async () => {
-    userEvent.click(el)
+    fireEvent.mouseDown(el)
+  })
+  await act(async () => {
+    fireEvent.mouseUp(el)
   })
 }
 


### PR DESCRIPTION
Previously, a toolbar button would get stuck down if the user clicks it and drags the mouse off the toolbar before releasing. This fixes that by listening for the `mouseLeave` event and deselecting the toolbar button when the mouse leaves the toolbar.

**Demo:**

https://github.com/user-attachments/assets/627779aa-3ffc-4d06-a5cf-d21faf47dd30
