### PR TITLE
fix: correctly activate bold/italic/strikethrough/underline buttons on selection, and refactor shortcut isActive logic

### DIFF
--- a/src/@types/Shortcut.ts
+++ b/src/@types/Shortcut.ts
@@ -49,7 +49,7 @@ interface Shortcut {
   id: ShortcutId
 
   /** A function that returns true if the shortcut should be highlighted in the Toolbar. */
-  isActive?: (getState: () => State) => boolean
+  isActive?: (getState: () => State, getCommandState?: () => Record<string, boolean | undefined>) => boolean
 
   /** When true, a small open dropdown indicator will be rendered beneath the icon. */
   isDropdownOpen?: (getState: () => State) => boolean

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -1,6 +1,7 @@
 import Thunk from '../@types/Thunk'
 import * as selection from '../device/selection'
 import pathToThought from '../selectors/pathToThought'
+import { updateCommandState } from '../stores/commandStateStore'
 import suppressFocusStore from '../stores/suppressFocus'
 
 /** Format the browser selection or cursor thought as bold, italic, strikethrough, underline. */
@@ -29,6 +30,7 @@ export const formatSelectionActionCreator =
       selection.restore(savedSelection)
     } else {
       document.execCommand(command)
+      updateCommandState()
     }
 
     suppressFocusStore.update(false)

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -57,15 +57,18 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
   const isDraggingAny = useSelector(state => !!state.dragShortcut)
   const dragShortcutZone = useSelector(state => state.dragShortcutZone)
 
-  const isCommandActive = commandStateStore.useSelector(state => state[shortcutId])
+  const commandState = commandStateStore.useSelector(state => state)
   const isButtonActive = useSelector(state => {
-    if (isCommandActive) {
-      return true
-    }
     if (customize) {
       return selected
     }
-    return !isActive || isActive(() => state)
+    return (
+      !isActive ||
+      isActive(
+        () => state,
+        () => commandState,
+      )
+    )
   })
   const buttonError = useSelector(state => (!customize && shortcut.error ? shortcut.error(() => state) : null))
   const isButtonExecutable = useSelector(state => customize || !canExecute || canExecute(() => state))

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -54,11 +54,19 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
     throw new Error('The svg property is required to render a shortcut in the Toolbar. ' + shortcutId)
   }
 
-  const commandState = commandStateStore.useSelector(state => state[shortcutId])
   const isDraggingAny = useSelector(state => !!state.dragShortcut)
   const dragShortcutZone = useSelector(state => state.dragShortcutZone)
-  const isButtonActive =
-    useSelector(state => (customize ? selected : !isActive || isActive(() => state))) || (!customize && commandState)
+
+  const isCommandActive = commandStateStore.useSelector(state => state[shortcutId])
+  const isButtonActive = useSelector(state => {
+    if (isCommandActive) {
+      return true
+    }
+    if (customize) {
+      return selected
+    }
+    return !isActive || isActive(() => state)
+  })
   const buttonError = useSelector(state => (!customize && shortcut.error ? shortcut.error(() => state) : null))
   const isButtonExecutable = useSelector(state => customize || !canExecute || canExecute(() => state))
   const dropToRemove = isDragging && dragShortcutZone === DragShortcutZone.Remove

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -8,6 +8,7 @@ import useToolbarLongPress from '../hooks/useToolbarLongPress'
 import themeColors from '../selectors/themeColors'
 import { shortcutById } from '../shortcuts'
 import store from '../stores/app'
+import commandStateStore from '../stores/commandStateStore'
 import fastClick from '../util/fastClick'
 import DragAndDropToolbarButton, { DraggableToolbarButtonProps } from './DragAndDropToolbarButton'
 
@@ -53,9 +54,11 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
     throw new Error('The svg property is required to render a shortcut in the Toolbar. ' + shortcutId)
   }
 
+  const commandState = commandStateStore.useSelector(state => state[shortcutId])
   const isDraggingAny = useSelector(state => !!state.dragShortcut)
   const dragShortcutZone = useSelector(state => state.dragShortcutZone)
-  const isButtonActive = useSelector(state => (customize ? selected : !isActive || isActive(() => state)))
+  const isButtonActive =
+    useSelector(state => (customize ? selected : !isActive || isActive(() => state))) || (!customize && commandState)
   const buttonError = useSelector(state => (!customize && shortcut.error ? shortcut.error(() => state) : null))
   const isButtonExecutable = useSelector(state => customize || !canExecute || canExecute(() => state))
   const dropToRemove = isDragging && dragShortcutZone === DragShortcutZone.Remove

--- a/src/shortcuts/bold.ts
+++ b/src/shortcuts/bold.ts
@@ -17,11 +17,8 @@ const bold: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('bold'))
   },
-  isActive: getState => {
-    const state = getState()
-    if (!state.cursor) return false
-    const thought = getThoughtById(state, head(state.cursor))
-    return thought.value.includes('<b>') || thought.value.includes('<strong>')
+  isActive: () => {
+    return false
   },
 }
 

--- a/src/shortcuts/bold.ts
+++ b/src/shortcuts/bold.ts
@@ -1,8 +1,6 @@
 import Shortcut from '../@types/Shortcut'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import Icon from '../components/icons/BoldTextIcon'
-import getThoughtById from '../selectors/getThoughtById'
-import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
 
 /** Toggles formatting of the current browser selection as bold. If there is no selection, formats the entire thought. */
@@ -17,8 +15,9 @@ const bold: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('bold'))
   },
-  isActive: () => {
-    return false
+  isActive: (getState, getCommandState) => {
+    const commandState = getCommandState()
+    return commandState.bold === true
   },
 }
 

--- a/src/shortcuts/italic.ts
+++ b/src/shortcuts/italic.ts
@@ -2,6 +2,7 @@ import Shortcut from '../@types/Shortcut'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import Icon from '../components/icons/ItalicTextIcon'
 import getThoughtById from '../selectors/getThoughtById'
+import commandStateStore from '../stores/commandStateStore'
 import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
 
@@ -17,11 +18,8 @@ const italic: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('italic'))
   },
-  isActive: getState => {
-    const state = getState()
-    if (!state.cursor) return false
-    const thought = getThoughtById(state, head(state.cursor))
-    return thought.value.includes('<i>') || thought.value.includes('<em>')
+  isActive: () => {
+    return false
   },
 }
 

--- a/src/shortcuts/italic.ts
+++ b/src/shortcuts/italic.ts
@@ -1,9 +1,6 @@
 import Shortcut from '../@types/Shortcut'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import Icon from '../components/icons/ItalicTextIcon'
-import getThoughtById from '../selectors/getThoughtById'
-import commandStateStore from '../stores/commandStateStore'
-import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
 
 /** Toggles formatting of the current browser selection as italic. If there is no selection, formats the entire thought. */
@@ -18,8 +15,9 @@ const italic: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('italic'))
   },
-  isActive: () => {
-    return false
+  isActive: (getState, getCommandState) => {
+    const commandState = getCommandState()
+    return commandState.italic === true
   },
 }
 

--- a/src/shortcuts/strikethrough.ts
+++ b/src/shortcuts/strikethrough.ts
@@ -18,11 +18,8 @@ const strikethrough: Shortcut = {
     e.preventDefault()
     dispatch(formatSelection('strikethrough'))
   },
-  isActive: getState => {
-    const state = getState()
-    if (!state.cursor) return false
-    const thought = getThoughtById(state, head(state.cursor))
-    return thought.value.includes('<strike>')
+  isActive: () => {
+    return false
   },
 }
 

--- a/src/shortcuts/strikethrough.ts
+++ b/src/shortcuts/strikethrough.ts
@@ -1,8 +1,6 @@
 import Shortcut from '../@types/Shortcut'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import Icon from '../components/icons/StrikethroughIcon'
-import getThoughtById from '../selectors/getThoughtById'
-import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
 
 /** Toggles formatting of the current browser selection as strikethrough. If there is no selection, formats the entire thought. */
@@ -18,8 +16,9 @@ const strikethrough: Shortcut = {
     e.preventDefault()
     dispatch(formatSelection('strikethrough'))
   },
-  isActive: () => {
-    return false
+  isActive: (getState, getCommandState) => {
+    const commandState = getCommandState()
+    return commandState.strikethrough === true
   },
 }
 

--- a/src/shortcuts/underline.ts
+++ b/src/shortcuts/underline.ts
@@ -17,11 +17,8 @@ const underline: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('underline'))
   },
-  isActive: getState => {
-    const state = getState()
-    if (!state.cursor) return false
-    const thought = getThoughtById(state, head(state.cursor))
-    return thought.value.includes('<u>')
+  isActive: () => {
+    return false
   },
 }
 

--- a/src/shortcuts/underline.ts
+++ b/src/shortcuts/underline.ts
@@ -1,8 +1,6 @@
 import Shortcut from '../@types/Shortcut'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import Icon from '../components/icons/UnderlineIcon'
-import getThoughtById from '../selectors/getThoughtById'
-import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
 
 /** Toggles formatting of the current browser selection as underline. If there is no selection, formats the entire thought. */
@@ -17,8 +15,9 @@ const underline: Shortcut = {
   exec: dispatch => {
     dispatch(formatSelection('underline'))
   },
-  isActive: () => {
-    return false
+  isActive: (getState, getCommandState) => {
+    const commandState = getCommandState()
+    return commandState.underline === true
   },
 }
 

--- a/src/stores/commandStateStore.ts
+++ b/src/stores/commandStateStore.ts
@@ -1,0 +1,31 @@
+import reactMinistore from './react-ministore'
+
+/** A store that tracks the document's command state. */
+const commandStateStore = reactMinistore<Record<string, boolean | undefined>>({
+  bold: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+})
+
+/** Resets the command state to false. */
+export const resetCommandState = () => {
+  commandStateStore.update({
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+  })
+}
+
+/** Updates the command state to the current state of the document. */
+export const updateCommandState = () => {
+  commandStateStore.update({
+    bold: document.queryCommandState('bold'),
+    italic: document.queryCommandState('italic'),
+    underline: document.queryCommandState('underline'),
+    strikethrough: document.queryCommandState('strikethrough'),
+  })
+}
+
+export default commandStateStore


### PR DESCRIPTION
Previously, the selected text was being ignored when determining whether the bold/italic/strikethrough/underline command buttons should be actively highlighted. Instead, they would be active if any text within the thought had the applicable style.

This pull request builds upon @finkef's commandStateStore to only highlight the buttons when the selected text has the applicable style, rather than any other text within the thought.

This is one of three proposed pull requests to fix https://github.com/cybersemics/em/issues/2060.

The refactoring in this pull request passes the state of the `updateCommands` ministore to the shortcut toolbar buttons so that they can each derive whether or not they should be active.

* [Simple functionality fix](https://github.com/cybersemics/em/pull/2211)
* [Simple functionality fix, plus refactor commands into main redux store](https://github.com/cybersemics/em/pull/2212) <-- My preference
* [Simple functionality fix, plus refactor while keeping the commands ministore](https://github.com/cybersemics/em/pull/2213) <-- This PR

https://github.com/user-attachments/assets/d2660b4f-e322-4275-bf2e-4e3555518f67

