### PR TITLE
fix: ensure that the full toolbar button animation plays

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,15 +14,13 @@ import { shallowEqual, useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import ShortcutType from '../@types/Shortcut'
 import ShortcutId from '../@types/ShortcutId'
-import { TOOLBAR_DEFAULT_SHORTCUTS } from '../constants'
+import { TOOLBAR_DEFAULT_SHORTCUTS, TOOLBAR_PRESS_ANIMATION_DURATION } from '../constants'
 import getUserToolbar from '../selectors/getUserToolbar'
 import { shortcutById } from '../shortcuts'
 import distractionFreeTypingStore from '../stores/distractionFreeTyping'
 import ToolbarButton from './ToolbarButton'
 import TriangleLeft from './TriangleLeft'
 import TriangleRight from './TriangleRight'
-
-const ANIMATION_MS = 80
 
 interface ToolbarProps {
   // places the toolbar into customize mode where buttons can be dragged and dropped.
@@ -56,7 +54,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
 
   /** Deselects the toolbar button. */
   const deselectPressingToolbarId = useCallback(() => {
-    const delay = Math.max(0, ANIMATION_MS - (Date.now() - latestPress))
+    const delay = Math.max(0, TOOLBAR_PRESS_ANIMATION_DURATION - (Date.now() - latestPress))
     setTimeout(() => {
       setPressingToolbarId(null)
       setLatestPress(0)

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -124,10 +124,6 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
     return userShortcutIds || state.storageCache?.userToolbar || TOOLBAR_DEFAULT_SHORTCUTS
   }, shallowEqual)
 
-  const onTapCancel = useCallback(() => {
-    deselectPressingToolbarId()
-  }, [deselectPressingToolbarId])
-
   const onTapUp = useCallback(
     id => {
       deselectPressingToolbarId()
@@ -189,7 +185,6 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
                   lastScrollLeft={lastScrollLeft}
                   onTapDown={selectPressingToolbarId}
                   onTapUp={onTapUp}
-                  onTapCancel={onTapCancel}
                   selected={selected === id}
                   shortcutId={id}
                 />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -54,7 +54,10 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
 
   /** Deselects the toolbar button. */
   const deselectPressingToolbarId = useCallback(() => {
-    const delay = Math.max(0, TOOLBAR_PRESS_ANIMATION_DURATION - (Date.now() - latestPress))
+    const timeSinceLastPress = Date.now() - latestPress
+    const timeUntilAnimationEnd = TOOLBAR_PRESS_ANIMATION_DURATION - timeSinceLastPress
+    // ensure that the delay is not negative
+    const delay = Math.max(0, timeUntilAnimationEnd)
     setTimeout(() => {
       setPressingToolbarId(null)
       setLatestPress(0)

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -96,7 +96,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [longPressTapUp, customize, isButtonExecutable, disabled],
+    [longPressTapUp, customize, isButtonExecutable, disabled, onTapUp],
   )
 
   /** Handles the onMouseDown/onTouchEnd event. Updates lastScrollPosition for tapUp. */
@@ -168,7 +168,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
           }em`,
           position: 'relative',
           cursor: isButtonExecutable ? 'pointer' : 'default',
-          transition: 'transform 200ms ease-out, max-width 200ms ease-out, margin-left 200ms ease-out',
+          transition: 'transform 80ms ease-out, max-width 80ms ease-out, margin-left 80ms ease-out',
           // extend drop area down, otherwise the drop hover is blocked by the user's finger
           // must match toolbar marginBottom
           paddingBottom: isDraggingAny ? '7em' : 0,

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -18,7 +18,6 @@ export interface ToolbarButtonProps {
   fontSize: number
   isPressing: boolean
   lastScrollLeft: MutableRefObject<number>
-  onTapCancel?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
   onTapDown?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
   onTapUp?: (id: ShortcutId, e: React.MouseEvent | React.TouchEvent) => void
   selected?: boolean
@@ -36,7 +35,6 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
   isHovering,
   isPressing,
   lastScrollLeft,
-  onTapCancel,
   onTapDown,
   onTapUp,
   selected,
@@ -174,7 +172,7 @@ const ToolbarButtonComponent: FC<DraggableToolbarButtonProps> = ({
           paddingBottom: isDraggingAny ? '7em' : 0,
         }}
         className='toolbar-icon'
-        {...fastClick(tapUp, tapDown, onTapCancel ? e => onTapCancel(shortcutId, e) : undefined, touchMove)}
+        {...fastClick(tapUp, tapDown, undefined, touchMove)}
       >
         {
           // selected top dash

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -500,5 +500,8 @@ export const THROTTLE_DISTRACTION_FREE_TYPING = 100
 /** The animation duration of a node in the LayoutTree component. */
 export const LAYOUT_NODE_ANIMATION_DURATION = 150
 
+/** The animation duration for a toolbar button press. */
+export const TOOLBAR_PRESS_ANIMATION_DURATION = 80
+
 export const GESTURE_GLOW_BLUR = 10
 export const GESTURE_GLOW_COLOR: keyof typeof colors.dark = 'gray'


### PR DESCRIPTION
This pull request implements two changes:

1. We reduce the bounce animation when pressing a toolbar button from 200ms to 80ms to make it appear snappier.
2. We add a fix to ensure that the full animation plays, even if the user quickly presses before the animation completes.

This fixes #1231.

Demo:

https://github.com/user-attachments/assets/7c2d5ae8-e007-41c0-b298-69f969a0f493