### PR TITLE
Handle `showHiddenThoughts` in `hasChildren`

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -57,6 +57,7 @@ const BulletLeaf = ({
         gray: missing,
         graypulse: pending,
       })}
+      data-bullet='leaf'
       ry={radius}
       rx={radius}
       cy='298'
@@ -104,6 +105,7 @@ const BulletParent = ({
   return (
     <path
       className={classNames({ 'glyph-fg': true, triangle: true, gray: childrenMissing, graypulse: pending })}
+      data-bullet='parent'
       style={{
         transformOrigin: calculateTransformOrigin(),
       }}

--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -139,7 +139,7 @@ describe('render', () => {
       toggleHiddenThoughts(),
     ])
 
-    const bullets = document.querySelectorAll('.triangle')
+    const bullets = document.querySelectorAll('[data-bullet="parent"]')
     expect(bullets.length).toBe(1)
   })
 })

--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -127,8 +127,7 @@ describe('render', () => {
     expect(bullets.length).toBe(4)
   })
 
-  // when hidden thoughts are enabled, we render a parent bullet for thoughts with meta attribute children
-  it('renders a parent bullet when hidden thoughts are enabled', async () => {
+  it('renders a parent bullet on the parent of a visible meta attribute', async () => {
     await dispatch([
       importText({
         text: `

--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -126,6 +126,22 @@ describe('render', () => {
     const bullets = document.querySelectorAll('.bullet')
     expect(bullets.length).toBe(4)
   })
+
+  // when hidden thoughts are enabled, we render a parent bullet for thoughts with meta attribute children
+  it('renders a parent bullet when hidden thoughts are enabled', async () => {
+    await dispatch([
+      importText({
+        text: `
+        - A
+          - =test
+      `,
+      }),
+      toggleHiddenThoughts(),
+    ])
+
+    const bullets = document.querySelectorAll('.triangle')
+    expect(bullets.length).toBe(1)
+  })
 })
 
 // TODO: findSubthoughts is broken after LayoutTree

--- a/src/selectors/getChildren.ts
+++ b/src/selectors/getChildren.ts
@@ -57,7 +57,8 @@ const getVisibleThoughtsById = _.curry(
 )
 
 /** Returns true if the context has any visible children. */
-export const hasChildren = (state: State, id: ThoughtId): boolean => !!findAnyChild(state, id, isVisible(state))
+export const hasChildren = (state: State, id: ThoughtId): boolean =>
+  !!findAnyChild(state, id, child => state.showHiddenThoughts || isVisible(state, child))
 
 /** Gets all visible children of an id, unordered. */
 export const getChildren = getVisibleThoughtsById(getAllChildrenAsThoughts)


### PR DESCRIPTION
Fixes #1918.

This PR handles `showHiddenThoughts` within `hasChildren`. The result is passed down the tree as the `leaf` property. I've added a test to cover the presence of a parent bullet for a thought with a single meta attribute child.

The fact that `hasChildren` has been altered might introduce regressions and should be handled with caution. However, I couldn't spot any regressions myself and all tests remain green.