### PR TITLE
Add tsc lint step

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,1 +1,1 @@
-npm run lint:src
+npm run lint

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint:src": "FORCE_COLOR=1 eslint . --cache --rule 'no-console: [2, { allow: [error, info, warn] }]'",
     "lint:lockfile": "npx lockfile-lint",
     "lint:no-npm": "node ./scripts/no-files.js package-lock.json",
+    "lint:tsc": "tsc",
     "postinstall": "scripts/install-hooks.sh",
     "servebuild": "npx serve -s build -l 3000",
     "test": "vitest --project unit",


### PR DESCRIPTION
Fixes #2235.

This PR adds a lint step for `tsc`.

NOTE: Until #2245 is merged, this will produce errors during push. `--no-verify` can be used to work around and push regardless.