### PR TITLE
Fix toggleSort tests 

### DIFF
--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -7,7 +7,7 @@ import store from '../../stores/app'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createRtlTestApp'
 import dispatch from '../../test-helpers/dispatch'
 import { findCursor } from '../../test-helpers/queries/findCursor'
-import { getBullet } from '../../test-helpers/queries/getBullet'
+import { getBulletByContext } from '../../test-helpers/queries/getBulletByContext'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 
 beforeEach(createTestApp)
@@ -141,7 +141,7 @@ describe('expansion', () => {
       setCursor(['a', 'b']),
     ])
 
-    const bulletOfThoughtB = getBullet(['a', 'b'])
+    const bulletOfThoughtB = getBulletByContext(['a', 'b'])
 
     userEvent.click(bulletOfThoughtB)
 
@@ -163,7 +163,7 @@ describe('expansion', () => {
       setCursor(['x', 'a', 'b', 'c']),
     ])
 
-    const bulletOfThoughtA = getBullet(['x', 'a'])
+    const bulletOfThoughtA = getBulletByContext(['x', 'a'])
 
     userEvent.click(bulletOfThoughtA)
 
@@ -184,7 +184,7 @@ describe('expansion', () => {
       setCursor(['a', 'b', 'c']),
     ])
 
-    const bulletOfThoughtA = getBullet(['a'])
+    const bulletOfThoughtA = getBulletByContext(['a'])
 
     userEvent.click(bulletOfThoughtA)
 
@@ -204,7 +204,7 @@ describe('expansion', () => {
       }),
     ])
 
-    const bulletOfThoughtB = getBullet(['a', 'b'])
+    const bulletOfThoughtB = getBulletByContext(['a', 'b'])
 
     userEvent.click(bulletOfThoughtB)
 
@@ -227,7 +227,7 @@ describe('expansion', () => {
       }),
     ])
 
-    const bulletOfThoughtB = getBullet(['a', 'b'])
+    const bulletOfThoughtB = getBulletByContext(['a', 'b'])
 
     userEvent.click(bulletOfThoughtB)
 
@@ -251,7 +251,7 @@ describe('expansion', () => {
       }),
     ])
 
-    const bulletOfThoughtB = getBullet(['a', 'b'])
+    const bulletOfThoughtB = getBulletByContext(['a', 'b'])
 
     userEvent.click(bulletOfThoughtB)
 
@@ -280,7 +280,7 @@ describe('expansion', () => {
       }),
     ])
 
-    const bulletOfThoughtB = getBullet(['a', 'b'])
+    const bulletOfThoughtB = getBulletByContext(['a', 'b'])
 
     userEvent.click(bulletOfThoughtB)
 

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -19,6 +19,7 @@ import { createTestStore } from '../../test-helpers/createTestStore'
 import { deleteThoughtAtFirstMatchActionCreator } from '../../test-helpers/deleteThoughtAtFirstMatch'
 import executeShortcut from '../../test-helpers/executeShortcut'
 import { findThoughtByText } from '../../test-helpers/queries'
+import { getThoughtByContext } from '../../test-helpers/queries/getThoughtContext'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import toggleSortShortcut from '../toggleSort'
 
@@ -330,31 +331,29 @@ describe('store', () => {
   })
 })
 
-// TODO: toggleSort DOM tests broke with LayoutTree since the DOM hierarchy changed.
 describe.skip('DOM', () => {
-  beforeEach(async () => {
-    await createTestApp()
-  })
+  beforeEach(createTestApp)
   afterEach(cleanupTestApp)
 
   describe('local', () => {
-    it('home: Asc', async () => {
+    it('none -> home: Asc', async () => {
       store.dispatch([
-        newThought({ value: 'c' }),
-        newThought({ value: 'a' }),
-        newThought({ value: 'b' }),
-        setCursor(null),
-
-        toggleAttribute({
-          path: HOME_PATH,
-          values: ['=sort', 'Alphabetical'],
+        importText({
+          text: `
+            - c
+            - a
+            - b
+          `,
         }),
+        setCursor(null),
       ])
 
-      const thought = await findThoughtByText('c')
-      expect(thought).toBeTruthy()
+      executeShortcut(toggleSortShortcut, { store })
 
-      const thoughts = await screen.findAllByPlaceholderText('Add a thought')
+      const thoughtC = getThoughtByContext(['c'])
+      expect(thoughtC).toBeTruthy()
+
+      const thoughts = screen.getAllByTestId(/thought/)
 
       expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['a', 'b', 'c'])
     })

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -523,7 +523,7 @@ describe('DOM', () => {
     })
   })
 
-  describe.skip('empty thought ordering is preserved at the point of creation', () => {
+  describe('empty thought ordering is preserved at the point of creation', () => {
     it('after first thought', async () => {
       store.dispatch([
         importText({
@@ -542,9 +542,7 @@ describe('DOM', () => {
         newThought({ value: '' }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -570,9 +568,8 @@ describe('DOM', () => {
         newThought({ value: '' }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -598,9 +595,8 @@ describe('DOM', () => {
         newThought({ value: '' }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -626,9 +622,8 @@ describe('DOM', () => {
         newThought({ value: '', insertBefore: true }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -654,9 +649,8 @@ describe('DOM', () => {
         newThought({ value: '', insertBefore: true }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -682,9 +676,8 @@ describe('DOM', () => {
         newThought({ value: '', insertBefore: true }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -716,9 +709,8 @@ describe('DOM', () => {
         newThought({ value: '' }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -744,11 +736,9 @@ describe('DOM', () => {
         newThought({ value: '', insertNewSubthought: true }),
       ])
 
-      const thought = await findThoughtByText('a')
+      const thoughts = screen.getAllByTestId(/thought/)
 
-      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
-      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
-      const childrenString = thoughtChildren
+      const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
         .join('')
@@ -756,7 +746,7 @@ describe('DOM', () => {
     })
 
     // TODO
-    it.skip('multiple contiguous empty thoughts', async () => {
+    it('multiple contiguous empty thoughts', async () => {
       store.dispatch([
         importText({
           text: `
@@ -775,9 +765,8 @@ describe('DOM', () => {
         newThought({ value: '' }),
       ])
 
-      const thought = await findThoughtByText('a')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -803,9 +792,8 @@ describe('DOM', () => {
         newThought({ value: '', insertNewSubthought: true }),
       ])
 
-      const thought = await findThoughtByText('d')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -831,9 +819,8 @@ describe('DOM', () => {
         newThought({ value: '', insertNewSubthought: true, insertBefore: true }),
       ])
 
-      const thought = await findThoughtByText('d')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')
@@ -866,9 +853,8 @@ describe('DOM', () => {
           ),
       ])
 
-      const thought = await findThoughtByText('b')
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
+
       const childrenString = thoughts
         .map((child: HTMLElement) => child.textContent)
         .map(value => value || '_')

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -19,7 +19,7 @@ import { deleteThoughtAtFirstMatchActionCreator } from '../../test-helpers/delet
 import executeShortcut from '../../test-helpers/executeShortcut'
 import { findThoughtByText } from '../../test-helpers/queries'
 import { getSubthoughtsByContext } from '../../test-helpers/queries/getSubthoughtsByContext'
-import { getThoughtByContext } from '../../test-helpers/queries/getThoughtContext'
+import { getThoughtByContext } from '../../test-helpers/queries/getThoughtByContext'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import toggleSortShortcut from '../toggleSort'
 
@@ -336,7 +336,7 @@ describe('DOM', () => {
   afterEach(cleanupTestApp)
 
   describe('local', () => {
-    it('none -> home: Asc', async () => {
+    it('home: Asc', async () => {
       store.dispatch([
         importText({
           text: `
@@ -745,7 +745,6 @@ describe('DOM', () => {
       expect(childrenString).toMatch('_')
     })
 
-    // TODO
     it('multiple contiguous empty thoughts', async () => {
       store.dispatch([
         importText({

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -381,31 +381,24 @@ describe.skip('DOM', () => {
 
     it('home: Desc', async () => {
       store.dispatch([
-        newThought({ value: 'c' }),
-        newThought({ value: 'a' }),
-        newThought({ value: 'b' }),
+        importText({
+          text: `
+            - =sort
+              - Alphabetical
+            -c
+            -a
+            -b`,
+        }),
+
         setCursor(null),
       ])
 
-      store.dispatch([
-        toggleAttribute({
-          path: HOME_PATH,
-          values: ['=sort', 'Alphabetical'],
-        }),
-        (dispatch, getState) =>
-          dispatch(
-            setFirstSubthought({
-              path: contextToPath(getState(), ['=sort', 'Alphabetical'])!,
-              value: 'Desc',
-            }),
-          ),
-      ])
+      executeShortcut(toggleSortShortcut, { store })
 
-      const thought = await findThoughtByText('c')
+      const thought = getThoughtByContext(['c'])
       expect(thought).toBeTruthy()
 
-      const thoughtsWrapper = thought!.closest('ul') as HTMLElement
-      const thoughts = await findAllByPlaceholderText(thoughtsWrapper, 'Add a thought')
+      const thoughts = screen.getAllByTestId(/thought/)
 
       expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['c', 'b', 'a'])
     })

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -374,9 +374,9 @@ describe.skip('DOM', () => {
 
       const pathOfThoughtA = contextToPath(store.getState(), ['a'])
       const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
-      const thoughts = screen.getAllByTestId(matcherThoughtA)
+      const subthoughtsOfA = screen.getAllByTestId(matcherThoughtA)
 
-      expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
+      expect(subthoughtsOfA.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
     })
 
     it('home: Desc', async () => {
@@ -412,30 +412,17 @@ describe.skip('DOM', () => {
         setCursor(['a']),
       ])
 
-      store.dispatch([
-        (dispatch, getState) =>
-          dispatch(
-            toggleAttribute({
-              path: contextToPath(getState(), ['a']),
-              values: ['=sort', 'Alphabetical'],
-            }),
-          ),
-        (dispatch, getState) =>
-          dispatch(
-            setFirstSubthought({
-              path: contextToPath(getState(), ['a', '=sort', 'Alphabetical'])!,
-              value: 'Desc',
-            }),
-          ),
-      ])
+      executeShortcut(toggleSortShortcut, { store })
+      executeShortcut(toggleSortShortcut, { store })
 
-      const thought = await findThoughtByText('a')
-      expect(thought).toBeTruthy()
+      const thoughtA = getThoughtByContext(['a'])
+      expect(thoughtA).toBeTruthy()
 
-      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
-      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+      const pathOfThoughtA = contextToPath(store.getState(), ['a'])
+      const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
+      const subthoughtsOfA = screen.getAllByTestId(matcherThoughtA)
 
-      expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['3', '2', '1'])
+      expect(subthoughtsOfA.map((child: HTMLElement) => child.textContent)).toMatchObject(['3', '2', '1'])
     })
   })
 

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -365,23 +365,18 @@ describe.skip('DOM', () => {
         newThought({ value: '1' }),
         newThought({ value: '2' }),
         setCursor(['a']),
-
-        (dispatch, getState) =>
-          dispatch(
-            toggleAttribute({
-              path: contextToPath(getState(), ['a']),
-              values: ['=sort', 'Alphabetical'],
-            }),
-          ),
       ])
 
-      const thought = await findThoughtByText('a')
+      executeShortcut(toggleSortShortcut, { store })
+
+      const thought = getThoughtByContext(['a'])
       expect(thought).toBeTruthy()
 
-      const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
-      const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+      const pathOfThoughtA = contextToPath(store.getState(), ['a'])
+      const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
+      const thoughts = screen.getAllByTestId(matcherThoughtA)
 
-      expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
+      expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
     })
 
     it('home: Desc', async () => {

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -5,7 +5,6 @@ import Thunk from '../../@types/Thunk'
 import { editThoughtActionCreator as editThought } from '../../actions/editThought'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
-import { setFirstSubthoughtActionCreator as setFirstSubthought } from '../../actions/setFirstSubthought'
 import { toggleAttributeActionCreator as toggleAttribute } from '../../actions/toggleAttribute'
 import { toggleSortActionCreator } from '../../actions/toggleSort'
 import { EM_TOKEN, HOME_PATH, HOME_TOKEN } from '../../constants'
@@ -19,6 +18,7 @@ import { createTestStore } from '../../test-helpers/createTestStore'
 import { deleteThoughtAtFirstMatchActionCreator } from '../../test-helpers/deleteThoughtAtFirstMatch'
 import executeShortcut from '../../test-helpers/executeShortcut'
 import { findThoughtByText } from '../../test-helpers/queries'
+import { getSubthoughtsByContext } from '../../test-helpers/queries/getSubthoughtsByContext'
 import { getThoughtByContext } from '../../test-helpers/queries/getThoughtContext'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import toggleSortShortcut from '../toggleSort'
@@ -331,7 +331,7 @@ describe('store', () => {
   })
 })
 
-describe.skip('DOM', () => {
+describe('DOM', () => {
   beforeEach(createTestApp)
   afterEach(cleanupTestApp)
 
@@ -372,9 +372,7 @@ describe.skip('DOM', () => {
       const thought = getThoughtByContext(['a'])
       expect(thought).toBeTruthy()
 
-      const pathOfThoughtA = contextToPath(store.getState(), ['a'])
-      const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
-      const subthoughtsOfA = screen.getAllByTestId(matcherThoughtA)
+      const subthoughtsOfA = getSubthoughtsByContext(['a'])
 
       expect(subthoughtsOfA.map((child: HTMLElement) => child.textContent)).toMatchObject(['1', '2', '3'])
     })
@@ -403,7 +401,7 @@ describe.skip('DOM', () => {
       expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['c', 'b', 'a'])
     })
 
-    it('subthoughts: Desc', async () => {
+    it.only('subthoughts: Desc', async () => {
       store.dispatch([
         newThought({ value: 'a' }),
         newThought({ value: '3', insertNewSubthought: true }),
@@ -418,9 +416,7 @@ describe.skip('DOM', () => {
       const thoughtA = getThoughtByContext(['a'])
       expect(thoughtA).toBeTruthy()
 
-      const pathOfThoughtA = contextToPath(store.getState(), ['a'])
-      const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
-      const subthoughtsOfA = screen.getAllByTestId(matcherThoughtA)
+      const subthoughtsOfA = getSubthoughtsByContext(['a'])
 
       expect(subthoughtsOfA.map((child: HTMLElement) => child.textContent)).toMatchObject(['3', '2', '1'])
     })

--- a/src/shortcuts/__tests__/toggleSort.ts
+++ b/src/shortcuts/__tests__/toggleSort.ts
@@ -360,10 +360,14 @@ describe('DOM', () => {
 
     it('subthoughts: Asc', async () => {
       store.dispatch([
-        newThought({ value: 'a' }),
-        newThought({ value: '3', insertNewSubthought: true }),
-        newThought({ value: '1' }),
-        newThought({ value: '2' }),
+        importText({
+          text: `
+            - a
+              - 3
+              - 1
+              - 2
+          `,
+        }),
         setCursor(['a']),
       ])
 
@@ -401,12 +405,16 @@ describe('DOM', () => {
       expect(thoughts.map((child: HTMLElement) => child.textContent)).toMatchObject(['c', 'b', 'a'])
     })
 
-    it.only('subthoughts: Desc', async () => {
+    it('subthoughts: Desc', async () => {
       store.dispatch([
-        newThought({ value: 'a' }),
-        newThought({ value: '3', insertNewSubthought: true }),
-        newThought({ value: '1' }),
-        newThought({ value: '2' }),
+        importText({
+          text: `
+            - a
+              - 3
+              - 1
+              - 2
+          `,
+        }),
         setCursor(['a']),
       ])
 
@@ -422,7 +430,7 @@ describe('DOM', () => {
     })
   })
 
-  describe('global', () => {
+  describe.skip('global', () => {
     it('home: Asc', async () => {
       store.dispatch([
         newThought({ value: 'c' }),
@@ -515,7 +523,7 @@ describe('DOM', () => {
     })
   })
 
-  describe('empty thought ordering is preserved at the point of creation', () => {
+  describe.skip('empty thought ordering is preserved at the point of creation', () => {
     it('after first thought', async () => {
       store.dispatch([
         importText({

--- a/src/test-helpers/queries/getBulletByContext.ts
+++ b/src/test-helpers/queries/getBulletByContext.ts
@@ -4,9 +4,10 @@ import store from '../../stores/app'
 import hashPath from '../../util/hashPath'
 
 /** Get the bullet of a thought with the context. */
-export const getBullet = (context: string[]): HTMLElement => {
+export const getBulletByContext = (context: string[]): HTMLElement => {
   const path = contextToPath(store.getState(), context)
   const pathOfThought = hashPath(path)
+  console.log({ pathOfThought })
   const bulletOfThought = screen.getByTestId('bullet-' + pathOfThought)
 
   return bulletOfThought

--- a/src/test-helpers/queries/getSubthoughtsByContext.ts
+++ b/src/test-helpers/queries/getSubthoughtsByContext.ts
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/dom'
+import contextToPath from '../../selectors/contextToPath'
+import store from '../../stores/app'
+
+/** Get the bullet of a thought with the context. */
+export function getSubthoughtsByContext(context: string[]) {
+  const pathOfThoughtA = contextToPath(store.getState(), context)
+  const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)
+  const subthoughtsOfA = screen.getAllByTestId(matcherThoughtA)
+  return subthoughtsOfA
+}

--- a/src/test-helpers/queries/getSubthoughtsByContext.ts
+++ b/src/test-helpers/queries/getSubthoughtsByContext.ts
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/dom'
 import contextToPath from '../../selectors/contextToPath'
 import store from '../../stores/app'
 
-/** Get the bullet of a thought with the context. */
+/** Get a list of subthoughts of a thought with the context. */
 export function getSubthoughtsByContext(context: string[]) {
   const pathOfThoughtA = contextToPath(store.getState(), context)
   const matcherThoughtA = new RegExp(`thought-${pathOfThoughtA}[^"]+`)

--- a/src/test-helpers/queries/getThoughtByContext.ts
+++ b/src/test-helpers/queries/getThoughtByContext.ts
@@ -3,7 +3,7 @@ import contextToPath from '../../selectors/contextToPath'
 import store from '../../stores/app'
 import hashPath from '../../util/hashPath'
 
-/** Get the bullet of a thought with the context. */
+/** Get a thought with the context. */
 export const getThoughtByContext = (context: string[]): HTMLElement => {
   const path = contextToPath(store.getState(), context)
   const pathOfThought = hashPath(path)

--- a/src/test-helpers/queries/getThoughtContext.ts
+++ b/src/test-helpers/queries/getThoughtContext.ts
@@ -4,10 +4,10 @@ import store from '../../stores/app'
 import hashPath from '../../util/hashPath'
 
 /** Get the bullet of a thought with the context. */
-export const getBulletByContext = (context: string[]): HTMLElement => {
+export const getThoughtByContext = (context: string[]): HTMLElement => {
   const path = contextToPath(store.getState(), context)
   const pathOfThought = hashPath(path)
-  const bulletOfThought = screen.getByTestId('bullet-' + pathOfThought)
+  const thought = screen.getByTestId('thought-' + pathOfThought)
 
-  return bulletOfThought
+  return thought
 }


### PR DESCRIPTION
- Enable DOM local tests and updated to match new Thought flatten tree structure
- Rename `getBullet` to `getBulletByContext` to be more descriptive
- Create `getThoughtByContext(string[])`
- Create `getSubthoughtsByContext`
- Skipping Global tests for now

Solves #2144 