### PR TITLE
feat: add a 'Scroll up for tutorial' button after scrolling past the instructions

### DIFF
--- a/src/components/Tutorial/TutorialScrollUpButton.tsx
+++ b/src/components/Tutorial/TutorialScrollUpButton.tsx
@@ -1,0 +1,39 @@
+import { FC, useCallback } from 'react'
+import TutorialNavigationButton from './TutorialNavigationButton'
+
+interface TutorialScrollUpButtonProps {
+  show: boolean
+}
+
+/** A button to scroll up to the tutorial. */
+const TutorialScrollUpButton: FC<TutorialScrollUpButtonProps> = ({ show }) => {
+  /**
+   * Scrolls to the top of the window.
+   */
+  const scrollUp = useCallback(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }, [])
+
+  return (
+    <div
+      style={{
+        visibility: show ? 'visible' : 'hidden',
+        opacity: show ? 1 : 0,
+        width: '100%',
+        position: 'fixed',
+        top: show ? '0.5em' : '-2em',
+        left: 0,
+        transition: 'opacity 0.25s ease-in-out, visibility 0.25s ease-in-out, top 0.25s ease-in-out',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <TutorialNavigationButton clickHandler={scrollUp} value='Scroll up for tutorial' />
+    </div>
+  )
+}
+
+export default TutorialScrollUpButton

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -24,6 +24,7 @@ import {
   TUTORIAL_STEP_SUBTHOUGHT,
   TUTORIAL_STEP_SUCCESS,
 } from '../../constants'
+import useIsVisible from '../../hooks/useIsVisible'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import getSetting from '../../selectors/getSetting'
 import { shortcutById } from '../../shortcuts'
@@ -32,6 +33,7 @@ import headValue from '../../util/headValue'
 import once from '../../util/once'
 import GestureDiagram from '../GestureDiagram'
 import TutorialNavigation from './TutorialNavigation'
+import TutorialScrollUpButton from './TutorialScrollUpButton'
 import TutorialStepComponentMap from './TutorialStepComponentMap'
 
 const NO_CHILDREN: Thought[] = []
@@ -58,6 +60,7 @@ if (!newThoughtShortcut) {
 
 /** Tutorial component. */
 const Tutorial: FC = () => {
+  const { isVisible, elementRef } = useIsVisible<HTMLDivElement>()
   const tutorialStep = useSelector(state => {
     const step = +(getSetting(state, 'Tutorial Step') || 1)
     return isNaN(step) ? 1 : step
@@ -106,7 +109,7 @@ const Tutorial: FC = () => {
   const cursorHeadValue = useSelector(state => state.cursor && headValue(state, state.cursor))
 
   return (
-    <div className='tutorial'>
+    <div className='tutorial' ref={elementRef}>
       <div className='tutorial-inner'>
         <a
           className='upper-right tutorial-skip text-small'
@@ -165,6 +168,7 @@ const Tutorial: FC = () => {
           </div>
         ) : null}
       </div>
+      <TutorialScrollUpButton show={!isVisible} />
     </div>
   )
 }

--- a/src/hooks/useIsVisible.ts
+++ b/src/hooks/useIsVisible.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Determines if an element is visible.
+ */
+const useIsVisible = <T extends HTMLElement>() => {
+  const [isVisible, setIsVisible] = useState(false)
+  const elementRef = useRef<T | null>(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      const visible = entry.isIntersecting
+      setIsVisible(visible)
+    })
+    const element = elementRef.current
+
+    if (element) {
+      observer.observe(element)
+    }
+
+    return () => {
+      if (element) {
+        observer.unobserve(element)
+      }
+      observer.disconnect()
+    }
+  }, [])
+
+  return { isVisible, elementRef }
+}
+
+export default useIsVisible


### PR DESCRIPTION
This pull request implements #172 by displaying a "Scroll up for tutorial" button when the user has scrolled far enough for the Tutorial component to no longer be visible. The visibility of the Tutorial component is detected using a new hook called `useIsVisible` which uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). The button has a slide and fade animation, and clicking it scrolls back to the top of the page to display the tutorial instructions.

Demo:

https://github.com/user-attachments/assets/4729455e-ca6a-4bb8-bd21-9f2682b3998f

