### PR TITLE
fix: use a new hook to combine the refs in Popup rather than overriding the passed ref

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { alertActionCreator as alert } from '../actions/alert'
 import { deleteResumableFile } from '../actions/importFiles'
 import { isTouch } from '../browser'
+import useCombinedRefs from '../hooks/useCombinedRefs'
 import useSwipeToDismiss from '../hooks/useSwipeToDismiss'
 import themeColors from '../selectors/themeColors'
 import syncStatusStore from '../stores/syncStatus'
@@ -33,11 +34,13 @@ const Popup = React.forwardRef<
     },
   })
 
+  const combinedRefs = useCombinedRefs(isTouch ? [useSwipeToDismissProps.ref, ref] : [ref])
+
   return (
     <div
-      ref={ref}
       className='popup z-index-popup'
       {...(isTouch ? useSwipeToDismissProps : null)}
+      ref={combinedRefs}
       // merge style with useSwipeToDismissProps.style (transform, transition, and touchAction for sticking to user's touch)
       style={{
         position: 'fixed',

--- a/src/hooks/useCombinedRefs.ts
+++ b/src/hooks/useCombinedRefs.ts
@@ -1,0 +1,20 @@
+import React, { useCallback } from 'react'
+
+/** Combines multiple refs into a single ref. */
+const useCombinedRefs = <T>(refs: React.Ref<T>[]): React.Ref<T> => {
+  return useCallback(
+    (instance: T) => {
+      refs.forEach(ref => {
+        if (typeof ref === 'function') {
+          ref(instance)
+        } else if (ref) {
+          const mutableRef = ref as React.MutableRefObject<T | null>
+          mutableRef.current = instance
+        }
+      })
+    },
+    [refs],
+  )
+}
+
+export default useCombinedRefs


### PR DESCRIPTION
This was a fun one to debug 😄

I eventually noticed that the passed `popupRef` always had a current value of `null`, so it wasn't being set even though the `Popup` component seemed to correctly use `React.forwardRef`. Later, I noticed that the `useSwipeToDismissProps` also have a `ref` prop. That was overriding the initial `ref={ref}` because we were spreading all of the `useSwipeToDismissProps` including the new `ref`.

I could have simply moved the `ref={ref}` line below `{...(isTouch ? useSwipeToDismissProps : null)}`, but then we would be overriding/losing the `ref` from `useSwipeToDismissProps` which is almost certainly not desirable either.

To solve this, I created a new hook called `useCombinedRefs` which lets us create a new ref combining multiple other refs. In `Popup`, we now use that hook to combine the passed `ref` with `useSwipeToDismissProps.ref`.

Now, with the ref being set, the CSS animation styles are being correctly applied to the popup in the gesture menu.

This fixes #2059.

Demo:

https://github.com/user-attachments/assets/182014e4-92ab-41ce-8e3b-983c0b83a45a