### PR TITLE
feat: add undo/redo buttons to the undo/redo alerts

### DIFF
--- a/src/@types/Alert.ts
+++ b/src/@types/Alert.ts
@@ -4,7 +4,6 @@ type Alert = {
   alertType?: keyof typeof AlertType
   showCloseLink?: boolean
   value: string | null
-  isInline?: boolean
   // used to cancel imports
   importFileId?: string
 }

--- a/src/actions/alert.ts
+++ b/src/actions/alert.ts
@@ -10,7 +10,6 @@ interface Options {
   alertType?: keyof typeof AlertType
   showCloseLink?: boolean
   value: string | null
-  isInline?: boolean
   // used to cancel imports
   importFileId?: string
 }
@@ -21,7 +20,7 @@ const ALERT_WITH_MINITORE = '__ALERT_WITH_MINITORE__'
 let clearAlertTimeoutId: ReturnType<typeof setTimeout> | null = null
 
 /** Set an alert with an optional close link. */
-const alertReducer = (state: State, { alertType, showCloseLink, value, isInline = false, importFileId }: Options) => {
+const alertReducer = (state: State, { alertType, showCloseLink, value, importFileId }: Options) => {
   if (value === state.alert?.value) return state
   return {
     ...state,
@@ -31,7 +30,6 @@ const alertReducer = (state: State, { alertType, showCloseLink, value, isInline 
           showCloseLink: showCloseLink !== false,
           value,
           importFileId,
-          isInline,
         }
       : null,
   }
@@ -52,7 +50,6 @@ export const alertActionCreator =
       alertType,
       showCloseLink,
       clearDelay,
-      isInline,
       importFileId,
     }: Omit<Alert, 'value'> & {
       clearDelay?: number
@@ -79,7 +76,6 @@ export const alertActionCreator =
           alertType,
           showCloseLink,
           value: null,
-          isInline,
         })
       })
       clearAlertTimeoutId = null
@@ -107,7 +103,6 @@ export const alertActionCreator =
       showCloseLink,
       value,
       importFileId,
-      isInline,
     })
   }
 

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -2,8 +2,15 @@ import React, { FC, useCallback, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { alertActionCreator } from '../actions/alert'
+import { AlertType } from '../constants'
+import redoShortcut from '../shortcuts/redo'
+import undoShortcut from '../shortcuts/undo'
 import alertStore from '../stores/alert'
+import store from '../stores/app'
+import fastClick from '../util/fastClick'
 import Popup from './Popup'
+import RedoIcon from './RedoIcon'
+import UndoIcon from './UndoIcon'
 
 /** An alert component that fades in and out. */
 const Alert: FC = () => {
@@ -21,6 +28,32 @@ const Alert: FC = () => {
     dispatch(alertActionCreator(null))
   }, [alert, dispatch])
 
+  const undoOrRedo = alert?.alertType === AlertType.Undo || alert?.alertType === AlertType.Redo
+  const buttons = undoOrRedo ? (
+    <div style={{ marginTop: '0.5em' }}>
+      <a
+        className='button button-small'
+        style={{ margin: '0.25em' }}
+        {...fastClick(e => {
+          undoShortcut.exec(dispatch, store.getState, e, { type: 'toolbar' })
+        })}
+      >
+        <UndoIcon fill='black' style={{ position: 'relative', top: '0.25em', right: '0.25em' }} />
+        Undo
+      </a>
+      <a
+        className='button button-small'
+        style={{ margin: '0.25em' }}
+        {...fastClick(e => {
+          redoShortcut.exec(dispatch, store.getState, e, { type: 'toolbar' })
+        })}
+      >
+        Redo
+        <RedoIcon fill='black' style={{ position: 'relative', top: '0.25em', left: '0.25em' }} />
+      </a>
+    </div>
+  ) : null
+
   // if dismissed, set timeout to 0 to remove alert component immediately. Otherwise it will block toolbar interactions until the timeout completes.
   return (
     <TransitionGroup
@@ -37,6 +70,7 @@ const Alert: FC = () => {
           {/* Specify a key to force the component to re-render and thus recalculate useSwipeToDismissProps when the alert changes. Otherwise the alert gets stuck off screen in the dismiss state. */}
           <Popup {...alert} ref={popupRef} onClose={onClose} key={value}>
             {value}
+            {buttons}
           </Popup>
         </CSSTransition>
       ) : null}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -16,18 +16,16 @@ const Popup = React.forwardRef<
   PropsWithChildren<{
     // used to cancel imports
     importFileId?: string
-    isInline?: boolean
     /** If defined, will show a small x in the upper right corner. */
     onClose?: () => void
     textAlign?: 'center' | 'left' | 'right'
     value?: string | null
   }>
->(({ children, importFileId, isInline, onClose, textAlign = 'center' }, ref) => {
+>(({ children, importFileId, onClose, textAlign = 'center' }, ref) => {
   const dispatch = useDispatch()
   const colors = useSelector(themeColors)
   const padding = useSelector(state => state.fontSize / 2 + 2)
   const useSwipeToDismissProps = useSwipeToDismiss({
-    ...(isInline ? { dx: '-50%' } : null),
     // dismiss after animation is complete to avoid touch events going to the Toolbar
     onDismissEnd: () => {
       dispatch(alert(null))
@@ -54,8 +52,6 @@ const Popup = React.forwardRef<
         maxHeight: '100%',
         maxWidth: '100%',
         textAlign,
-        /* if inline, leave room on the left side so the user can click undo/redo */
-        ...(isInline ? { left: '50%', width: 'auto' } : null),
         ...(isTouch ? useSwipeToDismissProps.style : null),
       }}
     >

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -442,6 +442,8 @@ export enum AlertType {
   GestureHint = 'GestureHint',
   // shown when importing one or more files via drag-and-drop or a large paste
   ImportFile = 'ImportFile',
+  // shown when the user redoes an action
+  Redo = 'Redo',
   // shown the first time the user types space to indent
   SpaceToIndentHint = 'SpaceToIndentHint',
   // shown when the sort setting is changed
@@ -458,6 +460,8 @@ export enum AlertType {
   ToolbarButtonRemoved = 'ToolbarButtonRemoved',
   // shown when the user has exceeded the maximimum number of characters allowed in feedback
   ModalFeedbackMaxChars = 'ModalFeedbackMaxChars',
+  // shown when the user undoes an action
+  Undo = 'Undo',
 }
 
 // User settings that can be saved to /EM/Settings/

--- a/src/shortcuts/redo.ts
+++ b/src/shortcuts/redo.ts
@@ -3,6 +3,7 @@ import Shortcut from '../@types/Shortcut'
 import { alertActionCreator as alert } from '../actions/alert'
 import { redoActionCreator as redo } from '../actions/redo'
 import RedoIcon from '../components/RedoIcon'
+import { AlertType } from '../constants'
 import getLatestActionType from '../util/getLastActionType'
 
 const redoShortcut: Shortcut = {
@@ -25,7 +26,13 @@ const redoShortcut: Shortcut = {
 
     if (!lastActionType) return
 
-    dispatch(alert(`Redo: ${startCase(lastActionType)}`, { isInline: true, clearDelay: 3000, showCloseLink: false }))
+    dispatch(
+      alert(`Redo: ${startCase(lastActionType)}`, {
+        clearDelay: 3000,
+        showCloseLink: false,
+        alertType: AlertType.Redo,
+      }),
+    )
   },
   canExecute: getState => getState().redoPatches.length > 0,
 }

--- a/src/shortcuts/undo.ts
+++ b/src/shortcuts/undo.ts
@@ -3,6 +3,7 @@ import Shortcut from '../@types/Shortcut'
 import { alertActionCreator as alert } from '../actions/alert'
 import { undoActionCreator as undo } from '../actions/undo'
 import UndoIcon from '../components/UndoIcon'
+import { AlertType } from '../constants'
 import { isUndoEnabled } from '../selectors/isUndoEnabled'
 import getLatestActionType from '../util/getLastActionType'
 
@@ -28,7 +29,13 @@ const undoShortcut: Shortcut = {
 
     if (!lastActionType) return
 
-    dispatch(alert(`Undo: ${startCase(lastActionType)}`, { isInline: true, clearDelay: 3000, showCloseLink: false }))
+    dispatch(
+      alert(`Undo: ${startCase(lastActionType)}`, {
+        clearDelay: 3000,
+        showCloseLink: false,
+        alertType: AlertType.Undo,
+      }),
+    )
   },
   canExecute: getState => isUndoEnabled(getState()),
 }


### PR DESCRIPTION
This fixes #1989 by removing the special inline-block case for undo/redo alerts, and instead adds Undo/Redo buttons to the alert.

Demo:

https://github.com/user-attachments/assets/60db9905-d9b9-4e42-96c8-181474210422