### PR TITLE
feat: add a box-shadow for the .nav-bottom

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -793,6 +793,8 @@ body.dark {
 
 .nav-bottom {
   padding: 0 15px;
+  background-color: black;
+  box-shadow: 0 20px 15px 25px black;
 }
 
 .nav-bottom .nav-container {


### PR DESCRIPTION
This fixes #2046 by adding a box-shadow to the footer/breadcrumbs.

The background-color has also been set to black because we can otherwise get the following issue when there are no breadcrumbs:

![Screenshot 2024-08-20 at 9 44 19 PM](https://github.com/user-attachments/assets/d8481257-ae75-4417-9860-b5d99200b55e)

Demo:

![Screenshot 2024-08-20 at 9 39 30 PM](https://github.com/user-attachments/assets/a37751dd-38c8-4f32-880d-7b06eb2ce5b5)