### PR TITLE
Allow =pin as standalone attribute

### DIFF
--- a/src/actions/__tests__/toggleAttribute.ts
+++ b/src/actions/__tests__/toggleAttribute.ts
@@ -268,7 +268,6 @@ it('preserve sorted context', () => {
   expect(exported).toBe(`- ${HOME_TOKEN}
   - a
     - =pin
-      - true
     - =sort
       - Alphabetical`)
 })

--- a/src/actions/toggleAttribute.ts
+++ b/src/actions/toggleAttribute.ts
@@ -31,6 +31,13 @@ const toggleAttribute = (
   // base case: delete or overwrite the first subthought with the last value in the sequence
   if (_values.length === 1) {
     const firstThought = getThoughtById(state, getAllChildren(state, thoughtId)[0])
+
+    // Handle standalone attributes, e.g. =pin as opposed to =pin/true, skip deleting the attribute
+    // The parent recursion will take care of deleting the attribute if it is set to true.
+    if (!firstThought && _values[0] === 'true') {
+      return state
+    }
+
     return firstThought?.value === _values[0]
       ? deleteThought(state, { pathParent: path, thoughtId: firstThought.id })
       : setFirstSubthought(state, {

--- a/src/selectors/__tests__/expandThoughts.ts
+++ b/src/selectors/__tests__/expandThoughts.ts
@@ -362,6 +362,46 @@ describe('pin', () => {
     })
   })
 
+  // Standalone variant of =pin/true, same tests as above.
+  describe('=pin', () => {
+    it('pinned thoughts are expanded when cursor is on parent', () => {
+      const text = `
+        - a
+          - b
+            - =pin
+            - c
+          - d
+            - e
+      `
+
+      const steps = [importText({ text }), setCursor(['a'])]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+
+      // unpinned sibling
+      expect(isContextExpanded(stateNew, ['a', 'd'])).toBeFalsy()
+    })
+
+    it('pinned thoughts are expanded when cursor is on sibling', () => {
+      const text = `
+        - a
+          - b
+            - =pin
+            - c
+          - d
+            - e
+      `
+
+      const steps = [importText({ text }), setCursor(['a', 'd'])]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+    })
+  })
+
   describe('=pin/false', () => {
     it('only child descendants are not expanded with =pin/false', () => {
       const text = `
@@ -481,7 +521,7 @@ describe('pin', () => {
   })
 })
 
-describe('=children/=pin', () => {
+describe('=children/=pin/true', () => {
   it('pinned children are expanded when cursor is on parent', () => {
     const text = `
       - a
@@ -562,6 +602,67 @@ describe('=children/=pin', () => {
     // expanded with cursor
     const stateNew1 = setCursor(stateNew, ['a', 'b'])
     expect(isContextExpanded(stateNew1, ['a', 'b'])).toBeTruthy()
+  })
+})
+
+describe('=children/=pin', () => {
+  it('pinned children are expanded when cursor is on parent', () => {
+    const text = `
+      - a
+        - =children
+          - =pin
+        - b
+          - c
+        - d
+          - e
+    `
+
+    const steps = [importText({ text }), setCursor(['a'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'd'])).toBeTruthy()
+  })
+
+  it('pinned children are expanded when cursor is on sibling', () => {
+    const text = `
+      - a
+        - =children
+          - =pin
+        - b
+          - c
+        - d
+          - e
+    `
+
+    const stateNew = importText(initialState(), { text })
+
+    const stateNew1 = setCursor(stateNew, ['a', 'b'])
+    expect(isContextExpanded(stateNew1, ['a', 'd'])).toBeTruthy()
+
+    const stateNew2 = setCursor(stateNew, ['a', 'd'])
+    expect(isContextExpanded(stateNew2, ['a', 'b'])).toBeTruthy()
+  })
+
+  it('pinned children are expanded when cursor is on niece', () => {
+    const text = `
+      - a
+        - =children
+          - =pin
+        - b
+          - c
+        - d
+          - e
+    `
+
+    const stateNew = importText(initialState(), { text })
+
+    const stateNew1 = setCursor(stateNew, ['a', 'b', 'c'])
+    expect(isContextExpanded(stateNew1, ['a', 'd'])).toBeTruthy()
+
+    const stateNew2 = setCursor(stateNew, ['a', 'd', 'e'])
+    expect(isContextExpanded(stateNew2, ['a', 'b'])).toBeTruthy()
   })
 })
 

--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -30,9 +30,14 @@ import getContexts from './getContexts'
 // pin state map
 const pinStateMap = { false: false, true: true }
 
-/** Returns true if a thought is pinned with =pin/true, false if =pin/false, and null if not pinned. */
+/** Returns true if a thought is pinned with =pin/true or =pin, false if =pin/false, and null if not pinned. */
 const pinned = (state: State, id: ThoughtId | null): boolean | null => {
+  const hasPinAttribute = findDescendant(state, id, '=pin')
   const pinState = attribute(state, id, '=pin') as keyof typeof pinStateMap
+
+  // Handle case =pin
+  if (hasPinAttribute && pinState == null) return true
+
   return pinStateMap[pinState] ?? null
 }
 

--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -4,7 +4,6 @@ import Path from '../@types/Path'
 import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
 import { EXPAND_THOUGHT_CHAR, HOME_PATH, HOME_TOKEN, MAX_EXPAND_DEPTH } from '../constants'
-import attribute from '../selectors/attribute'
 import attributeEquals from '../selectors/attributeEquals'
 import contextToThoughtId from '../selectors/contextToThoughtId'
 import findDescendant from '../selectors/findDescendant'
@@ -26,20 +25,7 @@ import unroot from '../util/unroot'
 import childIdsToThoughts from './childIdsToThoughts'
 import { anyChild, getAllChildrenAsThoughts } from './getChildren'
 import getContexts from './getContexts'
-
-// pin state map
-const pinStateMap = { false: false, true: true }
-
-/** Returns true if a thought is pinned with =pin/true or =pin, false if =pin/false, and null if not pinned. */
-const pinned = (state: State, id: ThoughtId | null): boolean | null => {
-  const hasPinAttribute = findDescendant(state, id, '=pin')
-  const pinState = attribute(state, id, '=pin') as keyof typeof pinStateMap
-
-  // Handle case =pin
-  if (hasPinAttribute && pinState == null) return true
-
-  return pinStateMap[pinState] ?? null
-}
+import pinned from './isPinned'
 
 /** Returns true if a thought's children are pinned with =children/=pin/true, false if =children/=pin/false, and null if not pinned. */
 const childrenPinned = (state: State, id: ThoughtId): boolean | null => {

--- a/src/selectors/isPinned.ts
+++ b/src/selectors/isPinned.ts
@@ -1,0 +1,20 @@
+import State from '../@types/State'
+import ThoughtId from '../@types/ThoughtId'
+import attribute from './attribute'
+import findDescendant from './findDescendant'
+
+// pin state map
+const pinStateMap = { false: false, true: true }
+
+/** Returns true if a thought is pinned with =pin/true or =pin, false if =pin/false, and null if not pinned. */
+const isPinned = (state: State, id: ThoughtId | null): boolean | null => {
+  const hasPinAttribute = findDescendant(state, id, '=pin')
+  const pinState = attribute(state, id, '=pin') as keyof typeof pinStateMap
+
+  // Handle case =pin
+  if (hasPinAttribute && pinState == null) return true
+
+  return pinStateMap[pinState] ?? null
+}
+
+export default isPinned

--- a/src/shortcuts/__tests__/pin.ts
+++ b/src/shortcuts/__tests__/pin.ts
@@ -4,9 +4,9 @@ import exportContext from '../../selectors/exportContext'
 import { createTestStore } from '../../test-helpers/createTestStore'
 import executeShortcut from '../../test-helpers/executeShortcut'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
-import pinAllShortcut from '../pinAll'
+import pinShortcut from '../pin'
 
-it('toggle on when there is no =children attribute', () => {
+it('toggle on when there is no =pin attribute', () => {
   const store = createTestStore()
 
   // import thoughts
@@ -25,15 +25,13 @@ it('toggle on when there is no =children attribute', () => {
     setCursor(['a', 'b']),
   ])
 
-  executeShortcut(pinAllShortcut, { store })
+  executeShortcut(pinShortcut, { store })
 
   const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
   expect(exported).toEqual(`- __ROOT__
   - a
-    - =children
-      - =pin
-        - true
     - b
+      - =pin
       - c
       - d
     - e
@@ -41,7 +39,7 @@ it('toggle on when there is no =children attribute', () => {
       - g`)
 })
 
-it('toggle on when =children/=pin is false', () => {
+it('toggle on when =pin/false', () => {
   const store = createTestStore()
 
   // import thoughts
@@ -49,10 +47,9 @@ it('toggle on when =children/=pin is false', () => {
     importText({
       text: `
         - a
-          - =children
+          - b
             - =pin
               - false
-          - b
             - c
             - d
           - e
@@ -63,14 +60,46 @@ it('toggle on when =children/=pin is false', () => {
     setCursor(['a', 'b']),
   ])
 
-  executeShortcut(pinAllShortcut, { store })
+  executeShortcut(pinShortcut, { store })
 
   const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
   expect(exported).toEqual(`- __ROOT__
   - a
-    - =children
+    - b
       - =pin
         - true
+      - c
+      - d
+    - e
+      - f
+      - g`)
+})
+
+it('remove =pin when toggling off', () => {
+  const store = createTestStore()
+
+  // import thoughts
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - b
+            - =pin
+            - c
+            - d
+          - e
+            - f
+            - g
+    `,
+    }),
+    setCursor(['a', 'b']),
+  ])
+
+  executeShortcut(pinShortcut, { store })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toEqual(`- __ROOT__
+  - a
     - b
       - c
       - d
@@ -79,18 +108,16 @@ it('toggle on when =children/=pin is false', () => {
       - g`)
 })
 
-it('remove =children when toggling off from =pin/true', () => {
+it('remove =pin/true when toggling off', () => {
   const store = createTestStore()
 
-  // import thoughts
   store.dispatch([
     importText({
       text: `
         - a
-          - =children
+          - b
             - =pin
               - true
-          - b
             - c
             - d
           - e
@@ -101,7 +128,7 @@ it('remove =children when toggling off from =pin/true', () => {
     setCursor(['a', 'b']),
   ])
 
-  executeShortcut(pinAllShortcut, { store })
+  executeShortcut(pinShortcut, { store })
 
   const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
   expect(exported).toEqual(`- __ROOT__
@@ -112,82 +139,4 @@ it('remove =children when toggling off from =pin/true', () => {
     - e
       - f
       - g`)
-})
-
-it('remove =children when toggling off from =pin', () => {
-  const store = createTestStore()
-
-  // import thoughts
-  store.dispatch([
-    importText({
-      text: `
-        - a
-          - =children
-            - =pin
-          - b
-            - c
-            - d
-          - e
-            - f
-            - g
-    `,
-    }),
-    setCursor(['a', 'b']),
-  ])
-
-  executeShortcut(pinAllShortcut, { store })
-
-  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-  expect(exported).toEqual(`- __ROOT__
-  - a
-    - b
-      - c
-      - d
-    - e
-      - f
-      - g`)
-})
-
-it('remove =pin/false from all subthoughts when toggling on', () => {
-  const store = createTestStore()
-
-  store.dispatch([
-    importText({
-      text: `
-        - a
-          - b
-            - =pin
-              - false
-            - c
-            - d
-          - e
-            - =pin
-              - false
-            - f
-            - g
-          - h
-            - i
-            - j
-    `,
-    }),
-    setCursor(['a', 'b']),
-  ])
-
-  executeShortcut(pinAllShortcut, { store })
-
-  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-  expect(exported).toEqual(`- __ROOT__
-  - a
-    - =children
-      - =pin
-        - true
-    - b
-      - c
-      - d
-    - e
-      - f
-      - g
-    - h
-      - i
-      - j`)
 })

--- a/src/shortcuts/pin.ts
+++ b/src/shortcuts/pin.ts
@@ -3,7 +3,7 @@ import { alertActionCreator as alert } from '../actions/alert'
 import { toggleAttributeActionCreator as toggleAttribute } from '../actions/toggleAttribute'
 import PinIcon from '../components/icons/PinIcon'
 import { HOME_PATH } from '../constants'
-import attributeEquals from '../selectors/attributeEquals'
+import isPinned from '../selectors/isPinned'
 import simplifyPath from '../selectors/simplifyPath'
 import head from '../util/head'
 
@@ -24,7 +24,7 @@ const pinShortcut: Shortcut = {
     // if the user used the keyboard to activate the shortcut, show an alert describing the sort direction
     // since the user won't have the visual feedbavk from the toolbar due to the toolbar hiding logic
     if (type === 'keyboard') {
-      const pinned = attributeEquals(state, head(cursor), '=pin', 'true')
+      const pinned = isPinned(state, head(cursor))
       dispatch(alert(pinned ? 'Unpinned thought' : 'Pinned thought', { clearDelay: 2000, showCloseLink: false }))
     }
 
@@ -39,7 +39,7 @@ const pinShortcut: Shortcut = {
     const state = getState()
     const { cursor } = state
     const path = cursor ? simplifyPath(state, cursor) : HOME_PATH
-    return attributeEquals(state, head(path), '=pin', 'true')
+    return isPinned(state, head(path)) ?? false
   },
 }
 

--- a/src/shortcuts/pinAll.ts
+++ b/src/shortcuts/pinAll.ts
@@ -8,6 +8,7 @@ import { HOME_PATH } from '../constants'
 import attribute from '../selectors/attribute'
 import findDescendant from '../selectors/findDescendant'
 import { getAllChildren } from '../selectors/getChildren'
+import isPinned from '../selectors/isPinned'
 import rootedParentOf from '../selectors/rootedParentOf'
 import simplifyPath from '../selectors/simplifyPath'
 import appendToPath from '../util/appendToPath'
@@ -84,7 +85,8 @@ const pinAllShortcut: Shortcut = {
     const state = getState()
     const { cursor } = state
     const path = cursor ? simplifyPath(state, cursor) : HOME_PATH
-    return !!findDescendant(state, head(path), ['=children', '=pin', 'true'])
+    const childrenAttributeId = findDescendant(state, head(path), '=children')
+    return isPinned(state, childrenAttributeId) ?? false
   },
 }
 


### PR DESCRIPTION
Closes #2117.

Adds support for a standalone `=pin` attribute in addition to the currently supported `=pin/true` and `=pin/false` variations.