### PR TITLE
fix: resolve a Safari-specific rendering glitch with bullet point SVG animations using will-change

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -282,6 +282,11 @@ const Bullet = ({
         className='glyph'
         viewBox='0 0 600 600'
         style={{
+          // Safari has a known issue with subpixel calculations, especially during animations and with SVGs.
+          // This caused the bullet slide animation to end with a jerky movement.
+          // By setting "will-change: transform;", we hint to the browser that the transform property will change in the future,
+          // allowing the browser to optimize the animation.
+          willChange: 'transform',
           height: lineHeight,
           width: lineHeight,
           marginLeft: -lineHeight,

--- a/src/components/Subthought.tsx
+++ b/src/components/Subthought.tsx
@@ -127,6 +127,11 @@ const Subthought = ({
           opacity: thought.value === '' ? opacity : '0',
           transition: opacityTransition,
           pointerEvents: !isVisible ? 'none' : undefined,
+          // Safari has a known issue with subpixel calculations, especially during animations and with SVGs.
+          // This caused the thought to jerk slightly to the left at the end of the horizontal shift animation.
+          // By setting "will-change: transform;", we hint to the browser that the transform property will change in the future,
+          // allowing the browser to optimize the animation.
+          willChange: 'opacity',
         }}
       >
         <Thought


### PR DESCRIPTION
**Overview**

This fixes issue #1915, a bug that appeared in Safari on iOS and MacOS (but was not present in Chrome or Firefox).

Safari has a known issue with sub-pixel calculations during animations, and this manifested in our bullet point SVGs with a jerking flicker at the end of the otherwise smooth sliding animation. Two known fixes were considered for the issue:

1. Apply `will-change: transform;` to the bullet point (https://developer.mozilla.org/en-US/docs/Web/CSS/will-change)
2. Apply `transform: translateZ(0);` to the bullet point (https://michaeluloth.com/css-translate-z/#the-fix)

Option (1) provides a hint to the browser that a transform will be applied to the element, prioritizing the calculations of it in advance. Doing so improves the performance and accuracy as Safari computes the sliding animation, resolving this particular quirky behavior.

Option (2) makes the animation run smoothly by tricking the browser into using the GPU for the animation rather than the CPU.

Both (1) and (2) have been tested and completely resolve the issue, but I am proposing (1) because it was made specifically for this purpose, while (2) is more of a hacky browser trick. Since (1) is still an uncommon fix, I've added a comment above it to provide context.

**Demo (MacOS Safari, font size 13):**

https://github.com/user-attachments/assets/94019c97-ef73-4366-9efe-02dfb61dac87

**Demo (iOS Safari, font size 13):**

https://github.com/user-attachments/assets/2d61a6cd-5d90-4ff0-b778-1941d7ff2ac1