### PR TITLE
fix: apply monospace font to editable thought annotations which are considered a meta attribute

### DIFF
--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -20,6 +20,7 @@ import equalPath from '../util/equalPath'
 import fastClick from '../util/fastClick'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
+import isAttribute from '../util/isAttribute'
 import isEmail from '../util/isEmail'
 import isURL from '../util/isURL'
 import isVisibleContext from '../util/isVisibleContext'
@@ -251,7 +252,10 @@ const ThoughtAnnotation = React.memo(
             // disable intrathought linking until add, edit, delete, and expansion can be implemented
             // 'subthought-highlight': isEditing && focusOffset != null && subthought.contexts.length > (subthought.text === value ? 1 : 0) && subthoughtUnderSelection() && subthought.text === subthoughtUnderSelection().text
           })}
-          style={styleAnnotation}
+          style={{
+            fontFamily: isAttribute(value) ? 'monospace' : undefined,
+            ...styleAnnotation,
+          }}
         >
           <span
             className='editable-annotation-text'


### PR DESCRIPTION
This change fixes #1917.

For meta attributes, the thought text was being rendered with a monospace font, but the thought annotation text was not. That caused a misalignment with the superscript text.

By applying the same monospace font to meta attributes' thought annotation text, the superscript becomes correctly aligned with the underlying thought text.

**Demo:**

<img width="1151" alt="Screenshot 2024-08-29 at 9 21 41 PM" src="https://github.com/user-attachments/assets/ca3ece39-1552-413c-b23f-3c2c5bdfb99f">