### PR TITLE
Fix #2314: VirtualThought Re-rendering on typing

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -61,7 +61,7 @@ type TreeThought = {
   simplePath: SimplePath
   // style inherited from parents with =children/=style and grandparents with =grandchildren/=style
   style?: React.CSSProperties | null
-  thought: Thought
+  thoughtId: string
   // keys of visible children
   // only used in table view to calculate the width of column 1
   visibleChildrenKeys?: string[]
@@ -311,7 +311,7 @@ const linearizeTree = (
       showContexts: contextViewActive,
       simplePath: contextViewActive ? thoughtToPath(state, child.id) : appendToPathMemo(simplePath, child.id),
       style,
-      thought: child,
+      thoughtId: child.id,
       ...(isTable
         ? { visibleChildrenKeys: getChildren(state, child.id).map(child => crossContextualKey(contextChain, child.id)) }
         : null),
@@ -651,7 +651,7 @@ const LayoutTree = () => {
               simplePath,
               singleLineHeightWithCliff,
               style,
-              thought,
+              thoughtId,
               width,
               x,
               y,
@@ -691,7 +691,7 @@ const LayoutTree = () => {
                 <VirtualThought
                   debugIndex={testFlags.simulateDrop ? indexChild : undefined}
                   depth={depth}
-                  dropUncle={thought.id === cursorUncleId}
+                  dropUncle={thoughtId === cursorUncleId}
                   env={env}
                   indexDescendant={indexDescendant}
                   // isMultiColumnTable={isMultiColumnTable}

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -240,7 +240,24 @@ const VirtualThought = ({
   )
 }
 
-const VirtualThoughtMemo = React.memo(VirtualThought)
+type VirtualThoughtPropsKeys = keyof typeof VirtualThought
+
+const VirtualThoughtMemo = React.memo(VirtualThought, (prevProps, nextProps) => {
+  let isEqual = true
+
+  for (const key in prevProps) {
+    if (key === 'path' || key === 'simplePath') {
+      isEqual = equalPath(prevProps[key], nextProps[key])
+      if (!isEqual) break
+    } else if (prevProps[key as VirtualThoughtPropsKeys] !== nextProps[key as VirtualThoughtPropsKeys]) {
+      isEqual = false
+      break
+    }
+  }
+
+  return isEqual
+})
+
 VirtualThoughtMemo.displayName = 'VirtualThought'
 
 export default VirtualThoughtMemo


### PR DESCRIPTION
This PR contains two changes, as discussed in the issue (#2314):
- It changes the TreeThought to store the ThoughtId instead of the Thought. This makes the selector provoke fewer re-renders. I tested this before and after, and it, in fact, improves rendering performance by not triggering unnecessary re-renders.
- It adds a custom `arePropsEqual` to the `VirtualThoughtMemo` component.

Adding the custom equality function fixes the rerenders when typing:

<img width="564" alt="Screenshot 2024-09-02 at 1 50 19 AM" src="https://github.com/user-attachments/assets/cc436bd5-510a-4db6-ac78-67c749482c38">
