### PR TITLE
Fix inconsistent width of table col1 

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -145,7 +145,7 @@ const useSizeTracking = () => {
         sizeRemovalTimeouts.current.delete(key)
 
         setSizes(sizesOld =>
-          height === sizesOld[key]?.height && isVisible === sizesOld[key]?.isVisible
+          height === sizesOld[key]?.height && width === sizesOld[key]?.width && isVisible === sizesOld[key]?.isVisible
             ? sizesOld
             : {
                 ...sizesOld,


### PR DESCRIPTION
fixes #1795 

This was caused by ignoring column width updates (as the thoughts tree populates with information that the parent is a table and therefore should use the true width rather than 3em min-width).

If this could caused a performance issue, then perhaps we can think about removing the min-width of 3em, or not using it until we're sure that the view attribute of the parent node in the path has been populated.

Demo following repro steps from https://github.com/cybersemics/em/issues/1792

[video](https://github.com/user-attachments/assets/d432be03-589d-4990-9220-8bfc58a20736)
