### PR TITLE
fix #2398: strip slows down expandThoughts

### DIFF
--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -20,12 +20,13 @@ import isURL from '../util/isURL'
 import keyValueBy from '../util/keyValueBy'
 import parentOf from '../util/parentOf'
 import publishMode from '../util/publishMode'
-import strip from '../util/strip'
 import unroot from '../util/unroot'
 import childIdsToThoughts from './childIdsToThoughts'
 import { anyChild, getAllChildrenAsThoughts } from './getChildren'
 import getContexts from './getContexts'
 import pinned from './isPinned'
+
+const EXPAND_THOUGHTS_REGEX = new RegExp(`${EXPAND_THOUGHT_CHAR}(</[^>]>)*$`, 'g')
 
 /** Returns true if a thought's children are pinned with =children/=pin/true, false if =children/=pin/false, and null if not pinned. */
 const childrenPinned = (state: State, id: ThoughtId): boolean | null => {
@@ -108,7 +109,7 @@ function expandThoughtsRecursive(state: State, expansionBasePath: Path, path: Pa
   const visibleChildren = state.showHiddenThoughts
     ? childrenUnfiltered
     : childrenUnfiltered.filter(child => {
-        const value = strip(child.value)
+        const value = child.value.replace(EXPAND_THOUGHTS_REGEX, EXPAND_THOUGHT_CHAR)
         const childPath = unroot([...path, child.id])
 
         /** Check of the path is the ancestor of the expansion path. */
@@ -162,7 +163,7 @@ function expandThoughtsRecursive(state: State, expansionBasePath: Path, path: Pa
             isHiddenAttribute() ||
             pinned(state, child.id) ||
             (childrenPinned(state, thoughtId) && pinned(state, child.id) === null) ||
-            strip(child.value).endsWith(EXPAND_THOUGHT_CHAR)
+            EXPAND_THOUGHTS_REGEX.test(child.value)
           )
         })
 


### PR DESCRIPTION
This PR replaces the use of `strip`  inside `expandThoughts` with a regex that strips closing tags and matches them. After testing it, I noticed I could feel the difference while using the app, and the data shows this approach is much more performant.

I profiled creating a new thought with 1000 thoughts already created. I did it by scrolling down to the final thoughts and then hitting Enter.

This change reduces the `newThought` execution times from 110-130ms to 3-5ms.

Before:
![Screenshot 2024-09-24 at 12 35 08 PM](https://github.com/user-attachments/assets/793f7b95-80c4-4649-a38a-b8100e2362bb)

After:
![Screenshot 2024-09-24 at 12 26 44 PM](https://github.com/user-attachments/assets/4e8f7346-b9f5-4270-9068-0b0e1f2f6e3f)