### PR TITLE
Duration and toMilliseconds helpers for PandaCSS durations configuration

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -22,6 +22,13 @@ import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
 
 const { colorTokens, colorSemanticTokens } = convertColorsToPandaCSS()
 
+const duration = (str: string) => ({
+  value: {
+    base: str,
+    _test: '0s',
+  }
+})
+
 const keyframes = defineKeyframes({
   fademostlyin: {
     from: {
@@ -319,32 +326,12 @@ export default defineConfig({
           },
         },
         durations: {
-          highlightPulseDuration: {
-            value: {
-              base: '500ms',
-              _test: '0s',
-            },
-          },
-          hoverPulseDuration: {
-            value: {
-              base: '300ms',
-              _test: '0s',
-            },
-          },
+          highlightPulseDuration: duration('500ms'),
+          hoverPulseDuration: duration('300ms'),
           /** The animation duration for the slower opacity transition and horizontal shift of the LayoutTree as the depth of the cursor changes. */
-          layoutSlowShiftDuration: {
-            value: {
-              base: '750ms',
-              _test: '0s',
-            },
-          },
+          layoutSlowShiftDuration: duration('750ms'),
           /** The animation duration of a node in the LayoutTree component. */
-          layoutNodeAnimationDuration: {
-            value: {
-              base: '150ms',
-              _test: '0s',
-            },
-          },
+          layoutNodeAnimationDuration: duration('150ms'),
         },
       },
     },

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -22,11 +22,12 @@ import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
 
 const { colorTokens, colorSemanticTokens } = convertColorsToPandaCSS()
 
+/** returns duration values with a zero duration for _test */
 const duration = (str: string) => ({
   value: {
     base: str,
-    _test: '0s',
-  }
+    _test: '0ms',
+  },
 })
 
 const keyframes = defineKeyframes({

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -22,7 +22,7 @@ import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
 
 const { colorTokens, colorSemanticTokens } = convertColorsToPandaCSS()
 
-/** returns duration values with a zero duration for _test */
+/** Returns duration values with a zero duration for _test. */
 const duration = (str: string) => ({
   value: {
     base: str,

--- a/src/util/__tests__/toMilliseconds.ts
+++ b/src/util/__tests__/toMilliseconds.ts
@@ -1,0 +1,15 @@
+import toMilliseconds from '../toMilliseconds'
+
+describe('toMilliseconds', () => {
+  it('should parse ms strings', () => {
+    expect(toMilliseconds('350ms')).toEqual(350)
+  })
+
+  it('should parse s strings', () => {
+    expect(toMilliseconds('5s')).toEqual(5000)
+  })
+
+  it('should parse unitless strings as milliseconds', () => {
+    expect(toMilliseconds('550')).toEqual(550)
+  })
+})

--- a/src/util/toMilliseconds.ts
+++ b/src/util/toMilliseconds.ts
@@ -1,0 +1,5 @@
+/** Converts strings to milliseconds based on the units in the string. Treats unitless strings as milliseconds. */
+const toMilliseconds = (str: string) =>
+  str.endsWith('ms') ? parseInt(str, 10) : str.endsWith('s') ? parseInt(str, 10) * 1000 : parseInt(str, 10)
+
+export default toMilliseconds


### PR DESCRIPTION
#2110 

Implement a helper to generate the durations for the PandaCSS configurations that will default the durations to `0ms` when testing.

Implement a helper to convert string durations to millisecond integer durations.