### PR TITLE
Make transition durations dynamic Part 1

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -45,14 +45,6 @@ const durationsReducer = (pv: Record<string, DurationToken>, [key, duration]: [s
 /** Add `ms` units to raw value. */
 const durations = Object.entries(durationsHelper.getAll()).reduce(durationsReducer, {})
 
-/** Returns duration values with a zero duration for _test. */
-const duration = (str: string) => ({
-  value: {
-    base: str,
-    _test: '0ms',
-  },
-})
-
 const keyframes = defineKeyframes({
   fademostlyin: {
     from: {

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -1,5 +1,6 @@
 // https://panda-css.com/docs/references/config
 import { defineConfig, defineGlobalStyles, defineKeyframes } from '@pandacss/dev'
+import durationsConfig from './src/durations.config'
 import anchorButtonRecipe from './src/recipes/anchorButton'
 import bulletRecipe from './src/recipes/bullet'
 import buttonRecipe from './src/recipes/button'
@@ -19,7 +20,6 @@ import thoughtRecipe from './src/recipes/thought'
 import tutorialBulletRecipe from './src/recipes/tutorialBullet'
 import upperRightRecipe from './src/recipes/upperRight'
 import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
-import durationsHelper from './src/util/durations'
 
 const { colorTokens, colorSemanticTokens } = convertColorsToPandaCSS()
 
@@ -43,7 +43,7 @@ const durationsReducer = (pv: Record<string, DurationToken>, [key, duration]: [s
 }
 
 /** Add `ms` units to raw value. */
-const durations = Object.entries(durationsHelper.getAll()).reduce(durationsReducer, {})
+const durations = Object.entries(durationsConfig).reduce(durationsReducer, {})
 
 const keyframes = defineKeyframes({
   fademostlyin: {

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -19,8 +19,31 @@ import thoughtRecipe from './src/recipes/thought'
 import tutorialBulletRecipe from './src/recipes/tutorialBullet'
 import upperRightRecipe from './src/recipes/upperRight'
 import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
+import durationsHelper from './src/util/durations'
 
 const { colorTokens, colorSemanticTokens } = convertColorsToPandaCSS()
+
+type DurationToken = {
+  value: {
+    base: string
+    _test: string
+  }
+}
+
+/** Returns durations formatted for the PandaCSS config. */
+const durationsReducer = (pv: Record<string, DurationToken>, [key, duration]: [string, number]) => {
+  pv[key] = {
+    value: {
+      base: `${duration}ms`,
+      _test: '0ms',
+    },
+  }
+
+  return pv
+}
+
+/** Add `ms` units to raw value. */
+const durations = Object.entries(durationsHelper.getAll()).reduce(durationsReducer, {})
 
 /** Returns duration values with a zero duration for _test. */
 const duration = (str: string) => ({
@@ -326,14 +349,7 @@ export default defineConfig({
             value: 'tomato !important',
           },
         },
-        durations: {
-          highlightPulseDuration: duration('500ms'),
-          hoverPulseDuration: duration('300ms'),
-          /** The animation duration for the slower opacity transition and horizontal shift of the LayoutTree as the depth of the cursor changes. */
-          layoutSlowShiftDuration: duration('750ms'),
-          /** The animation duration of a node in the LayoutTree component. */
-          layoutNodeAnimationDuration: duration('150ms'),
-        },
+        durations,
       },
     },
   },

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -9,6 +9,7 @@ import { undoActionCreator as undo } from '../actions/undo'
 import { AlertType } from '../constants'
 import isUndoEnabled from '../selectors/isUndoEnabled'
 import alertStore from '../stores/alert'
+import durations from '../util/durations'
 import fastClick from '../util/fastClick'
 import strip from '../util/strip'
 import Popup from './Popup'
@@ -66,7 +67,7 @@ const Alert: FC = () => {
         <CSSTransition
           key={0}
           nodeRef={popupRef}
-          timeout={800}
+          timeout={durations.get('alertFadeDuration')}
           classNames='fade-slow-out'
           onEntering={() => setDismiss(false)}
         >

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css, cva, cx } from '../../styled-system/css'
 import { bullet } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import ThoughtId from '../@types/ThoughtId'
@@ -54,7 +55,7 @@ const glyph = cva({
         position: 'relative',
         marginLeft: '-16.8px',
         opacity: 0.9,
-        transition: 'opacity 0.75s ease-in-out',
+        transition: `opacity ${token('durations.bulletOpacityDuration')} ease-in-out`,
         marginRight: '-5px',
         left: '3px',
         fontSize: '16px',
@@ -65,7 +66,7 @@ const glyph = cva({
         position: 'relative',
         marginLeft: '-16.8px',
         opacity: 0.8,
-        transition: 'opacity 0.75s ease-in-out',
+        transition: `opacity ${token('durations.bulletOpacityDuration')} ease-in-out`,
         marginRight: '-5px',
         left: '4px',
         fontSize: '28px',
@@ -208,7 +209,7 @@ const glyph = cva({
 
 const glyphFg = cva({
   base: {
-    transition: 'transform 0.1s ease-out, fill-opacity 0.5s ease-out',
+    transition: `transform ${token('durations.bulletFgTransformDuration')} ease-out, fill-opacity ${token('durations.bulletFgOpacityDuration')} ease-out`,
   },
   variants: {
     gray: {
@@ -524,7 +525,7 @@ const Bullet = ({
           },
           '@media (min-width: 560px) and (max-width: 1024px)': {
             _android: {
-              transition: 'transform 0.1s ease-in-out',
+              transition: `transform ${token('durations.bulletFgTransformDuration')} ease-in-out`,
               marginLeft: '-3px',
             },
           },

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css, cva, cx } from '../../styled-system/css'
 import { bullet } from '../../styled-system/recipes'
-import { token } from '../../styled-system/tokens'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import ThoughtId from '../@types/ThoughtId'
@@ -55,7 +54,7 @@ const glyph = cva({
         position: 'relative',
         marginLeft: '-16.8px',
         opacity: 0.9,
-        transition: `opacity ${token('durations.bulletOpacityDuration')} ease-in-out`,
+        transition: `opacity {durations.bulletOpacityDuration} ease-in-out`,
         marginRight: '-5px',
         left: '3px',
         fontSize: '16px',
@@ -66,7 +65,7 @@ const glyph = cva({
         position: 'relative',
         marginLeft: '-16.8px',
         opacity: 0.8,
-        transition: `opacity ${token('durations.bulletOpacityDuration')} ease-in-out`,
+        transition: `opacity {durations.bulletOpacityDuration} ease-in-out`,
         marginRight: '-5px',
         left: '4px',
         fontSize: '28px',
@@ -209,7 +208,7 @@ const glyph = cva({
 
 const glyphFg = cva({
   base: {
-    transition: `transform ${token('durations.bulletFgTransformDuration')} ease-out, fill-opacity ${token('durations.bulletFgOpacityDuration')} ease-out`,
+    transition: `transform {durations.bulletFgTransformDuration} ease-out, fill-opacity {durations.bulletFgOpacityDuration} ease-out`,
   },
   variants: {
     gray: {
@@ -526,7 +525,7 @@ const Bullet = ({
           },
           '@media (min-width: 560px) and (max-width: 1024px)': {
             _android: {
-              transition: `transform ${token('durations.bulletFgTransformDuration')} ease-in-out`,
+              transition: `transform {durations.bulletFgTransformDuration} ease-in-out`,
               marginLeft: '-3px',
             },
           },

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -14,6 +14,7 @@ import themeColors from '../selectors/themeColors'
 import { formatKeyboardShortcut, gestureString, hashKeyDown, hashShortcut, shortcutById } from '../shortcuts'
 import gestureStore from '../stores/gesture'
 import storageModel from '../stores/storageModel'
+import durations from '../util/durations'
 import { executeShortcutWithMulticursor } from '../util/executeShortcut'
 import GestureDiagram from './GestureDiagram'
 import HighlightedText from './HighlightedText'
@@ -479,7 +480,13 @@ const CommandPaletteWithTransition: FC = () => {
       childFactory={(child: ReactElement) => (!isDismissed ? child : React.cloneElement(child, { timeout: 0 }))}
     >
       {showCommandPalette ? (
-        <CSSTransition key={0} nodeRef={popupRef} timeout={200} classNames='fade' onEntering={() => setDismiss(false)}>
+        <CSSTransition
+          key={0}
+          nodeRef={popupRef}
+          timeout={durations.get('commandPaletteFadeDuration')}
+          classNames='fade'
+          onEntering={() => setDismiss(false)}
+        >
           <Popup
             ref={popupRef}
             // only show the close link on desktop

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -12,6 +12,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
 import simplifyPath from '../selectors/simplifyPath'
 import editingValueStore from '../stores/editingValue'
+import durations from '../util/durations'
 import ellipsize from '../util/ellipsize'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
@@ -244,7 +245,12 @@ const ContextBreadcrumbs = ({
             // Otherwise also it incorrectly animates a changed segment when moving the cursor to a sibling, which doesn't look as good as a direct replacement.
             // This way it will only animate when the length of the cursor changes.
             return (
-              <CSSTransition key={i} nodeRef={nodeRef} timeout={600} classNames='fade-600'>
+              <CSSTransition
+                key={i}
+                nodeRef={nodeRef}
+                timeout={durations.get('contextBreadcrumbsFadeDuration')}
+                classNames='fade-600'
+              >
                 <BreadCrumb
                   ref={nodeRef}
                   isOverflow={isOverflow}

--- a/src/components/ErrorBoundaryContainer.tsx
+++ b/src/components/ErrorBoundaryContainer.tsx
@@ -26,7 +26,7 @@ const Toggle = ({ children, expand, title }: { children?: any; expand?: boolean;
               className={css({
                 transform: expanded ? 'rotate(90deg) translateX(10px)' : '',
                 transformOrigin: 'center center',
-                transition: 'transform 0.1s ease-out',
+                transition: `transform ${token('durations.triangleToggleTransformDuration')} ease-out`,
               })}
             />
           </g>

--- a/src/components/ErrorBoundaryContainer.tsx
+++ b/src/components/ErrorBoundaryContainer.tsx
@@ -26,7 +26,7 @@ const Toggle = ({ children, expand, title }: { children?: any; expand?: boolean;
               className={css({
                 transform: expanded ? 'rotate(90deg) translateX(10px)' : '',
                 transformOrigin: 'center center',
-                transition: `transform ${token('durations.triangleToggleTransformDuration')} ease-out`,
+                transition: `transform {durations.triangleToggleTransformDuration} ease-out`,
               })}
             />
           </g>

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { css } from '../../styled-system/css'
 import { errorActionCreator as error } from '../actions/error'
+import durations from '../util/durations'
 import CloseButton from './CloseButton'
 
 /** An error message that can be dismissed with a close button. */
@@ -14,7 +15,12 @@ const ErrorMessage: FC = () => {
   return (
     <TransitionGroup>
       {value ? (
-        <CSSTransition key={0} nodeRef={errorMessageRef} timeout={200} classNames='fade'>
+        <CSSTransition
+          key={0}
+          nodeRef={errorMessageRef}
+          timeout={durations.get('errorMessageFadeDuration')}
+          classNames='fade'
+        >
           <div
             ref={errorMessageRef}
             className={css({

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -123,7 +123,7 @@ const FavoritesOptions = ({
             style={{
               display: 'inline-block',
               transform: `rotate(${showOptions ? 90 : 0}deg)`,
-              transition: 'transform 150ms ease-out',
+              transition: `transform ${token('durations.favoritesSlidedownDuration')} ease-out`,
               // avoid position:absolute to trivially achieve correct vertical alignment with text
               marginLeft: '-1em',
             }}

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import CSSTransition from 'react-transition-group/CSSTransition'
 import { css, cx } from '../../styled-system/css'
 import { dropHover } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import DragThoughtZone from '../@types/DragThoughtZone'
 import SimplePath from '../@types/SimplePath'
 import { toggleUserSettingActionCreator as toggleUserSetting } from '../actions/toggleUserSetting'
@@ -15,6 +16,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import getUserSetting from '../selectors/getUserSetting'
 import themeColors from '../selectors/themeColors'
 import thoughtToPath from '../selectors/thoughtToPath'
+import durations from '../util/durations'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
 import nonNull from '../util/nonNull'
@@ -135,7 +137,13 @@ const FavoritesOptions = ({
       </div>
 
       <div style={{ overflow: 'hidden' }}>
-        <CSSTransition in={showOptions} nodeRef={formRef} timeout={150} classNames='slidedown' unmountOnExit>
+        <CSSTransition
+          in={showOptions}
+          nodeRef={formRef}
+          timeout={durations.get('favoritesSlidedownDuration')}
+          classNames='slidedown'
+          unmountOnExit
+        >
           <form
             ref={formRef}
             className='text-small'

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -129,7 +129,7 @@ const FavoritesOptions = ({
             className={css({
               display: 'inline-block',
               transform: showOptions ? `rotate(90deg)` : `rotate(0deg)`,
-              transition: `transform ${token('durations.favoritesSlidedownDuration')} ease-out`,
+              transition: `transform {durations.favoritesSlidedownDuration} ease-out`,
               // avoid position:absolute to trivially achieve correct vertical alignment with text
               marginLeft: '-1em',
             })}

--- a/src/components/LatestShortcutsDiagram.tsx
+++ b/src/components/LatestShortcutsDiagram.tsx
@@ -32,9 +32,9 @@ const LatestShortcutsDiagram: FC<LatestShortcutsDiagramProps> = ({ position = 'm
         in={latestShortcuts.length > 0}
         classNames={{
           enter: css({ opacity: 0 }),
-          enterActive: css({ opacity: 1, transition: 'opacity 400ms' }),
+          enterActive: css({ opacity: 1, transition: `opacity ${token('durations.latestShortcutsOpacityDuration')}` }),
           exit: css({ opacity: 1 }),
-          exitActive: css({ opacity: 0, transition: 'opacity 400ms' }),
+          exitActive: css({ opacity: 0, transition: `opacity ${token('durations.latestShortcutsOpacityDuration')}` }),
         }}
         timeout={400}
         unmountOnExit

--- a/src/components/LatestShortcutsDiagram.tsx
+++ b/src/components/LatestShortcutsDiagram.tsx
@@ -2,7 +2,9 @@ import { FC, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens'
 import GesturePath from '../@types/GesturePath'
+import durations from '../util/durations'
 import GestureDiagram from './GestureDiagram'
 
 interface LatestShortcutsDiagramProps {
@@ -36,7 +38,7 @@ const LatestShortcutsDiagram: FC<LatestShortcutsDiagramProps> = ({ position = 'm
           exit: css({ opacity: 1 }),
           exitActive: css({ opacity: 0, transition: `opacity ${token('durations.latestShortcutsOpacityDuration')}` }),
         }}
-        timeout={400}
+        timeout={durations.get('latestShortcutsOpacityDuration')}
         unmountOnExit
       >
         <div

--- a/src/components/LatestShortcutsDiagram.tsx
+++ b/src/components/LatestShortcutsDiagram.tsx
@@ -2,7 +2,6 @@ import { FC, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import { css } from '../../styled-system/css'
-import { token } from '../../styled-system/tokens'
 import GesturePath from '../@types/GesturePath'
 import durations from '../util/durations'
 import GestureDiagram from './GestureDiagram'
@@ -34,9 +33,9 @@ const LatestShortcutsDiagram: FC<LatestShortcutsDiagramProps> = ({ position = 'm
         in={latestShortcuts.length > 0}
         classNames={{
           enter: css({ opacity: 0 }),
-          enterActive: css({ opacity: 1, transition: `opacity ${token('durations.latestShortcutsOpacityDuration')}` }),
+          enterActive: css({ opacity: 1, transition: `opacity {durations.latestShortcutsOpacityDuration}` }),
           exit: css({ opacity: 1 }),
-          exitActive: css({ opacity: 0, transition: `opacity ${token('durations.latestShortcutsOpacityDuration')}` }),
+          exitActive: css({ opacity: 0, transition: `opacity {durations.latestShortcutsOpacityDuration}` }),
         }}
         timeout={durations.get('latestShortcutsOpacityDuration')}
         unmountOnExit

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -770,7 +770,7 @@ const LayoutTree = () => {
                             position: 'relative',
                             top: '-0.2em',
                             left: `calc(${cliffDepth - depth}em - ${dropEndMarginLeft}px + ${isTouch ? -1 : 1}px)`,
-                            transition: 'left 0.15s ease-out',
+                            transition: `left ${token('durations.dropEndTransitionDuration')} ease-out`,
                           }}
                         >
                           <DropEnd

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,6 +10,7 @@ import { BASE_FONT_SIZE } from '../constants'
 import isTutorial from '../selectors/isTutorial'
 import themeColors from '../selectors/themeColors'
 import distractionFreeTypingStore from '../stores/distractionFreeTyping'
+import durations from '../util/durations'
 import isDocumentEditable from '../util/isDocumentEditable'
 import publishMode from '../util/publishMode'
 import ContextBreadcrumbs from './ContextBreadcrumbs'
@@ -108,7 +109,7 @@ const NavBar = ({ position }: { position: string }) => {
                   <CSSTransition
                     nodeRef={cursorBreadcrumbsWrapperRef}
                     in={!distractionFreeTyping}
-                    timeout={200}
+                    timeout={durations.get('cursorBreadcrumbsFadeDuration')}
                     classNames='fade'
                     unmountOnExit
                   >

--- a/src/components/NewThought.tsx
+++ b/src/components/NewThought.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css, cx } from '../../styled-system/css'
 import { anchorButton, bullet, child, thought } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import { createThoughtActionCreator as createThought } from '../actions/createThought'
@@ -74,7 +75,9 @@ const NewThought = ({ path, showContexts, label, value = '', type = 'bullet' }: 
   }, [dispatch, distance, path, value])
 
   return show ? (
-    <ul className={css({ transition: 'all 0.75s ease-out', marginTop: 0 })}>
+    <ul
+      className={css({ transition: `all ${token('durations.newThoughtTransitionDuration')} ease-out`, marginTop: 0 })}
+    >
       <li className={child()}>
         {type === 'bullet' ? <span className={bullet()} /> : null}
         <div className={thought()}>

--- a/src/components/NewThought.tsx
+++ b/src/components/NewThought.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css, cx } from '../../styled-system/css'
 import { anchorButton, bullet, child, thought } from '../../styled-system/recipes'
-import { token } from '../../styled-system/tokens'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import { createThoughtActionCreator as createThought } from '../actions/createThought'
@@ -75,9 +74,7 @@ const NewThought = ({ path, showContexts, label, value = '', type = 'bullet' }: 
   }, [dispatch, distance, path, value])
 
   return show ? (
-    <ul
-      className={css({ transition: `all ${token('durations.newThoughtTransitionDuration')} ease-out`, marginTop: 0 })}
-    >
+    <ul className={css({ transition: `all {durations.newThoughtTransitionDuration} ease-out`, marginTop: 0 })}>
       <li className={child()}>
         {type === 'bullet' ? <span className={bullet()} /> : null}
         <div className={thought()}>

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable'
 import { useDispatch, useSelector } from 'react-redux'
+import { token } from '../../styled-system/tokens'
 import Path from '../@types/Path'
 import { cursorDownActionCreator as cursorDown } from '../actions/cursorDown'
 import { deleteAttributeActionCreator as deleteAttribute } from '../actions/deleteAttribute'
@@ -117,7 +118,7 @@ const Note = React.memo(({ path }: { path: Path }) => {
         marginTop: -3,
         // offset editable's margin-left, which is dynamically set based on font size
         marginLeft: fontSize - 14,
-        transition: 'color 0.75s ease-in-out',
+        transition: `color ${token('durations.noteColorTransitionDuration')} ease-in-out`,
       }}
     >
       <ContentEditable

--- a/src/components/QuickDropPanel.tsx
+++ b/src/components/QuickDropPanel.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react'
 import { useSelector } from 'react-redux'
 import CSSTransition from 'react-transition-group/CSSTransition'
 import { isTouch } from '../browser'
+import durations from '../util/durations'
 import CopyOneDrop from './CopyOneDrop'
 import DeleteDrop from './DeleteDrop'
 import ExportDrop from './ExportDrop'
@@ -13,7 +14,13 @@ const QuickDropPanel = () => {
   const quickDropPanelRef = useRef<HTMLDivElement>(null)
 
   return (
-    <CSSTransition nodeRef={quickDropPanelRef} in={isDragging} timeout={200} classNames='slide-right' unmountOnExit>
+    <CSSTransition
+      nodeRef={quickDropPanelRef}
+      in={isDragging}
+      timeout={durations.get('quickDropPanelSlideDuration')}
+      classNames='slide-right'
+      unmountOnExit
+    >
       <div
         ref={quickDropPanelRef}
         style={{

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { dragHoldActionCreator as dragHold } from '../actions/dragHold'
 import { dragInProgressActionCreator as dragInProgress } from '../actions/dragInProgress'
 import { toggleSidebarActionCreator } from '../actions/toggleSidebar'
 import { isTouch } from '../browser'
+import durations from '../util/durations'
 import fastClick from '../util/fastClick'
 import Favorites from './Favorites'
 import RecentlyDeleted from './RecentlyDeleted'
@@ -151,7 +152,12 @@ const Sidebar = () => {
           })}
           data-scroll-at-edge
         >
-          <CSSTransition in={showSidebar} nodeRef={sidebarMenuRef} timeout={200} classNames='fade'>
+          <CSSTransition
+            in={showSidebar}
+            nodeRef={sidebarMenuRef}
+            timeout={durations.get('sidebarFadeDuration')}
+            classNames='fade'
+          >
             <div
               ref={sidebarMenuRef}
               style={{

--- a/src/components/Tips/Tip.tsx
+++ b/src/components/Tips/Tip.tsx
@@ -1,4 +1,5 @@
 import { FC, PropsWithChildren } from 'react'
+import { token } from '../../../styled-system/tokens'
 
 interface TipProps {
   display: boolean
@@ -16,7 +17,7 @@ const Tip: FC<PropsWithChildren<TipProps>> = ({ display, children }, ref) => {
         display: 'flex',
         justifyContent: 'center',
         transform: display ? 'translateY(0)' : 'translateY(100%)',
-        transition: 'transform 200ms ease-in-out, opacity 200ms ease-in-out',
+        transition: `transform ${token('durations.tipTransitionDuration')} ease-in-out, opacity ${token('durations.tipTransitionDuration')} ease-in-out`,
         opacity: display ? 1 : 0,
       }}
       className='z-index-popup'

--- a/src/components/Tips/Tip.tsx
+++ b/src/components/Tips/Tip.tsx
@@ -1,6 +1,5 @@
 import { FC, PropsWithChildren } from 'react'
 import { css } from '../../../styled-system/css'
-import { token } from '../../../styled-system/tokens'
 
 /** A tip that gets displayed at the bottom of the window. */
 const Tip: FC<
@@ -20,7 +19,7 @@ const Tip: FC<
         // disable pointer revents when hidden, otherwise it will block clicks on the NavBar
         pointerEvents: display ? 'auto' : 'none',
         transform: display ? 'translateY(0)' : 'translateY(100%)',
-        transition: `transform ${token('durations.tipTransitionDuration')} ease-in-out, opacity ${token('durations.tipTransitionDuration')} ease-in-out`,
+        transition: `transform {durations.tipTransitionDuration} ease-in-out, opacity {durations.tipTransitionDuration} ease-in-out`,
         opacity: display ? '1' : '0',
         zIndex: 'popup',
       })}

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -138,7 +138,7 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
         // Dim the gesture trace to 50% opacity when the gesture is cancelled.
         // Also dim when hidden, otherwise when releasing a cancelled gesture the opacity briefly goes back to 1 to start the fade-both animation. This also has the effect of immediately dimming a valid (non-cancelled) gesture as soon as it is released, which actually looks pretty good.
         opacity: cancelled || !show ? 0.5 : 1,
-        transition: 'opacity 150ms ease-in-out',
+        transition: `opacity ${token('durations.signaturePadOpacityDuration')} ease-in-out`,
         pointerEvents: eventNodeRef ? 'none' : undefined,
       }}
     >

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -16,6 +16,7 @@ import themeColors from '../selectors/themeColors'
 import { gestureString, globalShortcuts } from '../shortcuts'
 import gestureStore from '../stores/gesture'
 import viewportStore from '../stores/viewport'
+import durations from '../util/durations'
 
 interface TraceGestureProps {
   // Change the node to which pointer event handlers are attached. Defaults to the signature pad canvas.
@@ -143,7 +144,12 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
         pointerEvents: eventNodeRef ? 'none' : undefined,
       }}
     >
-      <CSSTransition nodeRef={fadeBothEnterElRef} in={show} timeout={400} classNames='fade-both'>
+      <CSSTransition
+        nodeRef={fadeBothEnterElRef}
+        in={show}
+        timeout={durations.get('signaturePadFadeDuration')}
+        classNames='fade-both'
+      >
         <div
           ref={fadeBothEnterElRef}
           // use fade-both-enter to start the opacity at 0, otherwise clicking will render small dots

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import SignaturePad from 'react-signature-pad-wrapper'
 import { CSSTransition } from 'react-transition-group'
+import { token } from '../../styled-system/tokens'
 import {
   AlertType,
   GESTURE_CANCEL_ALERT_TEXT,

--- a/src/components/Tutorial/TutorialNavigation.tsx
+++ b/src/components/Tutorial/TutorialNavigation.tsx
@@ -2,6 +2,7 @@ import { Ref } from 'react'
 import { useDispatch } from 'react-redux'
 import { css, cx } from '../../../styled-system/css'
 import { tutorialBullet } from '../../../styled-system/recipes'
+import { token } from '../../../styled-system/tokens'
 import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
 import { tutorialChoiceActionCreator as tutorialChoice } from '../../actions/tutorialChoice'
 import { tutorialNextActionCreator as tutorialNext } from '../../actions/tutorialNext'
@@ -58,7 +59,7 @@ const TutorialNavigation = ({
                   fontSize: '32px',
                   marginLeft: '1px',
                   marginRight: '1px',
-                  transition: 'all 400ms ease-in-out',
+                  transition: `all ${token('durations.tutorialStepNavigationDuration')} ease-in-out`,
                   opacity: step === Math.floor(tutorialStep) ? 1 : 0.25,
                 })}
                 key={step}

--- a/src/components/Tutorial/TutorialNavigation.tsx
+++ b/src/components/Tutorial/TutorialNavigation.tsx
@@ -2,7 +2,6 @@ import { Ref } from 'react'
 import { useDispatch } from 'react-redux'
 import { css, cx } from '../../../styled-system/css'
 import { tutorialBullet } from '../../../styled-system/recipes'
-import { token } from '../../../styled-system/tokens'
 import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
 import { tutorialChoiceActionCreator as tutorialChoice } from '../../actions/tutorialChoice'
 import { tutorialNextActionCreator as tutorialNext } from '../../actions/tutorialNext'
@@ -59,7 +58,7 @@ const TutorialNavigation = ({
                   fontSize: '32px',
                   marginLeft: '1px',
                   marginRight: '1px',
-                  transition: `all ${token('durations.tutorialStepNavigationDuration')} ease-in-out`,
+                  transition: `all {durations.tutorialStepNavigationDuration} ease-in-out`,
                   opacity: step === Math.floor(tutorialStep) ? 1 : 0.25,
                 })}
                 key={step}

--- a/src/components/Tutorial/TutorialScrollUpButton.tsx
+++ b/src/components/Tutorial/TutorialScrollUpButton.tsx
@@ -1,4 +1,5 @@
 import { FC, useCallback } from 'react'
+import { token } from '../../../styled-system/tokens'
 import scrollTo from '../../device/scrollTo'
 import scrollTopStore from '../../stores/scrollTop'
 import TutorialNavigationButton from './TutorialNavigationButton'
@@ -31,7 +32,7 @@ const TutorialScrollUpButton: FC<{ show: boolean }> = ({ show }) => {
           position: 'absolute',
           top: show ? '0.5em' : '-2em',
           left: 0,
-          transition: 'opacity 0.25s ease-in-out, visibility 0.25s ease-in-out, top 0.25s ease-in-out',
+          transition: `opacity ${token('durations.tutorialNavigationButtonDuration')} ease-in-out, visibility ${token('durations.tutorialNavigationButtonDuration')} ease-in-out, top ${token('durations.tutorialNavigationButtonDuration')} ease-in-out`,
           display: 'flex',
           justifyContent: 'center',
         }}

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -29,6 +29,7 @@ import useIsVisible from '../../hooks/useIsVisible'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import getSetting from '../../selectors/getSetting'
 import { shortcutById } from '../../shortcuts'
+import durationsHelper from '../../util/durations'
 import fastClick from '../../util/fastClick'
 import headValue from '../../util/headValue'
 import once from '../../util/once'
@@ -45,7 +46,13 @@ const WithCSSTransition = ({ component, ...props }: { component: FC<any>; [props
 
   const Component = component
   return (
-    <CSSTransition nodeRef={nodeRef} in={true} key={Math.floor(props.transitionKey)} timeout={400} classNames='slide'>
+    <CSSTransition
+      nodeRef={nodeRef}
+      in={true}
+      key={Math.floor(props.transitionKey)}
+      timeout={durationsHelper.get('tutorialStepSlideDuration')}
+      classNames='slide'
+    >
       <div ref={nodeRef}>
         <Component {...props} />
       </div>

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -29,7 +29,7 @@ import useIsVisible from '../../hooks/useIsVisible'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import getSetting from '../../selectors/getSetting'
 import { shortcutById } from '../../shortcuts'
-import durationsHelper from '../../util/durations'
+import durations from '../../util/durations'
 import fastClick from '../../util/fastClick'
 import headValue from '../../util/headValue'
 import once from '../../util/once'
@@ -50,7 +50,7 @@ const WithCSSTransition = ({ component, ...props }: { component: FC<any>; [props
       nodeRef={nodeRef}
       in={true}
       key={Math.floor(props.transitionKey)}
-      timeout={durationsHelper.get('tutorialStepSlideDuration')}
+      timeout={durations.get('tutorialStepSlideDuration')}
       classNames='slide'
     >
       <div ref={nodeRef}>

--- a/src/components/icons/TextColorWithColorPicker.tsx
+++ b/src/components/icons/TextColorWithColorPicker.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import IconType from '../../@types/Icon'
+import durations from '../../util/durations'
 import ColorPicker from '../ColorPicker'
 import TextColorIcon from './TextColor'
 
@@ -16,7 +17,7 @@ const Icon = ({ size = 20, style, cssRaw }: IconType) => {
       <CSSTransition
         nodeRef={toolbarPopupRef}
         in={showColorPicker}
-        timeout={200}
+        timeout={durations.get('colorPickerFadeDuration')}
         classNames='fade'
         exit={false}
         unmountOnExit

--- a/src/components/modals/CustomizeToolbar.tsx
+++ b/src/components/modals/CustomizeToolbar.tsx
@@ -19,6 +19,7 @@ import { isTouch } from '../../browser'
 import { AlertText, AlertType } from '../../constants'
 import themeColors from '../../selectors/themeColors'
 import { shortcutById } from '../../shortcuts'
+import durations from '../../util/durations'
 import fastClick from '../../util/fastClick'
 import ShortcutTableOnly from '../ShortcutTableOnly'
 import ShortcutTable from './../ShortcutTable'
@@ -149,7 +150,7 @@ const ModalCustomizeToolbar: FC = () => {
           nodeRef={shortcutsContainerRef}
           in={!!selectedShortcut}
           classNames='fade'
-          timeout={200}
+          timeout={durations.get('shortcutTableFadeDuration')}
           exit={false}
           unmountOnExit
         >
@@ -177,7 +178,13 @@ const ModalCustomizeToolbar: FC = () => {
         </CSSTransition>
       </div>
 
-      <CSSTransition in={!selectedShortcut} classNames='fade' timeout={200} exit={false} unmountOnExit>
+      <CSSTransition
+        in={!selectedShortcut}
+        classNames='fade'
+        timeout={durations.get('toolbarHelpTextFadeDuration')}
+        exit={false}
+        unmountOnExit
+      >
         <div className='dim' style={{ marginTop: '2em', marginBottom: '2.645em' }}>
           <p>Drag-and-drop to rearrange toolbar.</p>
           <p>{isTouch ? 'Tap' : 'Click'} a command for details.</p>

--- a/src/components/modals/Devices.tsx
+++ b/src/components/modals/Devices.tsx
@@ -15,7 +15,7 @@ import * as selection from '../../device/selection'
 import useSharedType from '../../hooks/useSharedType'
 import useStatus from '../../hooks/useStatus'
 import themeColors from '../../selectors/themeColors'
-import durationsHelper from '../../util/durations'
+import durations from '../../util/durations'
 import fastClick from '../../util/fastClick'
 import strip from '../../util/strip'
 import ActionButton from './../ActionButton'
@@ -65,7 +65,7 @@ const ModalDevices = () => {
               nodeRef={shareDetailRef}
               classNames='fade-400'
               exit={false}
-              timeout={durationsHelper.get('shareDetailFadeDuration')}
+              timeout={durations.get('shareDetailFadeDuration')}
               unmountOnExit
             >
               <ShareDetail
@@ -82,7 +82,7 @@ const ModalDevices = () => {
               nodeRef={shareListRef}
               classNames='fade-400'
               exit={false}
-              timeout={durationsHelper.get('shareListFadeDuration')}
+              timeout={durations.get('shareListFadeDuration')}
               unmountOnExit
             >
               <ShareList ref={shareListRef} onAdd={setSelected} onSelect={setSelected} permissions={permissions} />
@@ -168,7 +168,7 @@ const ShareList = React.forwardRef<
                   key='add-device-form'
                   classNames='fade-400'
                   exit={false}
-                  timeout={durationsHelper.get('addDeviceFormFadeDuration')}
+                  timeout={durations.get('addDeviceFormFadeDuration')}
                   unmountOnExit
                 >
                   <div>
@@ -197,7 +197,7 @@ const ShareList = React.forwardRef<
                   key='add-a-device'
                   classNames='fade-400'
                   exit={false}
-                  timeout={durationsHelper.get('addDeviceButtonFadeDuration')}
+                  timeout={durations.get('addDeviceButtonFadeDuration')}
                   unmountOnExit
                 >
                   <div style={{ marginTop: '1em' }}>

--- a/src/components/modals/Devices.tsx
+++ b/src/components/modals/Devices.tsx
@@ -65,7 +65,7 @@ const ModalDevices = () => {
               nodeRef={shareDetailRef}
               classNames='fade-400'
               exit={false}
-              timeout={400}
+              timeout={durationsHelper.get('shareDetailFadeDuration')}
               unmountOnExit
             >
               <ShareDetail
@@ -82,7 +82,7 @@ const ModalDevices = () => {
               nodeRef={shareListRef}
               classNames='fade-400'
               exit={false}
-              timeout={400}
+              timeout={durationsHelper.get('shareListFadeDuration')}
               unmountOnExit
             >
               <ShareList ref={shareListRef} onAdd={setSelected} onSelect={setSelected} permissions={permissions} />

--- a/src/components/modals/Devices.tsx
+++ b/src/components/modals/Devices.tsx
@@ -15,6 +15,7 @@ import * as selection from '../../device/selection'
 import useSharedType from '../../hooks/useSharedType'
 import useStatus from '../../hooks/useStatus'
 import themeColors from '../../selectors/themeColors'
+import durationsHelper from '../../util/durations'
 import fastClick from '../../util/fastClick'
 import strip from '../../util/strip'
 import ActionButton from './../ActionButton'
@@ -163,7 +164,13 @@ const ShareList = React.forwardRef<
             {
               // form
               showDeviceForm ? (
-                <CSSTransition key='add-device-form' classNames='fade-400' exit={false} timeout={400} unmountOnExit>
+                <CSSTransition
+                  key='add-device-form'
+                  classNames='fade-400'
+                  exit={false}
+                  timeout={durationsHelper.get('addDeviceFormFadeDuration')}
+                  unmountOnExit
+                >
                   <div>
                     <AddDeviceForm
                       onCancel={() => setShowDeviceForm(false)}
@@ -186,7 +193,13 @@ const ShareList = React.forwardRef<
                 </CSSTransition>
               ) : (
                 // "+ Add a device" button
-                <CSSTransition key='add-a-device' classNames='fade-400' exit={false} timeout={400} unmountOnExit>
+                <CSSTransition
+                  key='add-a-device'
+                  classNames='fade-400'
+                  exit={false}
+                  timeout={durationsHelper.get('addDeviceButtonFadeDuration')}
+                  unmountOnExit
+                >
                   <div style={{ marginTop: '1em' }}>
                     <a
                       {...fastClick(() => setShowDeviceForm(true))}

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import useOnClickOutside from 'use-onclickoutside'
 import { css, cx } from '../../../styled-system/css'
 import { extendTap } from '../../../styled-system/recipes'
+import { token } from '../../../styled-system/tokens'
 import ExportOption from '../../@types/ExportOption'
 import SimplePath from '../../@types/SimplePath'
 import State from '../../@types/State'
@@ -670,7 +671,7 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
                 userSelect: 'none',
                 display: 'flex',
                 position: 'relative',
-                transition: 'opacity 100ms ease-in-out',
+                transition: `opacity ${token('durations.advancedSettingsLinkOpacityDuration')} ease-in-out`,
                 color: 'fg',
                 opacity: advancedSettings ? 1 : 0.5,
               }),

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -14,7 +14,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import useOnClickOutside from 'use-onclickoutside'
 import { css, cx } from '../../../styled-system/css'
 import { extendTap } from '../../../styled-system/recipes'
-import { token } from '../../../styled-system/tokens'
 import ExportOption from '../../@types/ExportOption'
 import SimplePath from '../../@types/SimplePath'
 import State from '../../@types/State'
@@ -665,7 +664,7 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
                 userSelect: 'none',
                 display: 'flex',
                 position: 'relative',
-                transition: `opacity ${token('durations.advancedSettingsLinkOpacityDuration')} ease-in-out`,
+                transition: `opacity {durations.advancedSettingsLinkOpacityDuration} ease-in-out`,
                 color: 'fg',
                 opacity: advancedSettings ? 1 : 0.5,
               }),

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -5,8 +5,9 @@ const durationsMillis: DurationConfig = {
   hoverPulseDuration: 300,
   layoutSlowShiftDuration: 750,
   layoutNodeAnimationDuration: 150,
-  signaturePadOpacityDuration: 150,
+  newThoughtTransitionDuration: 750,
   noteColorTransitionDuration: 750,
+  signaturePadOpacityDuration: 150,
 }
 
 export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -1,0 +1,10 @@
+export type DurationConfig = Record<string, number>
+
+const durationsMillis: DurationConfig = {
+  highlightPulseDuration: 500,
+  hoverPulseDuration: 300,
+  layoutSlowShiftDuration: 750,
+  layoutNodeAnimationDuration: 150,
+}
+
+export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -1,13 +1,45 @@
 export type DurationConfig = Record<string, number>
 
 const durationsMillis: DurationConfig = {
+  addDeviceFormFadeDuration: 400,
+  addDeviceButtonFadeDuration: 400,
+  advancedSettingsLinkOpacityDuration: 100,
+  alertFadeDuration: 800,
+  bulletOpacityDuration: 750,
+  bulletFgTransformDuration: 100,
+  bulletFgOpacityDuration: 500,
+  colorPickerFadeDuration: 200,
+  commandPaletteFadeDuration: 200,
+  contextBreadcrumbsFadeDuration: 600,
+  cursorBreadcrumbsFadeDuration: 200,
+  dropEndTransitionDuration: 150,
+  errorMessageFadeDuration: 200,
+  favoritesSlidedownDuration: 150,
   highlightPulseDuration: 500,
   hoverPulseDuration: 300,
+  latestShortcutsOpacityDuration: 400,
+  /** The animation duration for the slower opacity transition and horizontal shift of the LayoutTree as the depth of the cursor changes. */
   layoutSlowShiftDuration: 750,
+  /** The animation duration of a node in the LayoutTree component. */
   layoutNodeAnimationDuration: 150,
   newThoughtTransitionDuration: 750,
   noteColorTransitionDuration: 750,
+  quickDropPanelSlideDuration: 200,
+  shareDetailFadeDuration: 400,
+  shareListFadeDuration: 400,
+  shortcutTableFadeDuration: 200,
+  sidebarFadeDuration: 200,
+  signaturePadFadeDuration: 400,
   signaturePadOpacityDuration: 150,
+  tipTransitionDuration: 200,
+  toolbarFadeDuration: 600,
+  toolbarButtonTransitionDuration: 80,
+  toolbarButtonSVGOpacityDuration: 200,
+  toolbarHelpTextFadeDuration: 200,
+  triangleToggleTransformDuration: 100,
+  tutorialNavigationButtonDuration: 250,
+  tutorialStepSlideDuration: 400,
+  tutorialStepNavigationDuration: 400,
 }
 
 export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -5,6 +5,8 @@ const durationsMillis: DurationConfig = {
   hoverPulseDuration: 300,
   layoutSlowShiftDuration: 750,
   layoutNodeAnimationDuration: 150,
+  signaturePadOpacityDuration: 150,
+  noteColorTransitionDuration: 750,
 }
 
 export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -1,6 +1,4 @@
-export type DurationConfig = Record<string, number>
-
-const durationsMillis: DurationConfig = {
+const durationsMillis = {
   addDeviceFormFadeDuration: 400,
   addDeviceButtonFadeDuration: 400,
   advancedSettingsLinkOpacityDuration: 100,
@@ -40,6 +38,6 @@ const durationsMillis: DurationConfig = {
   tutorialNavigationButtonDuration: 250,
   tutorialStepSlideDuration: 400,
   tutorialStepNavigationDuration: 400,
-}
+} as const
 
 export default durationsMillis

--- a/src/util/__tests__/durations.ts
+++ b/src/util/__tests__/durations.ts
@@ -18,10 +18,6 @@ describe('getDuration', () => {
     durationsHelper.setInTest(true)
     expect(durationsHelper.get(key)).toBe(0)
   })
-
-  it('should throw an error if the key does not exist', () => {
-    expect(() => durationsHelper.get('fake-key')).toThrow(Error)
-  })
 })
 
 describe('getDurations', () => {
@@ -33,7 +29,7 @@ describe('getDurations', () => {
 
     // Each duration value should match
     Object.entries(actualDurations).forEach(([key, duration]) => {
-      expect(duration).toEqual(durations[key])
+      expect(duration).toEqual(durations[key as keyof typeof durations])
     })
   })
 
@@ -52,12 +48,12 @@ describe('getDurations', () => {
 })
 
 /** Return the first configurad duration. */
-const getTestVals = (): [string, number] => {
+const getTestVals = (): [keyof typeof durations, number] => {
   const keys = Object.keys(durations)
 
   if (keys.length === 0) throw new Error('No durations configured.')
 
-  const key = keys[0]
+  const key = keys[0] as keyof typeof durations
 
   return [key, durations[key]]
 }

--- a/src/util/__tests__/durations.ts
+++ b/src/util/__tests__/durations.ts
@@ -1,10 +1,8 @@
 import durations from '../../durations.config'
-import init from '../durations'
-
-let durationsHelper: any
+import durationsHelper from '../durations'
 
 beforeEach(() => {
-  durationsHelper = init()
+  durationsHelper.setInTest(false)
 })
 
 describe('getDuration', () => {
@@ -17,8 +15,12 @@ describe('getDuration', () => {
   it('should return the zero duration when in test state', () => {
     const [key] = getTestVals()
 
-    durationsHelper.forceInTest()
+    durationsHelper.setInTest(true)
     expect(durationsHelper.get(key)).toBe(0)
+  })
+
+  it('should throw an error if the key does not exist', () => {
+    expect(() => durationsHelper.get('fake-key')).toThrow(Error)
   })
 })
 
@@ -36,7 +38,7 @@ describe('getDurations', () => {
   })
 
   it('should return the zero duration when in test state', () => {
-    durationsHelper.forceInTest()
+    durationsHelper.setInTest(true)
     const actualDurations = durationsHelper.getAll()
 
     // SHould have same number of keys

--- a/src/util/__tests__/durations.ts
+++ b/src/util/__tests__/durations.ts
@@ -1,0 +1,61 @@
+import durations from '../../durations.config'
+import init from '../durations'
+
+let durationsHelper: any
+
+beforeEach(() => {
+  durationsHelper = init()
+})
+
+describe('getDuration', () => {
+  it('should return the correct duration when not in test state', () => {
+    const [key, duration] = getTestVals()
+
+    expect(durationsHelper.get(key)).toBe(duration)
+  })
+
+  it('should return the zero duration when in test state', () => {
+    const [key] = getTestVals()
+
+    durationsHelper.forceInTest()
+    expect(durationsHelper.get(key)).toBe(0)
+  })
+})
+
+describe('getDurations', () => {
+  it('should return the correct durations when not in test state', () => {
+    const actualDurations = durationsHelper.getAll()
+
+    // SHould have same number of keys
+    expect(Object.keys(actualDurations).length).toEqual(Object.keys(durations).length)
+
+    // Each duration value should match
+    Object.entries(actualDurations).forEach(([key, duration]) => {
+      expect(duration).toEqual(durations[key])
+    })
+  })
+
+  it('should return the zero duration when in test state', () => {
+    durationsHelper.forceInTest()
+    const actualDurations = durationsHelper.getAll()
+
+    // SHould have same number of keys
+    expect(Object.keys(actualDurations).length).toEqual(Object.keys(durations).length)
+
+    // Each duration value should match
+    Object.entries(actualDurations).forEach(([, duration]) => {
+      expect(duration).toEqual(0)
+    })
+  })
+})
+
+/** Return the first configurad duration. */
+const getTestVals = (): [string, number] => {
+  const keys = Object.keys(durations)
+
+  if (keys.length === 0) throw new Error('No durations configured.')
+
+  const key = keys[0]
+
+  return [key, durations[key]]
+}

--- a/src/util/durations.ts
+++ b/src/util/durations.ts
@@ -1,18 +1,16 @@
-import durationsConfig, { type DurationConfig } from '../durations.config'
+import durationsConfig from '../durations.config'
 
 /** Initialize duration helper. */
 function init() {
   let inTest: boolean = !!navigator.webdriver
 
   /** Returns the duration for a particular key or undefined if it doesn't exist. */
-  const get = (key: string): number => {
-    if (durationsConfig[key]) return durationOrZero(durationsConfig[key])
-
-    throw new Error(`No config for duration key ${key}`)
+  const get = (key: keyof typeof durationsConfig): number => {
+    return durationOrZero(durationsConfig[key])
   }
 
   /** Returns all durations. */
-  const getAll = (): DurationConfig => Object.entries(durationsConfig).reduce(reduceDurations, {})
+  const getAll = () => Object.entries(durationsConfig).reduce(reduceDurations, {})
 
   /** Override inTest state. Should only be used for testing purposes. */
   const setInTest = (inTestOverride: boolean) => {

--- a/src/util/durations.ts
+++ b/src/util/durations.ts
@@ -2,17 +2,21 @@ import durations, { type DurationConfig } from '../durations.config'
 
 /** Initialize duration helper. */
 function init() {
-  let inTest = navigator.webdriver
+  let inTest: boolean = !!navigator.webdriver
 
   /** Returns the duration for a particular key or undefined if it doesn't exist. */
-  const get = (key: string): number | undefined => (durations[key] ? durationOrZero(durations[key]) : undefined)
+  const get = (key: string): number => {
+    if (durations[key]) return durationOrZero(durations[key])
+
+    throw new Error(`No config for duration key ${key}`)
+  }
 
   /** Returns all durations. */
   const getAll = (): DurationConfig => Object.entries(durations).reduce(reduceDurations, {})
 
   /** Override inTest state. Should only be used for testing purposes. */
-  const forceInTest = () => {
-    inTest = true
+  const setInTest = (inTestOverride: boolean) => {
+    inTest = inTestOverride
   }
 
   /** Returns the duration config with the durations or zero depending on whether we're in tests or not. */
@@ -28,8 +32,10 @@ function init() {
   return {
     get,
     getAll,
-    forceInTest,
+    setInTest,
   }
 }
 
-export default init
+const durationsHelper = init()
+
+export default durationsHelper

--- a/src/util/durations.ts
+++ b/src/util/durations.ts
@@ -1,0 +1,35 @@
+import durations, { type DurationConfig } from '../durations.config'
+
+/** Initialize duration helper. */
+function init() {
+  let inTest = navigator.webdriver
+
+  /** Returns the duration for a particular key or undefined if it doesn't exist. */
+  const get = (key: string): number | undefined => (durations[key] ? durationOrZero(durations[key]) : undefined)
+
+  /** Returns all durations. */
+  const getAll = (): DurationConfig => Object.entries(durations).reduce(reduceDurations, {})
+
+  /** Override inTest state. Should only be used for testing purposes. */
+  const forceInTest = () => {
+    inTest = true
+  }
+
+  /** Returns the duration config with the durations or zero depending on whether we're in tests or not. */
+  const reduceDurations = (pv: Record<string, number>, [key, duration]: [string, number]) => {
+    pv[key] = durationOrZero(duration)
+
+    return pv
+  }
+
+  /** Check if we're in e2e tests and return zero if we are else return the actual duration. */
+  const durationOrZero = (duration: number) => (inTest ? 0 : duration)
+
+  return {
+    get,
+    getAll,
+    forceInTest,
+  }
+}
+
+export default init

--- a/src/util/durations.ts
+++ b/src/util/durations.ts
@@ -36,6 +36,6 @@ function init() {
   }
 }
 
-const durationsHelper = init()
+const durations = init()
 
-export default durationsHelper
+export default durations

--- a/src/util/durations.ts
+++ b/src/util/durations.ts
@@ -1,4 +1,4 @@
-import durations, { type DurationConfig } from '../durations.config'
+import durationsConfig, { type DurationConfig } from '../durations.config'
 
 /** Initialize duration helper. */
 function init() {
@@ -6,13 +6,13 @@ function init() {
 
   /** Returns the duration for a particular key or undefined if it doesn't exist. */
   const get = (key: string): number => {
-    if (durations[key]) return durationOrZero(durations[key])
+    if (durationsConfig[key]) return durationOrZero(durationsConfig[key])
 
     throw new Error(`No config for duration key ${key}`)
   }
 
   /** Returns all durations. */
-  const getAll = (): DurationConfig => Object.entries(durations).reduce(reduceDurations, {})
+  const getAll = (): DurationConfig => Object.entries(durationsConfig).reduce(reduceDurations, {})
 
   /** Override inTest state. Should only be used for testing purposes. */
   const setInTest = (inTestOverride: boolean) => {


### PR DESCRIPTION
This replaces PR #2464 and makes progress on #2110 

The changes here are:

1. We now have a top-level config object for the duration timings.
2. We have a helper that wraps the config with getters that return `0` instead of the duration when we're in the e2e tests.
3. The PandaCSS config is generated based on the top-level config.
4. The CSSTransition components use the helper to get the appropriate duration.

NOTE: I wanted to be able to test the helper under testing conditions so I had to add some provisions to allow for overriding the state and force it to operate as if it was in tests. We could make this a bit simpler if we brought back the `isE2E` helper (in it's functional form) now that we're checking this in multiple places; then `isE2E` could be easily mocked so we can test both paths.