### PR TITLE
1901: [Safari] Table: Col1 cursor bullet incorrectly rendered on the right

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -541,9 +541,8 @@ const Bullet = ({
         }),
       )}
       style={{
-        marginTop: -extendClickHeight,
-        marginLeft: -extendClickWidth + marginLeft,
-        marginBottom: -extendClickHeight - 2,
+        top: -extendClickHeight,
+        left: -extendClickWidth + marginLeft,
         paddingTop: extendClickHeight,
         paddingLeft: extendClickWidth,
         paddingBottom: extendClickHeight + 2,


### PR DESCRIPTION
Fixes #1901

The issue was caused by margin CSS properties being ignored by Safari when the element is absolutely positioned.

Screenshot from safari.
![image](https://github.com/user-attachments/assets/9af6e99e-0921-47c6-9e32-c022e90f89de)
