### PR TITLE
Fix URL icon sometimes not appearing

### DIFF
--- a/src/actions/bulletColor.ts
+++ b/src/actions/bulletColor.ts
@@ -4,6 +4,7 @@ import Thunk from '../@types/Thunk'
 import setDescendant from '../actions/setDescendant'
 import * as selection from '../device/selection'
 import pathToThought from '../selectors/pathToThought'
+import stripTags from '../util/stripTags'
 import deleteAttribute from './deleteAttribute'
 
 /** Sets the bullet color of the cursor. */
@@ -30,7 +31,7 @@ export const bulletColorActionCreator =
   (dispatch, getState) => {
     const state = getState()
     const thought = pathToThought(state, state.cursor!)
-    const thoughtText = thought.value.replace(/<[^>]*>/g, '')
+    const thoughtText = stripTags(thought.value)
     const fullySelected =
       (selection.text()?.length === 0 && thoughtText.length !== 0) || selection.text()?.length === thoughtText.length
     dispatch({ type: 'bulletColor', ...payload, fullySelected })

--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -27,6 +27,7 @@ import isVisibleContext from '../util/isVisibleContext'
 import parentOf from '../util/parentOf'
 import publishMode from '../util/publishMode'
 import resolveArray from '../util/resolveArray'
+import stripTags from '../util/stripTags'
 import StaticSuperscript from './StaticSuperscript'
 import EmailIcon from './icons/EmailIcon'
 import UrlIcon from './icons/UrlIcon'
@@ -176,7 +177,7 @@ const ThoughtAnnotationContainer = React.memo(
           !isExpanded && childrenUrls.length === 1 && (!state.cursor || !equalPath(simplePath, parentOf(state.cursor)))
           ? childrenUrls[0].value
           : null
-      return urlValue
+      return urlValue ? stripTags(urlValue) : urlValue
     })
 
     const email = isEmail(value) ? value : undefined

--- a/src/util/__tests__/isURL.ts
+++ b/src/util/__tests__/isURL.ts
@@ -1,6 +1,6 @@
 import isURL from '../isURL'
 
-const valueUrls = [
+const validUrls = [
   'http://nonssl.com',
   'https://ssl.com',
   'localhost:3000/',
@@ -30,6 +30,11 @@ const valueUrls = [
   'http://a.b-c.de',
   'http://www.cs.cornell.edu/report.pdf',
   'http://test.com/?foo=1.0',
+  '<span style=“background-color: black”>test.com</span>',
+  '<span style="color: rgb(255, 255, 255);background-color: rgb(51, 51, 51);">https://test.com</span>',
+  '<code>test.com</code>',
+  '<code><i><b>test.com</b></i></code>',
+  '<b>test.com</b>',
 ]
 
 const invalidUrls = [
@@ -69,7 +74,7 @@ const invalidUrls = [
 ]
 
 describe('valid urls', () => {
-  valueUrls.forEach(url => {
+  validUrls.forEach(url => {
     it(url, () => {
       expect(isURL(url)).toBe(true)
     })

--- a/src/util/isURL.ts
+++ b/src/util/isURL.ts
@@ -1,9 +1,13 @@
 import isEmail from './isEmail'
+import stripTags from './stripTags'
 
 const REGEX_URL =
   /^(?:http(s)?:\/\/)?(www\.)?[a-zA-Z@:%_\\+~#=]+[-\w@:%_\\+~#=.]*[\w@:%_\\+~#=]+[.:][\w()]{2,6}((\/[\w-()@:%_\\+~#?&=.]*)*)$/i
 
 /** Checks if a string is a URL. */
-const isURL = (s: string) => REGEX_URL.test(s) && !isEmail(s)
+const isURL = (s: string) => {
+  const strippedValue = stripTags(s)
+  return REGEX_URL.test(strippedValue) && !isEmail(strippedValue)
+}
 
 export default isURL

--- a/src/util/stripTags.ts
+++ b/src/util/stripTags.ts
@@ -1,0 +1,4 @@
+/** Strips HTML-looking tags from the given string. */
+const stripTags = (s: string) => s.replace(/<[^>]*>/g, '')
+
+export default stripTags


### PR DESCRIPTION
Fixes #2481 by ignoring HTML-like tags when checking if a given string is a URL.

<img width="469" alt="image" src="https://github.com/user-attachments/assets/c617293d-5967-409e-a16a-70262b83656f">

I also noticed the same tag stripping regex was being used in the bulletColor action, so I have refactored them both into a separate utility function called `stripTags`.