### PR TITLE
Remove Puppeteer Test Delays Part 1

### DIFF
--- a/src/e2e/puppeteer/__tests__/ContextView.ts
+++ b/src/e2e/puppeteer/__tests__/ContextView.ts
@@ -29,19 +29,10 @@ it('load buffered ancestors of contexts when context view is activated', async (
 
   await waitForEditable('m')
 
-  // wait for a re-render in case the lexeme was loaded after the parent
-  // getEditingText will return undefined if we don't wait
-  // we don't currently have a way to tell if a lexeme is missing or just loading
-  await sleep(100)
-
   await clickThought('m')
   await scrollIntoView('[data-testid="toolbar-icon"][aria-label="Context View"]')
   await scrollBy('#toolbar', 50, 0)
   await click('[data-testid="toolbar-icon"][aria-label="Context View"]')
-
-  // allow ancestors to be loaded
-  // may not be practically necessary, but there could be a delay on slower machines
-  await sleep(10)
 
   // assert that c is loaded
   await waitForEditable('c')

--- a/src/e2e/puppeteer/__tests__/ContextView.ts
+++ b/src/e2e/puppeteer/__tests__/ContextView.ts
@@ -1,4 +1,3 @@
-import sleep from '../../../util/sleep'
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
 import paste from '../helpers/paste'

--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -20,11 +20,6 @@ it('set the cursor to a thought in the home context on load', async () => {
 
   await waitForEditable('b')
 
-  // wait for a re-render in case the lexeme was loaded after the parent
-  // getEditingText will return undefined if we don't wait
-  // we don't currently have a way to tell if a lexeme is missing or just loading
-  await sleep(100)
-
   const thoughtValue = await getEditingText()
   expect(thoughtValue).toBe('b')
 })

--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -45,12 +45,6 @@ it('set the cursor on a subthought on load', async () => {
 
   await waitForEditable('z')
 
-  // wait for a re-render in case the lexeme was loaded after the parent
-  // getEditingText will return undefined if we don't wait
-  // we don't currently have a way to tell if a lexeme is missing or just loading
-  // getting intermittent test failures at 200ms so try longer sleep
-  await sleep(400)
-
   const thoughtValue = await getEditingText()
   expect(thoughtValue).toBe('z')
 })

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -256,9 +256,6 @@ describe('drop', () => {
         - d
       `)
 
-      // wait for .child fade animation
-      await sleep(750)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import clickThought from '../helpers/clickThought'
 import dragAndDropThought from '../helpers/dragAndDropThought'
@@ -78,15 +77,7 @@ describe('drag', () => {
       `)
 
     await clickThought('b')
-
-    // wait for b to expand
-    await sleep(100)
-
     await clickThought('c')
-
-    // wait for c to expand and e to fade out
-    await sleep(400)
-
     await dragAndDropThought('c', 'e', { position: 'before', dropUncle: true })
 
     const image = await screenshot()

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -289,14 +289,7 @@ describe('drop', () => {
       `)
 
       await clickThought('b')
-
-      // wait for b to expand
-      await sleep(100)
-
       await clickThought('c')
-
-      // wait for c to expand and e to fade out
-      await sleep(400)
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -108,12 +108,6 @@ describe('drag', () => {
       `)
 
     await clickThought('x')
-
-    // Add delay before drag, otherwise the pointer position is sometimes off (intermittend).
-    // This is possibly because c is still animating into place, so it throws off the drag-and-drop coordinates.
-    // Try removing after animatoins are disabled during tests.
-    await sleep(400)
-
     await dragAndDropThought('x', 'd', { position: 'after', dropUncle: true })
 
     const image = await screenshot()
@@ -135,7 +129,6 @@ describe('drag', () => {
       `)
 
     await clickThought('x')
-
     await dragAndDropThought('x', 'c', { position: 'after' })
 
     const image = await screenshot()

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -136,11 +136,6 @@ describe('drag', () => {
 
     await clickThought('x')
 
-    // Add delay before drag, otherwise the pointer position is off (consistent).
-    // This is possibly because c is still animating into place, so it throws off the drag-and-drop coordinates.
-    // Try removing after animatoins are disabled during tests.
-    await sleep(400)
-
     await dragAndDropThought('x', 'c', { position: 'after' })
 
     const image = await screenshot()

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -1,4 +1,3 @@
-import sleep from '../../../util/sleep'
 import press from '../helpers/press'
 import type from '../helpers/type'
 import waitForEditable from '../helpers/waitForEditable'

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -9,15 +9,13 @@ vi.setConfig({ testTimeout: 20000 })
 /** Custom helper for pasting plain text, avoiding the existing `paste` helper that uses `importText` internally. */
 const pastePlainText = async (text: string) => {
   // Load text into clipboard
-  await page.evaluate(text => {
-    navigator.clipboard.write([
+  await page.evaluate(async text => {
+    await navigator.clipboard.write([
       new ClipboardItem({
         'text/plain': new Blob([text], { type: 'text/plain' }),
       }),
     ])
   }, text)
-
-  await sleep(300)
 
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')
@@ -27,16 +25,14 @@ const pastePlainText = async (text: string) => {
 /** Custom helper for pasting HTML, avoiding the existing `paste` helper that uses `importText` internally. */
 const pasteHTML = async (html: string) => {
   // Load HTML into clipboard
-  await page.evaluate(html => {
-    navigator.clipboard.write([
+  await page.evaluate(async html => {
+    await navigator.clipboard.write([
       new ClipboardItem({
         'text/plain': new Blob(['Plain text should be ignored when pasting as HTML.'], { type: 'text/plain' }),
         'text/html': new Blob([html], { type: 'text/html' }),
       }),
     ])
   }, html)
-
-  await sleep(300)
 
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -1,4 +1,3 @@
-import sleep from '../../../util/sleep'
 import press from '../helpers/press'
 import type from '../helpers/type'
 import waitForEditable from '../helpers/waitForEditable'
@@ -17,8 +16,6 @@ const pastePlainText = async (text: string) => {
     ])
   }, text)
 
-  await sleep(300)
-
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')
   await page.keyboard.up('Shift')
@@ -35,8 +32,6 @@ const pasteHTML = async (html: string) => {
       }),
     ])
   }, html)
-
-  await sleep(300)
 
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -1,3 +1,4 @@
+import sleep from '../../../util/sleep'
 import press from '../helpers/press'
 import type from '../helpers/type'
 import waitForEditable from '../helpers/waitForEditable'
@@ -16,6 +17,8 @@ const pastePlainText = async (text: string) => {
     ])
   }, text)
 
+  await sleep(300)
+
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')
   await page.keyboard.up('Shift')
@@ -32,6 +35,8 @@ const pasteHTML = async (html: string) => {
       }),
     ])
   }, html)
+
+  await sleep(300)
 
   await page.keyboard.down('Shift')
   await page.keyboard.press('Insert')

--- a/src/e2e/puppeteer/__tests__/gesture-diagram.ts
+++ b/src/e2e/puppeteer/__tests__/gesture-diagram.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import openModal from '../helpers/openModal'
 import screenshot from '../helpers/screenshot'
@@ -18,9 +17,6 @@ vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
 
 it('GestureDiagram', async () => {
   await openModal('testGestureDiagram')
-
-  // wait for modal to fade in
-  await sleep(400)
 
   const image = await screenshot()
   expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -47,9 +47,6 @@ const testSuite = () => {
           - b
       `)
 
-      // wait for render animation to complete
-      await sleep(1000)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -65,9 +65,6 @@ const testSuite = () => {
 
       await press('ArrowUp')
 
-      // wait for render animation to complete
-      await sleep(800)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })
@@ -97,9 +94,6 @@ const testSuite = () => {
 
       await press('ArrowUp')
 
-      // wait for render animation to complete
-      await sleep(1000)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })
@@ -120,9 +114,6 @@ const testSuite = () => {
       // move cursor to the multiline thought
       await press('ArrowUp')
       await press('ArrowUp')
-
-      // wait for render animation to complete
-      await sleep(1000)
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
@@ -155,9 +146,6 @@ const testSuite = () => {
       `)
 
       await press('ArrowUp')
-
-      // wait for render animation to complete
-      await sleep(1000)
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -126,9 +126,6 @@ const testSuite = () => {
 
       await press('ArrowUp')
 
-      // wait for render animation to complete
-      await sleep(1000)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })
@@ -157,9 +154,6 @@ describe('Font Size: 18 (default)', () => {
 
 describe('Font Size: 13', () => {
   beforeEach(async () => {
-    // TODO: identify what needs to be waited for specifically
-    await sleep(1000)
-
     await click('[data-testid=decrease-font]') // 17
     await click('[data-testid=decrease-font]') // 16
     await click('[data-testid=decrease-font]') // 15
@@ -171,9 +165,6 @@ describe('Font Size: 13', () => {
 
     // scroll to top
     await scroll(0, 0)
-
-    // wait for toolbar size transitions to complete
-    await sleep(400)
   })
 
   // run the snapshot tests at font size 14

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -25,7 +25,6 @@ vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
 const testSuite = () => {
   describe('', () => {
     it('initial load', async () => {
-      await sleep(1000)
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -165,6 +165,9 @@ describe('Font Size: 13', () => {
 
     // scroll to top
     await scroll(0, 0)
+
+    // wait for toolbar size transitions to complete
+    await sleep(400)
   })
 
   // run the snapshot tests at font size 14
@@ -173,9 +176,6 @@ describe('Font Size: 13', () => {
 
 describe('Font Size: 22', () => {
   beforeEach(async () => {
-    // TODO: identify what needs to be waited for specifically
-    await sleep(1000)
-
     await click('[data-testid=increase-font]') // 19
     await click('[data-testid=increase-font]') // 20
     await click('[data-testid=increase-font]') // 21

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -76,9 +76,6 @@ const testSuite = () => {
         - c
       `)
 
-      // wait for render animation to complete
-      await sleep(1000)
-
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -36,7 +36,6 @@ const testSuite = () => {
     it('one thought', async () => {
       await press('Enter')
       await type('a')
-      await sleep(1000)
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/url.ts
+++ b/src/e2e/puppeteer/__tests__/url.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import click from '../helpers/click'
 import hideHUD from '../helpers/hideHUD'
@@ -36,9 +35,6 @@ it.skip('single line', async () => {
 
   await press('ArrowUp')
 
-  // wait for render animation to complete
-  await sleep(1000)
-
   const image = await screenshot()
   expect(image).toMatchImageSnapshot()
 })
@@ -61,9 +57,6 @@ describe('multiline', () => {
 
     await press('ArrowUp')
 
-    // wait for render animation to complete
-    await sleep(1000)
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   }
@@ -71,9 +64,6 @@ describe('multiline', () => {
   it('Font Size: 18 (default)', multilineTest)
 
   it('Font Size: 13', async () => {
-    // TODO: identify what needs to be waited for specifically
-    await sleep(1000)
-
     await click('[data-testid=decrease-font]') // 17
     await click('[data-testid=decrease-font]') // 16
     await click('[data-testid=decrease-font]') // 15
@@ -101,9 +91,6 @@ it('collapsed thought with url child', async () => {
   `)
 
   await press('Escape')
-
-  // wait for render animation to complete
-  await sleep(1000)
 
   const image = await screenshot()
   expect(image).toMatchImageSnapshot()


### PR DESCRIPTION
This PR removes the bulk of the `sleep` calls from the puppeteer e2e tests resulting in a clean run of the e2e tests taking only ~38 seconds instead of ~60 on my machine and gets us pretty close to completing #2110.

These removals were the ones that were "easy" (i.e., didn't require any additional work beyond removing the `sleep` call itself). I suspect that it is highly likely we will get intermittent failures but they are rare enough that I cannot tell how often they will appear; it's entirely possible that they will be environment specific (e.g., they may appear more often or less often depending on the speed of the machine). 

IMO we've cut the time down by 1/3 so even if we have to rerun a test or two occasionally it's unlikely to negate the gains in this PR. 