### PR TITLE
Add toolbarPointerEvents recipe for typesafe pointer-events override

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -17,6 +17,7 @@ import modalTextRecipe from './src/recipes/modalText'
 import multilineRecipe from './src/recipes/multiline'
 import textNoteRecipe from './src/recipes/textNote'
 import thoughtRecipe from './src/recipes/thought'
+import toolbarPointerEventsRecipe from './src/recipes/toolbarPointerEvents'
 import tutorialBulletRecipe from './src/recipes/tutorialBullet'
 import upperRightRecipe from './src/recipes/upperRight'
 import convertColorsToPandaCSS from './src/util/convertColorsToPandaCSS'
@@ -329,6 +330,7 @@ export default defineConfig({
         editable: editableRecipe,
         textNote: textNoteRecipe,
         multiline: multilineRecipe,
+        toolbarPointerEvents: toolbarPointerEventsRecipe,
         tutorialBullet: tutorialBulletRecipe,
         upperRight: upperRightRecipe,
         dropHover: dropHoverRecipe,

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -11,7 +11,8 @@ Test:
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
-import { css, cva } from '../../styled-system/css'
+import { css, cva, cx } from '../../styled-system/css'
+import { toolbarPointerEvents } from '../../styled-system/recipes'
 import ShortcutType from '../@types/Shortcut'
 import ShortcutId from '../@types/ShortcutId'
 import TipId from '../@types/TipId'
@@ -197,22 +198,27 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
       <div
         ref={toolbarContainerRef}
         aria-label='toolbar'
-        className={css({
-          position: 'relative',
-          textAlign: 'right',
-          maxWidth: '100%',
-          userSelect: 'none',
-          WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
-          whiteSpace: 'nowrap',
-          ...(!customize && {
-            position: 'fixed',
-            top: '0',
-            right: '0',
-            zIndex: 'toolbarContainer',
-            marginTop: '-500px',
-            paddingTop: '500px',
+        className={cx(
+          // Set pointer-events to none, otherwise the toolbar will block the editor when a dropdown is open.
+          // This will need to be overridden by the toolbar buttons.
+          toolbarPointerEvents(),
+          css({
+            position: 'relative',
+            textAlign: 'right',
+            maxWidth: '100%',
+            userSelect: 'none',
+            WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            ...(!customize && {
+              position: 'fixed',
+              top: '0',
+              right: '0',
+              zIndex: 'toolbarContainer',
+              marginTop: '-500px',
+              paddingTop: '500px',
+            }),
           }),
-        })}
+        )}
         style={{
           // make toolbar flush with left padding
           marginLeft: customize ? -5 : 0,

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -1,6 +1,7 @@
 import React, { FC, MutableRefObject, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { css } from '../../styled-system/css'
+import { css, cx } from '../../styled-system/css'
+import { toolbarPointerEvents } from '../../styled-system/recipes'
 import { token } from '../../styled-system/tokens'
 import DragShortcutZone from '../@types/DragShortcutZone'
 import Icon from '../@types/Icon'
@@ -148,35 +149,39 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
       ref={node => dragSource(dropTarget(node))}
       key={shortcutId}
       title={`${shortcut.label}${(shortcut.keyboard ?? shortcut.overlay?.keyboard) ? ` (${formatKeyboardShortcut((shortcut.keyboard ?? shortcut.overlay?.keyboard)!)})` : ''}${buttonError ? '\nError: ' + buttonError : ''}`}
-      className={css({
-        display: 'inline-block',
-        padding: '15px 8px 5px 8px',
-        borderRadius: '3px',
-        zIndex: 'stack', // animate maxWidth to avoid having to know the exact width of the toolbar icon
-        // maxWidth just needs to exceed the width
-        maxWidth: fontSize * 2,
-        ...(dropToRemove
-          ? {
-              // offset 1toolbar-icon padding
-              marginLeft: -10,
-              maxWidth: 10,
-            }
-          : null),
-        // offset top to avoid changing container height
-        // marginBottom: isPressing ? -10 : 0,
-        // top: isButtonExecutable && isPressing ? 10 : 0,
-        transform:
-          isButtonExecutable && isPressing && !longPress.isPressed && !isDragging
-            ? `translateY(0.25em)`
-            : `translateY(0em)`,
-        position: 'relative',
-        cursor: isButtonExecutable ? 'pointer' : 'default',
-        transition:
-          'transform {durations.slowDuration} ease-out, max-width {durations.slowDuration} ease-out, margin-left {durations.slowDuration} ease-out',
-        // extend drop area down, otherwise the drop hover is blocked by the user's finger
-        // must match toolbar marginBottom
-        paddingBottom: isDraggingAny ? '7em' : 0,
-      })}
+      className={cx(
+        // Override the Toolbar's pointer-events: none to restore pointer behavior.
+        toolbarPointerEvents({ override: true }),
+        css({
+          display: 'inline-block',
+          padding: '15px 8px 5px 8px',
+          borderRadius: '3px',
+          zIndex: 'stack', // animate maxWidth to avoid having to know the exact width of the toolbar icon
+          // maxWidth just needs to exceed the width
+          maxWidth: fontSize * 2,
+          ...(dropToRemove
+            ? {
+                // offset 1toolbar-icon padding
+                marginLeft: -10,
+                maxWidth: 10,
+              }
+            : null),
+          // offset top to avoid changing container height
+          // marginBottom: isPressing ? -10 : 0,
+          // top: isButtonExecutable && isPressing ? 10 : 0,
+          transform:
+            isButtonExecutable && isPressing && !longPress.isPressed && !isDragging
+              ? `translateY(0.25em)`
+              : `translateY(0em)`,
+          position: 'relative',
+          cursor: isButtonExecutable ? 'pointer' : 'default',
+          transition:
+            'transform {durations.slowDuration} ease-out, max-width {durations.slowDuration} ease-out, margin-left {durations.slowDuration} ease-out',
+          // extend drop area down, otherwise the drop hover is blocked by the user's finger
+          // must match toolbar marginBottom
+          paddingBottom: isDraggingAny ? '7em' : 0,
+        }),
+      )}
       onMouseLeave={onMouseLeave}
       {...fastClick(tapUp, tapDown, undefined, touchMove)}
     >

--- a/src/recipes/toolbarPointerEvents.ts
+++ b/src/recipes/toolbarPointerEvents.ts
@@ -1,0 +1,18 @@
+import { defineRecipe } from '@pandacss/dev'
+
+const toolbarPointerEventsRecipe = defineRecipe({
+  className: 'toolbar-pointer-events',
+  description: 'A typesafe way to override pointerEvents: none on the Toolbar component.',
+  base: {
+    pointerEvents: 'none',
+  },
+  variants: {
+    override: {
+      true: {
+        pointerEvents: 'auto',
+      },
+    },
+  },
+})
+
+export default toolbarPointerEventsRecipe


### PR DESCRIPTION
# Problem

In cases where `pointer-events: none` needs to be overridden, there is an implicit relationship between the base and the override. For example, Toolbar needs `pointer-events: none` and ToolbarButton needs to override it with `pointer-events: auto` (in order to avoid blocking clicks in the editor when a dropdown menu is open). 

This may produce the correct behavior for the user, but the relationship between the base and the override are not enforced by the type system if implemented in a simple `css` call. This makes it easy for one value to be inadvertently changed in the future, when in fact they are tightly coupled.

# Solution

A recipe is created to apply `pointer-events: none` and override it with `pointer-events: auto` as needed. This creates an explicit link between their usage and provides a traceable type for developers to understand the impact of changing either one.

# Alternatives

The same effect could be accomplished with a pair of Javascript constants without the use of Panda.