### PR TITLE
Cursor offset should not block deleteEmptyThought

### DIFF
--- a/src/actions/__tests__/deleteEmptyThought.ts
+++ b/src/actions/__tests__/deleteEmptyThought.ts
@@ -126,6 +126,24 @@ describe('normal view', () => {
   - ab`)
   })
 
+  it('merge thoughts multiple times', () => {
+    // set the cursor
+    const steps = [
+      newThought('a'),
+      newThought('b'),
+      newThought('c'),
+      setCursor(['c']),
+      deleteEmptyThought,
+      deleteEmptyThought,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - abc`)
+  })
+
   it(`insert second thought's children`, () => {
     const steps = [
       newThought('a'),

--- a/src/actions/deleteEmptyThought.ts
+++ b/src/actions/deleteEmptyThought.ts
@@ -36,7 +36,6 @@ const deleteEmptyThought = (state: State): State => {
   const cursorThought = getThoughtById(state, head(cursor))
   const { value } = cursorThought
 
-  const offset = state.cursorOffset ?? 0
   const showContexts = isContextViewActive(state, rootedParentOf(state, cursor))
   const simplePath = simplifyPath(state, cursor)
   const allChildren = getChildrenRanked(state, head(cursor))

--- a/src/actions/deleteEmptyThought.ts
+++ b/src/actions/deleteEmptyThought.ts
@@ -86,7 +86,7 @@ const deleteEmptyThought = (state: State): State => {
     ])(state)
   }
   // delete from beginning and merge with previous sibling
-  else if (offset === 0 && !showContexts) {
+  else if (!showContexts) {
     const { value, splitSource } = cursorThought
     const prev = prevSibling(state, cursor)
 

--- a/src/e2e/puppeteer/__tests__/caret.ts
+++ b/src/e2e/puppeteer/__tests__/caret.ts
@@ -167,6 +167,38 @@ describe('all platforms', () => {
     const offset = await getSelection().focusOffset
     expect(offset).toBe(1)
   })
+
+  it('clicking backspace when the caret is at the beginning of a thought should merge it with the previous thought.', async () => {
+    const importText = `
+    - first
+    - last`
+
+    await paste(importText)
+
+    const editableNodeHandle = await waitForEditable('last')
+
+    await click(editableNodeHandle, { edge: 'left' })
+    await press('Backspace')
+
+    const textContext = await getSelection().focusNode?.textContent
+    expect(textContext).toBe('firstlast')
+  })
+})
+
+it('clicking backspace when the caret is at the end of a thought should delete a character.', async () => {
+  const importText = `
+  - first
+  - last`
+
+  await paste(importText)
+
+  const editableNodeHandle = await waitForEditable('last')
+
+  await click(editableNodeHandle, { edge: 'right' })
+  await press('Backspace')
+
+  const textContext = await getSelection().focusNode?.textContent
+  expect(textContext).toBe('las')
 })
 
 describe('mobile only', () => {


### PR DESCRIPTION
#1598 

Some notes for the future 🚀

* `state.cursorOffset` is not updated by keyboard/mouse events. It is set manually and infrequently, and this seems like a good opportunity to reduce its responsibilities
* [deleteEmptyThoughtOrOutdent](https://github.com/cybersemics/em/blob/main/src/shortcuts/deleteEmptyThoughtOrOutdent.tsx) decides whether the `deleteEmptyThought` action can be dispatched, and it directly checks the browser selection API to see if the caret is at the beginning of the cursor
* storing the `caretOffset` in `ministore` probably makes sense, but we can put off doing it for now because this is not a reactive context, and we would currently only access the store from a single place