### PR TITLE
ColorPicker: remove empty <font> element

### DIFF
--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -2,8 +2,6 @@ import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
-import press from '../helpers/press'
-// import refresh from '../helpers/refresh'
 import waitForEditable from '../helpers/waitForEditable'
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
@@ -33,8 +31,6 @@ it('Set the text color of the text', async () => {
   await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
   await click('[aria-label="text color swatches"] [aria-label="blue"]')
 
-  await press('ArrowUp')
-  await press('ArrowDown')
   const cursorText = await getEditingText()
   const result = extractStyleProperty(cursorText!)
   expect(result?.color).toBe('#00c7e6')
@@ -77,8 +73,6 @@ it('Clear the background color when selecting text color', async () => {
   expect(extractStyleProperty(cursorText!)?.color).toBe('#000000')
 
   await click('[aria-label="text color swatches"] [aria-label="purple"]')
-  await press('ArrowUp')
-  await press('ArrowDown')
   cursorText = await getEditingText()
   expect(extractStyleProperty(cursorText!)?.color).toBe('#aa80ff')
   expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe(null)
@@ -107,7 +101,25 @@ it('Clear the text color when setting background color', async () => {
   expect(extractStyleProperty(cursorText!)?.color).toBe('#000000')
 })
 
-it('Empty <font> or <span> element will be removed after setting color to default.', async () => {
+it('Empty <font> element will be removed after setting color to default.', async () => {
+  const importText = `
+  - Labrador
+  - Golden Retriever`
+
+  await paste(importText)
+
+  await waitForEditable('Golden Retriever')
+  await clickThought('Golden Retriever')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="background color swatches"] [aria-label="blue"]')
+
+  await click('[aria-label="text color swatches"] [aria-label="default"]')
+  const result = await getEditingText()
+  expect(result).toBe('Golden Retriever')
+})
+
+it('Empty <span> element will be removed after setting color to default.', async () => {
   const importText = `
   - Labrador
   - Golden Retriever`
@@ -121,8 +133,7 @@ it('Empty <font> or <span> element will be removed after setting color to defaul
   await click('[aria-label="text color swatches"] [aria-label="blue"]')
 
   await click('[aria-label="text color swatches"] [aria-label="default"]')
-  await clickThought('Labrador')
-  await clickThought('Golden Retriever')
+
   const result = await getEditingText()
   expect(result).toBe('Golden Retriever')
 })

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -2,6 +2,8 @@ import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
+import press from '../helpers/press'
+// import refresh from '../helpers/refresh'
 import waitForEditable from '../helpers/waitForEditable'
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
@@ -20,8 +22,8 @@ const extractStyleProperty = (html: string) => {
 
 it('Set the text color of the text', async () => {
   const importText = `
-    - Labrador
-    - Golden Retriever`
+  - Labrador
+  - Golden Retriever`
 
   await paste(importText)
 
@@ -31,10 +33,12 @@ it('Set the text color of the text', async () => {
   await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
   await click('[aria-label="text color swatches"] [aria-label="blue"]')
 
+  await press('ArrowUp')
+  await press('ArrowDown')
   const cursorText = await getEditingText()
   const result = extractStyleProperty(cursorText!)
   expect(result?.color).toBe('#00c7e6')
-  expect(result?.backgroundColor).toBe('rgb(0, 0, 0)')
+  expect(result?.backgroundColor).toBe(null)
 })
 
 it('Set the background color of the text', async () => {
@@ -54,28 +58,6 @@ it('Set the background color of the text', async () => {
   expect(result?.backgroundColor).toBe('rgb(0, 214, 136)')
 })
 
-it('Clear the text color when selecting white', async () => {
-  const importText = `
-    - Labrador
-    - Golden Retriever`
-
-  await paste(importText)
-
-  await waitForEditable('Golden Retriever')
-  await clickThought('Golden Retriever')
-  let cursorText = await getEditingText()
-  expect(extractStyleProperty(cursorText!)?.color).toBe(null)
-
-  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
-  await click('[aria-label="text color swatches"] [aria-label="green"]')
-  cursorText = await getEditingText()
-  expect(extractStyleProperty(cursorText!)?.color).toBe('#00d688')
-
-  await click('[aria-label="text color swatches"] [aria-label="default"]')
-  cursorText = await getEditingText()
-  expect(extractStyleProperty(cursorText!)?.color).toBe(null)
-})
-
 it('Clear the background color when selecting text color', async () => {
   const importText = `
     - Labrador
@@ -92,11 +74,14 @@ it('Clear the background color when selecting text color', async () => {
   await click('[aria-label="background color swatches"] [aria-label="green"]')
   cursorText = await getEditingText()
   expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe('rgb(0, 214, 136)')
+  expect(extractStyleProperty(cursorText!)?.color).toBe('#000000')
 
   await click('[aria-label="text color swatches"] [aria-label="purple"]')
+  await press('ArrowUp')
+  await press('ArrowDown')
   cursorText = await getEditingText()
   expect(extractStyleProperty(cursorText!)?.color).toBe('#aa80ff')
-  expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe('rgb(0, 0, 0)')
+  expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe(null)
 })
 
 it('Clear the text color when setting background color', async () => {
@@ -120,4 +105,24 @@ it('Clear the text color when setting background color', async () => {
   cursorText = await getEditingText()
   expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe('rgb(170, 128, 255)')
   expect(extractStyleProperty(cursorText!)?.color).toBe('#000000')
+})
+
+it('Empty <font> or <span> element will be removed after setting color to default.', async () => {
+  const importText = `
+  - Labrador
+  - Golden Retriever`
+
+  await paste(importText)
+
+  await waitForEditable('Golden Retriever')
+  await clickThought('Golden Retriever')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="blue"]')
+
+  await click('[aria-label="text color swatches"] [aria-label="default"]')
+  await clickThought('Labrador')
+  await clickThought('Golden Retriever')
+  const result = await getEditingText()
+  expect(result).toBe('Golden Retriever')
 })


### PR DESCRIPTION
Remove empty <font> element after setting text color to default.
Issue : #2469 
Remove the empty <font> and <span> elements in formatSelection.
Also fix this issue : Black background color not stripped from ContentEditable #2548