### PR TITLE
Wait for drag state to settle in puppeteer tests

### DIFF
--- a/src/components/QuickDropPanel.tsx
+++ b/src/components/QuickDropPanel.tsx
@@ -22,7 +22,11 @@ const QuickDropPanel = () => {
       classNames='slide-right'
       unmountOnExit
     >
-      <div ref={quickDropPanelRef} className={css({ position: 'fixed', right: 0, top: '20vh', zIndex: 'popup' })}>
+      <div
+        ref={quickDropPanelRef}
+        className={css({ position: 'fixed', right: 0, top: '20vh', zIndex: 'popup' })}
+        data-testid='quick-drop-panel'
+      >
         <DeleteDrop />
         {
           // CopyOneDrop does not work on Mobile Safari, so temporarily disable it.

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -6,8 +6,6 @@ import hideHUD from '../helpers/hideHUD'
 import paste from '../helpers/paste'
 import screenshot from '../helpers/screenshot'
 import simulateDragAndDrop from '../helpers/simulateDragAndDrop'
-import popup from '../locators/popup'
-import quickDropPanel from '../locators/quickDropPanel'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -20,12 +18,6 @@ vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
   Jest supports automatic retries on test failures. This can be useful for browser screenshot tests which tend to have more frequent false positives. Note that when using jest.retryTimes you'll have to use a unique customSnapshotIdentifier as that's the only way to reliably identify snapshots.
 
 */
-
-/** Waits for the expected drag state. */
-const waitForDraggingState = async () => {
-  await quickDropPanel()
-  await popup()
-}
 
 describe('drag', () => {
   beforeEach(hideHUD)
@@ -40,8 +32,6 @@ describe('drag', () => {
 
     await dragAndDropThought('a', 'd', { position: 'after' })
 
-    await waitForDraggingState()
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -55,8 +45,6 @@ describe('drag', () => {
       `)
 
     await dragAndDropThought('a', 'b', { position: 'child' })
-
-    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -73,8 +61,6 @@ describe('drag', () => {
     await clickThought('a')
 
     await dragAndDropThought('x', 'c', { position: 'after' })
-
-    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -93,8 +79,6 @@ describe('drag', () => {
     await clickThought('b')
     await clickThought('c')
     await dragAndDropThought('c', 'e', { position: 'before', dropUncle: true })
-
-    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -117,8 +101,6 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'after', dropUncle: true })
 
-    await waitForDraggingState()
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -140,8 +122,6 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'c', { position: 'after' })
 
-    await waitForDraggingState()
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -162,8 +142,6 @@ describe('drag', () => {
 
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'after' })
-
-    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -188,8 +166,6 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'before' })
 
-    await waitForDraggingState()
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -211,8 +187,6 @@ describe('drag', () => {
     await clickThought('b')
     await dragAndDropThought('e', 'f', { position: 'after' })
 
-    await waitForDraggingState()
-
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -227,8 +201,6 @@ describe('drag', () => {
     await simulateDragAndDrop({ drop: true })
 
     await dragAndDropThought('b', 'c', { position: 'after' })
-
-    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -277,8 +249,6 @@ describe('drop', () => {
       `)
 
       await dragAndDropThought('c', 'c', { position: 'after' })
-
-      await waitForDraggingState()
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -27,11 +27,6 @@ const waitForDraggingState = async () => {
   await popup()
 }
 
-/** Waits for the expected post-drop state. */
-const waitForDroppedState = async () => {
-  await popup()
-}
-
 describe('drag', () => {
   beforeEach(hideHUD)
 

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -6,6 +6,8 @@ import hideHUD from '../helpers/hideHUD'
 import paste from '../helpers/paste'
 import screenshot from '../helpers/screenshot'
 import simulateDragAndDrop from '../helpers/simulateDragAndDrop'
+import popup from '../locators/popup'
+import quickDropPanel from '../locators/quickDropPanel'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -18,6 +20,17 @@ vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
   Jest supports automatic retries on test failures. This can be useful for browser screenshot tests which tend to have more frequent false positives. Note that when using jest.retryTimes you'll have to use a unique customSnapshotIdentifier as that's the only way to reliably identify snapshots.
 
 */
+
+/** Waits for the expected drag state. */
+const waitForDraggingState = async () => {
+  await quickDropPanel()
+  await popup()
+}
+
+/** Waits for the expected post-drop state. */
+const waitForDroppedState = async () => {
+  await popup()
+}
 
 describe('drag', () => {
   beforeEach(hideHUD)
@@ -32,6 +45,8 @@ describe('drag', () => {
 
     await dragAndDropThought('a', 'd', { position: 'after' })
 
+    await waitForDraggingState()
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -45,6 +60,8 @@ describe('drag', () => {
       `)
 
     await dragAndDropThought('a', 'b', { position: 'child' })
+
+    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -61,6 +78,8 @@ describe('drag', () => {
     await clickThought('a')
 
     await dragAndDropThought('x', 'c', { position: 'after' })
+
+    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -79,6 +98,8 @@ describe('drag', () => {
     await clickThought('b')
     await clickThought('c')
     await dragAndDropThought('c', 'e', { position: 'before', dropUncle: true })
+
+    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -101,6 +122,8 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'after', dropUncle: true })
 
+    await waitForDraggingState()
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -122,6 +145,8 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'c', { position: 'after' })
 
+    await waitForDraggingState()
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -142,6 +167,8 @@ describe('drag', () => {
 
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'after' })
+
+    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -166,6 +193,8 @@ describe('drag', () => {
     await clickThought('x')
     await dragAndDropThought('x', 'd', { position: 'before' })
 
+    await waitForDraggingState()
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -187,6 +216,8 @@ describe('drag', () => {
     await clickThought('b')
     await dragAndDropThought('e', 'f', { position: 'after' })
 
+    await waitForDraggingState()
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -201,6 +232,8 @@ describe('drag', () => {
     await simulateDragAndDrop({ drop: true })
 
     await dragAndDropThought('b', 'c', { position: 'after' })
+
+    await waitForDraggingState()
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
@@ -221,6 +254,7 @@ describe('drop', () => {
       `)
 
     await dragAndDropThought('a', 'd', { position: 'after', mouseUp: true })
+
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
   })
@@ -248,6 +282,8 @@ describe('drop', () => {
       `)
 
       await dragAndDropThought('c', 'c', { position: 'after' })
+
+      await waitForDraggingState()
 
       const image = await screenshot()
       expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -1,4 +1,6 @@
 import sleep from '../../../util/sleep'
+import popup from '../locators/popup'
+import quickDropPanel from '../locators/quickDropPanel'
 import { page } from '../setup'
 import getEditable from './getEditable'
 import showMousePointer from './showMousePointer'
@@ -75,6 +77,10 @@ const dragAndDropThought = async (
     await page.mouse.up()
     await sleep(500)
   }
+
+  // wait for QuickDrop panel and Alert appear so that snapshots are consistent
+  await quickDropPanel()
+  await popup()
 }
 
 export default dragAndDropThought

--- a/src/e2e/puppeteer/locators/popup.ts
+++ b/src/e2e/puppeteer/locators/popup.ts
@@ -1,6 +1,6 @@
 import { page } from '../setup'
 
-/** Returns the QuickDropPanel element. */
+/** Returns the popup element. */
 const popup = () => page.locator('[data-testid="popup-value"]').wait()
 
 export default popup

--- a/src/e2e/puppeteer/locators/popup.ts
+++ b/src/e2e/puppeteer/locators/popup.ts
@@ -1,0 +1,6 @@
+import { page } from '../setup'
+
+/** Returns the QuickDropPanel element. */
+const popup = () => page.locator('[data-testid="popup-value"]').wait()
+
+export default popup

--- a/src/e2e/puppeteer/locators/quickDropPanel.ts
+++ b/src/e2e/puppeteer/locators/quickDropPanel.ts
@@ -1,0 +1,6 @@
+import { page } from '../setup'
+
+/** Returns the QuickDropPanel element. */
+const quickDropPanel = () => page.locator('[data-testid="quick-drop-panel"]').wait()
+
+export default quickDropPanel


### PR DESCRIPTION
This PR includes a possible implementation of code that will wait for state settlement in the Puppeteer tests. 

In particular, the issue is that there may be state propagation timing issues in the puppeteer tests. For example, let's say that we simulate a drag event that results in the `dragInProgress` state variable being set to true. When the `dragInProgress` state variable is set to `true`, an alert is displayed and the quick drop panel slides out from the right side of the screen. However, because the puppeteer tests run independently of the application itself, there is a possibility that puppeteer may take a snapshot of the browser prior to the application rendering the alert and quick drop panel, causing the test to fail.

In this example, we have a function that defines the settled state by checking for the alert and the quick drop panel prior to taking the snapshot.

I cannot recreate the test failures with the drag and drop test so I'm having difficulty verifying that this works.