### PR TITLE
Colors to design tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,9 @@
 
       // Load theme synchronously before React loads, otherwise it causes a white flash.
       const theme = localStorage.getItem('storageCache/theme')?.toLowerCase() || 'dark'
-      document.body.style.backgroundColor = theme === 'dark' ? '#000' : '#fff'
+      document.documentElement.style.backgroundColor = theme === 'dark' ? '#000' : '#fff'
       document.body.setAttribute('data-color-mode', theme)
       document.body.setAttribute('data-env', navigator.webdriver ? 'test' : '%MODE%')
-      document.body.classList.add(theme)
     </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -162,7 +162,7 @@ const globalCss = defineGlobalStyles({
     cursor: 'pointer',
     textDecorationLine: 'underline',
     outline: 'none',
-    color: { base: '#1b6f9a', _dark: '#87ceeb' },
+    color: 'link',
     fontWeight: 400,
     userSelect: 'none',
   },
@@ -198,10 +198,7 @@ const globalCss = defineGlobalStyles({
     marginBottom: '2vh',
   },
   'input:focus': {
-    border: {
-      base: 'solid 1px #eee',
-      _dark: 'solid 1px #999',
-    },
+    border: 'solid 1px {colors.inputBorder}',
     outline: '0 none',
   },
   /** Aligns checkbox and label vertically. */
@@ -223,7 +220,7 @@ const globalCss = defineGlobalStyles({
     backgroundColor: 'bg',
   },
   code: {
-    backgroundColor: { base: '#ccc', _dark: '#333' },
+    backgroundColor: 'codeBg',
     fontFamily: 'monospace',
   },
   'button[disabled]': {
@@ -240,7 +237,7 @@ const globalCss = defineGlobalStyles({
   /* :empty does not work because thought may contain <br> */
   '[placeholder]:empty::before': {
     fontStyle: 'italic',
-    color: { base: 'rgba(7, 7, 7, 0.5)', _dark: 'rgba(255, 255, 255, 0.5)' },
+    color: 'dim',
     content: 'attr(placeholder)',
     cursor: 'text',
   },
@@ -339,18 +336,6 @@ export default defineConfig({
       semanticTokens: {
         colors: {
           ...colorSemanticTokens,
-          bgMuted: {
-            value: {
-              base: '#ddd',
-              _dark: '#333',
-            },
-          },
-          dim: {
-            value: {
-              base: 'rgba(7, 7, 7, 0.5)',
-              _dark: 'rgba(255, 255, 255, 0.5)',
-            },
-          },
           invalidOption: {
             value: 'tomato !important',
           },

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -47,6 +47,9 @@ const colors = {
     transparent: 'transparent',
     bgTransparent: 'rgba(0, 0, 0, 0)',
     fgTransparent: 'rgba(255, 255, 255, 0)',
+    modalColor: 'rgba(227, 227, 227, 1)', // #e3e3e3
+    quickDropBgHover: 'rgba(40,40,40,0.8)',
+    quickDropBg: 'rgba(30,30,30,0.8)',
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
@@ -96,6 +99,9 @@ const colors = {
     transparent: 'transparent',
     fgTransparent: 'rgba(0, 0, 0, 0)',
     bgTransparent: 'rgba(255, 255, 255, 0)',
+    modalColor: 'rgba(28, 28, 28, 1)', // #1c1c1c
+    quickDropBgHover: 'rgba(215, 215, 215, 0.8)',
+    quickDropBg: 'rgba(225, 225, 225, 0.8)',
   },
 } as const
 

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -81,7 +81,7 @@ const colors = {
     gray15: 'rgba(38, 38, 38, 1)', // #262626
     gray33: 'rgba(85, 85, 85, 1)',
     gray50: 'rgba(128, 128, 128, 1)', // #808080 (gray)
-    gray66: 'rgba(169, 169, 169, 1)', // #a9a9a9
+    gray66: 'rgba(169, 169, 169, 1)', // #a9a9a9 (darkgray)
     gray: 'rgba(169, 169, 169, 1)', // #a9a9a9
     green: 'rgba(0, 214, 136, 1)', // #00d688
     highlight: 'rgba(65, 105, 225, 1)', // #4169e1 (royalblue)

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -29,13 +29,14 @@ const colors = {
     vividHighlight: '#63c9ea',
     white: 'rgba(255, 255, 255, 1)',
     yellow: 'rgba(255, 208, 20, 1)', // #ffd014
-    inputBorder: 'rgba(153, 153, 153, 1)', // #999
+    inputBorder: 'rgba(153, 153, 153, 1)', // #999, also used in navBar
+    breadcrumbs: 'rgba(153, 153, 153, 1)',
     link: 'rgba(135, 206, 235, 1)', // #87ceeb
     dim: 'rgba(255, 255, 255, 0.5)',
     dimInverse: 'rgba(7, 7, 7, 0.5)',
     bullet: 'rgba(217, 217, 217, 1)',
     codeBg: 'rgba(51, 51, 51, 1)', // #333333
-    modalExportUnused: 'rgba(68, 68, 68, 1)', // #444
+    modalExportUnused: 'rgba(68, 68, 68, 1)', // #444, used in dropdown menu
     divider: 'rgba(204, 204, 204, 1)',
     bgMuted: 'rgba(51, 51, 51, 1)', // #333
     footerBg: 'rgba(26, 26, 26, 1)', // #1a1a1a
@@ -50,6 +51,12 @@ const colors = {
     modalColor: 'rgba(227, 227, 227, 1)', // #e3e3e3
     quickDropBgHover: 'rgba(40,40,40,0.8)',
     quickDropBg: 'rgba(30,30,30,0.8)',
+    bulletGray: 'rgba(102, 102, 102, 1)', // #666
+    midPink: 'rgba(255, 123, 195, 1)', // #ff7bc3
+    purpleEggplant: '#32305f', // purple-eggplant
+    commandSelected: 'rgba(33, 33, 33, 1)', // #212121
+    eggplant: 'rgba(82, 48, 95, 1)', // eggplant
+    checkboxForm: 'rgba(62, 62, 62, 1)', // #3e3e3e
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
@@ -82,6 +89,7 @@ const colors = {
     vividHighlight: '#63c9ea',
     yellow: 'rgba(255, 208, 20, 1)', // #ffd014
     inputBorder: 'rgba(238, 238, 238, 1)', // #eeeeee
+    breadcrumbs: 'rgba(102, 102, 102, 1)',
     link: 'rgba(27, 111, 154, 1)', // #1b6f9a
     dim: 'rgba(7, 7, 7, 0.5)',
     dimInverse: 'rgba(255, 255, 255, 0.5)',
@@ -102,6 +110,12 @@ const colors = {
     modalColor: 'rgba(28, 28, 28, 1)', // #1c1c1c
     quickDropBgHover: 'rgba(215, 215, 215, 0.8)',
     quickDropBg: 'rgba(225, 225, 225, 0.8)',
+    bulletGray: 'rgba(153, 153, 153, 1)', // #999999
+    midPink: 'rgba(255, 123, 195, 1)',
+    purpleEggplant: '#32305f', // purple-eggplant
+    commandSelected: 'rgba(222, 222, 222, 1)',
+    eggplant: 'rgb(85, 51, 98)', // eggplant
+    checkboxForm: 'rgba(193, 193, 193, 1)',
   },
 } as const
 

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -78,10 +78,10 @@ const colors = {
     fgOverlay80: 'rgba(235, 235, 235, 0.8)',
     fgOverlay90: 'rgba(235, 235, 235, 0.9)',
     fgOverlay50: 'rgba(0, 0, 0, 0.5)',
-    gray15: 'rgba(38, 38, 38, 1)', // #262626
-    gray33: 'rgba(85, 85, 85, 1)',
+    gray15: 'rgba(217, 217, 217, 1)', // #262626
+    gray33: 'rgba(170, 170, 170, 1)',
     gray50: 'rgba(128, 128, 128, 1)', // #808080 (gray)
-    gray66: 'rgba(169, 169, 169, 1)', // #a9a9a9 (darkgray)
+    gray66: 'rgba(86, 86, 86, 1)', // #a9a9a9 (darkgray)
     gray: 'rgba(169, 169, 169, 1)', // #a9a9a9
     green: 'rgba(0, 214, 136, 1)', // #00d688
     highlight: 'rgba(65, 105, 225, 1)', // #4169e1 (royalblue)

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -3,6 +3,7 @@ const colors = {
     // Background colors in capacitor app needs to be in hexadecimal codes
     bg: '#000000',
     bgOverlay80: 'rgba(0, 0, 0, 0.8)',
+    bgOverlay30: 'rgba(0, 0, 0, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
     darkgray: 'rgba(17, 17, 17, 1)', // #111111
@@ -31,6 +32,7 @@ const colors = {
     // Background colors in capacitor app needs to be in hexadecimal codes
     bg: '#FFFFFF',
     bgOverlay80: 'rgba(0, 0, 0, 0.8)',
+    bgOverlay30: 'rgba(255, 255, 255, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
     darkgray: 'rgba(17, 17, 17, 1)', // #111111

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -119,7 +119,7 @@ const colors = {
     quickDropBg: 'rgba(225, 225, 225, 0.8)',
     bulletGray: 'rgba(153, 153, 153, 1)', // #999999
     midPink: 'rgba(255, 123, 195, 1)',
-    purpleEggplant: '#32305f', // purple-eggplant
+    purpleEggplant: '#32305f',
     commandSelected: 'rgba(222, 222, 222, 1)',
     eggplant: 'rgb(85, 51, 98)', // eggplant
     checkboxForm: 'rgba(193, 193, 193, 1)',

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -56,7 +56,7 @@ const colors = {
     midPink: 'rgba(255, 123, 195, 1)', // #ff7bc3
     purpleEggplant: '#32305f', // purple-eggplant
     commandSelected: 'rgba(33, 33, 33, 1)', // #212121
-    eggplant: 'rgba(82, 48, 95, 1)', // eggplant
+    eggplant: 'rgba(82, 48, 95, 1)',
     checkboxForm: 'rgba(62, 62, 62, 1)', // #3e3e3e
     error: 'rgba(204, 34, 51, 1)',
     activeBreadCrumb: 'rgba(144, 144, 144, 1)', // #909090

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -17,7 +17,7 @@ const colors = {
     gray33: 'rgba(85, 85, 85, 1)',
     gray50: 'rgba(128, 128, 128, 1)', // #808080 (gray)
     gray66: 'rgba(169, 169, 169, 1)', // #a9a9a9
-    gray: 'rgba(169, 169, 169, 1)', // #a9a9a9
+    gray: 'rgba(169, 169, 169, 1)', // #a9a9a9, this is used for disabled things + text color, unlike gray66 it is the same for both light and dark
     green: 'rgba(0, 214, 136, 1)', // #00d688
     highlight: 'rgba(173, 216, 230, 1)', // #add8e6 (lightblue)
     highlight2: 'rgba(155, 170, 220, 1)', // (slight variation on highlight color for alternating highlights)

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -36,6 +36,7 @@ const colors = {
     dimInverse: 'rgba(7, 7, 7, 0.5)',
     bullet: 'rgba(217, 217, 217, 1)',
     codeBg: 'rgba(51, 51, 51, 1)', // #333333
+    codeBgInverse: 'rgba(204, 204, 204, 1)', // #cccccc
     modalExportUnused: 'rgba(68, 68, 68, 1)', // #444, used in dropdown menu
     divider: 'rgba(204, 204, 204, 1)',
     bgMuted: 'rgba(51, 51, 51, 1)', // #333
@@ -57,6 +58,11 @@ const colors = {
     commandSelected: 'rgba(33, 33, 33, 1)', // #212121
     eggplant: 'rgba(82, 48, 95, 1)', // eggplant
     checkboxForm: 'rgba(62, 62, 62, 1)', // #3e3e3e
+    error: 'rgba(204, 34, 51, 1)',
+    activeBreadCrumb: 'rgba(144, 144, 144, 1)', // #909090
+    pinkRed: 'rgba(233, 12, 89, 1)',
+    brightBlue: 'rgba(70, 223, 240, 1)', // #46dff0
+    exportTextareaColor: 'rgba(170, 170, 170, 1)', // #aaa, also used in anchorButton
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
@@ -66,7 +72,7 @@ const colors = {
     bgOverlay30: 'rgba(255, 255, 255, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
-    darkgray: 'rgba(17, 17, 17, 1)', // #111111
+    darkgray: 'rgba(237, 237, 237, 1)', // #ededed
     fg85: 'rgba(39, 39, 39, 1)', // #272727
     fg: 'rgba(0, 0, 0, 1)',
     fgOverlay80: 'rgba(235, 235, 235, 0.8)',
@@ -95,6 +101,7 @@ const colors = {
     dimInverse: 'rgba(255, 255, 255, 0.5)',
     bullet: 'rgba(39, 39, 39, 1)',
     codeBg: 'rgba(204, 204, 204, 1)', // #cccccc
+    codeBgInverse: 'rgba(51, 51, 51, 1)', // #333333
     modalExportUnused: 'rgba(204, 204, 204, 1)', // #ccc
     divider: 'rgba(193, 193, 193, 1)',
     bgMuted: 'rgba(221, 221, 221, 1)', // #ddd
@@ -116,6 +123,11 @@ const colors = {
     commandSelected: 'rgba(222, 222, 222, 1)',
     eggplant: 'rgb(85, 51, 98)', // eggplant
     checkboxForm: 'rgba(193, 193, 193, 1)',
+    error: 'rgba(204, 34, 51, 1)',
+    activeBreadCrumb: 'rgba(144, 144, 144, 1)', // #909090
+    pinkRed: 'rgba(233, 12, 89, 1)',
+    brightBlue: 'rgba(70, 223, 240, 1)', // #46dff0
+    exportTextareaColor: 'rgba(85, 85, 85, 1)',
   },
 } as const
 

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -54,7 +54,7 @@ const colors = {
     quickDropBg: 'rgba(30,30,30,0.8)',
     bulletGray: 'rgba(102, 102, 102, 1)', // #666
     midPink: 'rgba(255, 123, 195, 1)', // #ff7bc3
-    purpleEggplant: '#32305f', // purple-eggplant
+    purpleEggplant: '#32305f',
     commandSelected: 'rgba(33, 33, 33, 1)', // #212121
     eggplant: 'rgba(82, 48, 95, 1)',
     checkboxForm: 'rgba(62, 62, 62, 1)', // #3e3e3e

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -121,7 +121,7 @@ const colors = {
     midPink: 'rgba(255, 123, 195, 1)',
     purpleEggplant: '#32305f',
     commandSelected: 'rgba(222, 222, 222, 1)',
-    eggplant: 'rgb(85, 51, 98)', // eggplant
+    eggplant: 'rgb(85, 51, 98)',
     checkboxForm: 'rgba(193, 193, 193, 1)',
     error: 'rgba(204, 34, 51, 1)',
     activeBreadCrumb: 'rgba(144, 144, 144, 1)', // #909090

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -3,6 +3,7 @@ const colors = {
     // Background colors in capacitor app needs to be in hexadecimal codes
     bg: '#000000',
     bgOverlay80: 'rgba(0, 0, 0, 0.8)',
+    bgOverlay50: 'rgba(0, 0, 0, 0.5)',
     bgOverlay30: 'rgba(0, 0, 0, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
@@ -11,6 +12,7 @@ const colors = {
     fg: 'rgba(255, 255, 255, 1)',
     fgOverlay80: 'rgba(20, 20, 20, 0.8)',
     fgOverlay90: 'rgba(20, 20, 20, 0.9)',
+    fgOverlay50: 'rgba(255, 255, 255, 0.5)',
     gray15: 'rgba(38, 38, 38, 1)', // #262626
     gray33: 'rgba(85, 85, 85, 1)',
     gray50: 'rgba(128, 128, 128, 1)', // #808080 (gray)
@@ -42,11 +44,15 @@ const colors = {
     sidebarBg: 'rgba(41, 42, 43, 1)', // #292a2b
     tutorialBg: 'rgba(33, 33, 33, 0.8)', // #212121
     thoughtAnnotation: 'rgba(34, 34, 34, 1)', // #222
+    transparent: 'transparent',
+    bgTransparent: 'rgba(0, 0, 0, 0)',
+    fgTransparent: 'rgba(255, 255, 255, 0)',
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
     bg: '#FFFFFF',
     bgOverlay80: 'rgba(255, 255, 255, 0.8)',
+    bgOverlay50: 'rgba(255, 255, 255, 0.5)',
     bgOverlay30: 'rgba(255, 255, 255, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
@@ -55,6 +61,7 @@ const colors = {
     fg: 'rgba(0, 0, 0, 1)',
     fgOverlay80: 'rgba(235, 235, 235, 0.8)',
     fgOverlay90: 'rgba(235, 235, 235, 0.9)',
+    fgOverlay50: 'rgba(0, 0, 0, 0.5)',
     gray15: 'rgba(38, 38, 38, 1)', // #262626
     gray33: 'rgba(85, 85, 85, 1)',
     gray50: 'rgba(128, 128, 128, 1)', // #808080 (gray)
@@ -86,6 +93,9 @@ const colors = {
     sidebarBg: 'rgba(245, 245, 245, 1)', // #f5f5f5
     tutorialBg: 'rgba(221, 221, 221, 1)', // #ddd
     thoughtAnnotation: 'rgba(221, 221, 221, 1)', // #ddd
+    transparent: 'transparent',
+    fgTransparent: 'rgba(0, 0, 0, 0)',
+    bgTransparent: 'rgba(255, 255, 255, 0)',
   },
 } as const
 

--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -27,11 +27,26 @@ const colors = {
     vividHighlight: '#63c9ea',
     white: 'rgba(255, 255, 255, 1)',
     yellow: 'rgba(255, 208, 20, 1)', // #ffd014
+    inputBorder: 'rgba(153, 153, 153, 1)', // #999
+    link: 'rgba(135, 206, 235, 1)', // #87ceeb
+    dim: 'rgba(255, 255, 255, 0.5)',
+    dimInverse: 'rgba(7, 7, 7, 0.5)',
+    bullet: 'rgba(217, 217, 217, 1)',
+    codeBg: 'rgba(51, 51, 51, 1)', // #333333
+    modalExportUnused: 'rgba(68, 68, 68, 1)', // #444
+    divider: 'rgba(204, 204, 204, 1)',
+    bgMuted: 'rgba(51, 51, 51, 1)', // #333
+    footerBg: 'rgba(26, 26, 26, 1)', // #1a1a1a
+    gestureDiagramWrapper: 'rgba(94, 94, 94, 1)',
+    letterCasePickerBg: 'rgba(20, 20, 20, 1)', // #141414
+    sidebarBg: 'rgba(41, 42, 43, 1)', // #292a2b
+    tutorialBg: 'rgba(33, 33, 33, 0.8)', // #212121
+    thoughtAnnotation: 'rgba(34, 34, 34, 1)', // #222
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
     bg: '#FFFFFF',
-    bgOverlay80: 'rgba(0, 0, 0, 0.8)',
+    bgOverlay80: 'rgba(255, 255, 255, 0.8)',
     bgOverlay30: 'rgba(255, 255, 255, 0.3)',
     black: 'rgba(0, 0, 0, 1)',
     blue: 'rgba(0, 199, 230, 1)', // #00c7e6
@@ -56,6 +71,21 @@ const colors = {
     white: 'rgba(255, 255, 255, 1)',
     vividHighlight: '#63c9ea',
     yellow: 'rgba(255, 208, 20, 1)', // #ffd014
+    inputBorder: 'rgba(238, 238, 238, 1)', // #eeeeee
+    link: 'rgba(27, 111, 154, 1)', // #1b6f9a
+    dim: 'rgba(7, 7, 7, 0.5)',
+    dimInverse: 'rgba(255, 255, 255, 0.5)',
+    bullet: 'rgba(39, 39, 39, 1)',
+    codeBg: 'rgba(204, 204, 204, 1)', // #cccccc
+    modalExportUnused: 'rgba(204, 204, 204, 1)', // #ccc
+    divider: 'rgba(193, 193, 193, 1)',
+    bgMuted: 'rgba(221, 221, 221, 1)', // #ddd
+    footerBg: 'rgba(228, 228, 228, 1)', // #e4e4e4
+    gestureDiagramWrapper: 'rgba(180, 180, 180, 1)',
+    letterCasePickerBg: 'rgba(235, 235, 235, 1)', // #ebebeb
+    sidebarBg: 'rgba(245, 245, 245, 1)', // #f5f5f5
+    tutorialBg: 'rgba(221, 221, 221, 1)', // #ddd
+    thoughtAnnotation: 'rgba(221, 221, 221, 1)', // #ddd
   },
 } as const
 

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { css, cx } from '../../styled-system/css'
 import { anchorButton } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import { alertActionCreator } from '../actions/alert'
 import { redoActionCreator as redo } from '../actions/redo'
 import { undoActionCreator as undo } from '../actions/undo'
@@ -43,7 +44,11 @@ const Alert: FC = () => {
           dispatch(undo())
         })}
       >
-        <UndoIcon size={14} fill='black' cssRaw={css.raw({ position: 'relative', top: '0.25em', right: '0.25em' })} />
+        <UndoIcon
+          size={14}
+          fill={token('colors.bg')}
+          cssRaw={css.raw({ position: 'relative', top: '0.25em', right: '0.25em' })}
+        />
         Undo
       </a>
       <a
@@ -53,7 +58,11 @@ const Alert: FC = () => {
         })}
       >
         Redo
-        <RedoIcon size={14} fill='black' cssRaw={css.raw({ position: 'relative', top: '0.25em', left: '0.25em' })} />
+        <RedoIcon
+          size={14}
+          fill={token('colors.bg')}
+          cssRaw={css.raw({ position: 'relative', top: '0.25em', left: '0.25em' })}
+        />
       </a>
     </div>
   ) : null

--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -216,7 +216,7 @@ const AppComponent: FC = () => {
               <SplitPane
                 paneClassName={css({ transition: isSplitting ? 'width 0.2s ease' : undefined, userSelect: 'none' })}
                 resizerClassName={css({
-                  background: '#fff',
+                  background: 'fg',
                   opacity: 0.2,
                   zIndex: 'resizer',
                   boxSizing: 'border-box',
@@ -228,25 +228,25 @@ const AppComponent: FC = () => {
                   '&.horizontal': {
                     height: '11px',
                     margin: '-5px 0',
-                    borderTop: '5px solid rgba(255, 255, 255, 0)',
-                    borderBottom: '5px solid rgba(255, 255, 255, 0)',
+                    borderTop: '5px solid {colors.fgTransparent}',
+                    borderBottom: '5px solid {colors.fgTransparent}',
                     cursor: 'row-resize',
                     width: '100%',
                   },
                   '&.horizontal:hover': {
-                    borderTop: '5px solid rgba(0, 0, 0, 0.5)',
-                    borderBottom: '5px solid rgba(0, 0, 0, 0.5)',
+                    borderTop: '5px solid {colors.bgOverlay50}',
+                    borderBottom: '5px solid {colors.bgOverlay50}',
                   },
                   '&.vertical': {
                     width: '11px',
                     margin: '0 -5px',
-                    borderLeft: '5px solid rgba(255, 255, 255, 0)',
-                    borderRight: '5px solid rgba(255, 255, 255, 0)',
+                    borderLeft: '5px solid {colors.fgTransparent}',
+                    borderRight: '5px solid {colors.fgTransparent}',
                     cursor: 'col-resize',
                   },
                   '&.vertical:hover': {
-                    borderLeft: '5px solid rgba(255, 255, 255, 0.5)',
-                    borderRight: '5px solid rgba(255, 255, 255, 0.5)',
+                    borderLeft: '5px solid {colors.fgOverlay50}',
+                    borderRight: '5px solid {colors.fgOverlay50}',
                   },
                   '&.disabled': { cursor: 'not-allowed' },
                   '&.disabled:hover': { borderColor: 'transparent' },

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -209,14 +209,14 @@ const glyphFg = cva({
   variants: {
     gray: {
       true: {
-        color: '#666',
-        fill: '#666',
+        color: 'bulletGray',
+        fill: 'bulletGray',
       },
     },
     graypulse: {
       true: {
-        color: '#666',
-        fill: '#666',
+        color: 'bulletGray',
+        fill: 'bulletGray',
         '-webkit-animation': {
           base: 'toblack 400ms infinite alternate ease-in-out',
           _dark: 'towhite 400ms infinite alternate ease-in-out',

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -47,7 +47,7 @@ const isIOSSafari = isTouch && isiPhone && isSafari()
 
 const glyph = cva({
   base: {
-    fill: { base: 'rgba(39, 39, 39, 1)', _dark: 'rgba(217, 217, 217, 1)' },
+    fill: 'bullet',
     position: 'relative',
     '@media (max-width: 500px)': {
       _android: {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -182,7 +182,7 @@ const CommandRow: FC<{
     >
       <div
         className={css({
-          backgroundColor: selected ? '#212121' : undefined,
+          backgroundColor: selected ? 'commandSelected' : undefined,
           padding: selected ? '5px 0 5px 0.5em' : undefined,
           ...(!isTouch
             ? {
@@ -227,7 +227,7 @@ const CommandRow: FC<{
         <div className={css({ maxHeight: !isTouch ? '1em' : undefined, flexGrow: 1, zIndex: 1 })}>
           <div
             className={css({
-              backgroundColor: selected ? '#212121' : undefined,
+              backgroundColor: selected ? 'commandSelected' : undefined,
               display: 'flex',
               padding: !isTouch ? '3px 0.6em 0.3em 0.2em' : undefined,
               marginLeft: !isTouch ? '2em' : undefined,

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -391,7 +391,12 @@ const CommandPalette: FC = () => {
       {!isTouch || (gestureInProgress && shortcuts.length > 0) ? (
         <div>
           <h2
-            className={css({ marginTop: 0, marginBottom: '1em', paddingLeft: 5, borderBottom: 'solid 1px gray' })}
+            className={css({
+              marginTop: 0,
+              marginBottom: '1em',
+              paddingLeft: 5,
+              borderBottom: 'solid 1px {colors.gray50}',
+            })}
             style={{ marginLeft: -fontSize * 1.8 }}
           >
             {!isTouch ? (

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -258,7 +258,7 @@ const ContextBreadcrumbs = ({
                     {
                       color: 'inherit',
                       textDecoration: 'none',
-                      '&:active': { color: '#909090', WebkitTextStrokeWidth: '0.05em' },
+                      '&:active': { color: 'activeBreadCrumb', WebkitTextStrokeWidth: '0.05em' },
                     },
                     linkCssRaw,
                   )}

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -4,6 +4,7 @@ import { shallowEqual, useSelector } from 'react-redux'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { css } from '../../styled-system/css'
 import { extendTap } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import { SystemStyleObject } from '../../styled-system/types'
 import Path from '../@types/Path'
 import ThoughtId from '../@types/ThoughtId'
@@ -121,7 +122,7 @@ const BreadCrumb = React.memo(
           (staticText ? (
             ellipsize(decodeCharacterEntities(value))
           ) : label === HOME_TOKEN ? (
-            <HomeLink color='gray' size={16} className={css({ position: 'static' })} />
+            <HomeLink color={token('colors.gray50')} size={16} className={css({ position: 'static' })} />
           ) : (
             <Link
               cssRaw={css.raw(linkCssRaw)}
@@ -236,7 +237,12 @@ const ContextBreadcrumbs = ({
       - The "c/d" context will render "d" as a thought and "c" as the breadcrumbs.
     */
         !homeContext ? (
-          <HomeLink className={css({ position: 'static' })} color='gray' size={16} iconStyle={homeIconStyle} />
+          <HomeLink
+            className={css({ position: 'static' })}
+            color={token('colors.gray50')}
+            size={16}
+            iconStyle={homeIconStyle}
+          />
         ) : null
       ) : (
         <TransitionGroup childFactory={factoryManager}>

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -208,7 +208,7 @@ const ContextBreadcrumbs = ({
       className={css(
         {
           fontSize: '0.867em',
-          color: 'gray',
+          color: 'gray66',
           marginLeft: 'calc(1.3em - 14.5px)',
           marginTop: '0.533em',
           minHeight: '1em',

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -54,7 +54,7 @@ const Divider = ({ path, cssRaw }: { path: Path; cssRaw?: SystemStyleObject }) =
         aria-label={'editable-' + head(path)}
         className={css(
           {
-            border: { base: 'solid 1px rgb(193, 193, 193)', _dark: 'solid 1px rgb(204, 204, 204)' },
+            border: 'solid 1px {colors.divider}',
             // requires editable-hash className to be selected by the cursor navigation via editableNode
           },
           cssRaw,

--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -45,7 +45,7 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
           dropEnd(),
           css({
             zIndex: 'dropEmpty',
-            backgroundColor: testFlags.simulateDrop ? '#32305f' : undefined, // purple-eggplant
+            backgroundColor: testFlags.simulateDrop ? 'purpleEggplant' : undefined, // purple-eggplant
             // shift the drop target to the right
             marginLeft: isTouch ? '33%' : 'calc(2.9em - 2px)',
             opacity: 0.9,
@@ -64,7 +64,7 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
               // make sure label does not interfere with drop target hovering
               pointerEvents: 'none',
               left: 0,
-              color: '#ff7bc3' /* mid pink */,
+              color: 'midPink' /* mid pink */,
             })}
           >
             {strip(value)}

--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -45,7 +45,7 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
           dropEnd(),
           css({
             zIndex: 'dropEmpty',
-            backgroundColor: testFlags.simulateDrop ? 'purpleEggplant' : undefined, // purple-eggplant
+            backgroundColor: testFlags.simulateDrop ? 'purpleEggplant' : undefined,
             // shift the drop target to the right
             marginLeft: isTouch ? '33%' : 'calc(2.9em - 2px)',
             opacity: 0.9,

--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -64,7 +64,7 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
               // make sure label does not interfere with drop target hovering
               pointerEvents: 'none',
               left: 0,
-              color: 'midPink' /* mid pink */,
+              color: 'midPink',
             })}
           >
             {strip(value)}

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -21,7 +21,7 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, DropDownMenuProps>(
       <div
         ref={ref}
         className={css({
-          boxShadow: '0 0 10px 0px black',
+          boxShadow: '0 0 10px 0px {colors.bg}',
           // display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-evenly',

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react'
 import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens'
 import ExportOption from '../@types/ExportOption'
 import fastClick from '../util/fastClick'
 
@@ -42,7 +43,7 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, DropDownMenuProps>(
             className={css({
               cursor: 'pointer',
               padding: '2px 0px',
-              borderTop: '1px solid #444',
+              borderTop: '1px solid {colors.modalExportUnused}',
               transition: 'opacity {durations.fastDuration} ease-in',
             })}
             // composite key is unique
@@ -59,7 +60,7 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, DropDownMenuProps>(
                   <svg width='16px' height='16px' viewBox='0 0 32 32'>
                     <path
                       d='M30.171,6.131l-0.858-0.858c-0.944-0.945-2.489-0.945-3.433,0L11.294,19.859l-5.175-5.174  c-0.943-0.944-2.489-0.944-3.432,0.001l-0.858,0.857c-0.943,0.944-0.943,2.489,0,3.433l7.744,7.75c0.944,0.945,2.489,0.945,3.433,0  L30.171,9.564C31.112,8.62,31.112,7.075,30.171,6.131z'
-                      fill='#fff'
+                      fill={token('colors.fg')}
                     />
                   </svg>
                 ) : (

--- a/src/components/DropEnd.tsx
+++ b/src/components/DropEnd.tsx
@@ -119,7 +119,7 @@ const DropEnd = ({
             left: '0.3em',
             // make sure label does not interfere with drop target hovering
             pointerEvents: 'none',
-            color: '#ff7bc3' /* mid pink */,
+            color: 'midPink' /* mid pink */,
           })}
         >
           {isHovering ? '*' : ''}

--- a/src/components/DropEnd.tsx
+++ b/src/components/DropEnd.tsx
@@ -119,7 +119,7 @@ const DropEnd = ({
             left: '0.3em',
             // make sure label does not interfere with drop target hovering
             pointerEvents: 'none',
-            color: 'midPink' /* mid pink */,
+            color: 'midPink',
           })}
         >
           {isHovering ? '*' : ''}

--- a/src/components/DropUncle.tsx
+++ b/src/components/DropUncle.tsx
@@ -44,7 +44,7 @@ const DropUncle = ({
       className={cx(
         dropEnd(),
         css({
-          backgroundColor: testFlags.simulateDrop ? '#52305f' : undefined, // eggplant
+          backgroundColor: testFlags.simulateDrop ? 'eggplant' : undefined, // eggplant
           opacity: 0.9,
         }),
       )}
@@ -59,7 +59,7 @@ const DropUncle = ({
             // make sure label does not interfere with drop target hovering
             pointerEvents: 'none',
             left: 0,
-            color: '#ff7bc3' /* mid pink */,
+            color: 'midPink',
           })}
         >
           {strip(value)}

--- a/src/components/DropUncle.tsx
+++ b/src/components/DropUncle.tsx
@@ -44,7 +44,7 @@ const DropUncle = ({
       className={cx(
         dropEnd(),
         css({
-          backgroundColor: testFlags.simulateDrop ? 'eggplant' : undefined, // eggplant
+          backgroundColor: testFlags.simulateDrop ? 'eggplant' : undefined,
           opacity: 0.9,
         }),
       )}

--- a/src/components/ErrorBoundaryContainer.tsx
+++ b/src/components/ErrorBoundaryContainer.tsx
@@ -47,7 +47,7 @@ const ErrorFallback = ({ error, componentStack }: { error?: Error; componentStac
       {error && (
         <div>
           <Toggle title='Details:'>
-            <pre className={css({ color: 'gray' })}>{error.stack}</pre>
+            <pre className={css({ color: 'gray66' })}>{error.stack}</pre>
           </Toggle>
         </div>
       )}

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -25,7 +25,7 @@ const ErrorMessage: FC = () => {
               left: '0',
               right: '0',
               padding: '5px 25px 5px 5px',
-              backgroundColor: '#c23',
+              backgroundColor: 'error',
               color: 'white',
               textAlign: 'center',
               zIndex: 'popup',

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -118,7 +118,7 @@ const FavoritesOptions = ({
         <span
           {...fastClick(() => setShowOptions(!showOptions))}
           className={css({
-            color: '#444',
+            color: 'modalExportUnused',
             cursor: 'pointer',
             fontSize: '0.7em',
             fontWeight: 'bold',
@@ -150,7 +150,7 @@ const FavoritesOptions = ({
         >
           <form
             ref={formRef}
-            className={css({ fontSize: 'sm', backgroundColor: '#3e3e3e', borderRadius: '0.5em', padding: '1em' })}
+            className={css({ fontSize: 'sm', backgroundColor: 'checkboxForm', borderRadius: '0.5em', padding: '1em' })}
           >
             <Checkbox
               checked={!hideContexts}

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -91,7 +91,7 @@ const DropEnd = ({ disableDragAndDrop }: { disableDragAndDrop?: boolean }) => {
             marginLeft: 0,
             marginTop: 0,
             width: 'calc(100% - 4em)',
-            background: isHovering ? 'rgba(155, 170, 220, 1)' : undefined,
+            background: isHovering ? 'highlight2' : undefined,
           }),
         )}
       />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -157,7 +157,7 @@ const Footer = () => {
         textAlign: 'right',
         fontSize: '75%',
         listStyle: 'none',
-        backgroundColor: { base: '#e4e4e4', _dark: '#1a1a1a' },
+        backgroundColor: 'footerBg',
         boxSizing: 'border-box',
         width: '100%',
         zIndex: 'modal',

--- a/src/components/HoverArrow.tsx
+++ b/src/components/HoverArrow.tsx
@@ -18,8 +18,8 @@ const HoverArrow = ({
         className={css({
           animation: `bobble {durations.verySlowPulseDuration} infinite`,
           borderBottom: '20px solid {colors.highlight2}',
-          borderLeft: '10px solid transparent',
-          borderRight: '10px solid transparent',
+          borderLeft: '10px solid {colors.transparent}',
+          borderRight: '10px solid {colors.transparent}',
           height: '0',
           left: '50%',
           position: 'absolute',

--- a/src/components/HoverArrow.tsx
+++ b/src/components/HoverArrow.tsx
@@ -17,7 +17,7 @@ const HoverArrow = ({
       <div
         className={css({
           animation: `bobble {durations.verySlowPulseDuration} infinite`,
-          borderBottom: '20px solid rgb(155, 170, 220)',
+          borderBottom: '20px solid {colors.highlight2}',
           borderLeft: '10px solid transparent',
           borderRight: '10px solid transparent',
           height: '0',

--- a/src/components/LatestShortcutsDiagram.tsx
+++ b/src/components/LatestShortcutsDiagram.tsx
@@ -60,10 +60,7 @@ const LatestShortcutsDiagram: FC<LatestShortcutsDiagramProps> = ({ position = 'm
               <div key={shortcut.id}>
                 <div
                   className={css({
-                    background: {
-                      _dark: 'rgb(94, 94, 94)',
-                      base: 'rgb(180, 180, 180)',
-                    },
+                    background: 'gestureDiagramWrapper',
                     borderRadius: '7px',
                     display: 'flex',
                     justifyContent: 'center',

--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -70,7 +70,7 @@ const LetterCasePicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = m
               className={css({
                 margin: '2px',
                 lineHeight: '0',
-                border: selected === type ? `solid 1px {colors.fg}` : `solid 1px transparent`,
+                border: selected === type ? `solid 1px {colors.fg}` : `solid 1px {colors.transparent}`,
               })}
               aria-label={type}
               {...fastClick(e => e.stopPropagation())}

--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -46,7 +46,7 @@ const LetterCasePicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = m
         style={{ ...(overflow.left ? { left: `${overflow.left}` } : { right: `${overflow.right}` }) }}
         className={css(
           {
-            background: { base: '#ebebeb', _dark: '#141414' },
+            background: 'letterCasePickerBg',
             borderRadius: '3',
             display: 'inline-block',
             padding: '0.2em 0.25em 0.25em',

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -37,8 +37,8 @@ const Loader = ({ size = 32, style, cssRaw }: LoaderProps) => {
           transformOrigin: '0 0',
         })}
       >
-        <div className={css(rippleLoaderChild, { borderColor: '#e90c59', animationDelay: '0s' })}></div>
-        <div className={css(rippleLoaderChild, { borderColor: '#46dff0', animationDelay: '-0.5s' })}></div>
+        <div className={css(rippleLoaderChild, { borderColor: 'pinkRed', animationDelay: '0s' })}></div>
+        <div className={css(rippleLoaderChild, { borderColor: 'brightBlue', animationDelay: '-0.5s' })}></div>
       </div>
     </div>
   )

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -24,7 +24,7 @@ const rippleLoaderChild = {
 const Loader = ({ size = 32, style, cssRaw }: LoaderProps) => {
   return (
     <div
-      className={css({ display: 'inline-block', overflow: 'hidden', background: 'rgba(255, 255, 255, 0)' }, cssRaw)}
+      className={css({ display: 'inline-block', overflow: 'hidden', background: 'fgTransparent' }, cssRaw)}
       style={{ ...style, height: size, width: size }}
     >
       <div

--- a/src/components/Logs.tsx
+++ b/src/components/Logs.tsx
@@ -12,7 +12,7 @@ const Logs = ({ logs }: { logs: Log[] }) => {
       defaultValue={logs.length > 0 ? logsFormatted : 'No logs.'}
       className={css({
         marginTop: 20,
-        backgroundColor: '#111',
+        backgroundColor: 'darkgray',
         border: 0,
         padding: 20,
         fontFamily: 'monospace',

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -26,14 +26,14 @@ const CursorBreadcrumbs = ({ position }: { position: string }) => {
     <ContextBreadcrumbs
       cssRaw={css.raw({
         width: '100%',
-        color: '#999',
+        color: 'breadcrumbs',
         paddingLeft: '15px',
         fontSize: '14px',
         verticalAlign: 'bottom',
         ...(position === 'bottom' && { width: 'calc(100% - 40px)', paddingLeft: '35px' }),
       })}
       linkCssRaw={css.raw({
-        color: '#999',
+        color: 'breadcrumbs',
         '&:hover': {
           color: 'fg',
         },

--- a/src/components/NewThought.tsx
+++ b/src/components/NewThought.tsx
@@ -83,10 +83,7 @@ const NewThought = ({ path, showContexts, label, value = '', type = 'bullet' }: 
               type === 'bullet'
                 ? css({
                     fontStyle: 'italic',
-                    color: {
-                      base: 'rgba(7, 7, 7, 0.5)',
-                      _dark: 'rgba(255, 255, 255, 0.5)',
-                    },
+                    color: 'dim',
                   })
                 : cx(
                     anchorButton({

--- a/src/components/NoOtherContexts.tsx
+++ b/src/components/NoOtherContexts.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '../../styled-system/css'
 import { textNote } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import GesturePath from '../@types/GesturePath'
 import SimplePath from '../@types/SimplePath'
 import { isTouch } from '../browser'
@@ -46,7 +47,7 @@ const NoOtherContexts = ({ allowSingleContext }: { allowSingleContext?: boolean;
                 inGestureContainer
                 path={toggleContextViewShortcut.gesture as GesturePath}
                 size={30}
-                color='darkgray'
+                color={token('colors.gray66')}
               />
             </span>
           ) : (

--- a/src/components/QuickDropIcon.tsx
+++ b/src/components/QuickDropIcon.tsx
@@ -90,7 +90,7 @@ const QuickDropIcon = ({
           zIndex: 'stack',
           padding: '1em',
           borderRadius: '999px 0 0 999px',
-          backgroundColor: isHovering ? 'rgba(40,40,40,0.8)' : 'rgba(30,30,30,0.8)',
+          backgroundColor: isHovering ? 'quickDropBgHover' : 'quickDropBg',
         })}
       >
         <Icon

--- a/src/components/ShortcutTable.tsx
+++ b/src/components/ShortcutTable.tsx
@@ -117,7 +117,7 @@ const SearchShortcut: FC<{
   onInput?: (value: string) => void
 }> = ({ onInput }) => {
   return (
-    <div id='search' className={css({ borderBottom: 'solid 1px gray' })}>
+    <div id='search' className={css({ borderBottom: 'solid 1px {colors.gray50}' })}>
       <input
         type='text'
         placeholder='Search commands by name...'

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -132,7 +132,7 @@ const Sidebar = () => {
         <div
           aria-label='sidebar'
           className={css({
-            background: { base: '#f5f5f5', _dark: '#292a2b' },
+            background: 'sidebarBg',
             overflowY: 'scroll',
             overscrollBehavior: 'contain',
             boxSizing: 'border-box',

--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -172,10 +172,7 @@ const ThoughtAnnotation = React.memo(
               multiline ? multilineRecipe() : null,
               css({
                 ...(isAttribute(value) && {
-                  backgroundColor: {
-                    base: '#ddd',
-                    _dark: '#222',
-                  },
+                  backgroundColor: 'thoughtAnnotation',
                   fontFamily: 'monospace',
                 }),
                 display: 'inline-block',

--- a/src/components/Tips/Tip.tsx
+++ b/src/components/Tips/Tip.tsx
@@ -26,13 +26,13 @@ const Tip: FC<
     >
       <div
         className={css({
-          backgroundColor: '#333',
+          backgroundColor: 'codeBg',
           display: 'inline-block',
           padding: '1em',
           maxWidth: '20em',
           borderRadius: '5',
           textAlign: 'center',
-          color: '#ccc',
+          color: 'codeBgInverse',
         })}
       >
         {children}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -211,7 +211,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
             textAlign: 'right',
             maxWidth: '100%',
             userSelect: 'none',
-            WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
+            WebkitTapHighlightColor: '{colors.bgTransparent}',
             whiteSpace: 'nowrap',
             ...(!customize && {
               zIndex: 'toolbarContainer',

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -41,7 +41,7 @@ const arrow = cva({
     fontSize: '80%',
     paddingTop: '16px',
     verticalAlign: 'middle',
-    color: 'gray',
+    color: 'gray66',
     backgroundColor: 'bg',
     display: 'inline-block',
     lineHeight: '20px',

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -13,6 +13,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
 import { css, cva, cx } from '../../styled-system/css'
 import { toolbarPointerEvents } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import ShortcutType from '../@types/Shortcut'
 import ShortcutId from '../@types/ShortcutId'
 import TipId from '../@types/TipId'
@@ -233,7 +234,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
             id='left-arrow'
             className={arrow({ direction: 'left', isHidden: !leftArrowIsShown, fixed: !customize })}
           >
-            <TriangleLeft width={arrowWidth} height={fontSize} fill='gray' />
+            <TriangleLeft width={arrowWidth} height={fontSize} fill={token('colors.gray50')} />
           </span>
           <div
             id='toolbar'
@@ -278,7 +279,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
             id='right-arrow'
             className={arrow({ direction: 'right', isHidden: !rightArrowIsShown, fixed: !customize })}
           >
-            <TriangleRight width={arrowWidth} height={fontSize} fill='gray' />
+            <TriangleRight width={arrowWidth} height={fontSize} fill={token('colors.gray50')} />
           </span>
         </div>
       </div>

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -158,7 +158,7 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
           ? undefined
           : isButtonExecutable && isButtonActive
             ? token('colors.fg')
-            : 'gray', // keep fill in style because some icons need the exact color
+            : token('colors.gray50'), // keep fill in style because some icons need the exact color
       width: fontSize + 4,
       height: fontSize + 4,
     }),

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -237,7 +237,7 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
         (isHovering || dropToRemove) && (
           <div
             className={css({
-              borderRight: dropToRemove ? `dashed 1px {colors.gray}` : undefined,
+              borderRight: dropToRemove ? `dashed 1px {colors.gray66}` : undefined,
               position: 'absolute',
               left: dropToRemove ? 15 : -2,
               // match the height of the inverted button

--- a/src/components/TriangleDown.tsx
+++ b/src/components/TriangleDown.tsx
@@ -1,8 +1,9 @@
 import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens/index.mjs'
 import Icon from '../@types/IconType'
 
 /** A down-facing triangle component. */
-const TriangleDown = ({ fill = 'black', size = 20, width, height, style, cssRaw }: Icon) => (
+const TriangleDown = ({ fill = token('colors.bg'), size = 20, width, height, style, cssRaw }: Icon) => (
   <svg
     xmlns=''
     version='1.1'

--- a/src/components/TriangleLeft.tsx
+++ b/src/components/TriangleLeft.tsx
@@ -1,8 +1,9 @@
 import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens'
 import Icon from '../@types/IconType'
 
 /** A left-facing svg triangle. */
-const TriangleLeft = ({ fill = 'black', size = 20, width, height, style, cssRaw }: Icon) => (
+const TriangleLeft = ({ fill = token('colors.bg'), size = 20, width, height, style, cssRaw }: Icon) => (
   <svg
     xmlns=''
     version='1.1'

--- a/src/components/TriangleRight.tsx
+++ b/src/components/TriangleRight.tsx
@@ -1,8 +1,9 @@
 import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens'
 import Icon from '../@types/IconType'
 
 /** A right-facing triangle component. */
-const TriangleRight = ({ fill = 'black', size = 20, width, height, style, cssRaw }: Icon) => (
+const TriangleRight = ({ fill = token('colors.bg'), size = 20, width, height, style, cssRaw }: Icon) => (
   <svg
     xmlns=''
     version='1.1'

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -103,7 +103,7 @@ const Tutorial: FC = () => {
     <div
       className={css({
         padding: '40px 20px 20px',
-        backgroundColor: { base: '#ddd', _dark: '#212121' },
+        backgroundColor: 'tutorialBg',
         position: 'relative',
         zIndex: 'tutorial',
         color: 'fg',
@@ -189,7 +189,7 @@ const Tutorial: FC = () => {
               textAlign: 'center',
               left: 0,
               right: 0,
-              backgroundColor: { base: 'rgba(255, 255, 255, 0.8)', _dark: 'rgba(0, 0, 0, 0.8)' },
+              backgroundColor: 'bgOverlay80',
               paddingBottom: '50px',
             })}
           >

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -118,7 +118,7 @@ const Tutorial: FC = () => {
           className={cx(
             css({
               position: 'absolute',
-              color: '#666',
+              color: 'bulletGray',
               top: '10px',
               right: '15px',
               fontSize: 'sm',

--- a/src/components/modals/CustomizeToolbar.tsx
+++ b/src/components/modals/CustomizeToolbar.tsx
@@ -215,7 +215,7 @@ const ModalCustomizeToolbar: FC = () => {
         </a>
 
         <div className={css({ fontSize: 'sm', marginTop: '4em' })}>
-          <p className={css({ color: 'gray', marginTop: '0.5em' })}>
+          <p className={css({ color: 'gray66', marginTop: '0.5em' })}>
             Reset the toolbar to its factory settings. Your current toolbar customization will be permanently deleted.
           </p>
           <a

--- a/src/components/modals/Devices.tsx
+++ b/src/components/modals/Devices.tsx
@@ -149,7 +149,7 @@ const AddDeviceForm = ({
         >
           Add
         </a>
-        <a {...fastClick(onCancel)} className={css({ color: 'gray', marginLeft: '1em' })}>
+        <a {...fastClick(onCancel)} className={css({ color: 'gray66', marginLeft: '1em' })}>
           Cancel
         </a>
       </div>
@@ -284,7 +284,7 @@ const ShareList = React.forwardRef<
           </TransitionGroup>
         </>
       ) : (
-        <div className={css({ color: 'gray', fontSize: 18, fontStyle: 'italic', margin: '40px 0 20px 0' })}>
+        <div className={css({ color: 'gray66', fontSize: 18, fontStyle: 'italic', margin: '40px 0 20px 0' })}>
           <p>This device is currently offline</p>
           <p>Please connect to the Internet to manage sharing.</p>
         </div>
@@ -322,7 +322,7 @@ const EditableName = React.memo(
             verticalAlign: 'bottom',
           })}
         >
-          <PencilIcon fill={token('colors.gray')} size={25} />
+          <PencilIcon fill={token('colors.gray66')} size={25} />
         </a>
       </div>
     )
@@ -472,7 +472,7 @@ const ShareDetail = React.memo(
             </div>
           )}
 
-          <p className={css({ color: 'gray' })}>
+          <p className={css({ color: 'gray66' })}>
             Created: {new Date(share.created).toLocaleString()}
             <br />
             Last Accessed: {share.accessed ? new Date(share.accessed).toLocaleString() : 'never'}
@@ -496,7 +496,7 @@ const ShareDetail = React.memo(
           )}
 
           <div className={css({ marginTop: '4em' })}>
-            <p className={css({ color: 'gray', marginTop: '0.5em' })}>
+            <p className={css({ color: 'gray66', marginTop: '0.5em' })}>
               {isLastDevice
                 ? 'This is the last device with access to this thoughtspace. If you clear the thoughtspace, all thoughts will be permanently deleted.'
                 : isCurrent

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -591,10 +591,10 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
           ref={textareaRef}
           readOnly
           className={css({
-            backgroundColor: '#111',
+            backgroundColor: 'darkgray',
             border: 'none',
             borderRadius: '10px',
-            color: '#aaa',
+            color: 'exportTextareaColor',
             fontSize: '1em',
             height: '120px',
             marginBottom: 'calc(max(1.2em, 20px))',

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -699,10 +699,7 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
       {/* isDocumentEditable() && (
         <>
           <div className={css({
-            borderTop: {
-              base:"solid 1px #ccc",
-              _dark:"solid 1px #444"
-            },
+            borderTop: "solid 1px {colors.modalExportUnused}",
             marginTop: "30px",
             marginBottom: "20px",
             paddingTop: "40px",

--- a/src/components/modals/ModalComponent.tsx
+++ b/src/components/modals/ModalComponent.tsx
@@ -132,14 +132,8 @@ class ModalComponent extends React.Component<ModalProps> {
                   display: 'inline-block',
                   width: '11px',
                   height: '11px',
-                  color: {
-                    base: 'rgba(0, 0, 0, 0.3)',
-                    _dark: 'rgba(255, 255, 255, 0.3)',
-                  },
-                  borderColor: {
-                    base: 'rgba(0, 0, 0, 0.3)',
-                    _dark: 'rgba(255, 255, 255, 0.3)',
-                  },
+                  color: 'bgOverlay30',
+                  borderColor: 'bgOverlay30',
                 },
               })}
               {...fastClick(() => this.close())}

--- a/src/recipes/anchorButton.ts
+++ b/src/recipes/anchorButton.ts
@@ -78,8 +78,7 @@ const anchorButtonRecipe = defineRecipe({
     },
     inActive: {
       true: {
-        // TODO: handle light mode
-        backgroundColor: '#aaa',
+        backgroundColor: 'exportTextareaColor',
       },
     },
     inverse: {

--- a/src/recipes/button.ts
+++ b/src/recipes/button.ts
@@ -6,12 +6,12 @@ const buttonRecipe = defineRecipe({
   base: {
     cursor: 'pointer',
     background: 'transparent',
-    color: '#ccc',
+    color: 'codeBgInverse',
     display: 'block',
     border: '0 none',
     margin: '10px auto 0',
     '&:focus': {
-      color: '#fff',
+      color: 'fg',
       outline: '0 none',
       border: '0 none',
     },

--- a/src/recipes/modal.ts
+++ b/src/recipes/modal.ts
@@ -16,7 +16,7 @@ const modalRecipe = defineSlotRecipe({
       //   boxShadow: '2px 5px 5px rgba(0, 0, 0, 0.5)',
       //   border: 'solid 1px rgba(0, 0, 0, 0.2)', // solid 1px rgba(255, 255, 255, 0.1) for dark mode
       //   padding: '15px',
-      color: '#e3e3e3',
+      color: 'modalColor',
       position: 'absolute',
       //   display: 'inline-block',
       lineHeight: 1.5,

--- a/src/recipes/textNote.ts
+++ b/src/recipes/textNote.ts
@@ -4,12 +4,12 @@ const textNoteRecipe = defineRecipe({
   className: 'text-note',
   base: {
     fontStyle: 'italic',
-    color: { base: 'rgba(7, 7, 7, 0.5)', _dark: 'rgba(255, 255, 255, 0.5)' },
+    color: 'dim',
   },
   variants: {
     inverse: {
       true: {
-        color: { base: 'rgba(255, 255, 255, 0.5)', _dark: 'rgba(7, 7, 7, 0.5)' },
+        color: 'dimInverse',
       },
     },
   },

--- a/src/recipes/thought.ts
+++ b/src/recipes/thought.ts
@@ -32,7 +32,7 @@ const thoughtRecipe = defineRecipe({
     inverse: {
       true: {
         // invert placeholder color if the color is inverted (such as when a background color is applied)
-        '[placeholder]:empty::before': { color: { _base: 'rgba(255, 255, 255, 0.5)', _dark: 'rgba(7, 7, 7, 0.5)' } },
+        '[placeholder]:empty::before': { color: { _base: 'dimInverse' } },
       },
     },
     flex: {

--- a/src/shortcuts/bindContext.tsx
+++ b/src/shortcuts/bindContext.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '../../styled-system/css'
 import { icon } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import IconType from '../@types/IconType'
 import Shortcut from '../@types/Shortcut'
 import { toggleAttributeActionCreator as toggleAttribute } from '../actions/toggleAttribute'
@@ -11,7 +12,7 @@ import isDocumentEditable from '../util/isDocumentEditable'
 import pathToContext from '../util/pathToContext'
 
 // eslint-disable-next-line jsdoc/require-jsdoc, react-refresh/only-export-components
-const Icon = ({ fill = 'black', size = 20, style, cssRaw }: IconType) => (
+const Icon = ({ fill = token('colors.bg'), size = 20, style, cssRaw }: IconType) => (
   <svg
     version='1.1'
     className={cx(icon(), css(cssRaw))}

--- a/src/shortcuts/cursorDown.tsx
+++ b/src/shortcuts/cursorDown.tsx
@@ -1,6 +1,7 @@
 import { Key } from 'ts-key-enum'
 import { css, cx } from '../../styled-system/css'
 import { icon } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import Dispatch from '../@types/Dispatch'
 import IconType from '../@types/IconType'
 import Shortcut from '../@types/Shortcut'
@@ -26,7 +27,7 @@ import parentOf from '../util/parentOf'
 import throttleByAnimationFrame from '../util/throttleByAnimationFrame'
 
 // eslint-disable-next-line jsdoc/require-jsdoc, react-refresh/only-export-components
-const Icon = ({ fill = 'black', size = 20, style, cssRaw }: IconType) => (
+const Icon = ({ fill = token('colors.bg'), size = 20, style, cssRaw }: IconType) => (
   <svg
     version='1.1'
     className={cx(icon(), css(cssRaw))}

--- a/src/shortcuts/cursorForward.tsx
+++ b/src/shortcuts/cursorForward.tsx
@@ -1,11 +1,12 @@
 import { css, cx } from '../../styled-system/css'
 import { icon } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import IconType from '../@types/IconType'
 import Shortcut from '../@types/Shortcut'
 import { cursorForwardActionCreator as cursorForward } from '../actions/cursorForward'
 
 // eslint-disable-next-line jsdoc/require-jsdoc, react-refresh/only-export-components
-const Icon = ({ fill = 'black', size = 20, style, cssRaw }: IconType) => (
+const Icon = ({ fill = token('colors.bg'), size = 20, style, cssRaw }: IconType) => (
   <svg
     version='1.1'
     className={cx(icon(), css(cssRaw))}

--- a/src/shortcuts/cursorUp.tsx
+++ b/src/shortcuts/cursorUp.tsx
@@ -1,6 +1,7 @@
 import { Key } from 'ts-key-enum'
 import { css, cx } from '../../styled-system/css'
 import { icon } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import Dispatch from '../@types/Dispatch'
 import IconType from '../@types/IconType'
 import Shortcut from '../@types/Shortcut'
@@ -25,7 +26,7 @@ import parentOf from '../util/parentOf'
 import throttleByAnimationFrame from '../util/throttleByAnimationFrame'
 
 // eslint-disable-next-line jsdoc/require-jsdoc, react-refresh/only-export-components
-const Icon = ({ fill = 'black', size = 20, style, cssRaw }: IconType) => (
+const Icon = ({ fill = token('colors.bg'), size = 20, style, cssRaw }: IconType) => (
   <svg
     version='1.1'
     className={cx(icon(), css(cssRaw))}

--- a/src/shortcuts/deleteEmptyThoughtOrOutdent.tsx
+++ b/src/shortcuts/deleteEmptyThoughtOrOutdent.tsx
@@ -1,6 +1,7 @@
 import { Key } from 'ts-key-enum'
 import { css, cx } from '../../styled-system/css'
 import { icon } from '../../styled-system/recipes'
+import { token } from '../../styled-system/tokens'
 import IconType from '../@types/IconType'
 import Shortcut from '../@types/Shortcut'
 import State from '../@types/State'
@@ -74,7 +75,7 @@ const exec: Shortcut['exec'] = (dispatch, getState) => {
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc, react-refresh/only-export-components
-const Icon = ({ fill = 'black', size = 20, style, cssRaw }: IconType) => (
+const Icon = ({ fill = token('colors.bg'), size = 20, style, cssRaw }: IconType) => (
   <svg
     version='1.1'
     className={cx(icon(), css(cssRaw))}


### PR DESCRIPTION
#2170 

I added `transparent` as a design token to replace `rgba(255, 255, 255, 0)`, which seemed quite unnecessary since using just 'transparent' would be the same thing. Let me know if it's better to get rid of it.

I moved the styles on body meant to prevent white flashes onto html, since it breaks light theme. Also you may get dark flashes on light theme if you change it programmatically instead of using the toggle, since it depends on localStorage
The problem with this still is that if you change the theme, then scroll, the html bg (at the edges) won't change, you have to refresh for that.