### PR TITLE
Corrected the display width of the editable part of a thought's note

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -142,6 +142,10 @@ const Note = React.memo(({ path }: { path: Path }) => {
         innerRef={noteRef}
         aria-label='note-editable'
         placeholder='Enter a note'
+        className={css({
+          display: 'inline-block',
+          padding: '0 1em 0 0.333em',
+        })}
         onKeyDown={onKeyDown}
         onChange={onChange}
         onPaste={() => {


### PR DESCRIPTION
### Overview

This pull request resolves #2096 by changing the display of the `<ContentEditable>` within a Note to be inline-block and adding padding to the left and right which matches the `<ContentEditable>` within a Thought. With this change, there is a very small clickable area left of the Note (0.333em) and a slightly larger one to the right (1em).

@raineorshine - Please note that there appears to be a separate bug where immediately after selecting a Note to edit it, the cursor shifts up to the parent Thought.

### Demo

https://github.com/user-attachments/assets/be0327ac-6d65-4a43-9c7a-1f10367cd326