### PR TITLE
Animation: Fade out unmounted thought

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -464,7 +464,9 @@ const TreeNode = ({
     >
       <FadeTransition
         id={thoughtKey}
-        duration='nodeOpacity'
+        // The FadeTransition is only responsible for fade out on unmount.
+        // See autofocusChanged for normal opacity transition.
+        duration='nodeFadeOut'
         nodeRef={fadeThoughtRef}
         in={transitionGroupsProps.in}
         unmountOnExit

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -412,6 +412,7 @@ const TreeNode = ({
   autofocusDepth: number
 } & Pick<CSSTransitionProps, 'in'>) => {
   const [y, setY] = useState(_y)
+  const fadeThoughtRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
     if (y !== _y) {
@@ -437,7 +438,6 @@ const TreeNode = ({
   const xCol2 = isTableCol1 ? nextThought?.x || previousThought?.x || 0 : 0
   // Increasing margin-right of thought for filling gaps and moving the thought to the left by adding negative margin from right.
   const marginRight = isTableCol1 ? xCol2 - (width || 0) - x - (bulletWidth || 0) : 0
-  const fadeThoughtRef = useRef<HTMLDivElement>(null)
 
   return (
     <div

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -462,7 +462,13 @@ const TreeNode = ({
         textAlign: isTableCol1 ? 'right' : undefined,
       }}
     >
-      <FadeTransition id={thoughtKey} duration='nodeOpacity' nodeRef={fadeThoughtRef} in={transitionGroupsProps.in}>
+      <FadeTransition
+        id={thoughtKey}
+        duration='nodeOpacity'
+        nodeRef={fadeThoughtRef}
+        in={transitionGroupsProps.in}
+        unmountOnExit
+      >
         <div ref={fadeThoughtRef}>
           <VirtualThought
             debugIndex={testFlags.simulateDrop ? indexChild : undefined}

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -94,7 +94,7 @@ const VirtualThought = ({
   const cursorLeaf = useSelector(state => !!state.cursor && !hasChildren(state, head(state.cursor)))
   const cursorDepth = useSelector(state => (state.cursor ? state.cursor.length : 0))
   const fontSize = useSelector(state => state.fontSize)
-  const note = useSelector(state => noteValue(state, thought.id))
+  const note = useSelector(state => noteValue(state, thought?.id))
   const ref = useRef<HTMLDivElement>(null)
 
   /***************************
@@ -149,11 +149,11 @@ const VirtualThought = ({
     onResize?.({
       height: heightNew,
       width: widthNew,
-      id: thought.id,
+      id: thought?.id,
       isVisible: isVisibleNew,
       key: crossContextualKey,
     })
-  }, [crossContextualKey, onResize, thought.id, autofocus])
+  }, [crossContextualKey, onResize, thought?.id, autofocus])
 
   // Recalculate height when anything changes that could indirectly affect the height of the thought. (Height observers are slow.)
   // Autofocus changes when the cursor changes depth or moves between a leaf and non-leaf. This changes the left margin and can cause thoughts to wrap or unwrap.
@@ -183,7 +183,7 @@ const VirtualThought = ({
   // TODO: useLayoutEffect does not work for some reason, causing the thought to briefly render at the incorrect height.
   const value = useSelector(state => {
     const thoughtId = head(simplePath)
-    return thoughtId ? getThoughtById(state, thoughtId).value : null
+    return thoughtId ? getThoughtById(state, thoughtId)?.value : null
   })
   useEffect(updateSize, [updateSize, value])
 
@@ -191,11 +191,11 @@ const VirtualThought = ({
   useEffect(
     () => {
       return () => {
-        onResize?.({ height: null, width: null, id: thought.id, isVisible: true, key: crossContextualKey })
+        onResize?.({ height: null, width: null, id: thought?.id, isVisible: true, key: crossContextualKey })
       }
     },
     // these should be memoized and not change for the life of the component, so this is effectively componentWillUnmount
-    [crossContextualKey, onResize, thought.id],
+    [crossContextualKey, onResize, thought?.id],
   )
 
   // Short circuit if thought has already been removed.

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -25,8 +25,8 @@ const durationsMillis = {
   layoutSlowShift: 750,
   /** The animation duration of a node in the LayoutTree component. This animates thought positions when they are moved. */
   layoutNodeAnimation: 150,
-  /* A fade out animation that matches the duration of layoutNodeAnimation and is triggered when a node unmounts. See autofocusChanged for normal opacity animations. */
-  nodeFadeOut: 150,
+  /* A fade out animation that is triggered when a node unmounts. See autofocusChanged for normal opacity animations. */
+  nodeFadeOut: 80,
 } as const
 
 export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -25,8 +25,8 @@ const durationsMillis = {
   layoutSlowShift: 750,
   /** The animation duration of a node in the LayoutTree component. This animates thought positions when they are moved. */
   layoutNodeAnimation: 150,
-  /* An opacity animation that matches the duration of layoutNodeAnimationDuration. */
-  nodeOpacity: 150,
+  /* A fade out animation that matches the duration of layoutNodeAnimation and is triggered when a node unmounts. See autofocusChanged for normal opacity animations. */
+  nodeFadeOut: 150,
 } as const
 
 export default durationsMillis

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -25,6 +25,8 @@ const durationsMillis = {
   layoutSlowShift: 750,
   /** The animation duration of a node in the LayoutTree component. This animates thought positions when they are moved. */
   layoutNodeAnimation: 150,
+  /* An opacity animation that matches the duration of layoutNodeAnimationDuration. */
+  nodeOpacity: 150,
 } as const
 
 export default durationsMillis

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -29,7 +29,6 @@ const fadeTransitionRecipe = defineSlotRecipe({
         exitActive: { transition: `opacity {durations.slow} ease 0ms` },
       },
       nodeOpacity: {
-        enterActive: { transition: `opacity {durations.nodeOpacity} cubic-bezier(0.4, 0, 0.6, 1)` },
         exitActive: { transition: `opacity {durations.nodeOpacity} ease-out` },
       },
     },

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -28,9 +28,9 @@ const fadeTransitionRecipe = defineSlotRecipe({
         enterActive: { transition: `opacity {durations.distractionFreeTyping} ease 0ms` },
         exitActive: { transition: `opacity {durations.slow} ease 0ms` },
       },
-      nodeOpacity: {
+      nodeFadeOut: {
         enter: { opacity: 1 },
-        exitActive: { transition: `opacity {durations.nodeOpacity} ease-out` },
+        exitActive: { transition: `opacity {durations.nodeFadeOut} ease-out` },
       },
     },
   },

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -8,6 +8,7 @@ const fadeTransitionRecipe = defineSlotRecipe({
     enterActive: { opacity: 1 },
     exit: { opacity: 1 },
     exitActive: { opacity: 0 },
+    exitDone: { opacity: 0 },
   },
   variants: {
     duration: {
@@ -26,6 +27,10 @@ const fadeTransitionRecipe = defineSlotRecipe({
       distractionFreeTyping: {
         enterActive: { transition: `opacity {durations.distractionFreeTyping} ease 0ms` },
         exitActive: { transition: `opacity {durations.slow} ease 0ms` },
+      },
+      nodeOpacity: {
+        enterActive: { transition: `opacity {durations.nodeOpacity} cubic-bezier(0.4, 0, 0.6, 1)` },
+        exitActive: { transition: `opacity {durations.nodeOpacity} ease-out` },
       },
     },
   },

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -29,6 +29,7 @@ const fadeTransitionRecipe = defineSlotRecipe({
         exitActive: { transition: `opacity {durations.slow} ease 0ms` },
       },
       nodeOpacity: {
+        enter: { opacity: 1 },
         exitActive: { transition: `opacity {durations.nodeOpacity} ease-out` },
       },
     },


### PR DESCRIPTION
#2526

This update implements the use of `CSSTransition` to apply the `.fade` CSS classes when items are unmounted. 

Please note that the current implementation uses the existing `.fade` classes, which have a transition duration of `200ms`, while the `timeout` for the transition is set to `veryFastDuration` (80ms).

https://github.com/cybersemics/em/blob/9e7f8a1e438468f3b1b8f330ffa8701f39074635/src/App.css#L21-L24

Let me know if you'd prefer to create a new CSS class to match the durations more closely.