### PR TITLE
Fix: Slow virtualization of thoughts

### DIFF
--- a/src/components/Subthought.tsx
+++ b/src/components/Subthought.tsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { shallowEqual, useSelector } from 'react-redux'
-import { css } from '../../styled-system/css'
 import Autofocus from '../@types/Autofocus'
 import LazyEnv from '../@types/LazyEnv'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import ThoughtId from '../@types/ThoughtId'
-import useChangeRef from '../hooks/useChangeRef'
 import attributeEquals from '../selectors/attributeEquals'
 import findFirstEnvContextWithZoom from '../selectors/findFirstEnvContextWithZoom'
 import { findAnyChild } from '../selectors/getChildren'
@@ -67,7 +65,6 @@ const Subthought = ({
   const parentId = thought.parentId
   const grandparentId = simplePath[simplePath.length - 3]
   const isVisible = zoomCursor || autofocus === 'show' || autofocus === 'dim'
-  const autofocusChanged = useChangeRef(autofocus)
 
   const childrenAttributeId = useSelector(
     state =>
@@ -104,40 +101,13 @@ const Subthought = ({
     [isEditingChildPath, style],
   )
 
-  // When autofocus changes, use a slow (750ms) ease-out to provide a gentle transition to non-focal thoughts.
-  // If autofocus has not changed, it means that the thought is being rendered for the first time, such as the children of a thought that was just expanded. In this case, match the tree-node top animation (150ms) to ensure that the newly rendered thoughts fade in to fill the space that is being opened up from the next uncle animating down.
-  // Note that ease-in is used in contrast to the tree-node's ease-out. This gives a little more time for the next uncle to animate down and clear space before the newly rendered thought fades in. Otherwise they overlap too much during the transition.
-  const opacity = autofocus === 'show' ? '1' : autofocus === 'dim' ? '0.5' : '0'
-  useEffect(() => {
-    if (!ref.current) return
-    // start opacity at 0 and set to actual opacity in useEffect
-    ref.current.style.opacity = opacity
-  })
-
   // Short circuit if thought has already been removed.
   // This can occur in a re-render even when thought is defined in the parent component.
   if (!thought) return null
 
   return (
     <>
-      <div
-        ref={ref}
-        className={css({
-          // Start opacity at 0 and set to actual opacity in useEffect.
-          // Do not fade in empty thoughts. An instant snap in feels better here.
-          // opacity creates a new stacking context, so it must only be applied to Thought, not to the outer VirtualThought which contains DropChild. Otherwise subsequent DropChild will be obscured.
-          opacity: thought.value === '' ? opacity : '0',
-          transition: autofocusChanged
-            ? `opacity {durations.layoutSlowShiftDuration} ease-out`
-            : `opacity {durations.layoutNodeAnimationDuration} ease-in`,
-          pointerEvents: !isVisible ? 'none' : undefined,
-          // Safari has a known issue with subpixel calculations, especially during animations and with SVGs.
-          // This caused the thought to jerk slightly to the left at the end of the horizontal shift animation.
-          // By setting "will-change: transform;", we hint to the browser that the transform property will change in the future,
-          // allowing the browser to optimize the animation.
-          willChange: 'opacity',
-        })}
-      >
+      <div ref={ref}>
         <Thought
           debugIndex={debugIndex}
           depth={depth + 1}

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -19,6 +19,8 @@ import noteValue from '../util/noteValue'
 import DropChild from './DropChild'
 import DropUncle from './DropUncle'
 import Subthought from './Subthought'
+import useChangeRef from '../hooks/useChangeRef';
+import { css } from '../../styled-system/css';
 
 /** A resize handler that should be called whenever a thought's height has changed. */
 export type OnResize = (args: {
@@ -96,6 +98,7 @@ const VirtualThought = ({
   const fontSize = useSelector(state => state.fontSize)
   const note = useSelector(state => noteValue(state, thought.id))
   const ref = useRef<HTMLDivElement>(null)
+  const autofocusChanged = useChangeRef(autofocus)
 
   /***************************
    * VirtualThought properties
@@ -201,6 +204,16 @@ const VirtualThought = ({
     [crossContextualKey, onResize, thought.id],
   )
 
+  // When autofocus changes, use a slow (750ms) ease-out to provide a gentle transition to non-focal thoughts.
+  // If autofocus has not changed, it means that the thought is being rendered for the first time, such as the children of a thought that was just expanded. In this case, match the tree-node top animation (150ms) to ensure that the newly rendered thoughts fade in to fill the space that is being opened up from the next uncle animating down.
+  // Note that ease-in is used in contrast to the tree-node's ease-out. This gives a little more time for the next uncle to animate down and clear space before the newly rendered thought fades in. Otherwise they overlap too much during the transition.
+  const opacity = autofocus === 'show' ? '1' : autofocus === 'dim' ? '0.5' : '0'
+  useEffect(() => {
+    if (!ref.current) return
+    // start opacity at 0 and set to actual opacity in useEffect
+    ref.current.style.opacity = opacity
+  })
+
   // Short circuit if thought has already been removed.
   // This can occur in a re-render even when thought is defined in the parent component.
   if (!thought) return null
@@ -208,6 +221,21 @@ const VirtualThought = ({
   return (
     <div
       ref={ref}
+      className={css({
+        // Start opacity at 0 and set to actual opacity in useEffect.
+        // Do not fade in empty thoughts. An instant snap in feels better here.
+        // opacity creates a new stacking context, so it must only be applied to Thought, not to the outer VirtualThought which contains DropChild. Otherwise subsequent DropChild will be obscured.
+        opacity: thought.value === '' ? opacity : '0',
+        transition: autofocusChanged
+          ? `opacity {durations.layoutSlowShiftDuration} ease-out`
+          : `opacity {durations.layoutNodeAnimationDuration} ease-in`,
+        pointerEvents: !isVisible ? 'none' : undefined,
+        // Safari has a known issue with subpixel calculations, especially during animations and with SVGs.
+        // This caused the thought to jerk slightly to the left at the end of the horizontal shift animation.
+        // By setting "will-change: transform;", we hint to the browser that the transform property will change in the future,
+        // allowing the browser to optimize the animation.
+        willChange: 'opacity',
+      })}
       style={{
         // Fix the height of the container to the last measured height to ensure that there is no layout shift when the Thought is removed from the DOM.
         // Must include DropChild, or it will shift when the cursor moves.

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -107,7 +107,10 @@ const VirtualThought = ({
   const isVisible = zoomCursor || autofocus === 'show' || autofocus === 'dim'
   const shimHiddenThought = useDelayedAutofocus(autofocus, {
     delay: 750,
-    selector: autofocusNew => autofocus === 'hide' && autofocusNew === 'hide' && !!height,
+    selector: autofocusNew =>
+      ((autofocus === 'hide' && autofocusNew === 'hide') ||
+        (autofocus === 'hide-parent' && autofocusNew === 'hide-parent')) &&
+      !!height,
   })
 
   // console.info('<VirtualThought>', prettyPath(childPath))

--- a/src/hooks/useDelayedAutofocus.ts
+++ b/src/hooks/useDelayedAutofocus.ts
@@ -13,7 +13,6 @@ const useDelayedAutofocus = <T = string>(
   // This ensures that the component is only re-rendered when the selector result changes, not every time the delayed autofocus value changes.
   const [autofocusDelayed, setAutofocusDelayed] = useState(selector(autofocus))
   const lastAutofocusRef = useRef(autofocus)
-  const unmounted = useRef(false)
   const autofocusTimerRef = useRef<number>(0)
   useEffect(
     () => {
@@ -24,17 +23,12 @@ const useDelayedAutofocus = <T = string>(
         (lastAutofocusRef.current === 'show' || lastAutofocusRef.current === 'dim')
       ) {
         autofocusTimerRef.current = setTimeout(() => {
-          if (unmounted.current) return
           setAutofocusDelayed(selector(autofocus))
           lastAutofocusRef.current = autofocus
         }, delay) as unknown as number
       } else {
         setAutofocusDelayed(selector(autofocus))
         lastAutofocusRef.current = autofocus
-      }
-
-      return () => {
-        unmounted.current = true
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem
This pull request resolves a bug causing slow virtualization of thoughts, ensuring smooth animation performance as expected. The issue occurred because the animation did not run smoothly when hidden thoughts were re-rendered; this was due to the animation being applied directly to the hiding DIV element.

## Solution
The solution is to remove the animation from the hiding DIV element and instead apply it to the parent DIV element, which maintains the animation's smoothness and performance.

Related to [#2399](https://github.com/cybersemics/em/issues/2399)