### PR TITLE
Fix/fade in new thought

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -426,7 +426,7 @@ const TreeNode = ({
   const [y, setY] = useState(_y)
   const fadeThoughtRef = useRef<HTMLDivElement>(null)
   const lastPatches = useSelector(state => state.undoPatches[state.undoPatches.length - 1])
-  const isLastActionNewThought = lastPatches?.filter(patch => patch.actions[0] === 'newThought')
+  const isLastActionNewThought = lastPatches?.some(patch => patch.actions[0] === 'newThought')
 
   useLayoutEffect(() => {
     if (y !== _y) {

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -425,6 +425,8 @@ const TreeNode = ({
 } & Pick<CSSTransitionProps, 'in'>) => {
   const [y, setY] = useState(_y)
   const fadeThoughtRef = useRef<HTMLDivElement>(null)
+  const lastPatches = useSelector(state => state.undoPatches[state.undoPatches.length - 1])
+  const isLastActionNewThought = lastPatches?.filter(patch => patch.actions[0] === 'newThought')
 
   useLayoutEffect(() => {
     if (y !== _y) {
@@ -452,10 +454,9 @@ const TreeNode = ({
   const marginRight = isTableCol1 ? xCol2 - (width || 0) - x - (bulletWidth || 0) : 0
 
   // Speed up the tree-node's transition (normally layoutNodeAnimationDuration) by 50% on New (Sub)Thought only.
-  const layoutTransition =
-    prevChild?.value === ''
-      ? `left {durations.layoutNodeAnimationFast} ease-out,top {durations.layoutNodeAnimationFast} ease-out`
-      : `left {durations.layoutNodeAnimation} ease-out,top {durations.layoutNodeAnimation} ease-out`
+  const layoutTransition = isLastActionNewThought
+    ? `left {durations.layoutNodeAnimationFast} ease-out,top {durations.layoutNodeAnimationFast} ease-out`
+    : `left {durations.layoutNodeAnimation} ease-out,top {durations.layoutNodeAnimation} ease-out`
 
   return (
     <div

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -26,6 +26,10 @@ const durationsConfig = {
   layoutSlowShift: 750,
   /** The animation duration of a node in the LayoutTree component. This animates thought positions when they are moved. */
   layoutNodeAnimation: 150,
+  /** A faster alternative to layoutNodeAnimation, currently used for new thoughts. */
+  layoutNodeAnimationFast: 75,
+  /* A fade in animation that is triggered for new thoughts. */
+  nodeFadeIn: 80,
   /* A fade out animation that is triggered when a node unmounts. See autofocusChanged for normal opacity animations. */
   nodeFadeOut: 80,
 } as const

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -28,6 +28,9 @@ const fadeTransitionRecipe = defineSlotRecipe({
         enterActive: { transition: `opacity {durations.distractionFreeTyping} ease 0ms` },
         exitActive: { transition: `opacity {durations.slow} ease 0ms` },
       },
+      nodeFadeIn: {
+        enterActive: { transition: `opacity {durations.nodeFadeIn} ease-in-out` },
+      },
       nodeFadeOut: {
         enter: { opacity: 1 },
         exitActive: { transition: `opacity {durations.nodeFadeOut} ease-out` },


### PR DESCRIPTION
Fixes #1790 

This PR is branched off of #2581 because it depends on the new `CSSTransition` for `tree-node` element.
Added new property `value` for the `TreeThought` to distinguish new thoughts.

<details>
<summary>End result:</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e92bf6f0-6256-4e8a-9dff-fc3f1c5e6a80

</details>