### PR TITLE
Fix: [Capacitor] Top safe area is covered

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -25,6 +25,7 @@ const config: CapacitorConfig = {
   ...serverConfig,
   ios: {
     backgroundColor: '000000',
+    contentInset: 'always'
   },
   plugins: {
     Keyboard: {

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -25,7 +25,7 @@ const config: CapacitorConfig = {
   ...serverConfig,
   ios: {
     backgroundColor: '000000',
-    contentInset: 'always'
+    contentInset: 'always',
   },
   plugins: {
     Keyboard: {

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <title>em</title>
 
   </head>
-  <body style="padding-top: env(safe-area-inset-top);">
+  <body>
     <div id="root"></div>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=contain"
     />
     <meta name="mobile-web-app-capable" content="yes" />
 
@@ -24,7 +24,7 @@
     <title>em</title>
 
   </head>
-  <body>
+  <body style="padding-top: env(safe-area-inset-top);">
     <div id="root"></div>
 
     <script>


### PR DESCRIPTION
#2514

This is a small fix for the overlap issue caused on IOS without the contentInset being set. By default, the app will overlap without this configuration.

Screenshots after fix on ios iPhone 15 emulator:

<img width="313" alt="Screenshot 2024-11-06 at 12 35 26 PM" src="https://github.com/user-attachments/assets/43a65e65-81a1-44c0-906a-ce862eebfa2e">

<img width="307" alt="Screenshot 2024-11-06 at 12 36 57 PM" src="https://github.com/user-attachments/assets/e5c36eba-e93f-49d7-a392-1dc6ab94197f">
