### PR TITLE
Fix: [Capacitor] Set overscroll background color from theme

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -24,7 +24,7 @@ const config: CapacitorConfig = {
   webDir: 'build',
   ...serverConfig,
   ios: {
-    backgroundColor: '000000',
+    scrollEnabled: true,
   },
   plugins: {
     Keyboard: {

--- a/ios/App/App/EnableBounce.m
+++ b/ios/App/App/EnableBounce.m
@@ -11,6 +11,6 @@
 @implementation UIScrollView (NoBounce)
 - (void)didMoveToWindow {
    [super didMoveToWindow];
-   self.bounces = YES;
+   self.bounces = NO;
 }
 @end

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,15 @@
   This file is deprecated. All styles should be added inline using PandaCSS.
   See: https://panda-css.com/docs/concepts/writing-styles
 */
-
+html,
+body,
+#root,
+#app {
+  height: 100%;
+  font-size: 16px;
+  overflow-y: auto;
+  clip-path: inset(0 0 0 0);
+}
 /* react-transition-group animation: fade */
 .fade-enter {
   opacity: 0;


### PR DESCRIPTION
[Issue 1700](https://github.com/cybersemics/em/issues/1700)

I added a way to eliminate the ios bounce outside the boundary of the app while adding a scroll feature within the controllable range of the app code instead of the device.