### PR TITLE
Cursor moves up instead of caret moving up one line

### DIFF
--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -93,7 +93,7 @@ export const isOnFirstLine = (): boolean => {
   const clientRects = selection.getRangeAt(0).getClientRects()
   if (!clientRects?.length) return true
 
-  const { y: rangeY } = clientRects[0]
+  const { y: rangeY } = clientRects[clientRects.length - 1]
   if (!rangeY) return true
 
   const baseNodeParentEl = baseNode?.parentElement as HTMLElement

--- a/src/e2e/puppeteer/__tests__/caret-multiline.ts
+++ b/src/e2e/puppeteer/__tests__/caret-multiline.ts
@@ -263,4 +263,27 @@ describe('all platforms', () => {
     const offset = await getSelection().focusOffset
     expect(offset).toBe(0)
   })
+
+  // test case 11
+  it('on cursorUp, the caret should move from the start of the 2nd line in a multi-line cursor to the start of the 1st line in the same cursor.', async () => {
+    const multiLineCursor =
+      "Beautiful antique furnishings fill this quiet, comfortable flat across from the Acropolis museum. AC works great. It is in an heavily touristic area, but the convenience can't be beat. Highly recommended."
+    const importText = `
+  - a
+  - ${multiLineCursor}`
+
+    await paste(importText)
+
+    const editableNodeHandle = await waitForEditable(multiLineCursor)
+    await click(editableNodeHandle, { y: 1 })
+
+    await press('ArrowUp')
+
+    // the focus must be at the start of the multi-line cursor after cursor up
+    const textContext = await getSelection().focusNode?.textContent
+    expect(textContext).toBe(multiLineCursor)
+
+    const offset = await getSelection().focusOffset
+    expect(offset).toBe(0)
+  })
 })


### PR DESCRIPTION
Fixes #2512

If the caret is at the beginning of a line, the selection seems to span from the end of the previous line to the start of the new line. This causes `window.getSelection().getRangeAt(0).getClientRects()` to return 2 rects, where the first has a y coordinate that corresponds to the previous line.