### PR TITLE
Fix pull queue tests 

### DIFF
--- a/src/redux-middleware/__tests__/pullQueue.ts
+++ b/src/redux-middleware/__tests__/pullQueue.ts
@@ -283,8 +283,6 @@ it('edit thought with buffered descendants', async () => {
 
   await refreshTestApp()
 
-  // await act(vi.runOnlyPendingTimersAsync)
-
   // // edit thought with buffered descendants
   await dispatch(editThought(['a'], 'k'))
 

--- a/src/redux-middleware/__tests__/pullQueue.ts
+++ b/src/redux-middleware/__tests__/pullQueue.ts
@@ -35,7 +35,7 @@ const matchContextsChildren = async (provider: DataProvider, context: Context, c
 }
 
 /**
- * getContext but automatically runs the timers forward
+ * Calls getContext but automatically runs the timers forward.
  */
 const getContextAsync = async (provider: DataProvider, context: Context) => {
   const ctxPromise = getContext(provider, context)

--- a/src/redux-middleware/__tests__/pullQueue.ts
+++ b/src/redux-middleware/__tests__/pullQueue.ts
@@ -41,7 +41,7 @@ const getContextAsync = async (provider: DataProvider, context: Context) => {
   const ctxPromise = getContext(provider, context)
   await vi.runAllTimersAsync()
 
-  return await ctxPromise
+  return ctxPromise
 }
 
 beforeEach(createTestApp)
@@ -51,7 +51,6 @@ it('disable isLoading after initialize', async () => {
   expect(store.getState().isLoading).toBe(false)
 })
 
-// y-indexeddb breaks tests
 it('load thought', async () => {
   // create a thought, which will get persisted to local db
   await dispatch(newThought({ value: 'a' }))
@@ -106,7 +105,6 @@ it('do not repopulate deleted thought', async () => {
   expect(parentEntryChild).toBe(null)
 })
 
-// y-indexeddb breaks tests
 it('load buffered thoughts', async () => {
   await dispatch(
     importText({
@@ -148,7 +146,6 @@ it('load buffered thoughts', async () => {
   expect(getAllChildrenByContext(state, ['a', 'b', 'c', 'd', 'e'])).toMatchObject([])
 })
 
-// y-indexeddb breaks tests
 it('delete thought with buffered descendants', async () => {
   await dispatch([
     importText({
@@ -187,7 +184,6 @@ it('delete thought with buffered descendants', async () => {
   expect(await getContextAsync(db, ['a', 'b', 'c', 'd', 'e'])).toBeFalsy()
 })
 
-// y-indexeddb breaks tests
 it('move thought with buffered descendants', async () => {
   await dispatch([
     importText({
@@ -254,7 +250,6 @@ it('move thought with buffered descendants', async () => {
   await matchContextsChildren(db, ['x', 'a', 'b', 'c', 'd', 'e'], [])
 })
 
-// y-indexeddb breaks tests
 it('edit thought with buffered descendants', async () => {
   await dispatch([
     importText({
@@ -283,7 +278,7 @@ it('edit thought with buffered descendants', async () => {
 
   await refreshTestApp()
 
-  // // edit thought with buffered descendants
+  // edit thought with buffered descendants
   await dispatch(editThought(['a'], 'k'))
 
   await act(vi.runOnlyPendingTimersAsync)

--- a/src/redux-middleware/__tests__/pullQueue.ts
+++ b/src/redux-middleware/__tests__/pullQueue.ts
@@ -34,6 +34,9 @@ const matchContextsChildren = async (provider: DataProvider, context: Context, c
   expect(childrenThoughts).toMatchObject(children)
 }
 
+/**
+ * getContext but automatically runs the timers forward
+ */
 const getContextAsync = async (provider: DataProvider, context: Context) => {
   const ctxPromise = getContext(provider, context)
   await vi.runAllTimersAsync()

--- a/src/redux-middleware/__tests__/pullQueue.ts
+++ b/src/redux-middleware/__tests__/pullQueue.ts
@@ -34,6 +34,13 @@ const matchContextsChildren = async (provider: DataProvider, context: Context, c
   expect(childrenThoughts).toMatchObject(children)
 }
 
+const getContextAsync = async (provider: DataProvider, context: Context) => {
+  const ctxPromise = getContext(provider, context)
+  await vi.runAllTimersAsync()
+
+  return await ctxPromise
+}
+
 beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 
@@ -139,7 +146,7 @@ it('load buffered thoughts', async () => {
 })
 
 // y-indexeddb breaks tests
-it.skip('delete thought with buffered descendants', async () => {
+it('delete thought with buffered descendants', async () => {
   await dispatch([
     importText({
       text: `
@@ -170,11 +177,11 @@ it.skip('delete thought with buffered descendants', async () => {
   await dispatch(deleteThoughtAtFirstMatchActionCreator(['a']))
 
   await matchContextsChildren(db, [HOME_TOKEN], [{ value: 'x' }])
-  expect(await getContext(db, ['a'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c', 'd'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c', 'd', 'e'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c', 'd'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c', 'd', 'e'])).toBeFalsy()
 })
 
 // y-indexeddb breaks tests
@@ -245,7 +252,7 @@ it('move thought with buffered descendants', async () => {
 })
 
 // y-indexeddb breaks tests
-it.skip('edit thought with buffered descendants', async () => {
+it('edit thought with buffered descendants', async () => {
   await dispatch([
     importText({
       text: `
@@ -271,21 +278,22 @@ it.skip('edit thought with buffered descendants', async () => {
   await matchContextsChildren(db, ['a', 'b', 'c', 'd'], [{ value: 'e' }])
   await matchContextsChildren(db, ['a', 'b', 'c', 'd', 'e'], [])
 
-  await act(vi.runOnlyPendingTimersAsync)
-
   await refreshTestApp()
 
-  // edit thought with buffered descendants
+  // await act(vi.runOnlyPendingTimersAsync)
+
+  // // edit thought with buffered descendants
   await dispatch(editThought(['a'], 'k'))
 
   await act(vi.runOnlyPendingTimersAsync)
 
   await matchContextsChildren(db, [HOME_TOKEN], [{ value: 'x' }, { value: 'k' }])
-  expect(await getContext(db, ['a'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c', 'd'])).toBeFalsy()
-  expect(await getContext(db, ['a', 'b', 'c', 'd', 'e'])).toBeFalsy()
+
+  expect(await getContextAsync(db, ['a'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c', 'd'])).toBeFalsy()
+  expect(await getContextAsync(db, ['a', 'b', 'c', 'd', 'e'])).toBeFalsy()
 
   await matchContextsChildren(db, ['k'], [{ value: 'm' }, { value: 'b' }])
   await matchContextsChildren(db, ['k!', 'b'], [{ value: 'c' }])


### PR DESCRIPTION
First problem here is that we can't `await getContext` when using fake timers and replication because `getContext` calls `getLexemeById` which then calls `await` itself, causing the code to sit there and wait because nothing is forwarding the timers. Thus, we must grab the `getContext` promise, run the timers forward, and _then_ `await` the getContext promise.

Second problem appears that `thoughtspace.ts` has at least one instance where it awaits an operation and then creates async operations afterwards. This means that `runOnlyPendingTimers` won't work since that simply forwards the pending timer and won't forward past the subsequent async operation(s). 

Closes #2139