### PR TITLE
Reference error document undefined

### DIFF
--- a/src/components/__tests__/headings.ts
+++ b/src/components/__tests__/headings.ts
@@ -9,23 +9,25 @@ beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 
 it('headings should set font weight', async () => {
-  store.dispatch([
-    importText({
-      text: `
-      - Normal Text
-      - My Heading 1
-        - =heading1
-      - My Heading 2
-        - =heading2
-      - My Heading 3
-        - =heading3
-      - My Heading 4
-        - =heading4
-      - My Heading 5
-        - =heading5
-    `,
-    }),
-  ])
+  act(() =>
+    store.dispatch([
+      importText({
+        text: `
+        - Normal Text
+        - My Heading 1
+          - =heading1
+        - My Heading 2
+          - =heading2
+        - My Heading 3
+          - =heading3
+        - My Heading 4
+          - =heading4
+        - My Heading 5
+          - =heading5
+      `,
+      }),
+    ]),
+  )
 
   await act(vi.runOnlyPendingTimersAsync)
 
@@ -50,7 +52,7 @@ it('headings should set font weight', async () => {
   expect(thought5).toHaveStyle({ fontWeight: 600 })
 
   // child should not be bold
-  store.dispatch(setCursor(['My Heading 1', '=heading1']))
+  act(() => store.dispatch(setCursor(['My Heading 1', '=heading1'])))
 
   await act(vi.runOnlyPendingTimersAsync)
 

--- a/src/redux-middleware/scrollCursorIntoView.ts
+++ b/src/redux-middleware/scrollCursorIntoView.ts
@@ -97,7 +97,7 @@ const scrollCursorIntoView = () => {
 
   setTimeout(
     () => {
-      scrollIntoViewIfNeeded(document.querySelector('[data-editing=true]'))
+      if (document && document.querySelector) scrollIntoViewIfNeeded(document.querySelector('[data-editing=true]'))
     },
     // If this is the result of a navigation, wait for the layout animation to complete to not get false bounding rect values
     userInteractedAfterNavigation ? 0 : durations.get('layoutNodeAnimationDuration'),

--- a/src/shortcuts/__tests__/splitThought.ts
+++ b/src/shortcuts/__tests__/splitThought.ts
@@ -8,18 +8,20 @@ beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 
 it('split thought after non-word character', async () => {
-  store.dispatch([
-    newThought({
-      value: '*test',
-    }),
-    {
-      type: 'splitThought',
-      splitResult: {
-        left: '*',
-        right: 'test',
+  act(() =>
+    store.dispatch([
+      newThought({
+        value: '*test',
+      }),
+      {
+        type: 'splitThought',
+        splitResult: {
+          left: '*',
+          right: 'test',
+        },
       },
-    },
-  ])
+    ]),
+  )
 
   await act(vi.runOnlyPendingTimersAsync)
 


### PR DESCRIPTION
This is a possible, temporary solution for the defect discussed in #2583.

Simply checking if `document` exists should clear up the error.