### PR TITLE
Freeze VirtualThought width during indent shift

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -395,6 +395,7 @@ const TreeNode = ({
   cliffPaddingStyle,
   dragInProgress,
   autofocusDepth,
+  indent,
 }: TreeThoughtPositioned & {
   thoughtKey: string
   index: number
@@ -406,6 +407,7 @@ const TreeNode = ({
   cliffPaddingStyle: { paddingBottom: number }
   dragInProgress: boolean
   autofocusDepth: number
+  indent: number
 }) => {
   const [y, setY] = useState(_y)
 
@@ -481,6 +483,7 @@ const TreeNode = ({
         isLastVisible={isLastVisible}
         autofocus={autofocus}
         marginRight={isTableCol1 ? marginRight : 0}
+        indent={indent}
       />
 
       {/* DropEnd (cliff) */}
@@ -895,14 +898,16 @@ const LayoutTree = () => {
         hoverArrowVisibility={hoverArrowVisibility}
       />
       <div
-        className={css({ transition: `transform {durations.layoutSlowShiftDuration} ease-out` })}
+        className={css({
+          transition: `transform {durations.layoutSlowShiftDuration} ease-out,margin {durations.layoutSlowShiftDuration} ease-out`,
+        })}
         style={{
           // Set a container height that fits all thoughts.
           // Otherwise scrolling down quickly will bottom out as virtualized thoughts are re-rendered and the document height is built back up.
           height: totalHeight + spaceBelow,
           // Use translateX instead of marginLeft to prevent multiline thoughts from continuously recalculating layout as their width changes during the transition.
           // Instead of using spaceAbove, we use -min(spaceAbove, c) + c, where c is the number of pixels of hidden thoughts above the cursor before cropping kicks in.
-          transform: `translateX(${1.5 - indent}em`,
+          transform: `translateX(${1.5 - indent}em)`,
           // Add a negative marginRight equal to translateX to ensure the thought takes up the full width. Not animated for a more stable visual experience.
           marginRight: `${-indent + (isTouch ? 2 : -1)}em`,
         }}
@@ -924,6 +929,7 @@ const LayoutTree = () => {
               cliffPaddingStyle,
               dragInProgress,
               autofocusDepth,
+              indent,
             }}
           />
         ))}

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -182,9 +182,7 @@ const VirtualThought = ({
 
   // Recalculate height when anything changes that could indirectly affect the height of the thought. (Height observers are slow.)
   // Autofocus changes when the cursor changes depth or moves between a leaf and non-leaf. This changes the left margin and can cause thoughts to wrap or unwrap.
-  useLayoutEffect(() => {
-    window.requestAnimationFrame(updateSize)
-  }, [
+  useLayoutEffect(updateSize, [
     cursorDepth,
     cursorLeaf,
     fontSize,

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,14 +1,18 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 
 /** Retains & returns the previous value passed in each time the hook is invoked. */
-function usePrevious<T>(value: T): T | undefined {
-  const ref = useRef<T>()
+function usePrevious<T>(value: T): T {
+  const [current, setCurrent] = useState(() => value)
+  const [previous, setPrevious] = useState(() => value)
 
   useEffect(() => {
-    ref.current = value
-  }, [value])
+    if (current !== value) {
+      setPrevious(current)
+      setCurrent(value)
+    }
+  }, [current, value])
 
-  return ref.current
+  return previous
 }
 
 export default usePrevious


### PR DESCRIPTION
Fixes #4

Animating `transform` doesn't update the caret position correctly in iOS Safari. Animating `margin` as well will pull the caret along in the correct direction, fixing the caret drift. It also causes the layout to update continuously during the animation, so it is beneficial to calculate the width (adding or subtracting new margins) that the thought will eventually occupy, and then apply that static width to the `VirtualThought` for the duration of the transition.