### PR TITLE
Apply bullet color automatically instead of metaprogramming.

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -443,6 +443,14 @@ const Bullet = ({
 
   /** Check if the entire value is wrapped in a single font or span tag. */
   const isWrappedInSingleTag = (str: string): boolean => {
+    // Check if there's any text before the first tag or after the last tag
+    const firstTagIndex = str.indexOf('<')
+    const lastTagIndex = str.lastIndexOf('>')
+
+    if (firstTagIndex > 0 || lastTagIndex < str.length - 1) {
+      return false
+    }
+
     const tagStack: string[] = []
     let currentPos = 0
 
@@ -481,7 +489,7 @@ const Bullet = ({
     }
 
     // Valid if exactly one tag remains in stack (the outer tag)
-    return tagStack.length === 1 && tagStack[0] === 'font'
+    return tagStack.length === 1 && (tagStack[0] === 'font' || tagStack[0] === 'span')
   }
 
   const fill = useSelector(state => {
@@ -489,7 +497,6 @@ const Bullet = ({
     if (!thought) return undefined
 
     const value = thought.value
-
     // Check if the entire value is wrapped in a single font or span tag
     const isWrappedInTag = isWrappedInSingleTag(value)
     if (isWrappedInTag) {

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -16,7 +16,6 @@ import attributeEquals from '../selectors/attributeEquals'
 import findDescendant from '../selectors/findDescendant'
 import { getAllChildrenAsThoughts, getChildren } from '../selectors/getChildren'
 import getLexeme from '../selectors/getLexeme'
-import getStyle from '../selectors/getStyle'
 import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
 import isMulticursorPath from '../selectors/isMulticursorPath'
@@ -442,11 +441,68 @@ const Bullet = ({
     return children.length < Object.keys(thought.childrenMap).length
   })
 
-  // fill =bullet/=style override
+  /** Check if the entire value is wrapped in a single font or span tag. */
+  const isWrappedInSingleTag = (str: string): boolean => {
+    const tagStack: string[] = []
+    let currentPos = 0
+
+    while (currentPos < str.length) {
+      // Find next tag
+      const openIndex = str.indexOf('<', currentPos)
+      if (openIndex === -1) break
+
+      const closeIndex = str.indexOf('>', openIndex)
+      if (closeIndex === -1) return false
+
+      const tag = str.substring(openIndex, closeIndex + 1)
+      currentPos = closeIndex + 1
+
+      if (tag.startsWith('</')) {
+        // Closing tag
+        const tagName = tag.slice(2, -1).toLowerCase()
+        // If stack is empty or last opening tag doesn't match, return false
+        if (tagStack.length === 0 || tagStack[tagStack.length - 1] !== tagName) {
+          return false
+        }
+
+        // Remove matching opening tag
+        tagStack.pop()
+
+        // If stack is empty before end of string, only valid if this is the last tag
+        if (tagStack.length === 0 && currentPos <= str.length) {
+          const remainingTags = str.slice(currentPos).match(/<\/?[a-z]+/g)
+          return !remainingTags
+        }
+      } else if (!tag.endsWith('/>')) {
+        // Opening tag (excluding self-closing tags)
+        const tagName = tag.slice(1).split(/[\s>]/)[0].toLowerCase()
+        tagStack.push(tagName)
+      }
+    }
+
+    // Valid if exactly one tag remains in stack (the outer tag)
+    return tagStack.length === 1 && tagStack[0] === 'font'
+  }
+
   const fill = useSelector(state => {
-    const bulletId = findDescendant(state, head(simplePath), '=bullet')
-    const styles = getStyle(state, bulletId)
-    return styles?.color
+    const thought = getThoughtById(state, thoughtId)
+    if (!thought) return undefined
+
+    const value = thought.value
+
+    // Check if the entire value is wrapped in a single font or span tag
+    const isWrappedInTag = isWrappedInSingleTag(value)
+    if (isWrappedInTag) {
+      // Check for background-color in style attribute
+      const bgColorMatch = value.match(/style="[^"]*background-color:\s*([^;"'>]+)[^"]*"/i)
+      if (bgColorMatch) return bgColorMatch[1]
+
+      // If no background-color, check for font color
+      const fontColorMatch = value.match(/<font[^>]*color="([^"]+)"[^>]*>/i)
+      if (fontColorMatch) return fontColorMatch[1]
+    }
+
+    return undefined
   })
 
   const isExpanded = useSelector(state => !!state.expanded[hashPath(path)])

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import { token } from '../../styled-system/tokens'
 import { SystemStyleObject } from '../../styled-system/types'
-import { bulletColorActionCreator as bulletColor } from '../actions/bulletColor'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import { isTouch } from '../browser'
 import { ColorToken } from '../colors.config'
@@ -99,21 +98,6 @@ const ColorSwatch: FC<{
     } else {
       dispatch(formatSelection('backColor', 'bg'))
     }
-
-    dispatch(
-      bulletColor({
-        ...(selected
-          ? {
-              color: 'default',
-            }
-          : color
-            ? { color: label }
-            : {
-                backgroundColor: label,
-              }),
-        shape,
-      }),
-    )
   }
   return (
     <span

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -1,5 +1,6 @@
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
+import getBulletColor from '../helpers/getBulletColor'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
@@ -18,7 +19,7 @@ const extractStyleProperty = (html: string) => {
   return { color, backgroundColor }
 }
 
-it('Set the text color of the text', async () => {
+it('Set the text color of the text and bullet', async () => {
   const importText = `
   - Labrador
   - Golden Retriever`
@@ -32,7 +33,9 @@ it('Set the text color of the text', async () => {
   await click('[aria-label="text color swatches"] [aria-label="blue"]')
 
   const cursorText = await getEditingText()
+  const bulletColor = await getBulletColor()
   const result = extractStyleProperty(cursorText!)
+  expect(bulletColor).toBe('rgb(0, 199, 230)')
   expect(result?.color).toBe('#00c7e6')
   expect(result?.backgroundColor).toBe(null)
 })
@@ -50,7 +53,9 @@ it('Set the background color of the text', async () => {
   await click('[aria-label="background color swatches"] [aria-label="green"]')
 
   const cursorText = await getEditingText()
+  const bulletColor = await getBulletColor()
   const result = extractStyleProperty(cursorText!)
+  expect(bulletColor).toBe('rgb(0, 214, 136)')
   expect(result?.backgroundColor).toBe('rgb(0, 214, 136)')
 })
 

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -3,6 +3,7 @@ import clickThought from '../helpers/clickThought'
 import getBulletColor from '../helpers/getBulletColor'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
+import setSelection from '../helpers/setSelection'
 import waitForEditable from '../helpers/waitForEditable'
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
@@ -104,6 +105,25 @@ it('Clear the text color when setting background color', async () => {
   cursorText = await getEditingText()
   expect(extractStyleProperty(cursorText!)?.backgroundColor).toBe('rgb(170, 128, 255)')
   expect(extractStyleProperty(cursorText!)?.color).toBe('#000000')
+})
+
+it('Bullet remains the default color when a substring color is set', async () => {
+  const importText = `
+  - Golden Retriever`
+
+  await paste(importText)
+
+  await waitForEditable('Golden Retriever')
+  await clickThought('Golden Retriever')
+
+  await setSelection(0, 6)
+  // Set color for selected text
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="blue"]')
+
+  // Verify bullet color remains default and only substring is colored
+  const bulletColor = await getBulletColor()
+  expect(bulletColor).toBe(null)
 })
 
 it('Empty <font> element will be removed after setting color to default.', async () => {

--- a/src/e2e/puppeteer/helpers/getBulletColor.ts
+++ b/src/e2e/puppeteer/helpers/getBulletColor.ts
@@ -1,7 +1,7 @@
 import { page } from '../setup'
 
 /**
- * Get the thought value that cursor on.
+ * Get the color of the bullet that cursor is on.
  */
 const getBulletColor = () =>
   page.evaluate(() => {

--- a/src/e2e/puppeteer/helpers/getBulletColor.ts
+++ b/src/e2e/puppeteer/helpers/getBulletColor.ts
@@ -1,0 +1,12 @@
+import { page } from '../setup'
+
+/**
+ * Get the thought value that cursor on.
+ */
+const getBulletColor = () =>
+  page.evaluate(() => {
+    const bullet = document.querySelector('[data-editing=true] [aria-label="bullet-glyph"]') as HTMLElement
+    return bullet?.style.fill || null
+  })
+
+export default getBulletColor

--- a/src/e2e/puppeteer/helpers/setSelection.ts
+++ b/src/e2e/puppeteer/helpers/setSelection.ts
@@ -1,0 +1,22 @@
+import { page } from '../setup'
+
+/** Sets the selection of the text in the editable. */
+const setSelection = async (start: number, end: number) => {
+  await page.evaluate(
+    (start: number, end: number) => {
+      const selection = window.getSelection()
+      const range = document.createRange()
+      const textNode = document.querySelector('[contenteditable="true"]')?.firstChild
+      if (textNode) {
+        range.setStart(textNode, start)
+        range.setEnd(textNode, end)
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+      }
+    },
+    start,
+    end,
+  )
+}
+
+export default setSelection


### PR DESCRIPTION
Issue : Apply bullet color automatically instead of with metaprogramming attribute https://github.com/cybersemics/em/issues/2549

In this PR, I have removed the using the metaprogamming attributes when setting text color with the color picker.
I changed the fix function in Bullet.tsx.
I checked thought value and get the current foreColor and backColor from the thought value.
And set the bullet color with that color.