### PR TITLE
fix UI issue on error popup

### DIFF
--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -6,7 +6,6 @@ import fastClick from '../util/fastClick'
 /** A close button with an ✕. */
 const CloseButton = ({ onClose, disableSwipeToDismiss }: { onClose: () => void; disableSwipeToDismiss?: boolean }) => {
   const fontSize = useSelector(state => state.fontSize)
-  const padding = fontSize / 2 + 2
   return (
     <a
       {...fastClick(onClose)}
@@ -15,12 +14,12 @@ const CloseButton = ({ onClose, disableSwipeToDismiss }: { onClose: () => void; 
         css({
           fontSize: 'sm',
           color: 'inherit',
-          right: '0',
+          right: '10',
           textDecoration: 'none',
-          top: '0',
+          top: '5',
         }),
       )}
-      style={{ fontSize, padding: `${padding}px ${padding * 1.25}px` }}
+      style={{ fontSize }}
       aria-label={disableSwipeToDismiss ? 'no-swipe-to-dismiss' : undefined}
       data-testid='close-button'
     >


### PR DESCRIPTION
Fix UI issue for https://github.com/cybersemics/em/issues/2431

Issue happened due to the padding
so I set position value instead of padding so whatever error content is long or not, close icon is always at the top-right corner of pop up.