### PR TITLE
remove cancelable from condition to prevent touch

### DIFF
--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -109,7 +109,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
     document.body.addEventListener(
       'touchmove',
       e => {
-        if (this.disableScroll && e.cancelable) {
+        if (this.disableScroll) {
           e.preventDefault()
         }
       },


### PR DESCRIPTION
fixes https://github.com/cybersemics/em/issues/2618

some touch events are not cancelable, thus we don't prevent those
perhaps, it's for times when you scroll over big chunks of text(that's where I've seen the most of not-being-canceled)
but if I remove the && e.cancelable part, it does prevents the event just fine, so it also claims that falsely.

the behavior of events being cancelable or not are not consitent on Android browsers, e.g. sometimes they are in Chrome, but not on Vivaldi.