### PR TITLE
"and" as in-sentence splitter

### DIFF
--- a/src/shortcuts/__tests__/splitSentences.ts
+++ b/src/shortcuts/__tests__/splitSentences.ts
@@ -69,6 +69,52 @@ describe('splitSentences', () => {
   - I'm fine, thanks.`)
   })
 
+  it('splits by comma if have only one sentence', () => {
+    const store = createTestStore()
+
+    store.dispatch([
+      importText({
+        text: `
+          - Gödel, Escher, Bach
+        `,
+      }),
+      setCursor(['Gödel, Escher, Bach']),
+    ])
+
+    executeShortcut(splitSentencesShortcut, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- __ROOT__
+  - Gödel
+  - Escher
+  - Bach`)
+  })
+
+  it('splits by "and" also, if have only one sentence', () => {
+    const store = createTestStore()
+
+    store.dispatch([
+      importText({
+        text: `
+          - me, you, he and she, them, thus, and, me
+        `,
+      }),
+      setCursor(['me, you, he and she, them, thus, and, me']),
+    ])
+
+    executeShortcut(splitSentencesShortcut, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- __ROOT__
+  - me
+  - you
+  - he
+  - she
+  - them
+  - thus
+  - me`)
+  })
+
   describe('multicursor', () => {
     it('splits sentences in multiple thoughts', async () => {
       const store = createTestStore()

--- a/src/util/splitSentence.ts
+++ b/src/util/splitSentence.ts
@@ -55,26 +55,21 @@ const splitSentence = (value: string): string[] => {
   // pattern2, multiple symbols: ?! !!! ...
   const mainSplitRegex = /[.;!?]+/g
 
-  const splitters = value.match(mainSplitRegex)
-
-  // When it cannot be split by the main spliter, spliter by ','
-  if (!splitters)
-    return value
-      .split(',')
-      .filter(s => s !== '')
-      .map(s => s.trim())
+  const sentenceSplitters = value.match(mainSplitRegex)
 
   /**
-   * Checks if the value has no other main split characters  except one period at the end.
+   * Checks if the value has no other main split characters  except one period at the end, i.e. value is just one sentence.
    * If so, allow split on comma only if there are no main split characters in the value or has only one period at the end.
    */
   const hasOnlyPeriodAtEnd = once(() => /^[^.;!?]*\.$[^.;!?]*/.test(value.trim()))
 
-  if (hasOnlyPeriodAtEnd())
+  // if we're sub-sentence or in one sentence territory, split by comma and "and"
+  // e.g. "john, johnson, and john doe" or "- john - johnson - john doe"
+  if (!sentenceSplitters || hasOnlyPeriodAtEnd())
     return value
-      .split(',')
+      .split(/\s*,\s*|\s*and\s*/i) // we have to check for extra space near "," and "and"
       .filter(s => s !== '')
-      .map(s => `${s.trim()}`)
+      .map(s => s.trim())
 
   /**
    * When the setences can be split, it has multiple situations.
@@ -88,11 +83,11 @@ const splitSentence = (value: string): string[] => {
   const initialValue = sentences[0]
 
   const resultSentences = sentences.reduce((newSentence: string, s: string, i: number) => {
-    if (i === 0) return newSentence + splitters[0]
+    if (i === 0) return newSentence + sentenceSplitters[0]
 
     const seperatorIndex = newSentence.lastIndexOf(SEPARATOR_TOKEN)
     const prevSentence = seperatorIndex < 0 ? newSentence : newSentence.slice(seperatorIndex + 7)
-    const currSentence = splitters[i] ? s + splitters[i] : s
+    const currSentence = sentenceSplitters[i] ? s + sentenceSplitters[i] : s
 
     /**
      * Combine the current sentence with the previous sentence to form one new sentence if it is the below conditions:


### PR DESCRIPTION
Fixes https://github.com/cybersemics/em/issues/2466

Now "and" counts just like a comma in separating <= 1 sentences

https://github.com/user-attachments/assets/e21abf29-56f2-4e69-96e8-6601ff19827a

