### PR TITLE
Fix Modal Export Tests

### DIFF
--- a/src/components/__tests__/ModalExport.ts
+++ b/src/components/__tests__/ModalExport.ts
@@ -1,19 +1,17 @@
 import { screen } from '@testing-library/dom'
+import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import { showModalActionCreator as showModal } from '../../actions/showModal'
 import store from '../../stores/app'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import dispatch from '../../test-helpers/dispatch'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
-import testTimer from '../../test-helpers/testTimer'
 
 beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 
-const fakeTimer = testTimer()
-
 // TODO: replicateThought is returning undefined. Either replication is broken in the tests or it is a timing issue.
-it.skip('Export a single thought', async () => {
+it('Export a single thought', async () => {
   await dispatch([
     importText({
       text: `
@@ -24,13 +22,15 @@ it.skip('Export a single thought', async () => {
 
   await dispatch(showModal({ id: 'export' }))
 
+  await act(vi.runOnlyPendingTimersAsync)
+
   // get the first match since there is a Download button also
   const exportPhraseElement = (await screen.findAllByText('Download'))[0]
   expect(exportPhraseElement.textContent).toEqual('Download "a" as Plain Text')
 })
 
 // TODO
-it.skip('Export a couple thoughts', async () => {
+it('Export a couple thoughts', async () => {
   await dispatch([
     importText({
       text: `
@@ -42,13 +42,15 @@ it.skip('Export a couple thoughts', async () => {
 
   await dispatch(showModal({ id: 'export' }))
 
+  await act(vi.runOnlyPendingTimersAsync)
+
   // get the first match since there is a Download button also
   const exportPhraseElement = (await screen.findAllByText('Download'))[0]
   expect(exportPhraseElement.textContent).toEqual('Download "a" and 1 subthought as Plain Text')
 })
 
 // TODO
-it.skip('Export the cursor and all descendants', async () => {
+it('Export the cursor and all descendants', async () => {
   await dispatch([
     importText({
       text: `
@@ -61,6 +63,8 @@ it.skip('Export the cursor and all descendants', async () => {
     showModal({ id: 'export' }),
   ])
 
+  await act(vi.runOnlyPendingTimersAsync)
+
   // get the first match since there is a Download button also
   const exportPhraseElement = (await screen.findAllByText('Download'))[0]
   expect(exportPhraseElement.textContent).toEqual('Download "b" and 1 subthought as Plain Text')
@@ -68,8 +72,7 @@ it.skip('Export the cursor and all descendants', async () => {
 
 // unable to figure out timer issues
 // it either doesn't wait for the push to resolve, or it goes into an infinite loop
-it.skip('Export buffered thoughts', async () => {
-  fakeTimer.useFakeTimer()
+it('Export buffered thoughts', async () => {
   await dispatch([
     importText({
       text: `
@@ -87,6 +90,8 @@ it.skip('Export buffered thoughts', async () => {
   // await refreshTestApp()
 
   await store.dispatch([showModal({ id: 'export' })])
+
+  await act(vi.runOnlyPendingTimersAsync)
 
   // get the first match since there is a Download button also
   const exportPhraseElement = (await screen.findAllByText('Download'))[0]


### PR DESCRIPTION
With the updates to fix the `thoughtspace` replication, these just needed to run the timers appropriately. We might be able to combine the sequential dispatches but I don't want to increase complexity until we confirm there aren't any timing issues.

If we encounter any intermittent errors in these tests then we might need to run the timers forward between the calls to `dispatch`. 