### PR TITLE
upgrade to redux-thunk 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-transition-group": "^4.4.5",
     "redux": "^4.2.1",
     "redux-devtools-extension": "^2.13.9",
-    "redux-thunk": "^2.4.2",
+    "redux-thunk": "^3.1.0",
     "reselect": "^5.1.1",
     "text-block-parser": "^1.1.1",
     "title-case": "^4.3.2",

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -4,7 +4,7 @@
 import _ from 'lodash'
 import { applyMiddleware, createStore } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
-import thunk from 'redux-thunk'
+import { thunk } from 'redux-thunk'
 import appReducer from '../actions/app'
 import pushQueue from '../redux-enhancers/pushQueue'
 import storageCache from '../redux-enhancers/storageCache'

--- a/src/test-helpers/createTestStore.ts
+++ b/src/test-helpers/createTestStore.ts
@@ -1,5 +1,5 @@
 import { Store, applyMiddleware, compose, createStore } from 'redux'
-import thunk from 'redux-thunk'
+import { thunk } from 'redux-thunk'
 import State from '../@types/State'
 import appReducer from '../actions/app'
 import pushQueue from '../redux-enhancers/pushQueue'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,7 +7769,7 @@ __metadata:
     redux: "npm:^4.2.1"
     redux-devtools-extension: "npm:^2.13.9"
     redux-mock-store: "npm:^1.5.5"
-    redux-thunk: "npm:^2.4.2"
+    redux-thunk: "npm:^3.1.0"
     reselect: "npm:^5.1.1"
     tcp-port-used: "npm:^1.0.2"
     text-block-parser: "npm:^1.1.1"
@@ -14931,12 +14931,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-thunk@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "redux-thunk@npm:2.4.2"
+"redux-thunk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "redux-thunk@npm:3.1.0"
   peerDependencies:
-    redux: ^4
-  checksum: 10c0/e202d6ef7dfa7df08ed24cb221aa89d6c84dbaa7d65fe90dbd8e826d0c10d801f48388f9a7598a4fd970ecbc93d335014570a61ca7bc8bf569eab5de77b31a3c
+    redux: ^5.0.0
+  checksum: 10c0/21557f6a30e1b2e3e470933247e51749be7f1d5a9620069a3125778675ce4d178d84bdee3e2a0903427a5c429e3aeec6d4df57897faf93eb83455bc1ef7b66fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
the only breaking change that affects us seems to be `export default thunk` -> `export thunk`, so just re-importing via named works.

other things they did were dropping UMD, going ESM, removing some type helpers, which we don't use.
all tests pass, and app works fine.
they recommend upgrading to Redux Toolkit as well, to use "Modern Redux", but I guess we don't really want that
so the changes are this simple :D