### PR TITLE
Upgrade to Redux 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react-signature-pad-wrapper": "^3.4.0",
     "react-split-pane": "^0.1.92",
     "react-transition-group": "^4.4.5",
-    "redux": "^4.2.1",
+    "redux": "^5.0.1",
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^3.1.0",
     "reselect": "^5.1.1",

--- a/src/@types/Dispatch.ts
+++ b/src/@types/Dispatch.ts
@@ -1,12 +1,12 @@
-import { AnyAction } from 'redux'
+import { UnknownAction } from 'redux'
 import Thunk from './Thunk'
 
 // allow explicit import
 interface Dispatch {
   <T = void>(thunks: Thunk<T>[]): T[]
   <T = void>(thunk: Thunk<T>): T
-  (actions: (AnyAction | Thunk | null)[]): void
-  (action: AnyAction | Thunk | null): void
+  (actions: (UnknownAction | Thunk | null)[]): void
+  (action: UnknownAction | Thunk | null): void
 }
 
 export default Dispatch

--- a/src/@types/Thunk.ts
+++ b/src/@types/Thunk.ts
@@ -1,7 +1,7 @@
 import Dispatch from './Dispatch'
 import State from './State'
 
-/** A basic Redux AnyAction creator thunk with no arguments. */
+/** A basic Redux UnknownAction creator thunk with no arguments. */
 // do not use ThunkDispatch since it has the wrong return type
 export type Thunk<R = void> = (dispatch: Dispatch, getState: () => State) => R
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -1,3 +1,4 @@
+import { UnknownAction } from 'redux'
 import Thunk from './Thunk'
 
 declare global {
@@ -37,7 +38,7 @@ declare module 'redux' {
   export interface Dispatch {
     <T = void>(thunks: Thunk<T>[]): T[]
     <T = void>(thunk: Thunk<T>): T
-    (actions: (AnyAction | Thunk)[]): void
-    (action: AnyAction | Thunk): void
+    (actions: (UnknownAction | Thunk)[]): void
+    (action: UnknownAction | Thunk): void
   }
 }

--- a/src/@types/react-redux.d.ts
+++ b/src/@types/react-redux.d.ts
@@ -12,3 +12,4 @@ export * from 'react-redux-default'
 
 export const useDispatch: () => Dispatch = useDefaultDispatch
 export const useSelector: TypedUseSelectorHook<State> = useDefaultSelector
+export const useStore: () => Store<State> = useDefaultStore

--- a/src/actions/authenticate.ts
+++ b/src/actions/authenticate.ts
@@ -25,4 +25,6 @@ export const authenticateActionCreator =
   dispatch =>
     dispatch({ type: 'authenticate', ...payload })
 
+export type AuthenticateAction = { type: 'authenticate' } & Parameters<typeof authenticate>[1]
+
 export default _.curryRight(authenticate)

--- a/src/commands/moveCursorForward.ts
+++ b/src/commands/moveCursorForward.ts
@@ -1,4 +1,4 @@
-import { Dispatch } from 'react'
+import { Dispatch } from 'redux'
 import { Key } from 'ts-key-enum'
 import Command from '../@types/Command'
 import MoveCursorForwardIcon from '../components/icons/MoveCursorForwardIcon'

--- a/src/redux-middleware/freeThoughts.ts
+++ b/src/redux-middleware/freeThoughts.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash'
+import { isAction } from 'redux'
 import { ThunkMiddleware } from 'redux-thunk'
 import State from '../@types/State'
 import { Thunk } from '../@types/Thunk'
 import { freeThoughtsActionCreator as freeThoughts } from '../actions/freeThoughts'
 import { FREE_THOUGHTS_THRESHOLD, FREE_THOUGHTS_THROTTLE } from '../constants'
-import { isAction } from 'redux'
 
 /** Checks if the thought cache has exceeded its memory limit. If so, dispatches freeThoughts which frees memory in the thoughtIndex, lexemeIndex, and YJS providers. */
 const checkThreshold: Thunk = (dispatch, getState): void => {

--- a/src/redux-middleware/freeThoughts.ts
+++ b/src/redux-middleware/freeThoughts.ts
@@ -4,6 +4,7 @@ import State from '../@types/State'
 import { Thunk } from '../@types/Thunk'
 import { freeThoughtsActionCreator as freeThoughts } from '../actions/freeThoughts'
 import { FREE_THOUGHTS_THRESHOLD, FREE_THOUGHTS_THROTTLE } from '../constants'
+import { isAction } from 'redux'
 
 /** Checks if the thought cache has exceeded its memory limit. If so, dispatches freeThoughts which frees memory in the thoughtIndex, lexemeIndex, and YJS providers. */
 const checkThreshold: Thunk = (dispatch, getState): void => {
@@ -22,7 +23,7 @@ const freeThoughtsMiddleware: ThunkMiddleware<State> = ({ dispatch, getState }) 
     next(action)
 
     // do not run checkThrottled on freeThoughts action to avoid infinite loop
-    if (action.type !== 'freeThoughts') {
+    if (isAction(action) && action.type !== 'freeThoughts') {
       checkThrottled(dispatch, getState)
     }
   }

--- a/src/test-helpers/dispatch.ts
+++ b/src/test-helpers/dispatch.ts
@@ -1,10 +1,10 @@
 import { act } from 'react'
-import { AnyAction } from 'redux'
+import { UnknownAction } from 'redux'
 import Thunk from '../@types/Thunk'
 import store from '../stores/app'
 
 /** Dispatches actions on the global store in an act block. */
-const dispatch = async (args: Thunk[] | Thunk | AnyAction) => {
+const dispatch = async (args: Thunk[] | Thunk | UnknownAction) => {
   await act(async () => {
     store.dispatch(Array.isArray(args) ? args : [args])
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7766,7 +7766,7 @@ __metadata:
     react-signature-pad-wrapper: "npm:^3.4.0"
     react-split-pane: "npm:^0.1.92"
     react-transition-group: "npm:^4.4.5"
-    redux: "npm:^4.2.1"
+    redux: "npm:^5.0.1"
     redux-devtools-extension: "npm:^2.13.9"
     redux-mock-store: "npm:^1.5.5"
     redux-thunk: "npm:^3.1.0"
@@ -14940,12 +14940,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.0, redux@npm:^4.0.5, redux@npm:^4.2.0, redux@npm:^4.2.1":
+"redux@npm:^4.0.0, redux@npm:^4.0.5, redux@npm:^4.2.0":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
   dependencies:
     "@babel/runtime": "npm:^7.9.2"
   checksum: 10c0/136d98b3d5dbed1cd6279c8c18a6a74c416db98b8a432a46836bdd668475de6279a2d4fd9d1363f63904e00f0678a8a3e7fa532c897163340baf1e71bb42c742
+  languageName: node
+  linkType: hard
+
+"redux@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "redux@npm:5.0.1"
+  checksum: 10c0/b10c28357194f38e7d53b760ed5e64faa317cc63de1fb95bc5d9e127fab956392344368c357b8e7a9bedb0c35b111e7efa522210cfdc3b3c75e5074718e9069c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes https://github.com/cybersemics/em/issues/2580

As per https://github.com/reduxjs/redux/releases/tag/v5.0.0

- Now we use `UnknownAction` instead of `AnyAction`. It's what the redux team recommends insistently. Why not, it didn't affect anything.
- We can't assume(as recommended) the `action` in middlewares being an action -- it's `unknown` now, so we have to check it via `isAction` or narrow the types. This affected a couple files, where I had to add checks.
- renamed the imports to use `legacyCreateStore` because seeing strikethrough is not pleasant, and they're being very insistent on deprecating ~`createStore`~ and going for rtk. 
- `useStore` now started giving an `{}` state instead of `State`, so i had to add global types for it.

