### PR TITLE
Hide tutorial gesture steps logic behind a portal & colocation

### DIFF
--- a/src/components/Tutorial/Tutorial2StepContext1.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1.tsx
@@ -49,7 +49,7 @@ const Tutorial2StepContext1 = () => {
             {readyToSelect ? `Select "${chosenTutorialText}". ` : null}
             {isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to
             create a new thought <i>within</i> "{chosenTutorialText}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
-            {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
+            {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
           </TutorialHint>
         </p>
       ) : (

--- a/src/components/Tutorial/Tutorial2StepContext1.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -11,19 +12,20 @@ import {
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Tutorial2StepContext1 = () => {
   const tutorialChoice = useSelector(selectTutorialChoice)
-  const noCursor = useSelector(state => !state.cursor)
-  const cursorValue = useSelector(state => state.cursor && headValue(state, state.cursor))
+  const chosenTutorialText = TUTORIAL_CONTEXT1_PARENT[tutorialChoice]
   const context1Exists = useSelector(state => {
     const rootChildren = getAllChildrenAsThoughts(state, HOME_TOKEN)
-    return rootChildren.find(
-      child => child.value.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase(),
-    )
+    return rootChildren.find(child => child.value.toLowerCase() === chosenTutorialText.toLowerCase())
   })
+  const readyToSelect = useSelector(
+    state => !state.cursor || headValue(state, state.cursor).toLowerCase() !== chosenTutorialText.toLowerCase(),
+  )
 
   return (
     <>
@@ -36,8 +38,7 @@ const Tutorial2StepContext1 = () => {
             : tutorialChoice === TUTORIAL_VERSION_BOOK
               ? `you hear a podcast on ${TUTORIAL_CONTEXT[tutorialChoice]}.`
               : null}{' '}
-        Add a thought with the text "{TUTORIAL_CONTEXT[tutorialChoice]}" <i>within</i> “
-        {TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}”.
+        Add a thought with the text "{TUTORIAL_CONTEXT[tutorialChoice]}" <i>within</i> “{chosenTutorialText}”.
       </p>
       {context1Exists ? (
         <p>
@@ -45,19 +46,14 @@ const Tutorial2StepContext1 = () => {
           <TutorialHint>
             <br />
             <br />
-            {noCursor || cursorValue?.toLowerCase() !== TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()
-              ? `Select "${TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". `
-              : null}
+            {readyToSelect ? `Select "${chosenTutorialText}". ` : null}
             {isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to
-            create a new thought <i>within</i> "{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}". Then type "
-            {TUTORIAL_CONTEXT[tutorialChoice]}".
+            create a new thought <i>within</i> "{chosenTutorialText}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
+            {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
           </TutorialHint>
         </p>
       ) : (
-        <p>
-          Oops, somehow “{TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}” was changed or deleted. Click the Prev button to go
-          back.
-        </p>
+        <p>Oops, somehow “{chosenTutorialText}” was changed or deleted. Click the Prev button to go back.</p>
       )}
     </>
   )

--- a/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
@@ -1,12 +1,14 @@
 import { isEqual } from 'lodash'
 import { useSelector } from 'react-redux'
 import { isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import { HOME_TOKEN, TUTORIAL_CONTEXT1_PARENT } from '../../constants'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import ellipsize from '../../util/ellipsize'
 import headValue from '../../util/headValue'
 import joinConjunction from '../../util/joinConjunction'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -39,6 +41,7 @@ const Tutorial2StepContext1Parent = () => {
           ) : null}
           {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought. Then type "
           {TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}".
+          <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
@@ -41,7 +41,7 @@ const Tutorial2StepContext1Parent = () => {
           ) : null}
           {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought. Then type "
           {TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}".
-          <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
+          <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
@@ -75,7 +75,7 @@ const Tutorial2StepContext1SubThought = () => {
               {select ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
-              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
+              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -12,6 +13,7 @@ import contextToThoughtId from '../../selectors/contextToThoughtId'
 import { getAllChildrenAsThoughts, getChildrenRanked } from '../../selectors/getChildren'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 import context1SubthoughtCreated from './utils/context1SubthoughtCreated'
 
@@ -73,6 +75,7 @@ const Tutorial2StepContext1SubThought = () => {
               {select ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
+              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2.tsx
@@ -52,7 +52,7 @@ const Tutorial2StepContext2 = () => {
                   to create a new thought <i>within</i> "{TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
                 </>
               )}
-              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
+              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2.tsx
@@ -1,10 +1,12 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import { HOME_TOKEN, TUTORIAL_CONTEXT, TUTORIAL_CONTEXT2_PARENT } from '../../constants'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -50,6 +52,7 @@ const Tutorial2StepContext2 = () => {
                   to create a new thought <i>within</i> "{TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
                 </>
               )}
+              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
@@ -50,7 +50,7 @@ const Tutorial2StepContext2Parent = () => {
               {TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
             </>
           )}
-          {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />}
+          {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newThought').gesture} />}
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import {
   TUTORIAL_CONTEXT,
   TUTORIAL_CONTEXT1_PARENT,
@@ -10,6 +11,7 @@ import {
 } from '../../constants'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
 const tutorialChoiceMap = {
@@ -48,6 +50,7 @@ const Tutorial2StepContext2Parent = () => {
               {TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
             </>
           )}
+          {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />}
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
@@ -103,7 +103,7 @@ const Tutorial2StepContext2Subthought = () => {
               {selectChoice ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
-              {!selectChoice && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
+              {!selectChoice && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -16,6 +17,7 @@ import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
 import joinConjunction from '../../util/joinConjunction'
 import StaticSuperscript from '../StaticSuperscript'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 import context2SubthoughtCreated from './utils/context2SubthoughtCreated'
 
@@ -101,6 +103,7 @@ const Tutorial2StepContext2Subthought = () => {
               {selectChoice ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
+              {!selectChoice && <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
+++ b/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
@@ -40,7 +40,7 @@ const Tutorial2StepContextViewToggle = () => {
               : `Hit ${formatKeyboardShortcut(commandById('toggleContextView')!.keyboard!)}`}{' '}
             to view the current thought's contexts.
           </p>
-          <TutorialGestureDiagram gesture={commandById('toggleContextView')?.gesture} />
+          <TutorialGestureDiagram gesture={commandById('toggleContextView').gesture} />
         </>
       )}
     </>

--- a/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
+++ b/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
@@ -6,6 +6,7 @@ import getContexts from '../../selectors/getContexts'
 import getSetting from '../../selectors/getSetting'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const Tutorial2StepContextViewToggle = () => {
@@ -39,6 +40,7 @@ const Tutorial2StepContextViewToggle = () => {
               : `Hit ${formatKeyboardShortcut(commandById('toggleContextView')!.keyboard!)}`}{' '}
             to view the current thought's contexts.
           </p>
+          <TutorialGestureDiagram gesture={commandById('toggleContextView')?.gesture} />
         </>
       )}
     </>

--- a/src/components/Tutorial/TutorialGestureDiagram.tsx
+++ b/src/components/Tutorial/TutorialGestureDiagram.tsx
@@ -1,0 +1,27 @@
+import { createPortal } from 'react-dom'
+import { css } from '../../../styled-system/css'
+import Command from '../../@types/Command'
+import GesturePath from '../../@types/GesturePath'
+import GestureDiagram from '../GestureDiagram'
+
+/** A portal for conditionally rendering Gesture hints. Used to show an appropriate gesture  below the tutorial UI up top, thus Portal. */
+const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) => {
+  const target = document.getElementById('tutorial-gesture-diagram-portal')
+
+  return (
+    gesture &&
+    target &&
+    createPortal(
+      <GestureDiagram
+        path={gesture as GesturePath}
+        size={160}
+        strokeWidth={10}
+        arrowSize={5}
+        cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
+      />,
+      target,
+    )
+  )
+}
+
+export default TutorialGestureDiagram

--- a/src/components/Tutorial/TutorialGestureDiagram.tsx
+++ b/src/components/Tutorial/TutorialGestureDiagram.tsx
@@ -12,13 +12,26 @@ const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) =>
     gesture &&
     target &&
     createPortal(
-      <GestureDiagram
-        path={gesture as GesturePath}
-        size={160}
-        strokeWidth={10}
-        arrowSize={5}
-        cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
-      />,
+      <div
+        className={css({
+          position: 'absolute',
+          marginTop: '50px',
+          zIndex: 'tutorialTraceGesture',
+          textAlign: 'center',
+          left: 0,
+          right: 0,
+          backgroundColor: 'bgOverlay80',
+          paddingBottom: '50px',
+        })}
+      >
+        <GestureDiagram
+          path={gesture as GesturePath}
+          size={160}
+          strokeWidth={10}
+          arrowSize={5}
+          cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
+        />
+      </div>,
       target,
     )
   )

--- a/src/components/Tutorial/TutorialGestureDiagram.tsx
+++ b/src/components/Tutorial/TutorialGestureDiagram.tsx
@@ -4,9 +4,12 @@ import Command from '../../@types/Command'
 import GesturePath from '../../@types/GesturePath'
 import GestureDiagram from '../GestureDiagram'
 
+/** During the totirla, a portal is used for rendering gestures on top of the thought space. It's the ID for the portal element. */
+const TUTORIAL_GESTURE_PORTAL_DOM_ID = 'tutorial-gesture-diagram-portal'
+
 /** A portal for conditionally rendering Gesture hints. Used to show an appropriate gesture  below the tutorial UI up top, thus Portal. */
 const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) => {
-  const target = document.getElementById('tutorial-gesture-diagram-portal')
+  const target = document.getElementById(TUTORIAL_GESTURE_PORTAL_DOM_ID)
 
   return (
     gesture &&
@@ -35,6 +38,11 @@ const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) =>
       target,
     )
   )
+}
+
+/** The element that serves as the portal target for the TutorialGestureDiagram. */
+export const TutorialGesturePortal = () => {
+  return <div id={TUTORIAL_GESTURE_PORTAL_DOM_ID} className={css({ display: 'contents' })} />
 }
 
 export default TutorialGestureDiagram

--- a/src/components/Tutorial/TutorialStepFirstThought.tsx
+++ b/src/components/Tutorial/TutorialStepFirstThought.tsx
@@ -11,7 +11,7 @@ const TutorialStepFirstThought = () => {
         {isTouch ? 'gesture' : 'keyboard shortcut'}. Just follow the instructions; this tutorial will stay open.
       </p>
       <p>{isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.</p>
-      <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
+      <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
     </>
   )
 }

--- a/src/components/Tutorial/TutorialStepFirstThought.tsx
+++ b/src/components/Tutorial/TutorialStepFirstThought.tsx
@@ -1,14 +1,19 @@
 import { isTouch } from '../../browser'
+import { commandById } from '../../commands'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-const TutorialStepFirstThought = () => (
-  <>
-    <p>
-      First, let me show you how to create a new thought in <b>em</b> using a{' '}
-      {isTouch ? 'gesture' : 'keyboard shortcut'}. Just follow the instructions; this tutorial will stay open.
-    </p>
-    <p>{isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.</p>
-  </>
-)
+const TutorialStepFirstThought = () => {
+  return (
+    <>
+      <p>
+        First, let me show you how to create a new thought in <b>em</b> using a{' '}
+        {isTouch ? 'gesture' : 'keyboard shortcut'}. Just follow the instructions; this tutorial will stay open.
+      </p>
+      <p>{isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.</p>
+      <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
+    </>
+  )
+}
 
 export default TutorialStepFirstThought

--- a/src/components/Tutorial/TutorialStepSecondThought.tsx
+++ b/src/components/Tutorial/TutorialStepSecondThought.tsx
@@ -1,4 +1,6 @@
 import { isTouch } from '../../browser'
+import { commandById } from '../../commands'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -11,6 +13,7 @@ const TutorialStepSecondThought = () => (
         <br />
         <br />
         {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.
+        <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
       </TutorialHint>
     </p>
   </>

--- a/src/components/Tutorial/TutorialStepSecondThought.tsx
+++ b/src/components/Tutorial/TutorialStepSecondThought.tsx
@@ -13,7 +13,7 @@ const TutorialStepSecondThought = () => (
         <br />
         <br />
         {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.
-        <TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />
+        <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
       </TutorialHint>
     </p>
   </>

--- a/src/components/Tutorial/TutorialStepSubThought.tsx
+++ b/src/components/Tutorial/TutorialStepSubThought.tsx
@@ -27,7 +27,7 @@ const TutorialStepSubThought = () => {
           .
         </p>
       )}
-      <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />
+      <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />
     </>
   )
 }

--- a/src/components/Tutorial/TutorialStepSubThought.tsx
+++ b/src/components/Tutorial/TutorialStepSubThought.tsx
@@ -1,6 +1,8 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
+import { commandById } from '../../commands'
 import headValue from '../../util/headValue'
+import TutorialGestureDiagram from './TutorialGestureDiagram'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const TutorialStepSubThought = () => {
@@ -25,6 +27,7 @@ const TutorialStepSubThought = () => {
           .
         </p>
       )}
+      <TutorialGestureDiagram gesture={commandById('newSubthought')?.gesture} />
     </>
   )
 }

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -2,35 +2,13 @@ import React, { FC, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { TransitionGroup } from 'react-transition-group'
 import { css, cx } from '../../../styled-system/css'
-import GesturePath from '../../@types/GesturePath'
-import State from '../../@types/State'
 import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
 import { isTouch } from '../../browser'
 import { commandById } from '../../commands'
-import {
-  TUTORIAL2_STEP_CONTEXT1_HINT,
-  TUTORIAL2_STEP_CONTEXT1_PARENT_HINT,
-  TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT,
-  TUTORIAL2_STEP_CONTEXT2_HINT,
-  TUTORIAL2_STEP_CONTEXT2_PARENT_HINT,
-  TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT,
-  TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE,
-  TUTORIAL2_STEP_SUCCESS,
-  TUTORIAL_CONTEXT,
-  TUTORIAL_CONTEXT1_PARENT,
-  TUTORIAL_CONTEXT2_PARENT,
-  TUTORIAL_STEP_FIRSTTHOUGHT,
-  TUTORIAL_STEP_SECONDTHOUGHT_HINT,
-  TUTORIAL_STEP_SUBTHOUGHT,
-  TUTORIAL_STEP_SUCCESS,
-} from '../../constants'
+import { TUTORIAL2_STEP_SUCCESS, TUTORIAL_STEP_SUCCESS } from '../../constants'
 import useIsVisible from '../../hooks/useIsVisible'
 import getSetting from '../../selectors/getSetting'
-import selectTutorialChoice from '../../selectors/selectTutorialChoice'
 import fastClick from '../../util/fastClick'
-import headValue from '../../util/headValue'
-import once from '../../util/once'
-import GestureDiagram from '../GestureDiagram'
 import SlideTransition from '../SlideTransition'
 import TutorialNavigation from './TutorialNavigation'
 import TutorialScrollUpButton from './TutorialScrollUpButton'
@@ -65,33 +43,9 @@ const Tutorial: FC = () => {
   })
 
   const dispatch = useDispatch()
-  const cursor = useSelector((state: State) => state.cursor)
-  const tutorialChoice = useSelector(selectTutorialChoice)
 
   const tutorialStepComponent =
     TutorialStepComponentMap[Math.floor(tutorialStep) as keyof typeof TutorialStepComponentMap]
-
-  const gesture = once(
-    () =>
-      ((tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
-      tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
-      tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
-      tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT
-        ? commandById('newThought')?.gesture
-        : tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT ||
-            tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT
-          ? commandById('newSubthought')?.gesture
-          : tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE
-            ? commandById('toggleContextView')?.gesture
-            : null) || null) as GesturePath | null, // Why does it add 'string' to the type union without this?
-  )
-
-  const cursorHeadValue = useSelector(state => state.cursor && headValue(state, state.cursor))
-
-  const gesturePath = gesture()
 
   return (
     <div
@@ -148,34 +102,9 @@ const Tutorial: FC = () => {
           <TutorialNavigation nextRef={nextRef} tutorialStep={tutorialStep} />
         </div>
 
-        {isTouch &&
-        (tutorialStep === TUTORIAL_STEP_FIRSTTHOUGHT ||
-          tutorialStep === TUTORIAL_STEP_SECONDTHOUGHT_HINT ||
-          tutorialStep === TUTORIAL_STEP_SUBTHOUGHT ||
-          tutorialStep === TUTORIAL2_STEP_CONTEXT_VIEW_TOGGLE ||
-          tutorialStep === TUTORIAL2_STEP_CONTEXT1_PARENT_HINT ||
-          (tutorialStep === TUTORIAL2_STEP_CONTEXT1_HINT &&
-            cursor &&
-            cursorHeadValue &&
-            cursorHeadValue.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) ||
-          (tutorialStep === TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT_HINT &&
-            cursor &&
-            cursorHeadValue &&
-            cursorHeadValue.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase()) ||
-          (tutorialStep === TUTORIAL2_STEP_CONTEXT2_PARENT_HINT &&
-            cursor &&
-            cursorHeadValue &&
-            cursorHeadValue.toLowerCase() === TUTORIAL_CONTEXT1_PARENT[tutorialChoice].toLowerCase()) ||
-          (tutorialStep === TUTORIAL2_STEP_CONTEXT2_HINT &&
-            cursor &&
-            cursorHeadValue &&
-            cursorHeadValue.toLowerCase() === TUTORIAL_CONTEXT2_PARENT[tutorialChoice].toLowerCase()) ||
-          (tutorialStep === TUTORIAL2_STEP_CONTEXT2_SUBTHOUGHT_HINT &&
-            cursor &&
-            cursorHeadValue &&
-            cursorHeadValue.toLowerCase() === TUTORIAL_CONTEXT[tutorialChoice].toLowerCase())) &&
-        gesturePath ? (
+        {isTouch && (
           <div
+            id='tutorial-gesture-diagram-portal'
             className={css({
               position: 'absolute',
               marginTop: '50px',
@@ -186,16 +115,8 @@ const Tutorial: FC = () => {
               backgroundColor: 'bgOverlay80',
               paddingBottom: '50px',
             })}
-          >
-            <GestureDiagram
-              path={gesturePath}
-              size={160}
-              strokeWidth={10}
-              arrowSize={5}
-              cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
-            />
-          </div>
-        ) : null}
+          />
+        )}
       </div>
       <TutorialScrollUpButton show={!isVisible} />
     </div>

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -102,21 +102,7 @@ const Tutorial: FC = () => {
           <TutorialNavigation nextRef={nextRef} tutorialStep={tutorialStep} />
         </div>
 
-        {isTouch && (
-          <div
-            id='tutorial-gesture-diagram-portal'
-            className={css({
-              position: 'absolute',
-              marginTop: '50px',
-              zIndex: 'tutorialTraceGesture',
-              textAlign: 'center',
-              left: 0,
-              right: 0,
-              backgroundColor: 'bgOverlay80',
-              paddingBottom: '50px',
-            })}
-          />
-        )}
+        {isTouch && <div id='tutorial-gesture-diagram-portal' className={css({ display: 'contents' })} />}
       </div>
       <TutorialScrollUpButton show={!isVisible} />
     </div>

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -10,6 +10,7 @@ import useIsVisible from '../../hooks/useIsVisible'
 import getSetting from '../../selectors/getSetting'
 import fastClick from '../../util/fastClick'
 import SlideTransition from '../SlideTransition'
+import { TutorialGesturePortal } from './TutorialGestureDiagram'
 import TutorialNavigation from './TutorialNavigation'
 import TutorialScrollUpButton from './TutorialScrollUpButton'
 import TutorialStepComponentMap from './TutorialStepComponentMap'
@@ -102,7 +103,7 @@ const Tutorial: FC = () => {
           <TutorialNavigation nextRef={nextRef} tutorialStep={tutorialStep} />
         </div>
 
-        {isTouch && <div id='tutorial-gesture-diagram-portal' className={css({ display: 'contents' })} />}
+        {isTouch && <TutorialGesturePortal />}
       </div>
       <TutorialScrollUpButton show={!isVisible} />
     </div>


### PR DESCRIPTION
Closes https://github.com/cybersemics/em/issues/2364

After considering:
- additional gesture exports per file tutorial file
- another map of step -> gesture
- esoteric shit like `TutorialStepSecondThought.gesture = ...`
- Portals

I decided to go with Portals. Now after finishing the stuff, I really like the decision.
- the gesture thing depends on an inner state of many possible components, and renders kinda independently -- isn't it what Portals are for?
- it allowed very subtle additions of `<TutorialGestureDiagram gesture={commandById('newThought')?.gesture} />` into already existing `<TutorialHint />` conditional component
- no export/map shenanigans, no new abstractions
- lots of conditional variables were already used in the step components, so most of files are just +2 lines(import and jsx)
- we got less additions than deletions, and got much more clarity

also, feels like I changed no behaviors(judging via human brain static analysis). Sadly, we don't have automated tests for this. I did manual testing though, and it all seems to work as it should.
Thought of adding tests, but it'd take me quite a bit more time.