### PR TITLE
Use smooth scrolling in scrollCursorIntoView when the scroll distance is less than the window height

### DIFF
--- a/src/redux-middleware/scrollCursorIntoView.ts
+++ b/src/redux-middleware/scrollCursorIntoView.ts
@@ -77,8 +77,17 @@ const scrollIntoViewIfNeeded = (el: Element | null | undefined) => {
   // scroll to 1 instead of 0
   // otherwise Mobile Safari scrolls to the top after MultiGesture
   // See: touchmove in MultiGesture.tsx
+  const top = Math.max(1, scrollYNew)
+
+  const scrollDistance = Math.abs(scrollYNew - window.scrollY)
+  const viewportHeight = viewport.innerHeight
+  const behavior = scrollDistance < viewportHeight ? 'smooth' : 'auto'
+
   startForcedScrolling()
-  window.scrollTo(0, Math.max(1, scrollYNew))
+  window.scrollTo({
+    top,
+    behavior,
+  })
 }
 
 /** Scrolls the cursor into view if needed. */


### PR DESCRIPTION
### Overview

This pull request resolves #2134 by updating `scrollIntoViewIfNeeded` to compare the scroll distance with the viewport height. If the scroll distance is less than the viewport height, the scroll behavior is changed to `'smooth'` so that the cursor is smoothly scrolled into view.

### Demo

https://github.com/user-attachments/assets/e9afb36d-e4a6-49fd-8fbc-fc4da7060418