### PR TITLE
Fix back button doesn't work properly after cursorDown.

### DIFF
--- a/src/e2e/puppeteer/__tests__/browserBack.ts
+++ b/src/e2e/puppeteer/__tests__/browserBack.ts
@@ -1,0 +1,53 @@
+import clickThought from '../helpers/clickThought'
+import paste from '../helpers/paste'
+import press from '../helpers/press'
+import waitForEditable from '../helpers/waitForEditable'
+import { page } from '../setup'
+
+vi.setConfig({ testTimeout: 20000 })
+
+it('browser back button should work correctly after cursor movements', async () => {
+  const importText = `
+  - a
+  - b`
+
+  await paste(importText)
+
+  await waitForEditable('b')
+  await clickThought('a')
+  await press('ArrowDown')
+  await page.goBack()
+  await waitForEditable('a')
+  await press('ArrowDown')
+  await page.goBack()
+  const editable = await waitForEditable('a')
+  expect(editable).toBeTruthy()
+})
+
+it('browser back button should work correctly with complex cursor navigation', async () => {
+  const importText = `
+  - a
+  - b
+  - c`
+
+  await paste(importText)
+
+  await waitForEditable('c')
+  await clickThought('c')
+  await press('ArrowUp')
+  await waitForEditable('b')
+  await press('ArrowUp')
+  await waitForEditable('a')
+  await page.goBack()
+  await waitForEditable('b')
+  await page.goBack()
+  await waitForEditable('c')
+  await press('ArrowUp')
+  await waitForEditable('b')
+  await press('ArrowUp')
+  await waitForEditable('a')
+  await page.goBack()
+  await waitForEditable('b')
+  const editable = await waitForEditable('b')
+  expect(editable).toBeTruthy()
+})

--- a/src/redux-middleware/updateUrlHistory.ts
+++ b/src/redux-middleware/updateUrlHistory.ts
@@ -13,6 +13,7 @@ import storageModel from '../stores/storageModel'
 import equalArrays from '../util/equalArrays'
 import equalPath from '../util/equalPath'
 import head from '../util/head'
+import { updateLastPath } from '../util/initEvents'
 import isRoot from '../util/isRoot'
 
 interface Options {
@@ -88,7 +89,7 @@ const updateUrlHistory = (state: State, path: Path, { replace, contextViews }: O
   // nothing to update if the cursor has not changed
   if (state.isLoading || equalPath(pathPrev, path)) return
   pathPrev = path
-
+  updateLastPath(path)
   const decoded = decodeThoughtsUrl(state)
   const encoded = head(path || HOME_PATH)
 

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -121,18 +121,20 @@ const initEvents = (store: Store<State, any>) => {
   /** Popstate event listener; setCursor on browser history forward/backward. */
   const onPopstate = (e: PopStateEvent) => {
     const state = store.getState()
-
     const { path, contextViews } = decodeThoughtsUrl(state)
 
+    // Initialize lastPath with current cursor if not set
     if (!lastPath) {
       lastPath = state.cursor
     }
 
     if (!path || !pathExists(state, pathToContext(state, path)) || equalPath(lastPath, path)) {
       window.history[!lastState || lastState > e.state ? 'back' : 'forward']()
+      return
     }
 
-    lastPath = path && pathExists(state, pathToContext(state, path)) ? path : lastPath
+    // Store the current cursor as lastPath before updating
+    lastPath = state.cursor
     lastState = e.state
 
     const toRoot = !path || isRoot(path)

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -113,10 +113,16 @@ const scrollAtEdge = (() => {
   return { start, stop }
 })()
 
+let lastPath: Path | null
+
+/** Update the LastPath. */
+export const updateLastPath = (path: Path) => {
+  lastPath = path
+}
+
 /** Add window event handlers. */
 const initEvents = (store: Store<State, any>) => {
   let lastState: number
-  let lastPath: Path | null
 
   /** Popstate event listener; setCursor on browser history forward/backward. */
   const onPopstate = (e: PopStateEvent) => {
@@ -126,15 +132,16 @@ const initEvents = (store: Store<State, any>) => {
     // Initialize lastPath with current cursor if not set
     if (!lastPath) {
       lastPath = state.cursor
+      lastState = e.state
     }
-
-    if (!path || !pathExists(state, pathToContext(state, path)) || equalPath(lastPath, path)) {
+    // Update lastPath before navigation check
+    const previousPath = lastPath
+    lastPath = path
+    if (!path || !pathExists(state, pathToContext(state, path)) || equalPath(previousPath, path)) {
       window.history[!lastState || lastState > e.state ? 'back' : 'forward']()
       return
     }
 
-    // Store the current cursor as lastPath before updating
-    lastPath = state.cursor
     lastState = e.state
 
     const toRoot = !path || isRoot(path)


### PR DESCRIPTION
Issue : Second browser back does not work after cursorDown #2535

Reason : The problem occurs because the code is checking for path `equality (equalPath(lastPath, path))` in the `onPopstate` handler, which is preventing proper navigation when you revisit the same path.

Solution : So, I updated the setting lastPath logic.   : lastPath = state.cursor

1. When user is on 'a' and navigates to 'b':
   lastPath becomes 'a'
2. When user hits back button:
   state.cursor is 'b', so lastPath becomes 'b'
   Navigation goes back to 'a'
3. When user navigates to 'b' again:
   lastPath is 'b' (preserved from previous step)
4. When user hits back button:
   Since lastPath is 'b', we know we came from 'b'