### PR TITLE
Remove asyncFocus from swapNote command

### DIFF
--- a/src/actions/swapNote.ts
+++ b/src/actions/swapNote.ts
@@ -6,6 +6,7 @@ import findDescendant from '../selectors/findDescendant'
 import { anyChild } from '../selectors/getChildren'
 import getRankAfter from '../selectors/getRankAfter'
 import isContextViewActive from '../selectors/isContextViewActive'
+import pathToThought from '../selectors/pathToThought'
 import simplifyPath from '../selectors/simplifyPath'
 import appendToPath from '../util/appendToPath'
 import ellipsize from '../util/ellipsize'
@@ -70,6 +71,8 @@ const swapNote = (state: State) => {
             const oldPath = appendToPath(cursor, noteId, noteChildId)
             const newPath = appendToPath(cursor, noteChildId)
             const newRank = getRankAfter(state, appendToPath(simplePath, noteId))
+            const note = pathToThought(state, oldPath)
+
             return reducerFlow([
               moveThought({ oldPath, newPath, newRank }),
               // delete =note
@@ -77,7 +80,7 @@ const swapNote = (state: State) => {
                 pathParent: cursor,
                 thoughtId: noteId,
               }),
-              setCursor({ path: newPath }),
+              setCursor({ offset: note.value.length, path: newPath }),
             ])(state)
           },
         ]

--- a/src/commands/swapNote.ts
+++ b/src/commands/swapNote.ts
@@ -1,7 +1,6 @@
 import Command from '../@types/Command'
 import { swapNoteActionCreator } from '../actions/swapNote'
 import ConvertToNoteIcon from '../components/icons/ConvertToNoteIcon'
-import asyncFocus from '../device/asyncFocus'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isDocumentEditable from '../util/isDocumentEditable'
 
@@ -17,7 +16,6 @@ const swapNote: Command = {
   },
   svg: ConvertToNoteIcon,
   exec: dispatch => {
-    asyncFocus()
     dispatch(swapNoteActionCreator())
   },
 }

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -57,8 +57,14 @@ export const isCollapsed = (): boolean => !!window.getSelection()?.isCollapsed
 export const isActive = (): boolean => !!window.getSelection()?.focusNode
 
 /** Returns true if the Node is an editable. */
-const isEditable = (node?: Node | null) =>
-  !!node && node.nodeType === Node.ELEMENT_NODE && !!(node as HTMLElement).hasAttribute?.('data-editable')
+const isEditable = (node?: Node | null) => {
+  const element = node as HTMLElement
+  return (
+    !!element &&
+    element.nodeType === Node.ELEMENT_NODE &&
+    (element.hasAttribute('data-editable') || element.ariaLabel === 'note-editable')
+  )
+}
 
 /** Returns true if the selection is on a thought. */
 // We should see if it is possible to just use state.editing and selection.isActive()


### PR DESCRIPTION
Fixes #2290 

The `swapNote` command explicitly calls `asyncFocus()` which create a browser selection and opens the keyboard. Removing this function call stops it from taking control of the selection & keyboard.