### PR TITLE
Thoughts marked =done should be collapsed

### DIFF
--- a/src/selectors/__tests__/expandThoughts.ts
+++ b/src/selectors/__tests__/expandThoughts.ts
@@ -730,3 +730,96 @@ describe('expand with : char', () => {
     expect(isContextExpanded(stateNew, ['<b>b:</b>', '<b><i>c:</i></b>'])).toBeTruthy()
   })
 })
+
+describe('=done', () => {
+  it('only child descendants are not expanded with =done', () => {
+    const text = `
+      - a
+        - b
+          - =done
+            - c
+    `
+
+    const steps = [importText({ text }), setCursor(['a'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeFalsy()
+    expect(isContextExpanded(stateNew, ['a', 'b', 'c'])).toBeFalsy()
+  })
+
+  it('child with =done is not expanded by =children/=pin/true', () => {
+    const text = `
+    - a
+      - =children
+        - =pin
+          - true
+      - b
+        - =done
+        - c
+      - d
+    `
+
+    const steps = [importText({ text }), setCursor(['a'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeFalsy()
+    expect(isContextExpanded(stateNew, ['a', 'd'])).toBeTruthy()
+  })
+
+  it('child with =done is expanded by cursor despite =children/=pin/true on parent', () => {
+    const text = `
+      - a
+        - =children
+          - =pin
+            - true
+        - b
+          - =done
+            - c
+    `
+
+    const steps = [importText({ text }), setCursor(['a', 'b'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+  })
+
+  it('children of cursor should always be visible, it should take precedence over =done', () => {
+    const text = `
+      - a
+        - =done
+        - b
+          - c
+    `
+
+    const steps = [importText({ text }), setCursor(['a', 'b'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+  })
+
+  it('siblings of thoughts with =done should not be expanded', () => {
+    const text = `
+      - a
+        - b
+          - =done
+            - c
+          - d
+            - e
+    `
+
+    const steps = [importText({ text }), setCursor(['a'])]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(isContextExpanded(stateNew, ['a'])).toBeTruthy()
+    expect(isContextExpanded(stateNew, ['a', 'b'])).toBeFalsy()
+    expect(isContextExpanded(stateNew, ['a', 'd'])).toBeFalsy()
+  })
+})


### PR DESCRIPTION
This PR resolves this issue : Thoughts marked =done should be collapsed #2687.
I think there is no need to explain the cause of bug. It's closer to implementing the function.

**Solution** : 

 - Added a new helper function isDone that checks if a thought has the =done attribute
 - Modified the hasOnlyChild condition to check for =done in addition to =pin/false
 - Modified the expansion filter to also check for =done when determining if a child should be expanded
 - These changes will make thoughts marked with =done behave like thoughts marked with =pin/false - they will be collapsed by 
    default unless the cursor is on them or one of their ancestors or they are explicitly pinned with =pin/true.

