### PR TITLE
Fix mui unsupported error.

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -20,6 +20,15 @@ import TextColorIcon from './icons/TextColor'
 /** A function that adds an alpha channel to a hex color. */
 const addAlphaToHex = (hex: string) => (hex.length === 7 ? hex + 'ff' : hex)
 
+/** Extracts and cleans a color value from a potential HTML-like string. */
+const getCleanColor = (color: string | null) => {
+  if (!color) return null
+  // Extract clean color value from potential HTML-like string.
+  const colorMatch = typeof color === 'string' ? color.match(/#[0-9a-fA-F]{6}/) : null
+  const cleanColor = colorMatch ? colorMatch[0] : color
+  return cleanColor && typeof cleanColor === 'string' ? addAlphaToHex(rgbToHex(cleanColor)) : null
+}
+
 /** A small, square color swatch that can be picked in the color picker. */
 const ColorSwatch: FC<{
   backgroundColor?: ColorToken
@@ -32,28 +41,10 @@ const ColorSwatch: FC<{
   const dispatch = useDispatch()
   const fontSize = useSelector(state => state.fontSize)
   const commandStateBackgroundColor = commandStateStore.useSelector(state => {
-    if (!state.backColor) return null
-    // Extract clean color value from potential HTML-like string
-    const colorMatch = typeof state.backColor === 'string' ? state.backColor.match(/#[0-9a-fA-F]{6}/) : null
-    const cleanColor = colorMatch ? colorMatch[0] : state.backColor
-    try {
-      return cleanColor && typeof cleanColor === 'string' ? addAlphaToHex(rgbToHex(cleanColor)) : null
-    } catch (e) {
-      console.warn('Invalid color format:', cleanColor)
-      return null
-    }
+    return getCleanColor(typeof state.backColor === 'string' ? state.backColor : null)
   })
   const commandStateColor = commandStateStore.useSelector(state => {
-    if (!state.foreColor) return null
-    // Extract clean color value from potential HTML-like string
-    const colorMatch = typeof state.foreColor === 'string' ? state.foreColor.match(/#[0-9a-fA-F]{6}/) : null
-    const cleanColor = colorMatch ? colorMatch[0] : state.foreColor
-    try {
-      return cleanColor && typeof cleanColor === 'string' ? addAlphaToHex(rgbToHex(cleanColor)) : null
-    } catch (e) {
-      console.warn('Invalid color format:', cleanColor)
-      return null
-    }
+    return getCleanColor(typeof state.foreColor === 'string' ? state.foreColor : null)
   })
 
   size = size || fontSize * 1.2

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -31,12 +31,30 @@ const ColorSwatch: FC<{
 }> = ({ backgroundColor, color, label, shape, size }) => {
   const dispatch = useDispatch()
   const fontSize = useSelector(state => state.fontSize)
-  const commandStateBackgroundColor = commandStateStore.useSelector(state =>
-    state.backColor ? addAlphaToHex(rgbToHex(state.backColor as string)) : null,
-  )
-  const commandStateColor = commandStateStore.useSelector(state =>
-    state.foreColor ? addAlphaToHex(rgbToHex(state.foreColor as string)) : null,
-  )
+  const commandStateBackgroundColor = commandStateStore.useSelector(state => {
+    if (!state.backColor) return null
+    // Extract clean color value from potential HTML-like string
+    const colorMatch = typeof state.backColor === 'string' ? state.backColor.match(/#[0-9a-fA-F]{6}/) : null
+    const cleanColor = colorMatch ? colorMatch[0] : state.backColor
+    try {
+      return cleanColor && typeof cleanColor === 'string' ? addAlphaToHex(rgbToHex(cleanColor)) : null
+    } catch (e) {
+      console.warn('Invalid color format:', cleanColor)
+      return null
+    }
+  })
+  const commandStateColor = commandStateStore.useSelector(state => {
+    if (!state.foreColor) return null
+    // Extract clean color value from potential HTML-like string
+    const colorMatch = typeof state.foreColor === 'string' ? state.foreColor.match(/#[0-9a-fA-F]{6}/) : null
+    const cleanColor = colorMatch ? colorMatch[0] : state.foreColor
+    try {
+      return cleanColor && typeof cleanColor === 'string' ? addAlphaToHex(rgbToHex(cleanColor)) : null
+    } catch (e) {
+      console.warn('Invalid color format:', cleanColor)
+      return null
+    }
+  })
 
   size = size || fontSize * 1.2
 


### PR DESCRIPTION
This PR resolves the issue : MUI: Unsupported &quot;#00c7e6&quot; >world</font> color #2684.

The cuase of bug : The color value being passed contains HTML markup ("#00c7e6" >world</font>), which is causing MUI's color parsing to fail. The color needs to be extracted from this string before being passed to rgbToHex.
The state update during render is happening because of the selector logic in the ColorSwatch component, which is trying to process an invalid color format.

Solution : So, I've made the following changes to fix the issues:
Added proper color extraction using regex to pull out clean hex color values from HTML-like strings.
Added error handling to prevent crashes when invalid color formats are encountered.