### PR TITLE
Fix : Uncaught IndexSizeError

### DIFF
--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -57,14 +57,8 @@ export const isCollapsed = (): boolean => !!window.getSelection()?.isCollapsed
 export const isActive = (): boolean => !!window.getSelection()?.focusNode
 
 /** Returns true if the Node is an editable. */
-const isEditable = (node?: Node | null) => {
-  const element = node as HTMLElement
-  return (
-    !!element &&
-    element.nodeType === Node.ELEMENT_NODE &&
-    (element.hasAttribute('data-editable') || element.ariaLabel === 'note-editable')
-  )
-}
+const isEditable = (node?: Node | null) =>
+  !!node && node.nodeType === Node.ELEMENT_NODE && !!(node as HTMLElement).hasAttribute?.('data-editable')
 
 /** Returns true if the selection is on a thought. */
 // We should see if it is possible to just use state.editing and selection.isActive()
@@ -205,10 +199,31 @@ export const restore = (savedSelection: SavedSelection | null): void => {
   }
 
   const sel = window.getSelection()
+  if (!sel) return
 
-  if (savedSelection.node) {
-    sel?.removeAllRanges()
-    sel?.collapse(savedSelection.node, savedSelection.offset)
+  try {
+    sel.removeAllRanges()
+
+    // Validate the node and offset before attempting to collapse
+    const node = savedSelection.node
+    let offset = savedSelection.offset
+
+    // If it's an element node, ensure offset doesn't exceed number of children
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      offset = Math.min(offset, node.childNodes.length)
+    }
+    // If it's a text node, ensure offset doesn't exceed text length
+    else if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+      offset = Math.min(offset, node.textContent.length)
+    }
+    // Default to 0 if we can't determine a valid offset
+    else {
+      offset = 0
+    }
+
+    sel.collapse(node, offset)
+  } catch (e) {
+    clear()
   }
 }
 

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -57,8 +57,14 @@ export const isCollapsed = (): boolean => !!window.getSelection()?.isCollapsed
 export const isActive = (): boolean => !!window.getSelection()?.focusNode
 
 /** Returns true if the Node is an editable. */
-const isEditable = (node?: Node | null) =>
-  !!node && node.nodeType === Node.ELEMENT_NODE && !!(node as HTMLElement).hasAttribute?.('data-editable')
+const isEditable = (node?: Node | null) => {
+  const element = node as HTMLElement
+  return (
+    !!element &&
+    element.nodeType === Node.ELEMENT_NODE &&
+    (element.hasAttribute('data-editable') || element.ariaLabel === 'note-editable')
+  )
+}
 
 /** Returns true if the selection is on a thought. */
 // We should see if it is possible to just use state.editing and selection.isActive()
@@ -201,30 +207,24 @@ export const restore = (savedSelection: SavedSelection | null): void => {
   const sel = window.getSelection()
   if (!sel) return
 
-  try {
-    sel.removeAllRanges()
+  sel.removeAllRanges()
 
-    // Validate the node and offset before attempting to collapse
-    const node = savedSelection.node
-    let offset = savedSelection.offset
+  // Validate the node and offset before attempting to collapse
+  const node = savedSelection.node
+  let offset = savedSelection.offset
 
-    // If it's an element node, ensure offset doesn't exceed number of children
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      offset = Math.min(offset, node.childNodes.length)
-    }
-    // If it's a text node, ensure offset doesn't exceed text length
-    else if (node.nodeType === Node.TEXT_NODE && node.textContent) {
-      offset = Math.min(offset, node.textContent.length)
-    }
-    // Default to 0 if we can't determine a valid offset
-    else {
-      offset = 0
-    }
-
-    sel.collapse(node, offset)
-  } catch (e) {
-    clear()
+  // If it's an element node, ensure offset doesn't exceed number of children
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    offset = Math.min(offset, node.childNodes.length)
   }
+  // If it's a text node, ensure offset doesn't exceed text length
+  else if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+    offset = Math.min(offset, node.textContent.length)
+  }
+  // Default to 0 if we can't determine a valid offset
+  else offset = 0
+
+  sel.collapse(node, offset)
 }
 
 /** Returns an object representing the current selection that can be passed to selection.restore to restore the selection. */


### PR DESCRIPTION
This PR resolves the issue : formatSelection: IndexSizeError on set whole thought color after selection color #2629

The error is actually occurring in the restore function when trying to collapse the selection.
Cause of bug :  We're directly saving the `focusNode` and `focusOffset` from the selection without validating what type of node it is or if the offset is valid for that node type. When the saved node is an `ELEMENT_NODE` and the saved offset is greater than the number of child nodes that element has, we got this error.

So, I handle this by checking the node type and adjusting the offset accordingly.

Solution : So, I have changed the `restore` function to handle the selection restoration more safely.
 - I added proper validation of the selection object.
 - And I added type-specific offset validation.
 - Wrapped the operation in a try-catch block with a fallback to clear the selection if restoration fails