### PR TITLE
Hide caret globally in puppeteer tests

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -158,6 +158,11 @@ const globalCss = defineGlobalStyles({
         userSelect: 'none',
       },
     },
+    _test: {
+      // Caret should be invisible in puppeteer tests as the blink timing differs between runs and will fail the screenshot tests.
+      // Do this here rather than programmatically in order to avoid an extra page.evaluate.
+      caretColor: 'transparent',
+    },
   },
   'html, body, #root, #app': { height: '100%', fontSize: '16px' },
   'body, textarea': {

--- a/src/e2e/puppeteer/helpers/screenshot.ts
+++ b/src/e2e/puppeteer/helpers/screenshot.ts
@@ -1,19 +1,7 @@
 import { ScreenshotOptions } from 'puppeteer'
 import { page } from '../setup'
 
-/** Takes a screenshot. Note: Clears the browser selection first, as the timing of the blinking caret differs between runs. */
-const screenshot = async (options?: ScreenshotOptions) => {
-  await page.evaluate(() => {
-    // For some reason, in headless mode, removeAllRanges is not enough to remove the caret. It will show up in the screenshot at the beginning of the focusNode.
-    // Blurring the active element works as expected (parallels the implementation of selection.clear).
-    window.getSelection()?.removeAllRanges()
-
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
-    }
-  })
-
-  return Buffer.from(await page.screenshot(options))
-}
+/** Takes a screenshot. */
+const screenshot = async (options?: ScreenshotOptions) => Buffer.from(await page.screenshot(options))
 
 export default screenshot


### PR DESCRIPTION
Caret should be invisible in puppeteer tests as the blink timing differs between runs and will fail the screenshot tests.

Do this globally in panda.config.ts rather than programmatically in the tests in order to avoid an extra page.evaluate.