### PR TITLE
Tests for Tutorial

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
 }

--- a/src/components/Tutorial/Tutorial2StepContextViewOpen.tsx
+++ b/src/components/Tutorial/Tutorial2StepContextViewOpen.tsx
@@ -46,7 +46,7 @@ const Tutorial2StepContextViewOpen = () => {
       {TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}" or "{TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}" to show it again.
     </p>
   ) : contextViewClosed ? (
-    <p>Oops, somehow the context view was closed. Select "Relationships".</p>
+    <p>Oops, somehow the context view was closed. Select "{TUTORIAL_CONTEXT[tutorialChoice]}".</p>
   ) : (
     <>
       <p>

--- a/src/components/Tutorial/TutorialNavigationButton.tsx
+++ b/src/components/Tutorial/TutorialNavigationButton.tsx
@@ -14,7 +14,7 @@ const TutorialNavigationButton = React.forwardRef<
 >(({ clickHandler, value, disabled = false, classes }, ref) => (
   <a
     className={cx(anchorButtonRecipe({ variableWidth: true, smallGapX: true }), classes)}
-    onClick={clickHandler}
+    // onClick={clickHandler}
     {...{ disabled }}
     {...fastClick(clickHandler)}
     ref={ref}

--- a/src/components/Tutorial/TutorialNavigationButton.tsx
+++ b/src/components/Tutorial/TutorialNavigationButton.tsx
@@ -14,7 +14,6 @@ const TutorialNavigationButton = React.forwardRef<
 >(({ clickHandler, value, disabled = false, classes }, ref) => (
   <a
     className={cx(anchorButtonRecipe({ variableWidth: true, smallGapX: true }), classes)}
-    // onClick={clickHandler}
     {...{ disabled }}
     {...fastClick(clickHandler)}
     ref={ref}

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -121,7 +121,7 @@ describe('Tutorial 2', async () => {
   beforeEach(() => createTestApp({ tutorial: true }))
   afterEach(cleanupTestEventHandlers)
   afterAll(cleanupTestApp)
-  it('we learn about context indicators', async () => {
+  it('we learn about context view', async () => {
     await user.click(screen.getByText('Learn more'))
 
     expect(screen.getByText(/shows a small number to the right of the thought, for example/)).toBeInTheDocument()
@@ -141,29 +141,29 @@ describe('Tutorial 2', async () => {
   })
 
   describe('step context 1 - create a "Home" to-do list', () => {
-    it('we create a Home thought', async () => {
+    it('we create a "Home" thought', async () => {
       await user.keyboard('{Enter}')
       await user.type(lastEmptyThought(), 'Home')
       await act(vi.runOnlyPendingTimersAsync)
       expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
     })
 
-    it('we add a Home->To Do subthought', async () => {
+    it('we add a "Home" • "To Do" subthought', async () => {
       await user.keyboard('{Control>}{Enter}{/Control}')
       await user.type(lastEmptyThought(), 'To Do')
       await act(vi.runOnlyPendingTimersAsync)
       expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
     })
 
-    it('we add a Home->To Do->or to not subthought sub-subthought', async () => {
+    it('we add a "Home" • "To Do" • "Or to not subthought" sub-subthought', async () => {
       await user.keyboard('{Control>}{Enter}{/Control}')
-      await user.type(lastEmptyThought(), 'or to not')
+      await user.type(lastEmptyThought(), 'Or to not')
       await act(vi.runOnlyPendingTimersAsync)
 
       /* thoughts:
       - Home
         - To Do
-          - or to not
+          - Or to not
       */
       expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
     })
@@ -191,18 +191,18 @@ describe('Tutorial 2', async () => {
       expect(screen.getByText(/Now add a thought with the text "To Do"/)).toBeInTheDocument()
     })
 
-    it('we add another Work->To Do thought', async () => {
+    it('we add another "Work" • "To Do" thought', async () => {
       await user.keyboard('{Control>}{Enter}{/Control}')
       await user.type(lastEmptyThought(), 'To Do')
       expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
     })
 
-    it('we see context indicators', async () => {
+    it('we see contexts with a superscript', async () => {
       expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
       expect(screen.getByText(/This means that “To Do” appears in two places/)).toBeInTheDocument()
     })
 
-    it('we add a Work->To Do->Text boss', async () => {
+    it('we add a "Work" • "To Do" • "Text boss" thought', async () => {
       await user.keyboard('{Control>}{Enter}{/Control}')
       await user.type(lastEmptyThought(), 'Text boss')
       await act(vi.runOnlyPendingTimersAsync)

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,140 +1,145 @@
 import { getByText, screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
-import { importTextActionCreator as importText } from '../../../actions/importText'
-import { newThoughtActionCreator as newThought } from '../../../actions/newThought'
 import {
   HOME_TOKEN,
   TUTORIAL2_STEP_CHOOSE,
+  TUTORIAL2_STEP_CONTEXT1,
+  TUTORIAL2_STEP_CONTEXT1_PARENT,
+  TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT,
+  TUTORIAL2_STEP_CONTEXT2_PARENT,
+  TUTORIAL2_STEP_CONTEXT_VIEW_EXAMPLES,
+  TUTORIAL2_STEP_CONTEXT_VIEW_OPEN,
+  TUTORIAL2_STEP_CONTEXT_VIEW_SELECT,
+  TUTORIAL2_STEP_START,
   TUTORIAL_STEP_AUTOEXPAND,
+  TUTORIAL_STEP_AUTOEXPAND_EXPAND,
+  TUTORIAL_STEP_FIRSTTHOUGHT,
   TUTORIAL_STEP_FIRSTTHOUGHT_ENTER,
   TUTORIAL_STEP_SECONDTHOUGHT,
+  TUTORIAL_STEP_SECONDTHOUGHT_ENTER,
+  TUTORIAL_STEP_START,
   TUTORIAL_STEP_SUBTHOUGHT,
+  TUTORIAL_STEP_SUBTHOUGHT_ENTER,
   TUTORIAL_STEP_SUCCESS,
 } from '../../../constants'
 import exportContext from '../../../selectors/exportContext'
 import store from '../../../stores/app'
-import createTestApp, { cleanupTestApp, createTestAppWithTutorial } from '../../../test-helpers/createTestApp'
-import dispatch from '../../../test-helpers/dispatch'
-import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../../test-helpers/setCursorFirstMatch'
+import createTestApp, { cleanupTestApp, cleanupTestEventHandlers } from '../../../test-helpers/createTestApp'
 
 // as per https://testing-library.com/docs/user-event/options/#advancetimers
 // we should avoid using { delay: null }, and use jest.advanceTimersByTime instead
 const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 
-describe.skip('Tutorial test keyboard events', () => {
-  beforeEach(createTestApp)
-  afterEach(cleanupTestApp)
-  it('2 enters', async () => {
-    await user.keyboard('{Enter}')
-    await user.keyboard('{Enter}')
-  })
+/** Get last created thought in the document, used mostly after `user.keyboard('{Enter}')`. */
+const lastThought = () => Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!
 
-  it('another 2 enters', async () => {
-    await user.keyboard('{Enter}')
-    await user.keyboard('{Enter}')
-  })
-
-  it('final 2 enters', async () => {
-    await user.keyboard('{Enter}')
-    await user.keyboard('{Enter}')
-
-    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    console.log(exported)
-  })
-
-  afterAll(() => {
-    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    console.log(exported)
-  })
-})
+/** Ensure we are at the given step of the tutorial. */
+const ensureStep = (step: number) => {
+  expect(store.getState().storageCache?.tutorialStep).toBe(step)
+}
 
 describe('Tutorial 1', async () => {
-  beforeEach(createTestAppWithTutorial)
+  beforeEach(() => createTestApp({ tutorial: true }))
+  afterEach(cleanupTestEventHandlers)
   afterAll(cleanupTestApp)
   describe('step start', () => {
     it('shows the welcome text', () => {
+      ensureStep(TUTORIAL_STEP_START)
       expect(screen.getByText('Welcome to your personal thoughtspace.')).toBeInTheDocument()
     })
 
     it('shows the "Next" button, that leads to the first step', async () => {
       await user.click(screen.getByText('Next'))
-      expect(
-        screen.getByText('First, let me show you how to create a new thought', { exact: false }),
-      ).toBeInTheDocument()
+      expect(screen.getByText(/First, let me show you how to create a new thought/)).toBeInTheDocument()
     })
   })
 
   it('step first thought - how to create a thought ', async () => {
+    ensureStep(TUTORIAL_STEP_FIRSTTHOUGHT)
     expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
-
-    await act(() => user.keyboard('{Enter}'))
+    await user.keyboard('{Enter}')
     expect(screen.getByText('You did it!')).toBeInTheDocument()
-    expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
 
-    await dispatch(newThought({ value: 'my first thought' }))
+    ensureStep(TUTORIAL_STEP_FIRSTTHOUGHT_ENTER)
+    expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
+    await user.type(lastThought(), 'my first thought')
+    await user.keyboard('{Enter}')
     await act(vi.runOnlyPendingTimersAsync)
-    expect(screen.getByText('Click the Next button when you are ready to continue.')).toBeInTheDocument()
-    expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_FIRSTTHOUGHT_ENTER)
   })
 
   it('step second thought - prompts to add another thought', async () => {
-    await dispatch(newThought({ value: 'a thought' }))
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SECONDTHOUGHT)
+    expect(screen.getByText('Well done!')).toBeInTheDocument()
+    expect(screen.getByText(/Try adding another thought/)).toBeInTheDocument()
+    ensureStep(TUTORIAL_STEP_SECONDTHOUGHT)
 
-    expect(screen.getByText('Try adding another thought. Do you remember how to do it?')).toBeInTheDocument()
-    await dispatch(newThought({ value: 'a new thought' }))
+    await user.type(lastThought(), 'my second thought')
+    await user.keyboard('{Enter}')
     await act(vi.runOnlyPendingTimersAsync)
+
+    ensureStep(TUTORIAL_STEP_SECONDTHOUGHT_ENTER)
+
     expect(screen.getByText('Good work!')).toBeInTheDocument()
+    expect(screen.getByText('Now type some text for the new thought.')).toBeInTheDocument()
+    await user.type(lastThought(), 'third thought')
+    await user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
   })
 
   it('step subthought - how to create a thought inside thought', async () => {
-    await user.click(screen.getByText('Next'))
-    expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SUBTHOUGHT)
-    await dispatch([
-      newThought({ value: 'uncle' }),
-      newThought({
-        value: 'parent',
-      }),
-      newThought({
-        value: 'child',
-        insertNewSubthought: true,
-      }),
-    ])
+    ensureStep(TUTORIAL_STEP_SUBTHOUGHT)
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
+      `- __ROOT__
+  - my first thought
+  - my second thought
+  - third thought
+  - `,
+    )
+
+    // Now I am going to show you how to add a thought within another thought.
+    expect(screen.getByText(/Now I am going to show you how to add a thought/)).toBeInTheDocument()
+
+    // since we have cursor on empty thought
+    expect(screen.getByText(/Hit the Delete key to delete the current blank thought/)).toBeInTheDocument()
+    expect(screen.getByText(/Then hold the Ctrl key and hit the Enter key/)).toBeInTheDocument()
+    await user.keyboard('{Backspace}')
+    await user.keyboard('{Control>}{Enter}{/Control}')
     await act(vi.runOnlyPendingTimersAsync)
 
-    expect(screen.getByText(`As you can see, the new thought "child" is nested`, { exact: false })).toBeInTheDocument()
-    expect(getByText(screen.getByTestId('tutorial-step'), 'parent', { exact: false })).toBeInTheDocument()
+    await user.type(lastThought(), 'child')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
+      `- __ROOT__
+  - my first thought
+  - my second thought
+  - third thought
+    - child`,
+    )
+    // as you can see, the new thought "child" is nested within "third thought"
+    expect(screen.getByText(/As you can see, the new thought "child" is nested/)).toBeInTheDocument()
+    expect(getByText(screen.getByTestId('tutorial-step'), /"third thought"/)).toBeInTheDocument()
+
+    ensureStep(TUTORIAL_STEP_SUBTHOUGHT_ENTER)
+    await user.click(screen.getByText('Next'))
   })
 
-  describe('step autoexpand - shows that thoughts expand and collapse on outside click', async () => {
-    it('tells us about thoughts being hidden when clicked away', async () => {
-      await user.click(screen.getByText('Next'))
-
-      expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_AUTOEXPAND)
-      expect(
-        screen.getByText('thoughts are automatically hidden when you click away', { exact: false }),
-      ).toBeInTheDocument()
+  describe('step autoexpand', async () => {
+    it('thoughts are automatically hidden when you click away', async () => {
+      ensureStep(TUTORIAL_STEP_AUTOEXPAND)
+      expect(screen.getByText(/thoughts are automatically hidden when you click away/)).toBeInTheDocument()
     })
 
-    it('tells us to click on uncle to hide the child', async () => {
-      await dispatch([
-        importText({
-          text: `
-      - parent
-        - child
-      - uncle
-      `,
-        }),
-      ])
-      await act(() => user.click(screen.getByText('uncle')))
+    it('click on "uncle" thought to hide child', async () => {
+      await user.click(screen.getByText('my second thought'))
       expect(screen.getByText('Notice that "child" is hidden now.', { exact: false })).toBeInTheDocument()
+      ensureStep(TUTORIAL_STEP_AUTOEXPAND_EXPAND)
     })
 
-    it('tells us to click on the parent to reveal the child', async () => {
-      await act(() => user.click(Array.from(screen.getAllByText('parent')).at(-1)!))
+    it('click back on a "parent" thought to reveal child', async () => {
+      expect(screen.getByText(/Click "third thought" to reveal its subthought "child"/)).toBeInTheDocument()
+      await user.click(screen.getAllByText('third thought').at(-1)!)
       expect(screen.getByText('Lovely. You have completed the tutorial', { exact: false })).toBeInTheDocument()
+      ensureStep(TUTORIAL_STEP_SUCCESS)
     })
   })
 
@@ -147,216 +152,145 @@ describe('Tutorial 1', async () => {
       expect(screen.getByText('Play on my own')).toBeInTheDocument()
       expect(screen.getByText('Learn more')).toBeInTheDocument()
     })
-
-    it.skip('hides tutorial after clicking "Play on my own"', async () => {
-      await user.click(screen.getByText('Play on my own'))
-      expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
-    })
   })
 })
 
 describe('Tutorial 2', async () => {
-  describe('step start - tell about context menu', async () => {
-    it('tell about context menu', async () => {
-      await cleanupTestApp()
-      await createTestAppWithTutorial()
-      expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SUCCESS)
+  beforeEach(() => createTestApp({ tutorial: true }))
+  afterEach(cleanupTestEventHandlers)
+  afterAll(cleanupTestApp)
+  it('step start - tell about context menu', async () => {
+    await user.click(screen.getByText('Learn more'))
 
-      await user.click(screen.getByText('Learn more'))
-
-      expect(
-        screen.getByText(`If the same thought appears in more than one place`, { exact: false }),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
-      ).toBeInTheDocument()
-    })
+    ensureStep(TUTORIAL2_STEP_START)
+    expect(screen.getByText(`If the same thought appears in more than one place`, { exact: false })).toBeInTheDocument()
+    expect(
+      screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
+    ).toBeInTheDocument()
   })
 
-  describe('step choose', async () => {
-    beforeEach(createTestAppWithTutorial)
-    it('gives 3 choices of what project to proceed with', async () => {
-      await user.click(screen.getByText('Next'))
-      expect(
-        screen.getByText('For this tutorial, choose what kind of content you want to create', { exact: false }),
-      ).toBeInTheDocument()
-      expect(screen.getByText('To-Do List')).toBeInTheDocument()
-      expect(screen.getByText('Journal Theme')).toBeInTheDocument()
-      expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
-    })
+  it('step choose - gives 3 choices of what project to proceed with', async () => {
+    await user.click(screen.getByText('Next'))
+    ensureStep(TUTORIAL2_STEP_CHOOSE)
+    expect(screen.getByText(/For this tutorial, choose what kind of content you want to create/)).toBeInTheDocument()
+    expect(screen.getByText('To-Do List')).toBeInTheDocument()
+    expect(screen.getByText('Journal Theme')).toBeInTheDocument()
+    expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
   })
 
-  describe('step context 1 parent, prompt for creating a first todo', async () => {
-    beforeEach(createTestAppWithTutorial)
+  it('step context 1 parent - we create "Home" thought with children', async () => {
+    await user.click(screen.getAllByText('To-Do List').at(-1)!)
+    expect(screen.getByText(/Excellent choice. Now create a new thought with the text “Home”/)).toBeInTheDocument()
+    ensureStep(TUTORIAL2_STEP_CONTEXT1_PARENT)
 
-    it('step context 1 parent, prompt for creating a first todo', async () => {
-      console.log(store.getState().storageCache?.tutorialStep)
-      expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL2_STEP_CHOOSE)
-      await user.click(screen.getAllByText('To-Do List').at(-1)!)
-      await act(vi.runOnlyPendingTimersAsync)
+    // we create a `Home` thought
+    await user.keyboard('{Enter}')
+    await user.type(lastThought(), 'Home')
+    await act(vi.runOnlyPendingTimersAsync)
+    ensureStep(TUTORIAL2_STEP_CONTEXT1)
 
-      expect(
-        screen.getByText('Excellent choice. Now create a new thought with the text “Home”', { exact: false }),
-      ).toBeInTheDocument()
-      await act(vi.runOnlyPendingTimersAsync)
+    // Home -> To Do
+    expect(screen.getByText(/Let's say that you want to make a list of things/)).toBeInTheDocument()
+    expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
+    await user.keyboard('{Control>}{Enter}{/Control}')
+    await user.type(lastThought(), 'To Do')
+    await act(vi.runOnlyPendingTimersAsync)
+    ensureStep(TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT)
 
-      await user.keyboard('{Enter}')
-      await user.type(document.querySelector('[contenteditable="true"]') as HTMLElement, 'Home', {
-        skipAutoClose: true,
-      })
-      // await user.keyboard('{Enter}')
-      await act(vi.runOnlyPendingTimersAsync)
+    // Home -> To Do -> or to not
+    expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
+    await user.keyboard('{Control>}{Enter}{/Control}')
+    await user.type(lastThought(), 'or to not')
+    await act(vi.runOnlyPendingTimersAsync)
 
-      expect(screen.getByText(/Let's say that you want to make a list of things/)).toBeInTheDocument()
-      expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
-
-      await act(vi.runOnlyPendingTimersAsync)
-      await user.keyboard('{Control>}{Enter}{/Control}')
-      await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'To Do')
-      await act(vi.runOnlyPendingTimersAsync)
-
-      expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
-
-      await user.keyboard('{Control>}{Enter}{/Control}')
-      await act(vi.runOnlyPendingTimersAsync)
-      await user.type(lastThought(), 'or to not')
-      await act(vi.runOnlyPendingTimersAsync)
-
-      expect(showAllThoughts()).toBe(
-        `- __ROOT__
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
+      `- __ROOT__
   - Home
     - To Do
       - or to not`,
-      )
-      expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
-    })
+    )
+    expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
   })
 
-  describe('step context 2', async () => {
-    beforeEach(createTestAppWithTutorial)
+  it('step context 2 - we create "Work" thought with children', async () => {
+    await user.click(screen.getByText('Next'))
+    ensureStep(TUTORIAL2_STEP_CONTEXT2_PARENT)
+    expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
 
-    it('prompt for creating a second todo, shows a superscript', async () => {
-      await user.click(screen.getByText('Next'))
-      expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
+    // we created a new thought on 3rd level, so we shift-tab our way back to root
+    await user.keyboard('{Enter}')
+    await user.keyboard('{Shift>}{Tab}{/Shift}')
+    await user.keyboard('{Shift>}{Tab}{/Shift}')
+    await user.type(lastThought(), 'Work')
+    await act(vi.runOnlyPendingTimersAsync)
 
-      await user.keyboard('{Enter}')
-      await user.keyboard('{Shift>}{Tab}{/Shift}') // we are at
-      await user.keyboard('{Shift>}{Tab}{/Shift}')
+    expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
+    await user.keyboard('{Control>}{Enter}{/Control}')
+    await user.type(lastThought(), 'To Do')
 
-      await act(vi.runOnlyPendingTimersAsync)
-
-      await user.type(lastThought(), 'Work')
-      await act(vi.runOnlyPendingTimersAsync)
-
-      expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
-
-      await user.keyboard('{Control>}{Enter}{/Control}')
-      await user.type(lastThought(), 'To Do')
-
-      expect(showAllThoughts()).toBe(
-        `- __ROOT__
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
+      `- __ROOT__
   - Home
     - To Do
       - or to not
   - Work
     - To Do`,
-      )
-      expect(screen.getByText('Very good!')).toBeInTheDocument()
+    )
+    expect(screen.getByText('Very good!')).toBeInTheDocument()
 
-      expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
-      expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
+    expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
+    expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
 
-      expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
-      await user.keyboard('{Control>}{Enter}{/Control}')
-      await user.type(lastThought(), 'new work task')
-    })
+    expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
+    await user.keyboard('{Control>}{Enter}{/Control}')
+    await user.type(lastThought(), 'new work task')
   })
 
-  describe('multiple contexts', () => {
-    beforeEach(createTestAppWithTutorial)
-    it('step context view open - showcase multiple contexts', async () => {
-      expect(showAllThoughts()).toBe(
-        `- __ROOT__
+  it('step context view open - we press Alt+Shift+S and see "To Do" in both "Home" and "Work"', async () => {
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
+      `- __ROOT__
   - Home
     - To Do
       - or to not
   - Work
     - To Do
       - new work task`,
-      )
-      await user.click(screen.getByText('Next'))
-      await act(vi.runOnlyPendingTimersAsync)
+    )
+    await user.click(screen.getByText('Next'))
+    await act(vi.runOnlyPendingTimersAsync)
 
-      expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
+    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_SELECT)
+    expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
+    await user.keyboard('{Escape}') // focus out
+    await user.click(screen.getAllByText('To Do').at(-1)!) // and click on To Do
+    await act(vi.runOnlyPendingTimersAsync)
 
-      console.log(screen.getAllByText('To Do').at(-1)!)
-      await user.keyboard('{Escape}') // focus out
-      await user.click(screen.getAllByText('To Do').at(-1)!) // and click on To Do
-
-      await act(vi.runOnlyPendingTimersAsync)
-
-      // await user.click(screen.getAllByText('To Do').at(-1)!) // focus on
-      await act(vi.runOnlyPendingTimersAsync)
-
-      // await dispatch(setCursorFirstMatch(['Work', 'To Do']))
-      showAllThoughts()
-
-      await act(vi.runOnlyPendingTimersAsync)
-      expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
-
-      await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
-      await act(vi.runOnlyPendingTimersAsync)
-
-      expect(
-        screen.getByText(
-          `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
-        ),
-      ).toBeInTheDocument()
-    })
+    expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
+    await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
+    await act(vi.runOnlyPendingTimersAsync)
+    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_OPEN)
+    expect(
+      screen.getByText(
+        `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
+      ),
+    ).toBeInTheDocument()
   })
 
-  describe('step context examples - show real world examples', async () => {
-    beforeEach(createTestAppWithTutorial)
-
-    it('show real world examples', async () => {
-      await user.click(screen.getByText('Next'))
-      expect(
-        screen.getByText('Here are some real-world examples of using contexts in', { exact: false }),
-      ).toBeInTheDocument()
-      expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
-      expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
-      expect(
-        screen.getByText('Create a link on the home screen to a deeply nested subthought for easy access.'),
-      ).toBeInTheDocument()
-    })
+  it('step context examples - we see real-world examples', async () => {
+    await user.click(screen.getByText('Next'))
+    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_EXAMPLES)
+    expect(screen.getByText(/Here are some real-world examples of using contexts in/)).toBeInTheDocument()
+    expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
+    expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
   })
 
-  describe('step success', async () => {
-    beforeEach(createTestAppWithTutorial)
+  it('step success - congratulations, hide tutorial after clicking "Finish"', async () => {
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByText(/Congratulations! You have completed Part II of the tutorial./)).toBeInTheDocument()
 
-    it('congratulates on finishing tutorial, hides it after "Finish"', async () => {
-      await user.click(screen.getByText('Next'))
-      expect(
-        screen.getByText('Congratulations! You have completed Part II of the tutorial.', { exact: false }),
-      ).toBeInTheDocument()
+    user.click(screen.getByText('Finish'))
+    await act(vi.runOnlyPendingTimersAsync)
 
-      user.click(screen.getByText('Finish'))
-      await act(vi.runOnlyPendingTimersAsync)
-
-      expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
-    })
+    expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
   })
 })
-
-function showAllThoughts(
-  logPostfix: string = '', // to differentiate between different tests
-) {
-  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-  console.log(`${exported} ${logPostfix}`)
-
-  return exported
-}
-
-function lastThought() {
-  return Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!
-}

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -31,7 +31,7 @@ describe('Tutorial 1', async () => {
   })
 
   it('step first thought - how to create a thought ', async () => {
-    await dispatch(tutorialNext({})) // we manually dispatch, because we can't do the gesture here
+    await dispatch(tutorialNext({}))
     await act(vi.runOnlyPendingTimersAsync)
 
     expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
@@ -69,10 +69,6 @@ describe('Tutorial 1', async () => {
     beforeAll(async () => {
       await dispatch(tutorialNext({}))
       await act(vi.runOnlyPendingTimersAsync)
-    })
-
-    it('display a tutorial on subthoughts, and an rdr gesture hint', async () => {
-      expect(screen.getByText(/within/)).toBeInTheDocument()
     })
 
     it('congratulate on creating a child for the <parent>', async () => {

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,28 +1,7 @@
 import { getByText, screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
-import {
-  HOME_TOKEN,
-  TUTORIAL2_STEP_CHOOSE,
-  TUTORIAL2_STEP_CONTEXT1,
-  TUTORIAL2_STEP_CONTEXT1_PARENT,
-  TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT,
-  TUTORIAL2_STEP_CONTEXT2_PARENT,
-  TUTORIAL2_STEP_CONTEXT_VIEW_EXAMPLES,
-  TUTORIAL2_STEP_CONTEXT_VIEW_OPEN,
-  TUTORIAL2_STEP_CONTEXT_VIEW_SELECT,
-  TUTORIAL2_STEP_START,
-  TUTORIAL_STEP_AUTOEXPAND,
-  TUTORIAL_STEP_AUTOEXPAND_EXPAND,
-  TUTORIAL_STEP_FIRSTTHOUGHT,
-  TUTORIAL_STEP_FIRSTTHOUGHT_ENTER,
-  TUTORIAL_STEP_SECONDTHOUGHT,
-  TUTORIAL_STEP_SECONDTHOUGHT_ENTER,
-  TUTORIAL_STEP_START,
-  TUTORIAL_STEP_SUBTHOUGHT,
-  TUTORIAL_STEP_SUBTHOUGHT_ENTER,
-  TUTORIAL_STEP_SUCCESS,
-} from '../../../constants'
+import { HOME_TOKEN } from '../../../constants'
 import exportContext from '../../../selectors/exportContext'
 import store from '../../../stores/app'
 import createTestApp, { cleanupTestApp, cleanupTestEventHandlers } from '../../../test-helpers/createTestApp'
@@ -34,18 +13,12 @@ const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 /** Get last created thought in the document, used mostly after `user.keyboard('{Enter}')`. */
 const lastThought = () => Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!
 
-/** Ensure we are at the given step of the tutorial. */
-const ensureStep = (step: number) => {
-  expect(store.getState().storageCache?.tutorialStep).toBe(step)
-}
-
 describe('Tutorial 1', async () => {
   beforeEach(() => createTestApp({ tutorial: true }))
   afterEach(cleanupTestEventHandlers)
   afterAll(cleanupTestApp)
   describe('step start', () => {
     it('shows the welcome text', () => {
-      ensureStep(TUTORIAL_STEP_START)
       expect(screen.getByText('Welcome to your personal thoughtspace.')).toBeInTheDocument()
     })
 
@@ -56,12 +29,10 @@ describe('Tutorial 1', async () => {
   })
 
   it('step first thought - how to create a thought ', async () => {
-    ensureStep(TUTORIAL_STEP_FIRSTTHOUGHT)
     expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
     await user.keyboard('{Enter}')
     expect(screen.getByText('You did it!')).toBeInTheDocument()
 
-    ensureStep(TUTORIAL_STEP_FIRSTTHOUGHT_ENTER)
     expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
     await user.type(lastThought(), 'my first thought')
     await user.keyboard('{Enter}')
@@ -71,13 +42,9 @@ describe('Tutorial 1', async () => {
   it('step second thought - prompts to add another thought', async () => {
     expect(screen.getByText('Well done!')).toBeInTheDocument()
     expect(screen.getByText(/Try adding another thought/)).toBeInTheDocument()
-    ensureStep(TUTORIAL_STEP_SECONDTHOUGHT)
-
     await user.type(lastThought(), 'my second thought')
     await user.keyboard('{Enter}')
     await act(vi.runOnlyPendingTimersAsync)
-
-    ensureStep(TUTORIAL_STEP_SECONDTHOUGHT_ENTER)
 
     expect(screen.getByText('Good work!')).toBeInTheDocument()
     expect(screen.getByText('Now type some text for the new thought.')).toBeInTheDocument()
@@ -87,7 +54,6 @@ describe('Tutorial 1', async () => {
   })
 
   it('step subthought - how to create a thought inside thought', async () => {
-    ensureStep(TUTORIAL_STEP_SUBTHOUGHT)
     expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
       `- __ROOT__
   - my first thought
@@ -119,27 +85,23 @@ describe('Tutorial 1', async () => {
     expect(screen.getByText(/As you can see, the new thought "child" is nested/)).toBeInTheDocument()
     expect(getByText(screen.getByTestId('tutorial-step'), /"third thought"/)).toBeInTheDocument()
 
-    ensureStep(TUTORIAL_STEP_SUBTHOUGHT_ENTER)
     await user.click(screen.getByText('Next'))
   })
 
   describe('step autoexpand', async () => {
     it('thoughts are automatically hidden when you click away', async () => {
-      ensureStep(TUTORIAL_STEP_AUTOEXPAND)
       expect(screen.getByText(/thoughts are automatically hidden when you click away/)).toBeInTheDocument()
     })
 
     it('click on "uncle" thought to hide child', async () => {
       await user.click(screen.getByText('my second thought'))
       expect(screen.getByText('Notice that "child" is hidden now.', { exact: false })).toBeInTheDocument()
-      ensureStep(TUTORIAL_STEP_AUTOEXPAND_EXPAND)
     })
 
     it('click back on a "parent" thought to reveal child', async () => {
       expect(screen.getByText(/Click "third thought" to reveal its subthought "child"/)).toBeInTheDocument()
       await user.click(screen.getAllByText('third thought').at(-1)!)
       expect(screen.getByText('Lovely. You have completed the tutorial', { exact: false })).toBeInTheDocument()
-      ensureStep(TUTORIAL_STEP_SUCCESS)
     })
   })
 
@@ -162,7 +124,6 @@ describe('Tutorial 2', async () => {
   it('step start - tell about context menu', async () => {
     await user.click(screen.getByText('Learn more'))
 
-    ensureStep(TUTORIAL2_STEP_START)
     expect(screen.getByText(`If the same thought appears in more than one place`, { exact: false })).toBeInTheDocument()
     expect(
       screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
@@ -171,7 +132,6 @@ describe('Tutorial 2', async () => {
 
   it('step choose - gives 3 choices of what project to proceed with', async () => {
     await user.click(screen.getByText('Next'))
-    ensureStep(TUTORIAL2_STEP_CHOOSE)
     expect(screen.getByText(/For this tutorial, choose what kind of content you want to create/)).toBeInTheDocument()
     expect(screen.getByText('To-Do List')).toBeInTheDocument()
     expect(screen.getByText('Journal Theme')).toBeInTheDocument()
@@ -181,13 +141,11 @@ describe('Tutorial 2', async () => {
   it('step context 1 parent - we create "Home" thought with children', async () => {
     await user.click(screen.getAllByText('To-Do List').at(-1)!)
     expect(screen.getByText(/Excellent choice. Now create a new thought with the text “Home”/)).toBeInTheDocument()
-    ensureStep(TUTORIAL2_STEP_CONTEXT1_PARENT)
 
     // we create a `Home` thought
     await user.keyboard('{Enter}')
     await user.type(lastThought(), 'Home')
     await act(vi.runOnlyPendingTimersAsync)
-    ensureStep(TUTORIAL2_STEP_CONTEXT1)
 
     // Home -> To Do
     expect(screen.getByText(/Let's say that you want to make a list of things/)).toBeInTheDocument()
@@ -195,7 +153,6 @@ describe('Tutorial 2', async () => {
     await user.keyboard('{Control>}{Enter}{/Control}')
     await user.type(lastThought(), 'To Do')
     await act(vi.runOnlyPendingTimersAsync)
-    ensureStep(TUTORIAL2_STEP_CONTEXT1_SUBTHOUGHT)
 
     // Home -> To Do -> or to not
     expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
@@ -214,7 +171,6 @@ describe('Tutorial 2', async () => {
 
   it('step context 2 - we create "Work" thought with children', async () => {
     await user.click(screen.getByText('Next'))
-    ensureStep(TUTORIAL2_STEP_CONTEXT2_PARENT)
     expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
 
     // we created a new thought on 3rd level, so we shift-tab our way back to root
@@ -259,7 +215,6 @@ describe('Tutorial 2', async () => {
     await user.click(screen.getByText('Next'))
     await act(vi.runOnlyPendingTimersAsync)
 
-    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_SELECT)
     expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
     await user.keyboard('{Escape}') // focus out
     await user.click(screen.getAllByText('To Do').at(-1)!) // and click on To Do
@@ -268,7 +223,6 @@ describe('Tutorial 2', async () => {
     expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
     await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
     await act(vi.runOnlyPendingTimersAsync)
-    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_OPEN)
     expect(
       screen.getByText(
         `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
@@ -278,7 +232,6 @@ describe('Tutorial 2', async () => {
 
   it('step context examples - we see real-world examples', async () => {
     await user.click(screen.getByText('Next'))
-    ensureStep(TUTORIAL2_STEP_CONTEXT_VIEW_EXAMPLES)
     expect(screen.getByText(/Here are some real-world examples of using contexts in/)).toBeInTheDocument()
     expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
     expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -11,6 +11,7 @@ import { cleanupTestApp, createTestAppWithTutorial } from '../../../test-helpers
 import dispatch from '../../../test-helpers/dispatch'
 import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../../test-helpers/setCursorFirstMatch'
 
+/** Ensures that a hint shows up on screen with text. TODO remove or use more. */
 async function hintShows(hint: string) {
   const user = userEvent.setup({ delay: null })
   await user.click(screen.getByText('hint'))
@@ -324,5 +325,3 @@ describe('Tutorial 2', async () => {
     expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
   })
 })
-
-

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -10,8 +10,11 @@ import createTestApp, { cleanupTestApp, cleanupTestEventHandlers } from '../../.
 // we should avoid using { delay: null }, and use jest.advanceTimersByTime instead
 const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 
-/** Get last created thought in the document, used mostly after `user.keyboard('{Enter}')`. */
-const lastThought = () => Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!
+/** Get last created empty thought in the document. Gets the last thought that is not empty. Mostly used after `user.keyboard('{Enter}')` to get the new thought. */
+const lastThought = () =>
+  Array.from(document.querySelectorAll('[data-editable="true"]'))
+    .filter(it => !it.textContent)
+    .at(-1)!
 
 describe('Tutorial 1', async () => {
   beforeEach(() => createTestApp({ tutorial: true }))
@@ -71,6 +74,7 @@ describe('Tutorial 1', async () => {
     await user.keyboard('{Backspace}')
     await user.keyboard('{Control>}{Enter}{/Control}')
     await act(vi.runOnlyPendingTimersAsync)
+    console.log(Array.from(document.querySelectorAll('[data-editable="true"]')).map(it => it.textContent))
 
     await user.type(lastThought(), 'child')
     await act(vi.runOnlyPendingTimersAsync)
@@ -81,6 +85,7 @@ describe('Tutorial 1', async () => {
   - third thought
     - child`,
     )
+
     // as you can see, the new thought "child" is nested within "third thought"
     expect(screen.getByText(/As you can see, the new thought "child" is nested/)).toBeInTheDocument()
     expect(getByText(screen.getByTestId('tutorial-step'), /"third thought"/)).toBeInTheDocument()

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,10 +1,11 @@
-import { fireEvent, getByText, screen } from '@testing-library/dom'
+import { getByText, screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
 import { importTextActionCreator as importText } from '../../../actions/importText'
 import { newThoughtActionCreator as newThought } from '../../../actions/newThought'
 import {
   HOME_TOKEN,
+  TUTORIAL2_STEP_CHOOSE,
   TUTORIAL_STEP_AUTOEXPAND,
   TUTORIAL_STEP_FIRSTTHOUGHT_ENTER,
   TUTORIAL_STEP_SECONDTHOUGHT,
@@ -13,11 +14,7 @@ import {
 } from '../../../constants'
 import exportContext from '../../../selectors/exportContext'
 import store from '../../../stores/app'
-import {
-  cleanupTestApp,
-  default as createTestApp,
-  createTestAppWithTutorial,
-} from '../../../test-helpers/createTestApp'
+import createTestApp, { cleanupTestApp, createTestAppWithTutorial } from '../../../test-helpers/createTestApp'
 import dispatch from '../../../test-helpers/dispatch'
 import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../../test-helpers/setCursorFirstMatch'
 
@@ -25,83 +22,36 @@ import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../.
 // we should avoid using { delay: null }, and use jest.advanceTimersByTime instead
 const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 
-describe.only('A curious case of me not being able to grasp keyboard', () => {
+describe.skip('Tutorial test keyboard events', () => {
   beforeEach(createTestApp)
   afterEach(cleanupTestApp)
-
-  it('creates a thought with two empty thoughts below it', async () => {
+  it('2 enters', async () => {
     await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[0], 'Socrates')
-    expect(screen.getByText('Socrates')).toBeInTheDocument()
-    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-
-    // eslint-disable-next-line no-console
-    console.debug('gotta be one thought', exported)
-
-    expect(exported).toBe(`- ${HOME_TOKEN}
-    - Socrates`)
-  })
-  it('creates a thought with six empty thoughts below it, if you press enter', async () => {
     await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[0], 'Socrates')
-    await user.keyboard('{Enter}')
-    expect(screen.getByText('Socrates')).toBeInTheDocument()
-    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-
-    // eslint-disable-next-line no-console
-    console.debug('after pressing enter', exported)
-    expect(exported).toBe(`- ${HOME_TOKEN}
-    - Socrates`)
   })
 
-  it('creating two thoughts produces something strange', async () => {
+  it('another 2 enters', async () => {
     await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[0], 'Socrates')
     await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'Plato')
-    await user.keyboard('{Enter}')
-
-    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-
-    // eslint-disable-next-line no-console
-    console.debug('two thoughts', exported)
   })
 
-  it('nested thoughts are broken', async () => {
+  it('final 2 enters', async () => {
     await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[0], 'Socrates')
-    await user.keyboard('{Meta>}{Enter}{/Meta}')
-    // await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'Plato')
     await user.keyboard('{Enter}')
 
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-
-    // eslint-disable-next-line no-console
-    console.debug('subthoughts', exported)
+    console.log(exported)
   })
 
-  it('nested thoughts are broken', async () => {
-    await user.keyboard('{Enter}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[0], 'Socrates')
-    await user.keyboard('{Meta>}{Enter}{/Meta}')
-    // await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'Plato')
-    await user.keyboard('{Meta>}{Enter}{/Meta}')
-
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[2], 'Aristole')
-    await user.keyboard('{Enter}')
-
+  afterAll(() => {
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-
-    // eslint-disable-next-line no-console
-    console.debug('subthoughts', exported)
+    console.log(exported)
   })
 })
 
-beforeEach(createTestAppWithTutorial)
-afterAll(cleanupTestApp)
 describe('Tutorial 1', async () => {
+  beforeEach(createTestAppWithTutorial)
+  afterAll(cleanupTestApp)
   describe('step start', () => {
     it('shows the welcome text', () => {
       expect(screen.getByText('Welcome to your personal thoughtspace.')).toBeInTheDocument()
@@ -203,154 +153,210 @@ describe('Tutorial 1', async () => {
       expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
     })
   })
-
-  afterAll(cleanupTestApp)
 })
 
 describe('Tutorial 2', async () => {
-  it('step start - tell about context menu', async () => {
-    expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SUCCESS)
+  describe('step start - tell about context menu', async () => {
+    it('tell about context menu', async () => {
+      await cleanupTestApp()
+      await createTestAppWithTutorial()
+      expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SUCCESS)
 
-    await user.click(screen.getByText('Learn more'))
+      await user.click(screen.getByText('Learn more'))
 
-    expect(screen.getByText(`If the same thought appears in more than one place`, { exact: false })).toBeInTheDocument()
-    expect(
-      screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
-    ).toBeInTheDocument()
-  })
-
-  it('step choose - gives 3 choices of what project to proceed with', async () => {
-    await user.click(screen.getByText('Next'))
-    expect(
-      screen.getByText('For this tutorial, choose what kind of content you want to create', { exact: false }),
-    ).toBeInTheDocument()
-    expect(screen.getByText('To-Do List')).toBeInTheDocument()
-    expect(screen.getByText('Journal Theme')).toBeInTheDocument()
-    expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
-    // await cleanupTestApp()
-  })
-
-  it('step context 1 parent, prompt for creating a first todo', async () => {
-    // await createTestAppWithTutorial()
-    await user.click(screen.getByText('To-Do List'))
-    await act(vi.runOnlyPendingTimersAsync)
-
-    expect(
-      screen.getByText('Excellent choice. Now create a new thought with the text “Home”', { exact: false }),
-    ).toBeInTheDocument()
-    await act(vi.runOnlyPendingTimersAsync)
-
-    await user.keyboard('{Enter}')
-    await user.type(document.querySelector('[contenteditable="true"]')!, 'Home')
-    // await user.keyboard('[Enter]')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    expect(screen.getByText(`Let's say that you want to make a list of things`, { exact: false })).toBeInTheDocument()
-    expect(screen.getByText(`Add a thought with the text "To Do"`, { exact: false })).toBeInTheDocument()
-
-    await dispatch([setCursorFirstMatch(['Home'])])
-    await act(vi.runOnlyPendingTimersAsync)
-    await user.keyboard('{Meta>}{Enter}{/Meta}')
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'To Do')
-
-    await user.keyboard('{Enter}')
-    expect(screen.getByText(`Now add a thought to “To Do”`, { exact: false })).toBeInTheDocument()
-    screen.getByText('To Do').focus()
-    fireEvent.keyUp(screen.getByText('To Do'), {
-      key: 'Enter',
-      ctrlKey: true,
-      keyCode: 13,
+      expect(
+        screen.getByText(`If the same thought appears in more than one place`, { exact: false }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
+      ).toBeInTheDocument()
     })
-    // await act(vi.runOnlyPendingTimersAsync)
-    await user.type(document.querySelectorAll('[contenteditable="true"]')[2], 'Hey')
-    await user.keyboard('{Enter}')
-
-    expect(screen.getByText(`Nice work!`, { exact: false })).toBeInTheDocument()
   })
 
-  it('step context 2 - prompt for creating a second todo, shows a superscript', async () => {
-    await user.click(screen.getByText('Next'))
-    await dispatch([
-      importText({
-        text: `
-      - Home
-        - To Do
-          - Hey
-    `,
-      }),
-      setCursorFirstMatch(['Home', 'To Do', 'Hey']),
-    ])
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(
-      screen.getByText(`Now we are going to create a different "To Do" list.`, { exact: false }),
-    ).toBeInTheDocument()
-
-    await user.click(screen.getByText('hint'))
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(getByText(screen.getByTestId('tutorial-step')!, 'Select "Home."', { exact: false })).toBeInTheDocument()
-    await user.click(screen.getByText('Home'))
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(screen.getByText(`Hit the Enter key to create a new thought`, { exact: false })).toBeInTheDocument()
-    await user.keyboard('{Enter}')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    const lastThought = Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)
-    await user.type(lastThought!, 'Work')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    expect(screen.getByText('Work')).toBeInTheDocument()
-    expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
-
-    await user.keyboard('{Control}{Enter}')
-    await user.type(Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!, 'To Do')
-    expect(screen.getByText('Very good!')).toBeInTheDocument()
-    expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
-    expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
-
-    await user.keyboard('{Control}{Enter}')
+  describe('step choose', async () => {
+    beforeEach(createTestAppWithTutorial)
+    it('gives 3 choices of what project to proceed with', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(
+        screen.getByText('For this tutorial, choose what kind of content you want to create', { exact: false }),
+      ).toBeInTheDocument()
+      expect(screen.getByText('To-Do List')).toBeInTheDocument()
+      expect(screen.getByText('Journal Theme')).toBeInTheDocument()
+      expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
+    })
   })
 
-  it('step context view open - showcase multiple contexts', async () => {
-    await user.click(screen.getByText('Next'))
-    await dispatch([setCursorFirstMatch(['To Do'])])
-    await act(vi.runOnlyPendingTimersAsync)
+  describe('step context 1 parent, prompt for creating a first todo', async () => {
+    beforeEach(createTestAppWithTutorial)
 
-    // await dispatch(setCursorFirstMatch(['Work', 'To Do']))
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
+    it('step context 1 parent, prompt for creating a first todo', async () => {
+      console.log(store.getState().storageCache?.tutorialStep)
+      expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL2_STEP_CHOOSE)
+      await user.click(screen.getAllByText('To-Do List').at(-1)!)
+      await act(vi.runOnlyPendingTimersAsync)
 
-    await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
-    await act(vi.runOnlyPendingTimersAsync)
+      expect(
+        screen.getByText('Excellent choice. Now create a new thought with the text “Home”', { exact: false }),
+      ).toBeInTheDocument()
+      await act(vi.runOnlyPendingTimersAsync)
 
-    expect(
-      screen.getByText(
-        `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
-      ),
-    ).toBeInTheDocument()
+      await user.keyboard('{Enter}')
+      await user.type(document.querySelector('[contenteditable="true"]') as HTMLElement, 'Home', {
+        skipAutoClose: true,
+      })
+      // await user.keyboard('{Enter}')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText(/Let's say that you want to make a list of things/)).toBeInTheDocument()
+      expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
+
+      await act(vi.runOnlyPendingTimersAsync)
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'To Do')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
+
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await act(vi.runOnlyPendingTimersAsync)
+      await user.type(lastThought(), 'or to not')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(showAllThoughts()).toBe(
+        `- __ROOT__
+  - Home
+    - To Do
+      - or to not`,
+      )
+      expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
+    })
   })
 
-  it('step context examples - show real world examples', async () => {
-    await user.click(screen.getByText('Next'))
+  describe('step context 2', async () => {
+    beforeEach(createTestAppWithTutorial)
 
-    expect(
-      screen.getByText('Here are some real-world examples of using contexts in', { exact: false }),
-    ).toBeInTheDocument()
-    expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
-    expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
-    expect(
-      screen.getByText('Create a link on the home screen to a deeply nested subthought for easy access.'),
-    ).toBeInTheDocument()
+    it('prompt for creating a second todo, shows a superscript', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
+
+      await user.keyboard('{Enter}')
+      await user.keyboard('{Shift>}{Tab}{/Shift}') // we are at
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      await user.type(lastThought(), 'Work')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
+
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastThought(), 'To Do')
+
+      expect(showAllThoughts()).toBe(
+        `- __ROOT__
+  - Home
+    - To Do
+      - or to not
+  - Work
+    - To Do`,
+      )
+      expect(screen.getByText('Very good!')).toBeInTheDocument()
+
+      expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
+      expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
+
+      expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastThought(), 'new work task')
+    })
   })
 
-  it('congratulates on finishing tutorial, hides it after "Finish"', async () => {
-    await user.click(screen.getByText('Next'))
-    expect(
-      screen.getByText('Congratulations! You have completed Part II of the tutorial.', { exact: false }),
-    ).toBeInTheDocument()
+  describe('multiple contexts', () => {
+    beforeEach(createTestAppWithTutorial)
+    it('step context view open - showcase multiple contexts', async () => {
+      expect(showAllThoughts()).toBe(
+        `- __ROOT__
+  - Home
+    - To Do
+      - or to not
+  - Work
+    - To Do
+      - new work task`,
+      )
+      await user.click(screen.getByText('Next'))
+      await act(vi.runOnlyPendingTimersAsync)
 
-    user.click(screen.getByText('Finish'))
-    await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
 
-    expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+      console.log(screen.getAllByText('To Do').at(-1)!)
+      await user.keyboard('{Escape}') // focus out
+      await user.click(screen.getAllByText('To Do').at(-1)!) // and click on To Do
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      // await user.click(screen.getAllByText('To Do').at(-1)!) // focus on
+      await act(vi.runOnlyPendingTimersAsync)
+
+      // await dispatch(setCursorFirstMatch(['Work', 'To Do']))
+      showAllThoughts()
+
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
+
+      await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(
+        screen.getByText(
+          `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('step context examples - show real world examples', async () => {
+    beforeEach(createTestAppWithTutorial)
+
+    it('show real world examples', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(
+        screen.getByText('Here are some real-world examples of using contexts in', { exact: false }),
+      ).toBeInTheDocument()
+      expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
+      expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
+      expect(
+        screen.getByText('Create a link on the home screen to a deeply nested subthought for easy access.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('step success', async () => {
+    beforeEach(createTestAppWithTutorial)
+
+    it('congratulates on finishing tutorial, hides it after "Finish"', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(
+        screen.getByText('Congratulations! You have completed Part II of the tutorial.', { exact: false }),
+      ).toBeInTheDocument()
+
+      user.click(screen.getByText('Finish'))
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+    })
   })
 })
+
+function showAllThoughts(
+  logPostfix: string = '', // to differentiate between different tests
+) {
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  console.log(`${exported} ${logPostfix}`)
+
+  return exported
+}
+
+function lastThought() {
+  return Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!
+}

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -21,6 +21,8 @@ import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../.
 beforeEach(createTestAppWithTutorial)
 afterEach(cleanupTestApp)
 
+const user = userEvent.setup({ delay: null })
+
 describe('Tutorial 1', async () => {
   describe('step start', () => {
     it('shows the welcome text', () => {
@@ -28,7 +30,6 @@ describe('Tutorial 1', async () => {
     })
 
     it('shows the "Next" button, that leads to the first step', async () => {
-      const user = userEvent.setup({ delay: null })
       await user.click(screen.getByText('Next'))
       await act(vi.runOnlyPendingTimersAsync)
       expect(
@@ -40,7 +41,6 @@ describe('Tutorial 1', async () => {
   it('step first thought - how to create a thought ', async () => {
     expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
 
-    const user = userEvent.setup({ delay: null })
     await act(() => user.keyboard('{Enter}'))
     expect(screen.getByText('You did it!')).toBeInTheDocument()
     expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
@@ -178,7 +178,6 @@ describe('Tutorial 2', async () => {
     await dispatch(tutorialNext({}))
     await act(vi.runOnlyPendingTimersAsync)
 
-    const user = userEvent.setup({ delay: null })
     expect(
       screen.getByText('Excellent choice. Now create a new thought with the text “Home”', { exact: false }),
     ).toBeInTheDocument()
@@ -225,7 +224,6 @@ describe('Tutorial 2', async () => {
       screen.getByText(`Now we are going to create a different "To Do" list.`, { exact: false }),
     ).toBeInTheDocument()
 
-    const user = userEvent.setup({ delay: null })
     await user.click(screen.getByText('hint'))
     await act(vi.runOnlyPendingTimersAsync)
     expect(getByText(screen.getByTestId('tutorial-step')!, 'Select "Home."', { exact: false })).toBeInTheDocument()
@@ -278,7 +276,6 @@ describe('Tutorial 2', async () => {
 
     expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
 
-    const user = userEvent.setup({ delay: null })
     await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
     await act(vi.runOnlyPendingTimersAsync)
     expect(
@@ -308,7 +305,6 @@ describe('Tutorial 2', async () => {
       screen.getByText('Congratulations! You have completed Part II of the tutorial.', { exact: false }),
     ).toBeInTheDocument()
 
-    const user = userEvent.setup({ delay: null })
     user.click(screen.getByText('Finish'))
     await act(vi.runOnlyPendingTimersAsync)
 

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,0 +1,328 @@
+import { getByText, screen } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../../actions/importText'
+import { newSubthoughtActionCreator as newSubthought } from '../../../actions/newSubthought'
+import { newThoughtActionCreator as newThought } from '../../../actions/newThought'
+import { tutorialNextActionCreator as tutorialNext } from '../../../actions/tutorialNext'
+import { tutorialStepActionCreator as tutorialStep } from '../../../actions/tutorialStep'
+import { TUTORIAL2_STEP_START, TUTORIAL_STEP_SECONDTHOUGHT } from '../../../constants'
+import { cleanupTestApp, createTestAppWithTutorial } from '../../../test-helpers/createTestApp'
+import dispatch from '../../../test-helpers/dispatch'
+import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../../test-helpers/setCursorFirstMatch'
+
+async function hintShows(hint: string) {
+  const user = userEvent.setup({ delay: null })
+  await user.click(screen.getByText('hint'))
+  await act(vi.runOnlyPendingTimersAsync)
+  expect(getByText(screen.getByTestId('tutorial-step')!, hint, { exact: false })).toBeInTheDocument()
+}
+
+describe('Tutorial 1', async () => {
+  beforeEach(createTestAppWithTutorial)
+  afterEach(cleanupTestApp)
+
+  it('step start - welcome text', async () => {
+    const welcomeText = screen.getByText('Welcome to your personal thoughtspace.')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(welcomeText).toBeInTheDocument()
+  })
+
+  it('step first thought - how to create a thought ', async () => {
+    await dispatch(tutorialNext({})) // we manually dispatch, because we can't do the gesture here
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
+    const user = userEvent.setup({ delay: null })
+    await user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(screen.getByText('You did it!')).toBeInTheDocument()
+    user.click(screen.getByText('Next'))
+  })
+
+  describe('step second thought - create another thought', () => {
+    it('reminds us how to create a thought', async () => {
+      await dispatch(tutorialStep({ value: TUTORIAL_STEP_SECONDTHOUGHT }))
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText('Try adding another thought. Do you remember how to do it?')).toBeInTheDocument()
+    })
+
+    it('prompts to type some text to the created thought, then congratulates on typing', async () => {
+      await dispatch(newThought({}))
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText('Now type some text for the new thought.')).toBeInTheDocument()
+
+      const user = userEvent.setup({ delay: null })
+      await user.type(document.querySelector('[contenteditable="true"]')!, 'a rather banale thing')
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText(/a rather banale thing/)).toBeInTheDocument()
+      expect(screen.getByText(/Wonderful\./)).toBeInTheDocument()
+    })
+  })
+
+  describe('step subthought - how to create a thought inside thought', async () => {
+    beforeAll(async () => {
+      await dispatch(tutorialNext({}))
+      await act(vi.runOnlyPendingTimersAsync)
+    })
+
+    it('display a tutorial on subthoughts, and an rdr gesture hint', async () => {
+      expect(screen.getByText(/within/)).toBeInTheDocument()
+    })
+
+    it('congratulate on creating a child for the <parent>', async () => {
+      const PARENT_NAME = 'papa'
+      await dispatch([
+        newThought({
+          value: PARENT_NAME,
+        }),
+      ])
+
+      await dispatch(newSubthought())
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const tutorialContainer = screen.getByTestId('tutorial-step')
+      expect(getByText(tutorialContainer, PARENT_NAME, { exact: false })).toBeInTheDocument()
+    })
+  })
+
+  describe('step autoexpand - show that thoughts expand and collapse on outside click', async () => {
+    beforeAll(async () => {
+      await dispatch([tutorialNext({})])
+      await act(vi.runOnlyPendingTimersAsync)
+    })
+
+    it('display a tutorial on autoexpand', async () => {
+      expect(screen.getByText(/thoughts are automatically hidden when you/, { exact: false })).toBeInTheDocument()
+    })
+
+    it('prompts for adding a subthought', async () => {
+      await dispatch([
+        newThought({
+          value: 'uncle',
+        }),
+      ])
+
+      expect(screen.getByText('Add a subthought', { exact: false })).toBeInTheDocument()
+    })
+
+    it('tells us to click away from the subthought to collapse the tree', async () => {
+      await dispatch([
+        newThought({
+          value: 'uncle',
+        }),
+        newThought({
+          value: 'father',
+        }),
+        newThought({
+          value: 'child',
+          insertNewSubthought: true,
+        }),
+      ])
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const tutorialContainer = screen.getByTestId('tutorial-step')
+
+      expect(
+        screen.getByText(`Try clicking on thought "uncle"`, { exact: false, collapseWhitespace: true }),
+      ).toBeInTheDocument()
+      expect(screen.getByText('to hide subthought "child"', { exact: false })).toBeInTheDocument()
+      const user = userEvent.setup({ delay: null })
+      await user.click(screen.getByText('uncle'))
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(getByText(tutorialContainer, `Notice that "child" is hidden now.`)).toBeInTheDocument()
+      expect(
+        getByText(tutorialContainer, `Click "father" to reveal its subthought "child".`, { exact: false }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('step success - ', async () => {
+    beforeAll(async () => {
+      await dispatch(tutorialNext({}))
+      await act(vi.runOnlyPendingTimersAsync)
+    })
+    it('congratulate on completing first tutorial', async () => {
+      expect(screen.getByText('Lovely. You have completed the tutorial', { exact: false })).toBeInTheDocument()
+      expect(screen.getByText('Play on my own')).toBeInTheDocument()
+      expect(screen.getByText('Learn more')).toBeInTheDocument()
+
+      const user = userEvent.setup({ delay: null })
+      user.click(screen.getByText('Learn more'))
+      // await act(vi.runOnlyPendingTimersAsync)
+    })
+  })
+})
+
+describe('Tutorial 2', async () => {
+  beforeEach(createTestAppWithTutorial)
+  afterEach(cleanupTestApp)
+
+  it('step start - tell about context menu', async () => {
+    await dispatch(tutorialStep({ value: TUTORIAL2_STEP_START }))
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(screen.getByText('If the same thought appears in more than one place', { exact: false })).toBeInTheDocument()
+  })
+
+  it('step choose - gives 3 choices of what project to proceed with', async () => {
+    await dispatch(tutorialNext({}))
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText('For this tutorial, choose what kind of content you want to create', { exact: false }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('To-Do List')).toBeInTheDocument()
+    expect(screen.getByText('Journal Theme')).toBeInTheDocument()
+    expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
+
+    // expect(screen.getByText('Project 2')).toBeInTheDocument()
+  })
+
+  it('step context 1 parent, prompt for creating a first todo', async () => {
+    await dispatch(tutorialNext({}))
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const user = userEvent.setup({ delay: null })
+    expect(
+      screen.getByText('Excellent choice. Now create a new thought with the text “Home”', { exact: false }),
+    ).toBeInTheDocument()
+
+    await dispatch(newThought({}))
+    await act(vi.runOnlyPendingTimersAsync)
+
+    user.type(document.querySelector('[contenteditable="true"]')!, 'Home')
+    user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText(`Let's say that you want to make a list of things`, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(`Add a thought with the text "To Do"`, { exact: false })).toBeInTheDocument()
+
+    await dispatch([setCursorFirstMatch(['Home']), newSubthought()])
+    await act(vi.runOnlyPendingTimersAsync)
+    user.type(document.querySelectorAll('[contenteditable="true"]')[1]!, 'To Do')
+    user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText(`Now add a thought to “To Do”`, { exact: false })).toBeInTheDocument()
+
+    await dispatch([setCursorFirstMatch(['Home', 'To Do']), newSubthought()])
+    await act(vi.runOnlyPendingTimersAsync)
+
+    user.type(document.querySelectorAll('[contenteditable="true"]')[2]!, 'Hey')
+    user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText(`Nice work!`, { exact: false })).toBeInTheDocument()
+  })
+
+  it('step context 2 - prompt for creating a second todo, shows a superscript', async () => {
+    await dispatch([
+      tutorialNext({}),
+      importText({
+        text: `
+      - Home
+        - To Do
+          - Hey
+    `,
+      }),
+      setCursorFirstMatch(['Home', 'To Do', 'Hey']),
+    ])
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText(`Now we are going to create a different "To Do" list.`, { exact: false }),
+    ).toBeInTheDocument()
+
+    const user = userEvent.setup({ delay: null })
+    await hintShows('Select "Home."')
+    await user.click(screen.getByText('Home'))
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText(`Hit the Enter key to create a new thought`, { exact: false })).toBeInTheDocument()
+    await user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const lastThought = Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)
+    await user.type(lastThought!, 'Work')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(screen.getByText('Work')).toBeInTheDocument()
+    expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
+    await dispatch(setCursorFirstMatch(['Work']))
+    await act(vi.runOnlyPendingTimersAsync)
+
+    await user.keyboard('{Ctrl}{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
+    await user.type(Array.from(document.querySelectorAll('[contenteditable="true"]')).at(-1)!, 'To Do')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText('Very good!')).toBeInTheDocument()
+    expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
+    expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
+
+    // ** test adding a grandchild of Work, which I'm struggling with
+  })
+
+  it('step context view open - showcase multiple contexts', async () => {
+    await dispatch([tutorialNext({})])
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText("Now I'm going to show you the keyboard shortcut to view multiple contexts."),
+    ).toBeInTheDocument()
+    expect(screen.getByText('First select "to do".', { exact: false })).toBeInTheDocument()
+    await dispatch([
+      tutorialNext({}),
+      importText({
+        text: `
+      - Home
+        - To Do
+          - Hey
+      - Work
+        - To Do
+          - New task
+    `,
+      }),
+      setCursorFirstMatch(['Home', 'To Do']),
+    ])
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
+
+    const user = userEvent.setup({ delay: null })
+    await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText(
+        `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('step context examples - show real world examples', async () => {
+    await dispatch(tutorialNext({}))
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText('Here are some real-world examples of using contexts in', { exact: false }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
+    expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Create a link on the home screen to a deeply nested subthought for easy access.'),
+    ).toBeInTheDocument()
+  })
+
+  it('congratulates on finishing tutorial, hides it after "Finish"', async () => {
+    await dispatch(tutorialNext({}))
+    await act(vi.runOnlyPendingTimersAsync)
+    expect(
+      screen.getByText('Congratulations! You have completed Part II of the tutorial.', { exact: false }),
+    ).toBeInTheDocument()
+
+    const user = userEvent.setup({ delay: null })
+    user.click(screen.getByText('Finish'))
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+  })
+})
+
+

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../constants'
 import exportContext from '../../../selectors/exportContext'
 import store from '../../../stores/app'
-import { cleanupTestApp, createTestAppWithTutorial, default as createTestApp } from '../../../test-helpers/createTestApp'
+import {
+  cleanupTestApp,
+  default as createTestApp,
+  createTestAppWithTutorial,
+} from '../../../test-helpers/createTestApp'
 import dispatch from '../../../test-helpers/dispatch'
 import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../../test-helpers/setCursorFirstMatch'
 
@@ -31,6 +35,7 @@ describe.only('A curious case of me not being able to grasp keyboard', () => {
     expect(screen.getByText('Socrates')).toBeInTheDocument()
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
 
+    // eslint-disable-next-line no-console
     console.debug('gotta be one thought', exported)
 
     expect(exported).toBe(`- ${HOME_TOKEN}
@@ -42,7 +47,8 @@ describe.only('A curious case of me not being able to grasp keyboard', () => {
     await user.keyboard('{Enter}')
     expect(screen.getByText('Socrates')).toBeInTheDocument()
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    
+
+    // eslint-disable-next-line no-console
     console.debug('after pressing enter', exported)
     expect(exported).toBe(`- ${HOME_TOKEN}
     - Socrates`)
@@ -56,7 +62,9 @@ describe.only('A curious case of me not being able to grasp keyboard', () => {
     await user.keyboard('{Enter}')
 
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    console.debug('two thoughts',exported)
+
+    // eslint-disable-next-line no-console
+    console.debug('two thoughts', exported)
   })
 
   it('nested thoughts are broken', async () => {
@@ -68,7 +76,9 @@ describe.only('A curious case of me not being able to grasp keyboard', () => {
     await user.keyboard('{Enter}')
 
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    console.debug('subthoughts',exported)
+
+    // eslint-disable-next-line no-console
+    console.debug('subthoughts', exported)
   })
 
   it('nested thoughts are broken', async () => {
@@ -78,12 +88,14 @@ describe.only('A curious case of me not being able to grasp keyboard', () => {
     // await user.keyboard('{Control>}{Enter}{/Control}')
     await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'Plato')
     await user.keyboard('{Meta>}{Enter}{/Meta}')
-    
+
     await user.type(document.querySelectorAll('[contenteditable="true"]')[2], 'Aristole')
     await user.keyboard('{Enter}')
 
     const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
-    console.debug('subthoughts',exported)
+
+    // eslint-disable-next-line no-console
+    console.debug('subthoughts', exported)
   })
 })
 
@@ -196,7 +208,6 @@ describe('Tutorial 1', async () => {
 })
 
 describe('Tutorial 2', async () => {
-  
   it('step start - tell about context menu', async () => {
     expect(store.getState().storageCache?.tutorialStep).toBe(TUTORIAL_STEP_SUCCESS)
 
@@ -216,9 +227,9 @@ describe('Tutorial 2', async () => {
     expect(screen.getByText('To-Do List')).toBeInTheDocument()
     expect(screen.getByText('Journal Theme')).toBeInTheDocument()
     expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
-    // await cleanupTestApp()  
+    // await cleanupTestApp()
   })
-  
+
   it('step context 1 parent, prompt for creating a first todo', async () => {
     // await createTestAppWithTutorial()
     await user.click(screen.getByText('To-Do List'))
@@ -237,16 +248,12 @@ describe('Tutorial 2', async () => {
     expect(screen.getByText(`Let's say that you want to make a list of things`, { exact: false })).toBeInTheDocument()
     expect(screen.getByText(`Add a thought with the text "To Do"`, { exact: false })).toBeInTheDocument()
 
-    
-    await dispatch([
-      setCursorFirstMatch(['Home']),
-    ])
+    await dispatch([setCursorFirstMatch(['Home'])])
     await act(vi.runOnlyPendingTimersAsync)
     await user.keyboard('{Meta>}{Enter}{/Meta}')
     await user.type(document.querySelectorAll('[contenteditable="true"]')[1], 'To Do')
 
     await user.keyboard('{Enter}')
-    console.log(exportContext(store.getState(), [HOME_TOKEN], 'text/plain'))
     expect(screen.getByText(`Now add a thought to “To Do”`, { exact: false })).toBeInTheDocument()
     screen.getByText('To Do').focus()
     fireEvent.keyUp(screen.getByText('To Do'), {

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,17 +1,14 @@
 import { screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
-import { HOME_TOKEN } from '../../../constants'
-import exportContext from '../../../selectors/exportContext'
-import store from '../../../stores/app'
 import createTestApp, { cleanupTestApp, cleanupTestEventHandlers } from '../../../test-helpers/createTestApp'
 
 // as per https://testing-library.com/docs/user-event/options/#advancetimers
 // we should avoid using { delay: null }, and use jest.advanceTimersByTime instead
 const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 
-/** Get last created empty thought in the document. Gets the last thought that is not empty. Mostly used after `user.keyboard('{Enter}')` to get the new thought. */
-const lastThought = () =>
+/** Gets the last empty thought in the document. Mostly used after `user.keyboard('{Enter}')` to get the new thought. */
+const lastEmptyThought = () =>
   Array.from(document.querySelectorAll('[data-editable="true"]'))
     .filter(it => !it.textContent)
     .at(-1)!
@@ -21,95 +18,100 @@ describe('Tutorial 1', async () => {
   afterEach(cleanupTestEventHandlers)
   afterAll(cleanupTestApp)
   describe('step start', () => {
-    it('shows the welcome text', () => {
+    it('we see the welcome text', () => {
       expect(screen.getByText('Welcome to your personal thoughtspace.')).toBeInTheDocument()
     })
 
-    it('shows the "Next" button, that leads to the first step', async () => {
+    it('we can proceed to first step by clicking Next', async () => {
       await user.click(screen.getByText('Next'))
-      expect(screen.getByText(/First, let me show you how to create a new thought/)).toBeInTheDocument()
+      expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
     })
   })
 
-  it('step first thought - how to create a thought ', async () => {
-    expect(screen.getByText('Hit the Enter key to create a new thought.')).toBeInTheDocument()
-    await user.keyboard('{Enter}')
-    expect(screen.getByText('You did it!')).toBeInTheDocument()
+  describe('step first thought', () => {
+    it('we learn how to create a thought', async () => {
+      await user.keyboard('{Enter}')
+      expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
+    })
 
-    expect(screen.getByText('Now type something. Anything will do.')).toBeInTheDocument()
-    await user.type(lastThought(), 'my first thought')
-    await user.keyboard('{Enter}')
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(screen.getByText('Well done!')).toBeInTheDocument()
+    it('we create our first thought', async () => {
+      await user.type(lastEmptyThought(), 'first')
+      await user.keyboard('{Enter}')
+      await act(vi.runOnlyPendingTimersAsync)
+
+      expect(screen.getByText('Well done!')).toBeInTheDocument()
+    })
   })
 
-  it('step second thought - prompts to add another thought', async () => {
+  it('we create a second thought', async () => {
     expect(screen.getByText(/Try adding another thought/)).toBeInTheDocument()
-    await user.type(lastThought(), 'my second thought')
+    await user.type(lastEmptyThought(), 'second')
     await user.keyboard('{Enter}')
     await act(vi.runOnlyPendingTimersAsync)
 
-    expect(screen.getByText('Good work!')).toBeInTheDocument()
     expect(screen.getByText('Now type some text for the new thought.')).toBeInTheDocument()
-    await user.type(lastThought(), 'third thought')
-    await user.keyboard('{Enter}')
-    await act(vi.runOnlyPendingTimersAsync)
   })
 
-  it('step subthought - how to create a thought inside thought', async () => {
-    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
-      `- __ROOT__
-  - my first thought
-  - my second thought
-  - third thought
-  - `,
-    )
+  it('we create a third thought', async () => {
+    await user.type(lastEmptyThought(), 'third')
+    await user.keyboard('{Enter}')
+    await act(vi.runOnlyPendingTimersAsync)
 
     expect(screen.getByText(/Hit the Delete key to delete the current blank thought/)).toBeInTheDocument()
-    expect(screen.getByText(/Then hold the Ctrl key and hit the Enter key/)).toBeInTheDocument()
+  })
+
+  it('we learn to create nested thoughts', async () => {
+    /* thoughts:
+  - first
+  - second
+  - third
+  -
+    */
     await user.keyboard('{Backspace}')
     await user.keyboard('{Control>}{Enter}{/Control}')
     await act(vi.runOnlyPendingTimersAsync)
 
-    await user.type(lastThought(), 'child')
+    await user.type(lastEmptyThought(), 'child of third')
     await act(vi.runOnlyPendingTimersAsync)
-    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
-      `- __ROOT__
-  - my first thought
-  - my second thought
-  - third thought
-    - child`,
-    )
 
-    expect(screen.getByText(/As you can see, the new thought "child" is nested/)).toBeInTheDocument()
-
-    await user.click(screen.getByText('Next'))
+    expect(screen.getByText(/As you can see, the new thought "child of third" is nested/)).toBeInTheDocument()
   })
 
   describe('step autoexpand', async () => {
-    it('thoughts are automatically hidden when you click away', async () => {
+    it('we learn about automatic thought hiding', async () => {
+      await user.click(screen.getByText('Next'))
       expect(screen.getByText(/thoughts are automatically hidden when you click away/)).toBeInTheDocument()
     })
 
-    it('click on "uncle" thought to hide child', async () => {
-      await user.click(screen.getByText('my second thought'))
-      expect(screen.getByText(/Notice that "child" is hidden now/)).toBeInTheDocument()
+    it('we hide nested thoughts by clicking away', async () => {
+      /* thoughts:
+      - first
+      - second
+      - third
+        - child of third
+      */
+      await user.click(screen.getByText('second'))
+      expect(screen.getByText(/Notice that "child of third" is hidden now/)).toBeInTheDocument()
     })
 
-    it('click back on a "parent" thought to reveal child', async () => {
-      expect(screen.getByText(/Click "third thought" to reveal its subthought "child"/)).toBeInTheDocument()
-      await user.click(screen.getAllByText('third thought').at(-1)!)
-      expect(screen.getByText(/Lovely\. You have completed the tutorial/)).toBeInTheDocument()
+    it('we reveal hidden thoughts by clicking parent', async () => {
+      await user.click(screen.getAllByText('third').at(-1)!)
+      expect(screen.getByText('child of third')).toBeInTheDocument()
     })
   })
 
-  describe('step success - congratulates on completing first tutorial', async () => {
-    it('congratulate on completing first tutorial', async () => {
+  describe('step success', async () => {
+    it('we complete the first tutorial', async () => {
       expect(screen.getByText(/Lovely\. You have completed the tutorial/)).toBeInTheDocument()
     })
 
-    it('asks to continue with tutorial or play on own', async () => {
-      expect(screen.getByText('Play on my own')).toBeInTheDocument()
+    it('we can exit tutorial mode', async () => {
+      await user.click(screen.getByText('Play on my own'))
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+    })
+
+    it('we can continue to advanced tutorial', async () => {
       expect(screen.getByText('Learn more')).toBeInTheDocument()
     })
   })
@@ -119,14 +121,13 @@ describe('Tutorial 2', async () => {
   beforeEach(() => createTestApp({ tutorial: true }))
   afterEach(cleanupTestEventHandlers)
   afterAll(cleanupTestApp)
-  it('step start - tell about context menu', async () => {
+  it('we learn about context indicators', async () => {
     await user.click(screen.getByText('Learn more'))
 
-    expect(screen.getByText(/If the same thought appears in more than one place/)).toBeInTheDocument()
     expect(screen.getByText(/shows a small number to the right of the thought, for example/)).toBeInTheDocument()
   })
 
-  it('step choose - gives 3 choices of what project to proceed with', async () => {
+  it('we choose a project type, one of three options', async () => {
     await user.click(screen.getByText('Next'))
     expect(screen.getByText(/For this tutorial, choose what kind of content you want to create/)).toBeInTheDocument()
     expect(screen.getByText('To-Do List')).toBeInTheDocument()
@@ -134,109 +135,126 @@ describe('Tutorial 2', async () => {
     expect(screen.getByText('Book/Podcast Notes')).toBeInTheDocument()
   })
 
-  it('step context 1 parent - we create "Home" thought with children', async () => {
+  it('we start creating a to-do list', async () => {
     await user.click(screen.getAllByText('To-Do List').at(-1)!)
-    expect(screen.getByText(/Excellent choice. Now create a new thought with the text “Home”/)).toBeInTheDocument()
-
-    await user.keyboard('{Enter}')
-    await user.type(lastThought(), 'Home')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    // Home -> To Do
-    expect(screen.getByText(/Let's say that you want to make a list of things/)).toBeInTheDocument()
-    expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
-    await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(lastThought(), 'To Do')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    // Home -> To Do -> or to not
-    expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
-    await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(lastThought(), 'or to not')
-    await act(vi.runOnlyPendingTimersAsync)
-
-    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
-      `- __ROOT__
-  - Home
-    - To Do
-      - or to not`,
-    )
-    expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
+    expect(screen.getByText(/Excellent choice\. Now create a new thought with the text “Home”/)).toBeInTheDocument()
   })
 
-  it('step context 2 - we create "Work" thought with children', async () => {
-    await user.click(screen.getByText('Next'))
-    expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
+  describe('step context 1 - create a "Home" to-do list', () => {
+    it('we create a Home thought', async () => {
+      await user.keyboard('{Enter}')
+      await user.type(lastEmptyThought(), 'Home')
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText(/Add a thought with the text "To Do"/)).toBeInTheDocument()
+    })
 
-    // we created a new thought on 3rd level, clicking "Home" gets us to root
-    await user.click(screen.getByText('Home'))
-    await user.keyboard('{Enter}')
-    await user.type(lastThought(), 'Work')
-    await act(vi.runOnlyPendingTimersAsync)
+    it('we add a Home->To Do subthought', async () => {
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastEmptyThought(), 'To Do')
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText(/Now add a thought to “To Do”/)).toBeInTheDocument()
+    })
 
-    expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
-    await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(lastThought(), 'To Do')
-    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
-      `- __ROOT__
-  - Home
-    - To Do
-      - or to not
-  - Work
-    - To Do`,
-    )
-    expect(screen.getByText('Very good!')).toBeInTheDocument()
+    it('we add a Home->To Do->or to not subthought sub-subthought', async () => {
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastEmptyThought(), 'or to not')
+      await act(vi.runOnlyPendingTimersAsync)
 
-    expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
-    expect(screen.getByText('This means that “To Do” appears in two places', { exact: false })).toBeInTheDocument()
-
-    expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
-    await user.keyboard('{Control>}{Enter}{/Control}')
-    await user.type(lastThought(), 'new work task')
+      /* thoughts:
+      - Home
+        - To Do
+          - or to not
+      */
+      expect(screen.getByText(/Nice work!/)).toBeInTheDocument()
+    })
   })
 
-  it('step context view open - we press Alt+Shift+S and see "To Do" in both "Home" and "Work"', async () => {
-    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
-      `- __ROOT__
-  - Home
-    - To Do
-      - or to not
-  - Work
-    - To Do
-      - new work task`,
-    )
-    await user.click(screen.getByText('Next'))
-    await act(vi.runOnlyPendingTimersAsync)
+  describe('step context 2 - create a "Work" to-do list', () => {
+    it('we prepare to create another list', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
+    })
 
-    expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
-    await user.keyboard('{Escape}')
-    await user.click(screen.getAllByText('To Do').at(-1)!)
-    await act(vi.runOnlyPendingTimersAsync)
+    it('we create a Work thought', async () => {
+      // we created a new thought on 3rd level, clicking "Home" gets us to root
+      await user.click(screen.getByText('Home'))
+      await user.keyboard('{Enter}')
+      await user.type(lastEmptyThought(), 'Work')
+      await act(vi.runOnlyPendingTimersAsync)
 
-    expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
-    await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
-    await act(vi.runOnlyPendingTimersAsync)
-    expect(
-      screen.getByText(
-        `Well, look at that. We now see all of the contexts in which "To Do" appears, namely "Home" and "Work".`,
-      ),
-    ).toBeInTheDocument()
+      /* thoughts:
+      - Home
+        - To Do
+          - or to not
+      - Work
+      */
+      expect(screen.getByText(/Now add a thought with the text "To Do"/)).toBeInTheDocument()
+    })
+
+    it('we add another Work->To Do thought', async () => {
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastEmptyThought(), 'To Do')
+      expect(screen.getByText('Imagine a new work task. Add it to this “To Do” list.'))
+    })
+
+    it('we see context indicators', async () => {
+      expect(screen.getAllByRole('superscript')[0]).toHaveTextContent('2')
+      expect(screen.getByText(/This means that “To Do” appears in two places/)).toBeInTheDocument()
+    })
+
+    it('we add a Work->To Do->Text boss', async () => {
+      await user.keyboard('{Control>}{Enter}{/Control}')
+      await user.type(lastEmptyThought(), 'Text boss')
+      await act(vi.runOnlyPendingTimersAsync)
+      /* thoughts:
+      - Home
+        - To Do
+          - or to not
+      - Work
+        - To Do
+          - Text boss
+      */
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
   })
 
-  it('step context examples - we see real-world examples', async () => {
+  describe('step context view open', () => {
+    it('we learn about multiple contexts', async () => {
+      await user.click(screen.getByText('Next'))
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
+    })
+
+    it('we select a thought with multiple contexts', async () => {
+      await user.click(screen.getAllByText('To Do').at(-1)!)
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()
+    })
+
+    it('we view contexts of a thought', async () => {
+      await user.keyboard('{Alt>}{Shift>}S{/Shift}{/Alt}')
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(
+        screen.getByText(/We now see all of the contexts in which "To Do" appears, namely "Home" and "Work"./),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('we see real-world context examples', async () => {
     await user.click(screen.getByText('Next'))
     expect(screen.getByText(/Here are some real-world examples of using contexts in/)).toBeInTheDocument()
-    expect(screen.getByText('View all thoughts related to a particular person, place, or thing.')).toBeInTheDocument()
-    expect(screen.getByText('Keep track of quotations from different sources.')).toBeInTheDocument()
   })
 
-  it('step success - congratulations, hide tutorial after clicking "Finish"', async () => {
-    await user.click(screen.getByText('Next'))
-    expect(screen.getByText(/Congratulations! You have completed Part II of the tutorial./)).toBeInTheDocument()
+  describe('step success', () => {
+    it('we complete the advanced tutorial', async () => {
+      await user.click(screen.getByText('Next'))
+      expect(screen.getByText(/Congratulations! You have completed Part II of the tutorial./)).toBeInTheDocument()
+    })
 
-    user.click(screen.getByText('Finish'))
-    await act(vi.runOnlyPendingTimersAsync)
-
-    expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+    it('we exit the tutorial', async () => {
+      user.click(screen.getByText('Finish'))
+      await act(vi.runOnlyPendingTimersAsync)
+      expect(() => screen.getByTestId('tutorial-step')).toThrow('Unable to find an element')
+    })
   })
 })

--- a/src/components/Tutorial/__tests__/Tutorial.ts
+++ b/src/components/Tutorial/__tests__/Tutorial.ts
@@ -1,4 +1,4 @@
-import { getByText, screen } from '@testing-library/dom'
+import { screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
 import { HOME_TOKEN } from '../../../constants'
@@ -40,10 +40,10 @@ describe('Tutorial 1', async () => {
     await user.type(lastThought(), 'my first thought')
     await user.keyboard('{Enter}')
     await act(vi.runOnlyPendingTimersAsync)
+    expect(screen.getByText('Well done!')).toBeInTheDocument()
   })
 
   it('step second thought - prompts to add another thought', async () => {
-    expect(screen.getByText('Well done!')).toBeInTheDocument()
     expect(screen.getByText(/Try adding another thought/)).toBeInTheDocument()
     await user.type(lastThought(), 'my second thought')
     await user.keyboard('{Enter}')
@@ -65,16 +65,11 @@ describe('Tutorial 1', async () => {
   - `,
     )
 
-    // Now I am going to show you how to add a thought within another thought.
-    expect(screen.getByText(/Now I am going to show you how to add a thought/)).toBeInTheDocument()
-
-    // since we have cursor on empty thought
     expect(screen.getByText(/Hit the Delete key to delete the current blank thought/)).toBeInTheDocument()
     expect(screen.getByText(/Then hold the Ctrl key and hit the Enter key/)).toBeInTheDocument()
     await user.keyboard('{Backspace}')
     await user.keyboard('{Control>}{Enter}{/Control}')
     await act(vi.runOnlyPendingTimersAsync)
-    console.log(Array.from(document.querySelectorAll('[data-editable="true"]')).map(it => it.textContent))
 
     await user.type(lastThought(), 'child')
     await act(vi.runOnlyPendingTimersAsync)
@@ -86,9 +81,7 @@ describe('Tutorial 1', async () => {
     - child`,
     )
 
-    // as you can see, the new thought "child" is nested within "third thought"
     expect(screen.getByText(/As you can see, the new thought "child" is nested/)).toBeInTheDocument()
-    expect(getByText(screen.getByTestId('tutorial-step'), /"third thought"/)).toBeInTheDocument()
 
     await user.click(screen.getByText('Next'))
   })
@@ -100,19 +93,19 @@ describe('Tutorial 1', async () => {
 
     it('click on "uncle" thought to hide child', async () => {
       await user.click(screen.getByText('my second thought'))
-      expect(screen.getByText('Notice that "child" is hidden now.', { exact: false })).toBeInTheDocument()
+      expect(screen.getByText(/Notice that "child" is hidden now/)).toBeInTheDocument()
     })
 
     it('click back on a "parent" thought to reveal child', async () => {
       expect(screen.getByText(/Click "third thought" to reveal its subthought "child"/)).toBeInTheDocument()
       await user.click(screen.getAllByText('third thought').at(-1)!)
-      expect(screen.getByText('Lovely. You have completed the tutorial', { exact: false })).toBeInTheDocument()
+      expect(screen.getByText(/Lovely\. You have completed the tutorial/)).toBeInTheDocument()
     })
   })
 
   describe('step success - congratulates on completing first tutorial', async () => {
     it('congratulate on completing first tutorial', async () => {
-      expect(screen.getByText('Lovely. You have completed the tutorial', { exact: false })).toBeInTheDocument()
+      expect(screen.getByText(/Lovely\. You have completed the tutorial/)).toBeInTheDocument()
     })
 
     it('asks to continue with tutorial or play on own', async () => {
@@ -129,10 +122,8 @@ describe('Tutorial 2', async () => {
   it('step start - tell about context menu', async () => {
     await user.click(screen.getByText('Learn more'))
 
-    expect(screen.getByText(`If the same thought appears in more than one place`, { exact: false })).toBeInTheDocument()
-    expect(
-      screen.getByText(`shows a small number to the right of the thought, for example`, { exact: false }),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/If the same thought appears in more than one place/)).toBeInTheDocument()
+    expect(screen.getByText(/shows a small number to the right of the thought, for example/)).toBeInTheDocument()
   })
 
   it('step choose - gives 3 choices of what project to proceed with', async () => {
@@ -147,7 +138,6 @@ describe('Tutorial 2', async () => {
     await user.click(screen.getAllByText('To-Do List').at(-1)!)
     expect(screen.getByText(/Excellent choice. Now create a new thought with the text “Home”/)).toBeInTheDocument()
 
-    // we create a `Home` thought
     await user.keyboard('{Enter}')
     await user.type(lastThought(), 'Home')
     await act(vi.runOnlyPendingTimersAsync)
@@ -178,17 +168,15 @@ describe('Tutorial 2', async () => {
     await user.click(screen.getByText('Next'))
     expect(screen.getByText(/Now we are going to create a different "To Do" list./)).toBeInTheDocument()
 
-    // we created a new thought on 3rd level, so we shift-tab our way back to root
+    // we created a new thought on 3rd level, clicking "Home" gets us to root
+    await user.click(screen.getByText('Home'))
     await user.keyboard('{Enter}')
-    await user.keyboard('{Shift>}{Tab}{/Shift}')
-    await user.keyboard('{Shift>}{Tab}{/Shift}')
     await user.type(lastThought(), 'Work')
     await act(vi.runOnlyPendingTimersAsync)
 
     expect(screen.getByText('Now add a thought with the text "To Do"', { exact: false })).toBeInTheDocument()
     await user.keyboard('{Control>}{Enter}{/Control}')
     await user.type(lastThought(), 'To Do')
-
     expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(
       `- __ROOT__
   - Home
@@ -221,8 +209,8 @@ describe('Tutorial 2', async () => {
     await act(vi.runOnlyPendingTimersAsync)
 
     expect(screen.getByText(/First select "To Do"./)).toBeInTheDocument()
-    await user.keyboard('{Escape}') // focus out
-    await user.click(screen.getAllByText('To Do').at(-1)!) // and click on To Do
+    await user.keyboard('{Escape}')
+    await user.click(screen.getAllByText('To Do').at(-1)!)
     await act(vi.runOnlyPendingTimersAsync)
 
     expect(screen.getByText("Hit Alt + Shift + S to view the current thought's contexts.")).toBeInTheDocument()

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -85,8 +85,8 @@ const Tutorial: FC = () => {
         >
           ✕ close tutorial
         </a>
-        <div className={css({ clear: 'both' })}>
-          <div data-testid='tutorial-step'>
+        <div className={css({ clear: 'both' })} data-testid='tutorial-step'>
+          <div>
             <TransitionGroup>
               {tutorialStepComponent ? (
                 <WithCSSTransition

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -86,7 +86,7 @@ const Tutorial: FC = () => {
           ✕ close tutorial
         </a>
         <div className={css({ clear: 'both' })}>
-          <div>
+          <div data-testid='tutorial-step'>
             <TransitionGroup>
               {tutorialStepComponent ? (
                 <WithCSSTransition

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -13,7 +13,7 @@ import storage from '../util/storage'
 let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
 
 /** Set up testing and mock document and window functions. */
-const createTestApp = async ({ tutorial } = { tutorial: false }) => {
+const createTestApp = async ({ tutorial }: { tutorial?: boolean } = {}) => {
   await act(async () => {
     vi.useFakeTimers({ loopLimit: 100000 })
     // calls initEvents, which must be manually cleaned up
@@ -33,7 +33,7 @@ const createTestApp = async ({ tutorial } = { tutorial: false }) => {
 
     store.dispatch([
       // there are cases where we want to show tutorial on test runs, whilst mostly we don't
-      { type: 'tutorial', value: tutorial },
+      { type: 'tutorial', value: !!tutorial },
 
       // close welcome modal
       { type: 'closeModal' },

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -13,10 +13,9 @@ import storage from '../util/storage'
 let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
 
 /** Set up testing and mock document and window functions. */
-const createTestApp = async ({ tutorial = false } = {}) => {
+const createTestApp = async ({ tutorial } = { tutorial: false }) => {
   await act(async () => {
     vi.useFakeTimers({ loopLimit: 100000 })
-
     // calls initEvents, which must be manually cleaned up
     const init = await initialize()
     cleanup = init.cleanup
@@ -46,9 +45,6 @@ const createTestApp = async ({ tutorial = false } = {}) => {
     document.DND = dndRef.current
   })
 }
-
-/** Set up testing and mock document and window functions, and show tutorial. */
-export const createTestAppWithTutorial = () => createTestApp({ tutorial: true })
 
 /** Clear store, localStorage, local db, and window event handlers. */
 export const cleanupTestApp = async () => {
@@ -81,6 +77,15 @@ export const refreshTestApp = async () => {
   })
 
   await act(vi.runOnlyPendingTimersAsync)
+}
+
+/** Clear exisiting event listeners, but without clearing the app. */
+export const cleanupTestEventHandlers = async () => {
+  await act(async () => {
+    if (cleanup) {
+      cleanup()
+    }
+  })
 }
 
 export default createTestApp

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -13,7 +13,7 @@ import storage from '../util/storage'
 let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
 
 /** Set up testing and mock document and window functions. */
-const createTestApp = async () => {
+const createTestApp = async ({ tutorial = false } = {}) => {
   await act(async () => {
     vi.useFakeTimers({ loopLimit: 100000 })
 
@@ -33,8 +33,8 @@ const createTestApp = async () => {
     )
 
     store.dispatch([
-      // skip tutorial
-      { type: 'tutorial', value: false },
+      // sometimes we wan't to show tutorial on test runs, sometimes we don't
+      { type: 'tutorial', value: tutorial },
 
       // close welcome modal
       { type: 'closeModal' },
@@ -46,6 +46,9 @@ const createTestApp = async () => {
     document.DND = dndRef.current
   })
 }
+
+/** Set up testing and mock document and window functions, and show tutorial. */
+export const createTestAppWithTutorial = () => createTestApp({ tutorial: true })
 
 /** Clear store, localStorage, local db, and window event handlers. */
 export const cleanupTestApp = async () => {

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -32,7 +32,7 @@ const createTestApp = async ({ tutorial } = { tutorial: false }) => {
     )
 
     store.dispatch([
-      // sometimes we wan't to show tutorial on test runs, sometimes we don't
+      // there are cases where we want to show tutorial on test runs, whilst mostly we don't
       { type: 'tutorial', value: tutorial },
 
       // close welcome modal

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -79,7 +79,7 @@ export const refreshTestApp = async () => {
   await act(vi.runOnlyPendingTimersAsync)
 }
 
-/** Clear exisiting event listeners, but without clearing the app. */
+/** Clear existing event listeners(e.g. keyboard, gestures), but without clearing the app. */
 export const cleanupTestEventHandlers = async () => {
   await act(async () => {
     if (cleanup) {


### PR DESCRIPTION
closes https://github.com/cybersemics/em/issues/2313

A `userEvents`-only run through the Tutorial.
Assumes desktop, as relies on keyboard shortctuts.
Goes through _most_ steps(excluding mostly hint steps), ensures those and faithfully replicates a user going through the instructions.
0 dispatches used.

![{C0A862A8-D2FD-46F0-8491-5A8911420188}](https://github.com/user-attachments/assets/bc4d1abf-fcb6-4dfa-beb4-37ebe6c79ce3)


