### PR TITLE
implement prevThought

### DIFF
--- a/src/actions/__tests__/cursorUp.ts
+++ b/src/actions/__tests__/cursorUp.ts
@@ -22,6 +22,19 @@ describe('normal view', () => {
     expect(stateNew.cursor).toMatchObject(contextToPath(stateNew, ['a'])!)
   })
 
+  it('move cursor to previous collapsed sibling', () => {
+    const text = `
+      - a
+        - a1
+      - b
+    `
+    const steps = [importText({ text }), setCursor(['b']), cursorUp]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(stateNew.cursor).toMatchObject(contextToPath(stateNew, ['a'])!)
+  })
+
   it('move cursor to previous attribute when showHiddenThoughts is true', () => {
     const steps = [
       toggleHiddenThoughts,

--- a/src/actions/__tests__/cursorUp.ts
+++ b/src/actions/__tests__/cursorUp.ts
@@ -232,22 +232,4 @@ describe('context view', () => {
     expect(isContextViewActive(stateNew, contextToPath(stateNew, ['a', 'm']))).toBeTruthy()
     expect(pathToContext(stateNew, stateNew.cursor!)).toEqual(['a', 'z'])
   })
-
-  it('move cursor from normal view into context view child', () => {
-    const text = `
-      - =children
-        - =pin
-      - a
-        - m
-          - x
-      - b
-        - m
-          - y
-    `
-
-    const steps = [importText({ text }), setCursor(['a', 'm']), toggleContextView, setCursor(['b']), cursorUp]
-    const stateNew = reducerFlow(steps)(initialState())
-
-    expect(pathToContext(stateNew, stateNew.cursor!)).toEqual(['a', 'm', 'b'])
-  })
 })

--- a/src/actions/cursorUp.ts
+++ b/src/actions/cursorUp.ts
@@ -1,3 +1,4 @@
+import Path from '../@types/Path'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import setCursor from '../actions/setCursor'
@@ -13,16 +14,14 @@ const cursorUp = (state: State, { preserveMulticursor }: { preserveMulticursor?:
     ? // if cursor exists, get the previous thought in visual order
       prevThought(state, cursor)
     : // otherwise, get the last thought in the home context
-      getChildrenSorted(state, HOME_TOKEN).slice(-1)[0]?.id
-      ? [getChildrenSorted(state, HOME_TOKEN).slice(-1)[0].id]
+      getChildrenSorted(state, HOME_TOKEN).at(-1)?.id
+      ? ([getChildrenSorted(state, HOME_TOKEN).at(-1)!.id] as unknown as Path)
       : null
 
   // noop if there is no previous path, i.e. the cursor is on the very first thought
   return path && path.length > 0
     ? setCursor(state, {
-        path: [path[0], ...path.slice(1)],
-        cursorHistoryClear: true,
-        editing: true,
+        path: path,
         preserveMulticursor,
       })
     : state

--- a/src/actions/cursorUp.ts
+++ b/src/actions/cursorUp.ts
@@ -15,7 +15,7 @@ const cursorUp = (state: State, { preserveMulticursor }: { preserveMulticursor?:
       prevThought(state, cursor)
     : // otherwise, get the last thought in the home context
       getChildrenSorted(state, HOME_TOKEN).at(-1)?.id
-      ? ([getChildrenSorted(state, HOME_TOKEN).at(-1)!.id] as unknown as Path)
+      ? ([getChildrenSorted(state, HOME_TOKEN).at(-1)!.id] as Path)
       : null
 
   // noop if there is no previous path, i.e. the cursor is on the very first thought

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -12,15 +12,12 @@ import simplifyPath from './simplifyPath'
 
 /** Gets the last visible descendant of a thought. */
 const lastVisibleDescendant = (state: State, path: Path): Path => {
-  // Use simplifyPath only if we're in context view mode
-  const isInContextView = Object.keys(state.contextViews).length > 0 && path.length > 1
-  const effectivePath = isInContextView ? simplifyPath(state, path) : path
-  const id = head(effectivePath)
+  const simplePath = simplifyPath(state, path)
 
   // Only traverse children if the thought or its parent is expanded
-  if (!state.expanded[hashPath(effectivePath)]) return path
+  if (!state.expanded[hashPath(simplePath)]) return path
 
-  const children = getChildren(state, id)
+  const children = getChildren(state, head(simplePath))
   // If no children, return current path
   if (children.length === 0) return path
 

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -1,0 +1,82 @@
+import Path from '../@types/Path'
+import State from '../@types/State'
+import { HOME_TOKEN } from '../constants'
+import expandThoughts from '../selectors/expandThoughts'
+import { getAllChildrenAsThoughts, isVisible } from '../selectors/getChildren'
+import prevSibling from '../selectors/prevSibling'
+import rootedParentOf from '../selectors/rootedParentOf'
+import appendToPath from '../util/appendToPath'
+import hashPath from '../util/hashPath'
+import head from '../util/head'
+import isRoot from '../util/isRoot'
+import parentOf from '../util/parentOf'
+
+/** Checks if a thought is expanded using the expandThoughts selector. */
+const isExpanded = (state: State, path: Path): boolean => {
+  const expandedPathMap = expandThoughts(state, state.cursor)
+  return !!expandedPathMap[hashPath(path)]
+}
+
+/** Gets the last visible descendant of a thought. */
+const lastVisibleDescendant = (state: State, path: Path): Path => {
+  const id = head(path)
+
+  // Only traverse children if the thought or its parent is expanded
+  if (!isExpanded(state, path)) return path
+
+  // When showHiddenThoughts is true, show all children, otherwise filter hidden ones
+  const children = state.showHiddenThoughts
+    ? getAllChildrenAsThoughts(state, id)
+    : getAllChildrenAsThoughts(state, id).filter(child => isVisible(state, child))
+
+  // If no children, return current path
+  if (children.length === 0) return path
+
+  const lastChild = children[children.length - 1]
+  if (!lastChild) return path
+
+  const childPath = appendToPath(path, lastChild.id)
+  return lastVisibleDescendant(state, childPath)
+}
+
+/** Gets the previous thought in visual order. */
+const prevThought = (state: State, path?: Path): Path | null => {
+  if (!path) {
+    // Get all root children, showing hidden thoughts if showHiddenThoughts is true
+    const rootChildren = state.showHiddenThoughts
+      ? getAllChildrenAsThoughts(state, HOME_TOKEN)
+      : getAllChildrenAsThoughts(state, HOME_TOKEN).filter(child => isVisible(state, child))
+
+    if (rootChildren.length === 0) return null
+
+    // Return the last visible root child
+    const lastChild = rootChildren[rootChildren.length - 1]
+    return [lastChild.id]
+  }
+
+  const pathParent = rootedParentOf(state, path)
+  const isRootLevel = isRoot(pathParent)
+
+  // Get previous visible sibling
+  let prevSiblingThought = prevSibling(state, path)
+
+  // Skip hidden thoughts only when showHiddenThoughts is false
+  while (!state.showHiddenThoughts && prevSiblingThought && !isVisible(state, prevSiblingThought)) {
+    const prevPath = appendToPath(parentOf(path), prevSiblingThought.id)
+    prevSiblingThought = prevSibling(state, prevPath)
+  }
+
+  if (prevSiblingThought) {
+    // If previous sibling exists, get its last visible descendant
+    const prevSiblingPath = appendToPath(parentOf(path), prevSiblingThought.id)
+    return lastVisibleDescendant(state, prevSiblingPath)
+  }
+
+  // If at root level, stop here - don't traverse up to parent
+  if (isRootLevel) return null
+
+  // If not at root level and no previous sibling, return parent
+  return pathParent
+}
+
+export default prevThought

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -4,14 +4,10 @@ import getChildren, { isVisible } from '../selectors/getChildren'
 import isContextViewActive from '../selectors/isContextViewActive'
 import prevContext from '../selectors/prevContext'
 import prevSibling from '../selectors/prevSibling'
-import rootedParentOf from '../selectors/rootedParentOf'
 import appendToPath from '../util/appendToPath'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
-import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
-import getContextsSortedAndRanked from './getContextsSortedAndRanked'
-import getThoughtById from './getThoughtById'
 import simplifyPath from './simplifyPath'
 
 /** Gets the last visible descendant of a thought. */
@@ -32,23 +28,6 @@ const lastVisibleDescendant = (state: State, path: Path): Path => {
   return lastVisibleDescendant(state, appendToPath(path, lastChild.id))
 }
 
-/** Gets the last context in a context view. */
-const lastContext = (state: State, path: Path): Path | null => {
-  const thought = getThoughtById(state, head(path))
-  const contexts = getContextsSortedAndRanked(state, thought.value).filter(
-    context => state.showHiddenThoughts || isVisible(state, getThoughtById(state, context.id)),
-  )
-
-  // if context view is empty or no visible contexts, return null
-  if (contexts.length === 0) return null
-
-  // get the last visible context
-  const lastContext = getThoughtById(state, contexts[contexts.length - 1]?.id)
-  if (!state.expanded[hashPath(appendToPath(path, lastContext.parentId))])
-    return appendToPath(path, lastContext.parentId)
-  return lastVisibleDescendant(state, appendToPath(path, lastContext.parentId))
-}
-
 /**
  * Gets the last visible descendant of the previous sibling.
  * If the previous sibling is hidden, recursively tries the next previous sibling.
@@ -60,10 +39,11 @@ const getLastVisibleDescendantOfPreviousSibling = (
 ): Path | null => {
   const currentPath = currentSibling || path
   const prevSiblingThought = prevSibling(state, currentPath)
+
   if (!prevSiblingThought) return null
+
   // Skip hidden thoughts only when showHiddenThoughts is false
-  const isHidden = !state.showHiddenThoughts && !isVisible(state, prevSiblingThought)
-  if (!isHidden) {
+  if (state.showHiddenThoughts || isVisible(state, prevSiblingThought)) {
     const prevSiblingPath = appendToPath(parentOf(path), prevSiblingThought.id)
     return lastVisibleDescendant(state, prevSiblingPath)
   }
@@ -72,53 +52,22 @@ const getLastVisibleDescendantOfPreviousSibling = (
   return getLastVisibleDescendantOfPreviousSibling(state, path, prevPath)
 }
 
-/** Recursively checks if any parent up to root is a context view root. */
-const findContextViewRoot = (state: State, path: Path): Path | null => {
-  if (isRoot(path)) return null
-  if (isContextViewActive(state, path)) return path
-  return findContextViewRoot(state, rootedParentOf(state, path))
-}
-
 /** Gets the previous thought in visual order. */
-const prevThought = (state: State, path?: Path): Path | null => {
-  if (!path) return null
+const prevThought = (state: State, path: Path): Path | null => {
+  const pathParent = path.length > 1 ? parentOf(path) : null
 
-  const pathParent = rootedParentOf(state, path)
-  const isRootLevel = isRoot(pathParent)
-
-  // Check if we're in a context view
-  const inContextView = isContextViewActive(state, pathParent)
-  const hasActiveContextViews = Object.keys(state.contextViews).length > 0
   // If in context view, try to get previous context first
-  if (inContextView) {
+  if (isContextViewActive(state, pathParent)) {
     const prevContextThought = prevContext(state, path)
     if (prevContextThought) return appendToPath(pathParent, prevContextThought.id)
 
     // If no previous context, move to parent if not at root
-    return isRootLevel ? null : pathParent
+    return pathParent
   }
 
-  const prevSiblingPath = getLastVisibleDescendantOfPreviousSibling(state, path)
-  // If we have active context views, check for context view boundaries
-  if (hasActiveContextViews && prevSiblingPath && path.length === 1) {
-    // Check if previous sibling is in a context view
-    const prevContextViewRoot = findContextViewRoot(state, prevSiblingPath)
-    if (prevContextViewRoot) return lastContext(state, prevContextViewRoot)
-  }
-
-  if (prevSiblingPath) return prevSiblingPath
-
-  // If at root level, stop here - don't traverse up to parent
-  if (isRootLevel) return null
-
-  // If not at root level and no previous sibling, check if parent is in context view
-  if (hasActiveContextViews && path.length === 1) {
-    const parentContextViewRoot = findContextViewRoot(state, pathParent)
-    if (parentContextViewRoot) return lastContext(state, parentContextViewRoot)
-  }
-
-  // If not in any context view and no previous sibling, return parent
-  return pathParent
+  // If the previous sibling is expanded, return its last descendant.
+  // Otherwise, if not in any context view and no previous sibling, return parent.
+  return getLastVisibleDescendantOfPreviousSibling(state, path) || pathParent
 }
 
 export default prevThought

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -1,7 +1,8 @@
 import Path from '../@types/Path'
 import State from '../@types/State'
-import expandThoughts from '../selectors/expandThoughts'
-import { getAllChildrenAsThoughts, isVisible } from '../selectors/getChildren'
+import getChildren, { isVisible } from '../selectors/getChildren'
+import isContextViewActive from '../selectors/isContextViewActive'
+import prevContext from '../selectors/prevContext'
 import prevSibling from '../selectors/prevSibling'
 import rootedParentOf from '../selectors/rootedParentOf'
 import appendToPath from '../util/appendToPath'
@@ -9,42 +10,57 @@ import hashPath from '../util/hashPath'
 import head from '../util/head'
 import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
-
-/** Checks if a thought is expanded using the expandThoughts selector. */
-const isExpanded = (state: State, path: Path): boolean => {
-  const expandedPathMap = expandThoughts(state, state.cursor)
-  return !!expandedPathMap[hashPath(path)]
-}
+import getContextsSortedAndRanked from './getContextsSortedAndRanked'
+import getThoughtById from './getThoughtById'
+import simplifyPath from './simplifyPath'
 
 /** Gets the last visible descendant of a thought. */
 const lastVisibleDescendant = (state: State, path: Path): Path => {
-  const id = head(path)
+  // Use simplifyPath only if we're in context view mode
+  const isInContextView = Object.keys(state.contextViews).length > 0 && path.length > 1
+  const effectivePath = isInContextView ? simplifyPath(state, path) : path
+  const id = head(effectivePath)
 
   // Only traverse children if the thought or its parent is expanded
-  if (!isExpanded(state, path)) return path
+  if (!state.expanded[hashPath(effectivePath)]) return path
 
-  // When showHiddenThoughts is true, show all children, otherwise filter hidden ones
-  const children = state.showHiddenThoughts
-    ? getAllChildrenAsThoughts(state, id)
-    : getAllChildrenAsThoughts(state, id).filter(child => isVisible(state, child))
-
+  const children = getChildren(state, id)
   // If no children, return current path
   if (children.length === 0) return path
 
   const lastChild = children[children.length - 1]
-  if (!lastChild) return path
-
-  const childPath = appendToPath(path, lastChild.id)
-  return lastVisibleDescendant(state, childPath)
+  return lastVisibleDescendant(state, appendToPath(path, lastChild.id))
 }
 
-/** Gets the previous visible sibling, recursively skipping hidden thoughts if needed. */
-const getPreviousVisibleSibling = (state: State, path: Path, currentSibling: Path | null = null): Path | null => {
+/** Gets the last context in a context view. */
+const lastContext = (state: State, path: Path): Path | null => {
+  const thought = getThoughtById(state, head(path))
+  const contexts = getContextsSortedAndRanked(state, thought.value).filter(
+    context => state.showHiddenThoughts || isVisible(state, getThoughtById(state, context.id)),
+  )
+
+  // if context view is empty or no visible contexts, return null
+  if (contexts.length === 0) return null
+
+  // get the last visible context
+  const lastContext = getThoughtById(state, contexts[contexts.length - 1]?.id)
+  if (!state.expanded[hashPath(appendToPath(path, lastContext.parentId))])
+    return appendToPath(path, lastContext.parentId)
+  return lastVisibleDescendant(state, appendToPath(path, lastContext.parentId))
+}
+
+/**
+ * Gets the last visible descendant of the previous sibling.
+ * If the previous sibling is hidden, recursively tries the next previous sibling.
+ */
+const getLastVisibleDescendantOfPreviousSibling = (
+  state: State,
+  path: Path,
+  currentSibling: Path | null = null,
+): Path | null => {
   const currentPath = currentSibling || path
   const prevSiblingThought = prevSibling(state, currentPath)
-
   if (!prevSiblingThought) return null
-
   // Skip hidden thoughts only when showHiddenThoughts is false
   const isHidden = !state.showHiddenThoughts && !isVisible(state, prevSiblingThought)
   if (!isHidden) {
@@ -53,7 +69,14 @@ const getPreviousVisibleSibling = (state: State, path: Path, currentSibling: Pat
   }
 
   const prevPath = appendToPath(parentOf(path), prevSiblingThought.id)
-  return getPreviousVisibleSibling(state, path, prevPath)
+  return getLastVisibleDescendantOfPreviousSibling(state, path, prevPath)
+}
+
+/** Recursively checks if any parent up to root is a context view root. */
+const findContextViewRoot = (state: State, path: Path): Path | null => {
+  if (isRoot(path)) return null
+  if (isContextViewActive(state, path)) return path
+  return findContextViewRoot(state, rootedParentOf(state, path))
 }
 
 /** Gets the previous thought in visual order. */
@@ -63,13 +86,38 @@ const prevThought = (state: State, path?: Path): Path | null => {
   const pathParent = rootedParentOf(state, path)
   const isRootLevel = isRoot(pathParent)
 
-  const prevSiblingPath = getPreviousVisibleSibling(state, path)
+  // Check if we're in a context view
+  const inContextView = isContextViewActive(state, pathParent)
+  const hasActiveContextViews = Object.keys(state.contextViews).length > 0
+  // If in context view, try to get previous context first
+  if (inContextView) {
+    const prevContextThought = prevContext(state, path)
+    if (prevContextThought) return appendToPath(pathParent, prevContextThought.id)
+
+    // If no previous context, move to parent if not at root
+    return isRootLevel ? null : pathParent
+  }
+
+  const prevSiblingPath = getLastVisibleDescendantOfPreviousSibling(state, path)
+  // If we have active context views, check for context view boundaries
+  if (hasActiveContextViews && prevSiblingPath && path.length === 1) {
+    // Check if previous sibling is in a context view
+    const prevContextViewRoot = findContextViewRoot(state, prevSiblingPath)
+    if (prevContextViewRoot) return lastContext(state, prevContextViewRoot)
+  }
+
   if (prevSiblingPath) return prevSiblingPath
 
   // If at root level, stop here - don't traverse up to parent
   if (isRootLevel) return null
 
-  // If not at root level and no previous sibling, return parent
+  // If not at root level and no previous sibling, check if parent is in context view
+  if (hasActiveContextViews && path.length === 1) {
+    const parentContextViewRoot = findContextViewRoot(state, pathParent)
+    if (parentContextViewRoot) return lastContext(state, parentContextViewRoot)
+  }
+
+  // If not in any context view and no previous sibling, return parent
   return pathParent
 }
 

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -29,13 +29,8 @@ const lastVisibleDescendant = (state: State, path: Path): Path => {
  * Gets the last visible descendant of the previous sibling.
  * If the previous sibling is hidden, recursively tries the next previous sibling.
  */
-const getLastVisibleDescendantOfPreviousSibling = (
-  state: State,
-  path: Path,
-  currentSibling: Path | null = null,
-): Path | null => {
-  const currentPath = currentSibling || path
-  const prevSiblingThought = prevSibling(state, currentPath)
+const getLastVisibleDescendantOfPreviousSibling = (state: State, path: Path): Path | null => {
+  const prevSiblingThought = prevSibling(state, path)
 
   if (!prevSiblingThought) return null
 
@@ -46,7 +41,7 @@ const getLastVisibleDescendantOfPreviousSibling = (
   }
 
   const prevPath = appendToPath(parentOf(path), prevSiblingThought.id)
-  return getLastVisibleDescendantOfPreviousSibling(state, path, prevPath)
+  return getLastVisibleDescendantOfPreviousSibling(state, prevPath)
 }
 
 /** Gets the previous thought in visual order. */


### PR DESCRIPTION
This PR implements the feature : prevThought #2676 

I implemented `prevThought.ts` to get the prevThought of current thought.
In this function, I need to check if the prevThought is expanded or not.
I can see that there's already a function called `expandThoughts`. 
So, I use this function to check if the thought is expanded or not.

1. The `prevThought` function first gets the previous sibling using prevSibling.
2. If there is a previous sibling, it uses lastVisibleDescendant which internally.
3. Checks if the thought is expanded using isExpanded. 
    - If expanded, it returns the last visible child recursively.
    - If not expanded, it returns the thought itself
4. If no previous sibling exists and not at root level, return the parent.

It's the main logic of `prevThought` function.

And I added tests for this in cursorUp.
