### PR TITLE
Update gesture pad & use touch events

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -23,11 +23,6 @@ module.exports = {
     // https://gitlab.com/nfriend/ts-key-enum#which-version-should-i-use
     'ts-key-enum',
 
-    // Breaks on mobile Safari.
-    // undefined is not an object (evaluating signaturePad._handlePonterStart.bind')
-    // https://github.com/szimek/signature_pad/releases/tag/v5.0.0
-    'react-signature-pad-wrapper',
-
     // customSnapshotIdentifier breaks in puppeteer snapshot tests on puppeteer v23.
     // Error running image diff: Unknown Error
     // https://github.com/vitest-dev/vitest/releases/tag/v2.0.0

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-native-gesture-handler": "^2.21.1",
     "react-native-web": "^0.19.13",
     "react-redux": "^9.1.2",
-    "react-signature-pad-wrapper": "^3.4.0",
+    "react-signature-pad-wrapper": "^4.1.0",
     "react-split-pane": "^0.1.92",
     "react-transition-group": "^4.4.5",
     "redux": "^5.0.1",

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -83,10 +83,10 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
     })
 
     eventNode?.addEventListener('touchmove', e => {
-      const isGesturizing = gestureStore.getState().length > 0
+      const isGestureInProgress = gestureStore.getState().length > 0
       const touch = e.touches[0]
 
-      if (isGesturizing && isInGestureZone(touch.clientX, touch.clientY, leftHanded)) {
+      if (isGestureInProgress && isInGestureZone(touch.clientX, touch.clientY, leftHanded)) {
         handleTouchMove(e)
       }
     })

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -83,9 +83,10 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
     })
 
     eventNode?.addEventListener('touchmove', e => {
-      if (!show) return
+      const isGesturizing = gestureStore.getState().length > 0
       const touch = e.touches[0]
-      if (isInGestureZone(touch.clientX, touch.clientY, leftHanded)) {
+
+      if (isGesturizing && isInGestureZone(touch.clientX, touch.clientY, leftHanded)) {
         handleTouchMove(e)
       }
     })
@@ -111,7 +112,7 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
       eventNode?.removeEventListener('touchend', handleTouchEnd)
       signaturePad.removeEventListener('beginStroke', onBeginStroke)
     }
-  }, [eventNodeRef, onBeginStroke, leftHanded, show])
+  }, [eventNodeRef, onBeginStroke, leftHanded])
 
   return (
     <div

--- a/src/components/TraceGesture.tsx
+++ b/src/components/TraceGesture.tsx
@@ -83,6 +83,7 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
     })
 
     eventNode?.addEventListener('touchmove', e => {
+      if (!show) return
       const touch = e.touches[0]
       if (isInGestureZone(touch.clientX, touch.clientY, leftHanded)) {
         handleTouchMove(e)
@@ -110,7 +111,7 @@ const TraceGesture = ({ eventNodeRef }: TraceGestureProps) => {
       eventNode?.removeEventListener('touchend', handleTouchEnd)
       signaturePad.removeEventListener('beginStroke', onBeginStroke)
     }
-  }, [eventNodeRef, onBeginStroke, leftHanded])
+  }, [eventNodeRef, onBeginStroke, leftHanded, show])
 
   return (
     <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -8078,7 +8078,7 @@ __metadata:
     react-native-gesture-handler: "npm:^2.21.1"
     react-native-web: "npm:^0.19.13"
     react-redux: "npm:^9.1.2"
-    react-signature-pad-wrapper: "npm:^3.4.0"
+    react-signature-pad-wrapper: "npm:^4.1.0"
     react-split-pane: "npm:^0.1.92"
     react-transition-group: "npm:^4.4.5"
     redux: "npm:^5.0.1"
@@ -15303,16 +15303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-signature-pad-wrapper@npm:^3.4.0":
-  version: 3.4.1
-  resolution: "react-signature-pad-wrapper@npm:3.4.1"
+"react-signature-pad-wrapper@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "react-signature-pad-wrapper@npm:4.1.0"
   dependencies:
-    signature_pad: "npm:^4.0.0"
+    prop-types: "npm:^15.8.1"
+    signature_pad: "npm:^5.0.1"
     throttle-debounce: "npm:^5.0.0"
   peerDependencies:
-    react: 17 - 18
-    react-dom: 17 - 18
-  checksum: 10c0/f38c58ed30e1d7ed02348430ddc7b18d21db6049ee2cd5ff689377be7ed586d3550a33ba1f06c92274153f44ab75ab2652fb8e0872f307bdc739ea43e066ac4a
+    react: 17 - 19
+    react-dom: 17 - 19
+  checksum: 10c0/0f8beb9dd14b31a8c915e78ff2983c13adbff5f5949916a9c33f76bcfa8e8ccd5a0cd598ca733513e239637dc17d0243070cb426f082fc6e8d4b5624c35eb475
   languageName: node
   linkType: hard
 
@@ -16229,10 +16230,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signature_pad@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "signature_pad@npm:4.2.0"
-  checksum: 10c0/9b7792c90fea0d90b095ddb724d046ecaea20ce2de9845c270f08407ca8402888e0b04b9bab2865271e7d18fe765e1954d4a142e0cbfd551f428e9298f3fb890
+"signature_pad@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "signature_pad@npm:5.0.4"
+  checksum: 10c0/bf6fa4393e00c86d32b66b7cd613db37491918576b00bdd1d99ae7250ff664305b28b7d64706b5c7111a67ecc8e82e959221514b15a6d0b35acaa418b0562eaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes https://github.com/cybersemics/em/issues/2303

Long story short: they had  `handlePointerStart` and `handlePointerEnd` functions that did some custom stuff, differing from very standard `pointerdown` and `pointerup` events. So they dumped that, and made two new functions: `handlePointerDown` and `handlePointerUp`, which led to many unexpected problems if we use them. 
https://github.com/szimek/signature_pad/commit/29a8b5a2a19387782c3eec1055389011eb7f9699

After spending considerable amount of time trying to trick it to work the same way, I ended up just using `touch` events, as suggested in the original issue.
There's just two big differences between the original implementation:
| before | after |
| - | - |
| custom pointer start/end functions handled native `down/up` events |  now we manually call `touchend = pointerup` |
| on pointer move we'd monkey-patch `preventDefault` | we only apply it in the gesture zone |
