### PR TITLE
fix cursor move tests

### DIFF
--- a/src/actions/__tests__/cursorDown.ts
+++ b/src/actions/__tests__/cursorDown.ts
@@ -1,13 +1,16 @@
-import State from '../../@types/State'
+import { act } from 'react'
 import cursorDown from '../../actions/cursorDown'
 import importText from '../../actions/importText'
+import { importTextActionCreator as importTextAction } from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
-import toggleAttribute from '../../actions/toggleAttribute'
 import toggleContextView from '../../actions/toggleContextView'
-import contextToPath from '../../selectors/contextToPath'
+import toggleSortShortcut from '../../commands/toggleSort'
+import createTestStore from '../../test-helpers/createTestStore'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import { setCursorFirstMatchActionCreator as setCursorAction } from '../../test-helpers/setCursorFirstMatch'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
+import executeCommand from '../../util/executeCommand'
 import initialState from '../../util/initialState'
 import pathToContext from '../../util/pathToContext'
 import reducerFlow from '../../util/reducerFlow'
@@ -64,19 +67,25 @@ describe('normal view', () => {
     expectPathToEqual(stateNew, stateNew.cursor, ['b'])
   })
 
-  it('work for sorted thoughts', () => {
-    const steps = [
-      newThought('a'),
-      newSubthought('n'),
-      newThought('m'),
-      setCursor(['a']),
-      (state: State) =>
-        toggleAttribute(state, { path: contextToPath(state, ['a']), values: ['=sort', 'Alphabetical'] }),
-      cursorDown,
-    ]
-
-    const stateNew = reducerFlow(steps)(initialState())
-
+  it('work for sorted thoughts', async () => {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch([
+        importTextAction({
+          text: `
+              - a
+                - n
+                - m
+          `,
+        }),
+        setCursorAction(['a', 'n']),
+      ])
+    })
+    act(() => executeCommand(toggleSortShortcut, { store }))
+    act(() => {
+      store.dispatch([setCursorAction(['a'])])
+    })
+    const stateNew = cursorDown(store.getState())
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm'])
   })
 })

--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -1,4 +1,5 @@
 import sleep from '../../../util/sleep'
+import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
@@ -131,4 +132,39 @@ it('set the cursor on click after cursorBack sets it to null', async () => {
 
   const thoughtValue = await getEditingText()
   expect(thoughtValue).toBe('a')
+})
+
+it('move cursor from formatted thought to first unformatted thought in descending order', async () => {
+  await paste(`
+    - fruits
+      - apple
+      - orange
+      - banana
+      - pear
+  `)
+
+  // Wait for the thought to be editable and click it
+  await waitForEditable('apple')
+  await clickThought('apple')
+
+  // Toggle sort twice (ascending then descending)
+  await click('[data-testid="toolbar-icon"][aria-label="Sort"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Sort"]')
+
+  // Make text bold using the toolbar
+  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
+
+  // Press arrow down to move cursor
+  await press('ArrowDown')
+
+  // Verify cursor moved to 'pear' (when cursorDown)
+  const downThoughtValue = await getEditingText()
+  expect(downThoughtValue).toBe('pear')
+
+  await press('ArrowUp')
+  await press('ArrowUp')
+
+  // Verify cursor moved to 'fruits' (when cursorUp)
+  const upThoughtValue = await getEditingText()
+  expect(upThoughtValue).toBe('fruits')
 })


### PR DESCRIPTION
This PR resolves the issue : Cursor Up does not work correctly in sorted context with bold thought #2686

The cause of Issue : The problem is that when the list is sorted in descending order, the `prevSibling` function is still looking for the previous sibling in the internal order, not the visual order.

When you sort in descending order, the internal order and visual order of thouths become :
   Internal order:                   
   - pear                                 
   - orange                              
   - banana                             
   - apple

   Visual order:     
   - apple 
   - banana  
   - orange                            
   - pear
   
   So, when cursorUp and cursorDown, it doesn't work properly.
   
Solution for this Issue : To get the visual order of thoughts, I used `getChildrenRanked` instead of `getChildrenSorted` in 
    prevSibling and nextSibling. And it has been solved.
   

