### PR TITLE
fix sort error on bold thought

### DIFF
--- a/src/selectors/getSortedRank.ts
+++ b/src/selectors/getSortedRank.ts
@@ -1,15 +1,21 @@
 import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
-import { compareReasonable } from '../util/compareThought'
+import { compareReasonable, compareReasonableDescending } from '../util/compareThought'
 import { getAllChildrenSorted } from './getChildren'
+import getSortPreference from './getSortPreference'
 
 /** Gets the new rank of a value to be inserted into a sorted context. */
 const getSortedRank = (state: State, id: ThoughtId, value: string) => {
   const children = id ? getAllChildrenSorted(state, id) : []
 
+  const sortPreference = getSortPreference(state, id)
+  const isDescending = sortPreference.direction === 'Desc'
   // find the first child with value greater than or equal to the new value
-  const index = children.findIndex(child => compareReasonable(child.value, value) !== -1)
-
+  const index = children.findIndex(child =>
+    isDescending
+      ? compareReasonableDescending(child.value, value) !== -1
+      : compareReasonable(child.value, value) !== -1,
+  )
   // if there is no such child, return the rank of the last child + 1
   return index === -1
     ? (children[children.length - 1]?.rank || 0) + 1

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -179,16 +179,19 @@ const reverse =
   (a: T, b: T) =>
     comparator(b, a)
 
+export const compareReasonableDescending: ComparatorFunction<string> = makeOrderedComparator<string>([
+  compareFormatting,
+  (a, b) => compareReadableText(normalizeCharacters(b), normalizeCharacters(a)),
+  reverse(compareStringsWithEmoji),
+  reverse(compareStringsWithMetaAttributes),
+  reverse(comparePunctuationAndOther),
+  reverse(compareEmpty),
+])
+
 /** Compare the value of two thoughts. If the thought has a sortValue, it takes precedence over value. This preserves the sort order of a thought edited to empty instead of moving it to the top of thi list. */
 export const compareThought: ComparatorFunction<Thought> = (a: Thought, b: Thought) =>
   compareReasonable(a.sortValue || a.value, b.sortValue || b.value)
 
 /** A comparator that sorts in descending order, with formatted text prioritized first. */
-export const compareThoughtDescending: ComparatorFunction<Thought> = (a: Thought, b: Thought): ComparatorValue => {
-  // First check formatting - formatted text should come first
-  const formatCompare = compareFormatting(a.sortValue || a.value, b.sortValue || b.value)
-  if (formatCompare !== 0) return formatCompare
-
-  // Then compare values in descending order
-  return reverse(compareThought)(a, b)
-}
+export const compareThoughtDescending: ComparatorFunction<Thought> = (a: Thought, b: Thought) =>
+  compareReasonableDescending(a.sortValue || a.value, b.sortValue || b.value)

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -183,5 +183,12 @@ const reverse =
 export const compareThought: ComparatorFunction<Thought> = (a: Thought, b: Thought) =>
   compareReasonable(a.sortValue || a.value, b.sortValue || b.value)
 
-/** A comparator that sorts in descending order. */
-export const compareThoughtDescending = reverse(compareThought)
+/** A comparator that sorts in descending order, with formatted text prioritized first. */
+export const compareThoughtDescending: ComparatorFunction<Thought> = (a: Thought, b: Thought): ComparatorValue => {
+  // First check formatting - formatted text should come first
+  const formatCompare = compareFormatting(a.sortValue || a.value, b.sortValue || b.value)
+  if (formatCompare !== 0) return formatCompare
+
+  // Then compare values in descending order
+  return reverse(compareThought)(a, b)
+}

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -181,11 +181,11 @@ const reverse =
 
 export const compareReasonableDescending: ComparatorFunction<string> = makeOrderedComparator<string>([
   compareFormatting,
-  (a, b) => compareReadableText(normalizeCharacters(b), normalizeCharacters(a)),
-  reverse(compareStringsWithEmoji),
-  reverse(compareStringsWithMetaAttributes),
-  reverse(comparePunctuationAndOther),
   reverse(compareEmpty),
+  reverse(comparePunctuationAndOther),
+  reverse(compareStringsWithMetaAttributes),
+  reverse(compareStringsWithEmoji),
+  (a, b) => compareReadableText(normalizeCharacters(b), normalizeCharacters(a)),
 ])
 
 /** Compare the value of two thoughts. If the thought has a sortValue, it takes precedence over value. This preserves the sort order of a thought edited to empty instead of moving it to the top of thi list. */


### PR DESCRIPTION
This PR resolves the issue : Sort error on bold thought #2685

This issue casued because of `compareThougtDescending`.
Currently, in `compareThoughtDescending` function, return the reverse of `compareThought`.

I found the best solution for this issue.
So, I changed the `compareThoughtDescending` function to check if either thought has HTML formatting. And `compareFormatting` first.
This resolves the current Issue.