### PR TITLE
=pin should not be applied on context

### DIFF
--- a/src/selectors/__tests__/expandThoughts.ts
+++ b/src/selectors/__tests__/expandThoughts.ts
@@ -3,6 +3,7 @@ import State from '../../@types/State'
 import importText from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
+import toggleContextView from '../../actions/toggleContextView'
 import { HOME_TOKEN } from '../../constants'
 import contextToPath from '../../selectors/contextToPath'
 import expandThoughts from '../../selectors/expandThoughts'
@@ -399,6 +400,25 @@ describe('pin', () => {
       const stateNew = reducerFlow(steps)(initialState())
 
       expect(isContextExpanded(stateNew, ['a', 'b'])).toBeTruthy()
+    })
+
+    it('pinned thoughts are not expanded in context view', () => {
+      const text = `
+        - a
+          - m
+            - x
+        - b
+          - m
+            - =pin
+            - y
+      `
+
+      const steps = [importText({ text }), setCursor(['a', 'm']), toggleContextView]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(isContextExpanded(stateNew, ['a', 'm', 'a'])).toBeFalsy()
+      expect(isContextExpanded(stateNew, ['a', 'm', 'b'])).toBeFalsy()
     })
   })
 

--- a/src/selectors/expandThoughts.ts
+++ b/src/selectors/expandThoughts.ts
@@ -145,8 +145,10 @@ function expandThoughtsRecursive(state: State, expansionBasePath: Path, path: Pa
             isAncestor() ||
             isExpansionBasePath() ||
             isHiddenAttribute() ||
-            pinned(state, child.id) ||
-            (childrenPinned(state, thoughtId) && pinned(state, child.id) === null && !isDone(state, child.id)) ||
+            // Only apply pin expansion if not in context view
+            (!showContexts &&
+              (pinned(state, child.id) ||
+                (childrenPinned(state, thoughtId) && pinned(state, child.id) === null && !isDone(state, child.id)))) ||
             EXPAND_THOUGHTS_REGEX.test(child.value)
           )
         })


### PR DESCRIPTION
This PR resolves the Issue : Context View: =pin should not be applied on context #2723

In this PR, I've modified the `expandThoughtsRecursive` function to only apply pin expansion when not in context view.
Added a condition !showContexts to check if we're not in context view before applying pin expansion.