### PR TITLE
Fix failing note cursor

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -7,35 +7,16 @@ import Path from '../@types/Path'
 import { cursorDownActionCreator as cursorDown } from '../actions/cursorDown'
 import { deleteAttributeActionCreator as deleteAttribute } from '../actions/deleteAttribute'
 import { editingActionCreator as editing } from '../actions/editing'
-import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
 import { setNoteFocusActionCreator as setNoteFocus } from '../actions/setNoteFocus'
 import { toggleNoteActionCreator as toggleNote } from '../actions/toggleNote'
 import { isSafari, isTouch } from '../browser'
 import * as selection from '../device/selection'
-import simplifyPath from '../selectors/simplifyPath'
 import store from '../stores/app'
 import equalPathHead from '../util/equalPathHead'
 import head from '../util/head'
 import noteValue from '../util/noteValue'
 import strip from '../util/strip'
-
-/** Sets the cursor on the note's thought as it is being edited. */
-const setCursorOnLiveThought = ({ path }: { path: Path }) => {
-  const state = store.getState()
-  const simplePath = simplifyPath(state, path)
-
-  if (simplePath?.length > 0) {
-    store.dispatch(
-      setCursor({
-        path: simplePath,
-        cursorHistoryClear: true,
-        editing: true,
-        noteFocus: true,
-      }),
-    )
-  }
-}
 
 /** Renders an editable note that modifies the content of the hidden =note attribute. */
 const Note = React.memo(({ path }: { path: Path }) => {
@@ -113,6 +94,9 @@ const Note = React.memo(({ path }: { path: Path }) => {
     }
   }
 
+  /** Sets the cursor on the note's thought as it is being edited. */
+  const onFocus = () => store.dispatch(setNoteFocus({ value: true }))
+
   return (
     <div
       aria-label='note'
@@ -157,7 +141,7 @@ const Note = React.memo(({ path }: { path: Path }) => {
           setJustPasted(true)
         }}
         onBlur={onBlur}
-        onFocus={() => setCursorOnLiveThought({ path })}
+        onFocus={onFocus}
       />
     </div>
   )

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -23,16 +23,18 @@ import strip from '../util/strip'
 /** Sets the cursor on the note's thought as it is being edited. */
 const setCursorOnLiveThought = ({ path }: { path: Path }) => {
   const state = store.getState()
-  const simplePath = simplifyPath(state, path) || path
+  const simplePath = simplifyPath(state, path)
 
-  store.dispatch(
-    setCursor({
-      path: simplePath,
-      cursorHistoryClear: true,
-      editing: true,
-      noteFocus: true,
-    }),
-  )
+  if (simplePath?.length > 0) {
+    store.dispatch(
+      setCursor({
+        path: simplePath,
+        cursorHistoryClear: true,
+        editing: true,
+        noteFocus: true,
+      }),
+    )
+  }
 }
 
 /** Renders an editable note that modifies the content of the hidden =note attribute. */


### PR DESCRIPTION
fixes https://github.com/cybersemics/em/issues/2721, is ad-hoc fix, needs a deeper think to be not-ad-hoc

it was `onFocus` of a newly created note that triggered an incorrect dispatch of `setCursor`:


```
const simplePath = simplifyPath(state, path) || path
.
.
.
setCursor({
  path: simplePath,
  .
  .
}
```

the problem was: `simplifyPath` would return an empty array at times like this.
The and we'd get `simplifyPath(state, path) || path) = `[] || path` = `[]` , so the fallback never really worked 😄 

After putting a more elaborate condition, and using `path` as a fallback, we get broken editor behavior: the part of the tree collapses(we go to a wrong `path`)

In the end, when I just did not allow `[]` paths, it fixed the thing. And the app, from my manual tests, works just fine. The cursor is there, everything is smooth.
`setDescendant` action puts the appropriate state, from what I observed.

and on the reasons why we even get to the case of `simplifyPath` returning `[]` here, I'm not really sure, and feels like, we should dig there, if we want more than just a ad-hoc bug fix.
