### PR TITLE
=table should not be applied on context

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -40,6 +40,7 @@ interface BulletProps {
   // debugIndex?: number
   isCursorGrandparent?: boolean
   isCursorParent?: boolean
+  isInContextView?: boolean
 }
 
 const isIOSSafari = isTouch && isiPhone && isSafari()
@@ -394,6 +395,7 @@ const Bullet = ({
   thoughtId,
   isCursorGrandparent,
   isCursorParent,
+  isInContextView,
   // depth,
   // debugIndex,
 }: BulletProps) => {
@@ -525,7 +527,7 @@ const Bullet = ({
 
   // calculate position of bullet for different font sizes
   // Table column 1 needs more space between the bullet and thought for some reason
-  const width = 11 - (fontSize - 9) * 0.5 + (isTableCol1 ? fontSize / 4 : 0)
+  const width = 11 - (fontSize - 9) * 0.5 + (!isInContextView && isTableCol1 ? fontSize / 4 : 0)
   const marginLeft = -width
 
   // expand or collapse on click

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -179,7 +179,16 @@ const ThoughtContainer = ({
     attributeEquals(state, head(rootedParentOf(state, parentOf(simplePath))), '=view', 'Table'),
   )
 
-  const hideBullet = useHideBullet({ children, env, hideBulletProp, isEditing, simplePath, thoughtId })
+  const isInContextView = useSelector(state => {
+    /** Check if the thought is in the context view. */
+    const checkContextView = (currentPath: Path): boolean => {
+      if (currentPath.length <= 1) return false
+      return isContextViewActive(state, currentPath) || checkContextView(parentOf(currentPath))
+    }
+    return checkContextView(path)
+  })
+
+  const hideBullet = useHideBullet({ children, env, hideBulletProp, isEditing, simplePath, isInContextView, thoughtId })
   const style = useThoughtStyle({ children, env, styleProp, thoughtId })
   const styleAnnotation = useSelector(
     state =>
@@ -436,6 +445,7 @@ const ThoughtContainer = ({
             publish={publish}
             simplePath={simplePath}
             thoughtId={thoughtId}
+            isInContextView={isInContextView}
             // debugIndex={debugIndex}
             // depth={depth}
           />

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -178,15 +178,7 @@ const ThoughtContainer = ({
   const isTableCol2 = useSelector(state =>
     attributeEquals(state, head(rootedParentOf(state, parentOf(simplePath))), '=view', 'Table'),
   )
-
-  const isInContextView = useSelector(state => {
-    /** Check if the thought is in the context view. */
-    const checkContextView = (currentPath: Path): boolean => {
-      if (currentPath.length <= 1) return false
-      return isContextViewActive(state, parentOf(currentPath))
-    }
-    return checkContextView(path)
-  })
+  const isInContextView = useSelector(state => isContextViewActive(state, parentOf(path)))
 
   const hideBullet = useHideBullet({ children, env, hideBulletProp, isEditing, simplePath, isInContextView, thoughtId })
   const style = useThoughtStyle({ children, env, styleProp, thoughtId })

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -183,7 +183,7 @@ const ThoughtContainer = ({
     /** Check if the thought is in the context view. */
     const checkContextView = (currentPath: Path): boolean => {
       if (currentPath.length <= 1) return false
-      return isContextViewActive(state, currentPath) || checkContextView(parentOf(currentPath))
+      return isContextViewActive(state, parentOf(currentPath))
     }
     return checkContextView(path)
   })

--- a/src/hooks/useHideBullet.ts
+++ b/src/hooks/useHideBullet.ts
@@ -45,9 +45,8 @@ const useHideBullet = ({
 
     /** Returns true if the bullet should be hidden because it is in table column 1 and is not the cursor. */
     const hideBulletTable = () => {
-      // Don't hide bullets in context view
-      if (isInContextView) return false
       return (
+        !isInContextView &&
         !equalPath(simplePath, state.cursor) &&
         attributeEquals(state, head(rootedParentOf(state, simplePath)), '=view', 'Table')
       )

--- a/src/hooks/useHideBullet.ts
+++ b/src/hooks/useHideBullet.ts
@@ -23,6 +23,7 @@ const useHideBullet = ({
   hideBulletProp,
   isEditing,
   simplePath,
+  isInContextView,
   thoughtId,
 }: {
   children: Thought[]
@@ -30,6 +31,7 @@ const useHideBullet = ({
   hideBulletProp: boolean | undefined
   isEditing: boolean
   simplePath: SimplePath
+  isInContextView: boolean
   thoughtId: ThoughtId
 }) => {
   const hideBullet = useSelector(state => {
@@ -42,9 +44,14 @@ const useHideBullet = ({
       thought.value !== '=grandchildren' && attributeEquals(state, head(simplePath), '=bullet', 'None')
 
     /** Returns true if the bullet should be hidden because it is in table column 1 and is not the cursor. */
-    const hideBulletTable = () =>
-      !equalPath(simplePath, state.cursor) &&
-      attributeEquals(state, head(rootedParentOf(state, simplePath)), '=view', 'Table')
+    const hideBulletTable = () => {
+      // Don't hide bullets in context view
+      if (isInContextView) return false
+      return (
+        !equalPath(simplePath, state.cursor) &&
+        attributeEquals(state, head(rootedParentOf(state, simplePath)), '=view', 'Table')
+      )
+    }
 
     /** Returns true if the bullet should be hidden if zoomed. */
     const hideBulletZoom = (): boolean => {


### PR DESCRIPTION
This PR resolves the issue : Context View: =table should not be applied on context #2724.

In this PR, I have modified the `useHideBullet` to not hide bullets(=table) in context view.
And I added a function to check if the current thought is in context view.
If the current thougt is in context view, show bullet.