### PR TITLE
fix Cursor up/down on empty thought in sorted context

### DIFF
--- a/src/actions/__tests__/cursorDown.ts
+++ b/src/actions/__tests__/cursorDown.ts
@@ -5,6 +5,7 @@ import { importTextActionCreator as importTextAction } from '../../actions/impor
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
 import toggleContextView from '../../actions/toggleContextView'
+import newSubthoughtTopShortcut from '../../commands/newSubthoughtTop'
 import toggleSortShortcut from '../../commands/toggleSort'
 import createTestStore from '../../test-helpers/createTestStore'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
@@ -87,6 +88,28 @@ describe('normal view', () => {
     })
     const stateNew = cursorDown(store.getState())
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm'])
+  })
+
+  it('move cursor from empty thought to next thought', () => {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch([
+        importTextAction({
+          text: `
+              - x
+                - b
+                - a
+                - =sort
+                  - Alphabetical
+                    - Desc
+            `,
+        }),
+        setCursorAction(['x']),
+      ])
+    })
+    act(() => executeCommand(newSubthoughtTopShortcut, { store }))
+    const stateNew = cursorDown(store.getState())
+    expectPathToEqual(stateNew, stateNew.cursor, ['x', 'b'])
   })
 })
 

--- a/src/actions/__tests__/cursorDown.ts
+++ b/src/actions/__tests__/cursorDown.ts
@@ -90,7 +90,7 @@ describe('normal view', () => {
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm'])
   })
 
-  it('move cursor from empty thought to next thought', () => {
+  it('move cursor from empty thought to next thought in context sorted in descending order', () => {
     const store = createTestStore()
     act(() => {
       store.dispatch([

--- a/src/actions/__tests__/cursorUp.ts
+++ b/src/actions/__tests__/cursorUp.ts
@@ -1,14 +1,21 @@
+import { act } from 'react-dom/test-utils'
 import cursorUp from '../../actions/cursorUp'
 import importText from '../../actions/importText'
+import { importTextActionCreator as importTextAction } from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
 import toggleContextView from '../../actions/toggleContextView'
 import toggleHiddenThoughts from '../../actions/toggleHiddenThoughts'
+import newSubthoughtTopShortcut from '../../commands/newSubthoughtTop'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
 import contextToPath from '../../selectors/contextToPath'
 import isContextViewActive from '../../selectors/isContextViewActive'
 import prevThought from '../../selectors/prevThought'
+import createTestStore from '../../test-helpers/createTestStore'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
+import { setCursorFirstMatchActionCreator as setCursorAction } from '../../test-helpers/setCursorFirstMatch'
+import executeCommand from '../../util/executeCommand'
 import initialState from '../../util/initialState'
 import pathToContext from '../../util/pathToContext'
 import reducerFlow from '../../util/reducerFlow'
@@ -170,6 +177,28 @@ describe('normal view', () => {
     const state = reducerFlow(steps)(initialState())
     const cursor = state.cursor
     expect(pathToContext(state, prevThought(state, cursor!)!)).toEqual(['a'])
+  })
+
+  it('move cursor from empty thought to previous thought', () => {
+    const store = createTestStore()
+    act(() => {
+      store.dispatch([
+        importTextAction({
+          text: `
+              - x
+                - b
+                - a
+                - =sort
+                  - Alphabetical
+                    - Desc
+            `,
+        }),
+        setCursorAction(['x']),
+      ])
+    })
+    act(() => executeCommand(newSubthoughtTopShortcut, { store }))
+    const stateNew = cursorUp(store.getState())
+    expectPathToEqual(stateNew, stateNew.cursor, ['x'])
   })
 })
 

--- a/src/actions/__tests__/cursorUp.ts
+++ b/src/actions/__tests__/cursorUp.ts
@@ -179,7 +179,7 @@ describe('normal view', () => {
     expect(pathToContext(state, prevThought(state, cursor!)!)).toEqual(['a'])
   })
 
-  it('move cursor from empty thought to previous thought', () => {
+  it('move cursor from empty thought to previous thought in context sorted in descending order', () => {
     const store = createTestStore()
     act(() => {
       store.dispatch([

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -181,7 +181,7 @@ const reverse =
 
 export const compareReasonableDescending: ComparatorFunction<string> = makeOrderedComparator<string>([
   compareFormatting,
-  reverse(compareEmpty),
+  compareEmpty,
   reverse(comparePunctuationAndOther),
   reverse(compareStringsWithMetaAttributes),
   reverse(compareStringsWithEmoji),


### PR DESCRIPTION
This PR resolves the issue : Cursor up/down does not work on empty thought in sorted context #2733

The cause of bug : This issue caused because of mismatching results from `getAllChildrenSorted` and `getChildrenRanked`.

So, I updated the `compareReasonableDescending` function to check compareEmpty first.
And this issue resolved.