### PR TITLE
add new split sentence feature : parenthetical

### DIFF
--- a/src/actions/__tests__/splitSentences.ts
+++ b/src/actions/__tests__/splitSentences.ts
@@ -297,8 +297,8 @@ describe('abbreviations', () => {
     const exported = splitThought(value)
 
     expect(exported).toBe(`- ${HOME_TOKEN}
-  - One.
-  - Two ( U.N.)`)
+  - One. Two
+    - U.N.`)
   })
 
   it('split thought as expected if the dot comes from an abbreviation followed by empty spaces and a quotation mark', () => {
@@ -645,5 +645,33 @@ describe('complicated cases', () => {
   - react.js;
   - file: abc.txt, def.doc"One.Two.Three".
   - IPv4: 11.11.11.111`)
+  })
+})
+
+describe('parenthetical content', () => {
+  it('splits thought with parenthetical content at the end into main thought and subthought', () => {
+    const value = 'This is a thought (and a subthought)'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - This is a thought
+    - and a subthought`)
+  })
+
+  it('splits thought with parenthetical content that ends with a period', () => {
+    const value = 'This is a thought (and a subthought).'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - This is a thought
+    - and a subthought`)
+  })
+
+  it('does not split when parentheses are not at the end', () => {
+    const value = 'This (has parentheses) in the middle'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - This (has parentheses) in the middle`)
   })
 })

--- a/src/actions/splitSentences.ts
+++ b/src/actions/splitSentences.ts
@@ -30,12 +30,14 @@ const splitSentences = (state: State) => {
   const reducers = [
     editThought({
       oldValue: value,
-      newValue: firstSentence,
+      newValue: firstSentence.value,
       path: simplifyPath(state, cursor),
       rankInContext: rank,
     }),
-    ...otherSentences.map(sentence => newThought({ value: sentence })),
-    setCursor({ path: cursor, offset: getTextContentFromHTML(firstSentence).length }),
+    ...otherSentences.map(sentence =>
+      newThought({ value: sentence.value, insertNewSubthought: sentence.insertNewSubThought }),
+    ),
+    setCursor({ path: cursor, offset: getTextContentFromHTML(firstSentence.value).length }),
     editableRender,
   ]
 


### PR DESCRIPTION
This PR implements this feature : splitSentence: Parenthetical #1801

In this PR, I have implemented new parenthetical split sentence feature.
First, I check if the thought ends with parenthetical content using the regex pattern.
And capture both the main thought and the content inside parentheses.
Return them as separate thoughts after trimming whitespace.

And in this PR, I have added `insertNewSubThought` parameter to `splitSentence` function.
For about the abbreviation test case, it doesn't work with the new feature.
So,  I modified the test to match with the new parenthetical feature.
