### PR TITLE
Fix undo persistence test

### DIFF
--- a/src/commands/__tests__/undo-redo.ts
+++ b/src/commands/__tests__/undo-redo.ts
@@ -1,3 +1,4 @@
+import { act } from 'react'
 import { archiveThoughtActionCreator as archiveThought } from '../../actions/archiveThought'
 import { clearActionCreator as clear } from '../../actions/clear'
 import { cursorBackActionCreator as cursorBack } from '../../actions/cursorBack'

--- a/src/commands/__tests__/undo-redo.ts
+++ b/src/commands/__tests__/undo-redo.ts
@@ -1,4 +1,3 @@
-import { act } from 'react'
 import { archiveThoughtActionCreator as archiveThought } from '../../actions/archiveThought'
 import { clearActionCreator as clear } from '../../actions/clear'
 import { cursorBackActionCreator as cursorBack } from '../../actions/cursorBack'


### PR DESCRIPTION
This fixes the remaining undo/redo test. 

**Problem #1:** It looks like we must use fake timers if we want the `store` state to be updated based on database operations (e.g., if we use `initialize()` to reload the state). I think this is because the `thoughtspace` operations are asynchronous and don't call the store operations prior to the test ending. (I'm not sure why we didn't get other errors that made this clear.)

**Problem #2**: There appears to be some store state that isn't cleaned up between tests that persists from the previous tests and breaks this one. The other tests probably aren't effected because they all call `createTestStore`, which presumably creates a brand new store. 

This second issue is somewhat ancillary but might come up when mixing tests that do/don't require `createTestStore` and should figure out the root cause at some point. My initial guess is that we'll just need to figure out a way reverse whatever happens in `createTestStore`. 

Closes #2145 