### PR TITLE
Consolidate test store with global app store

### DIFF
--- a/src/test-helpers/createTestStore.ts
+++ b/src/test-helpers/createTestStore.ts
@@ -1,53 +1,11 @@
-import { Store, applyMiddleware, compose, createStore } from 'redux'
-import { thunk } from 'redux-thunk'
-import State from '../@types/State'
-import appReducer from '../actions/app'
-import pushQueue from '../redux-enhancers/pushQueue'
-import undoRedoEnhancer from '../redux-enhancers/undoRedoEnhancer'
-import updateJumpHistoryEnhancer from '../redux-enhancers/updateJumpHistoryEnhancer'
-import clearSelection from '../redux-middleware/clearSelection'
-import doNotDispatchReducer from '../redux-middleware/doNotDispatchReducer'
-import freeThoughts from '../redux-middleware/freeThoughts'
-import multi from '../redux-middleware/multi'
-import pullQueueMiddleware from '../redux-middleware/pullQueue'
-import scrollCursorIntoViewMiddleware from '../redux-middleware/scrollCursorIntoView'
-import updateEditingValue from '../redux-middleware/updateEditingValue'
-
-// import updateUrlHistoryMiddleware from '../redux-middleware/updateUrlHistory'
-// import storageCacheStoreEnhancer from '../redux-enhancers/storageCache'
-
-const middlewareEnhancer = applyMiddleware(
-  // prevent accidentally passing a reducer to the dispatch function (dev and test only)
-  // (must go before the thunk middleware so that it can throw an error before the thunk middleware tries to execute it)
-  ...(import.meta.env.MODE === 'development' || import.meta.env.MODE === 'test' ? [doNotDispatchReducer] : []),
-  multi,
-  thunk,
-  pullQueueMiddleware,
-  scrollCursorIntoViewMiddleware,
-  clearSelection,
-  updateEditingValue,
-  // TODO: TypeError: middleware is not a function
-  // updateUrlHistoryMiddleware,
-  freeThoughts,
-)
+import { clearActionCreator as clear } from '../actions/clear'
+import store from '../stores/app'
 
 /**
  * Returns new store for test.
  */
 export default function createTestStore() {
-  // TODO: Type properly
-  const store = createStore(
-    appReducer,
-    compose(
-      middlewareEnhancer,
-      // TypeError: Cannot read properties of undefined (reading 'apply')
-      // storageCacheStoreEnhancer,
-      undoRedoEnhancer,
-      updateJumpHistoryEnhancer,
-      pushQueue,
-    ) as any,
-  )
-
+  store.dispatch(clear())
   store.dispatch([
     // skip tutorial
     { type: 'tutorial', value: false },
@@ -56,5 +14,5 @@ export default function createTestStore() {
     { type: 'closeModal' },
   ])
 
-  return store as Store<State, any>
+  return store
 }


### PR DESCRIPTION
My theory is that the reason the enhancers wouldn't work with the test store is because of some weird import issues that resulted in the real `createStore` being called in `src/stores/app.ts`. We can bypass fixing #2336 and #2337 by just going straight to the global store.

This change does the following:

1. Updates `createTestStore` to grab the global store and return it instead of creating a test store
2. Calls the `clear` action to reset the store state

Closes #2336 
Closes #2337 
Closes #2338 