### PR TITLE
Add question mark gesture to Help command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -221,7 +221,8 @@ export const inputHandlers = (store: Store<State, any>) => ({
   handleGestureEnd: ({ sequence, e }: { sequence: GesturePath | null; e: GestureResponderEvent }) => {
     const state = store.getState()
 
-    // Get the help command and its gesture
+    // Get the command from the command gesture index.
+    // When the command palette  is displayed, disable gesture aliases (i.e. gestures hidden from instructions). This is because the gesture hints are meant only as an aid when entering gestures quickly.
     const helpCommand = commandIdIndex['help']
     const helpGesture = helpCommand?.gesture as string
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -151,6 +151,13 @@ let commandPaletteGesture: number | undefined
 
 const { commandKeyIndex, commandIdIndex, commandGestureIndex } = index()
 
+/** Gets the canonical gesture of the command as a string, ignoring aliases. Returns an empty string if the command does not have a gesture. */
+export const gestureString = (command: Command): string =>
+  (typeof command.gesture === 'string' ? command.gesture : command.gesture?.[0] || '') as string
+
+/** Get a command by its id. */
+export const commandById = (id: CommandId): Command => commandIdIndex[id]
+
 /**
  * Keyboard and gesture handlers factory function that binds the store to event handlers.
  *
@@ -223,8 +230,9 @@ export const inputHandlers = (store: Store<State, any>) => ({
 
     // Get the command from the command gesture index.
     // When the command palette  is displayed, disable gesture aliases (i.e. gestures hidden from instructions). This is because the gesture hints are meant only as an aid when entering gestures quickly.
-    const helpCommand = commandIdIndex['help']
-    const helpGesture = helpCommand?.gesture as string
+
+    const helpCommand = commandById('help')
+    const helpGesture = gestureString(helpCommand)
 
     // If sequence ends with help gesture, use help command
     // Otherwise use the normal command lookup
@@ -323,10 +331,3 @@ export const inputHandlers = (store: Store<State, any>) => ({
     }
   },
 })
-
-/** Gets the canonical gesture of the command as a string, ignoring aliases. Returns an empty string if the command does not have a gesture. */
-export const gestureString = (command: Command): string =>
-  (typeof command.gesture === 'string' ? command.gesture : command.gesture?.[0] || '') as string
-
-/** Get a command by its id. */
-export const commandById = (id: CommandId): Command => commandIdIndex[id]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -221,12 +221,17 @@ export const inputHandlers = (store: Store<State, any>) => ({
   handleGestureEnd: ({ sequence, e }: { sequence: GesturePath | null; e: GestureResponderEvent }) => {
     const state = store.getState()
 
-    // Get the command from the command gesture index.
-    // When the command palette  is displayed, disable gesture aliases (i.e. gestures hidden from instructions). This is because the gesture hints are meant only as an aid when entering gestures quickly.
-    const command =
-      !state.showCommandPalette || !commandGestureIndex[sequence as string]?.hideFromHelp
+    // Get the help command and its gesture
+    const helpCommand = commandIdIndex['help']
+    const helpGesture = helpCommand?.gesture as string
+
+    // If sequence ends with help gesture, use help command
+    // Otherwise use the normal command lookup
+    const command = sequence?.toString().endsWith(helpGesture)
+      ? helpCommand
+      : (!state.showCommandPalette || !commandGestureIndex[sequence as string]?.hideFromHelp
         ? commandGestureIndex[sequence as string]
-        : null
+        : null)
 
     // execute command
     // do not execute when modal is displayed or a drag is in progress

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -229,9 +229,9 @@ export const inputHandlers = (store: Store<State, any>) => ({
     // Otherwise use the normal command lookup
     const command = sequence?.toString().endsWith(helpGesture)
       ? helpCommand
-      : (!state.showCommandPalette || !commandGestureIndex[sequence as string]?.hideFromHelp
+      : !state.showCommandPalette || !commandGestureIndex[sequence as string]?.hideFromHelp
         ? commandGestureIndex[sequence as string]
-        : null)
+        : null
 
     // execute command
     // do not execute when modal is displayed or a drag is in progress

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -10,6 +10,7 @@ const openHelpShortcut: Command = {
   description: `Opens the Help screen, which contains the tutorials and a list of all ${
     isTouch ? 'gestures' : 'keyboard shortcuts'
   }.`,
+  gesture: 'rdld',
   keyboard: { key: '/', meta: true },
   multicursor: 'ignore',
   svg: HelpIcon,

--- a/src/commands/newThought.tsx
+++ b/src/commands/newThought.tsx
@@ -82,7 +82,7 @@ export const newThoughtAliases: Command = {
   id: 'newThoughtAliases',
   label: 'New Thought',
   hideFromHelp: true,
-  gesture: ['rdld', 'rdldl', 'rdldld', 'rldl', 'rldld', 'rldldl'],
+  gesture: ['rdldl', 'rdldld', 'rldl', 'rldld', 'rldldl'],
   multicursor,
   // on mobile, the shift key should cause a normal newThought, not newThoughtAbove
   // smuggle it in with the aliases

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -210,14 +210,11 @@ const CommandRow: FC<{
                     ? // For help command, only highlight the matching portion at the end
                       (() => {
                         const helpGesture = gestureString(shortcut)
-                        // If the current gesture ends with part of the help gesture, highlight only the matching portion
-                        for (let i = helpGesture.length; i > 0; i--) {
-                          const helpSubsequence = helpGesture.slice(0, i)
-                          if (gestureInProgress.endsWith(helpSubsequence)) {
-                            return helpSubsequence.length
-                          }
-                        }
-                        return 0
+                        const subsequences = Array.from({ length: helpGesture.length }, (_, i) =>
+                          helpGesture.slice(0, helpGesture.length - i),
+                        )
+                        const matchingSubsequence = subsequences.find(seq => gestureInProgress.endsWith(seq))
+                        return matchingSubsequence?.length || 0
                       })()
                     : // For other commands, use normal highlighting
                       gestureInProgress.length

--- a/src/hooks/useFilteredCommands.ts
+++ b/src/hooks/useFilteredCommands.ts
@@ -34,6 +34,9 @@ const useFilteredCommands = (
 
   const possibleCommandsSorted = useMemo(() => {
     const possibleCommands = visibleCommands.filter(command => {
+      // Always include help command in gesture mode
+      if (isTouch && command.id === 'help') return true
+
       // gesture
       if (isTouch) {
         // only commands with gestures are visible
@@ -71,10 +74,12 @@ const useFilteredCommands = (
         command.labelInverse && command.isActive?.(store.getState()) ? command.labelInverse : command.label
       ).toLowerCase()
 
+      // In gesture mode, help command should always be at the end
+      if (isTouch && command.id === 'help') return '\x99'
       // always sort exact match to top
       if (gestureInProgress === command.gesture || search.trim().toLowerCase() === label) return '\x00'
       // sort inactive commands to the bottom alphabetically
-      else if (sortActiveCommandsFirst && !isExecutable(store.getState(), command)) return `\x99${label}`
+      else if (sortActiveCommandsFirst && !isExecutable(store.getState(), command)) return `\x98${label}`
       // sort gesture by length and then label
       // no padding of length needed since no gesture exceeds a single digit
       else if (gestureInProgress) return `\x01${label}`


### PR DESCRIPTION
This PR implements the new feature : [mobile] Add question mark gesture to Help command. #2729

In this PR, I implented the code like this.
In `commands.ts`'s `handleGestureEnd` function, I first check if the sequence ends with the help gesture (rdld).
If it does end with rdld, I use the help command regardless of what came before.
If it doesn't end with rdld, I use the normal command lookup logic.