### PR TITLE
Editable: cancel tap if it moves beyond threshold

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -49,6 +49,7 @@ import addEmojiSpace from '../util/addEmojiSpace'
 import containsURL from '../util/containsURL'
 import ellipsize from '../util/ellipsize'
 import equalPath from '../util/equalPath'
+import fastClick from '../util/fastClick'
 import head from '../util/head'
 import isDivider from '../util/isDivider'
 import strip from '../util/strip'
@@ -612,7 +613,7 @@ const Editable = ({
       placeholder={placeholder}
       // stop propagation to prevent default content onClick (which removes the cursor)
       onClick={stopPropagation}
-      onTouchEnd={onTap}
+      {...fastClick(onTap)}
       // must call onMouseDown on mobile since onTap cannot preventDefault
       // otherwise gestures and scrolling can trigger cursorBack (#1054)
       onMouseDown={onTap}


### PR DESCRIPTION
Fixes #1453

When a touch begins on an `Editable`, the `onTap` handler fires even if the touch has moved far away before it ends. `fastClick` already contains a `MOVE_THRESHOLD` that will cancel the touch after it moves a certain distance.

Executing `clearThought`, then closing the keyboard, then executing `clearThought` again will result in the keyboard failing to open the 2nd time. This is the same issue that popped up in #2752 and is fixed by that PR. Specifically, by calling `contentRef.current?.focus()` after `selection.set`.