### PR TITLE
URL false positives

### DIFF
--- a/src/util/__tests__/isURL.ts
+++ b/src/util/__tests__/isURL.ts
@@ -66,6 +66,11 @@ const invalidUrls = [
   'http://.www.foo.bar./',
   'a.b.c',
   'test@test.com',
+  'one:two',
+  'key:value',
+  'v1.10',
+  'v2:latest',
+  'version:1.0',
 ]
 
 describe('valid urls', () => {

--- a/src/util/isURL.ts
+++ b/src/util/isURL.ts
@@ -1,7 +1,7 @@
 import isEmail from './isEmail'
 
 const REGEX_URL =
-  /^(?:http(s)?:\/\/)?(www\.)?[a-zA-Z@:%_\\+~#=]+[-\w@:%_\\+~#=.]*[\w@:%_\\+~#=]+[.:][\w()]{2,6}((\/[\w-()@:%_\\+~#?&=.]*)*)$/i
+  /^(?:https?:\/\/)?(?:[^\s:@\/]+(?::[^\s:@\/]*)?@)?(?:www\.)?(?:(?:localhost)|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6})(?::\d{1,5})?(?:\/[^\s]*)?$/i
 
 /** Checks if a string is a URL. */
 const containsURL = (s: string) => REGEX_URL.test(s) && !isEmail(s)


### PR DESCRIPTION
This PR resolves the issue : URL false positives: v1.10 and one:two #1745.

In this PR, I have updated the URL regex pattern in `isURL.ts` to be more specific and not match simple colon-separated text and version numbers are not marked as URLs.

And I add unit test for invalid urls.