### PR TITLE
show arrow in tutorial gesture

### DIFF
--- a/src/components/Tutorial/TutorialGestureDiagram.tsx
+++ b/src/components/Tutorial/TutorialGestureDiagram.tsx
@@ -30,8 +30,8 @@ const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) =>
         <GestureDiagram
           path={gesture as GesturePath}
           size={250}
-          strokeWidth={10}
-          arrowSize={35}
+          strokeWidth={5}
+          arrowSize={50}
           cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
         />
       </div>,

--- a/src/components/Tutorial/TutorialGestureDiagram.tsx
+++ b/src/components/Tutorial/TutorialGestureDiagram.tsx
@@ -29,9 +29,9 @@ const TutorialGestureDiagram = ({ gesture }: { gesture: Command['gesture'] }) =>
       >
         <GestureDiagram
           path={gesture as GesturePath}
-          size={160}
+          size={250}
           strokeWidth={10}
-          arrowSize={5}
+          arrowSize={35}
           cssRaw={css.raw({ animation: 'pulse 1s infinite alternate' })}
         />
       </div>,


### PR DESCRIPTION
This PR resolves the issue : [Mobile] Tutorial: GestureDiagram is cut off #2279

Previously, strokeWidth was bigger than arrowSize. So, we can't see the arrow.
So, I changed the arrowSize and the size of gesture.