### PR TITLE
fix error importing empty parent in root

### DIFF
--- a/src/actions/importFiles.ts
+++ b/src/actions/importFiles.ts
@@ -272,11 +272,7 @@ export const importFilesActionCreator =
           const parentContext =
             ancestors.length === 0 ? baseContext : [...unroot(baseContext), ...relativeAncestorContext]
 
-          // Special handling for empty parent nodes
-          const parentPath =
-            parentContext.length === 1 && parentContext[0] === ''
-              ? path // Use the current path for empty parent nodes
-              : contextToPath(stateAfterPull, parentContext)
+          const parentPath = contextToPath(stateAfterPull, parentContext)
 
           // validate parentPath
           if (!parentPath) {

--- a/src/actions/importFiles.ts
+++ b/src/actions/importFiles.ts
@@ -271,8 +271,12 @@ export const importFilesActionCreator =
           )
           const parentContext =
             ancestors.length === 0 ? baseContext : [...unroot(baseContext), ...relativeAncestorContext]
-          // TODO: It would be better to get the id from importText rather than contextToPath
-          const parentPath = contextToPath(stateAfterPull, parentContext)
+
+          // Special handling for empty parent nodes
+          const parentPath =
+            parentContext.length === 1 && parentContext[0] === ''
+              ? path // Use the current path for empty parent nodes
+              : contextToPath(stateAfterPull, parentContext)
 
           // validate parentPath
           if (!parentPath) {

--- a/src/selectors/contextToPath.ts
+++ b/src/selectors/contextToPath.ts
@@ -15,6 +15,11 @@ import simplifyPath from './simplifyPath'
 
 /** DEPRECATED: Converts a Context to a Path. This is a lossy function! If there is a duplicate thought in the same context, it takes the first. Works with cyclic Paths. Should be converted to a test-helper only. */
 const contextToPath = (state: State, context: string[]): SimplePath | null => {
+  // Handle empty context or single empty string context
+  if (context.length === 0 || (context.length === 1 && context[0] === '')) {
+    return getRootPath(state)
+  }
+
   if (isRoot(context)) return getRootPath(state)
 
   if (context.length > 1 && context[0] === HOME_TOKEN) {


### PR DESCRIPTION
This PR resolves the issue : Error importing empty parent in root #2167

Cause of the issue : There is a problem in handling the empty parents in import process. When we have an empty parent node, the context-to-path conversion is failing because it's treating the empty string as an invalid value.

Solution : I've modified the `importFiles.ts` file to handle empty parent nodes correctly. So, when I detect an empty parent node, I use the current path instead of trying to convert the empty context to a path.

Thanks.