### PR TITLE
fix inherit design tokens not working.

### DIFF
--- a/src/colors.config.ts
+++ b/src/colors.config.ts
@@ -63,8 +63,6 @@ const colors = {
     pinkAgainstFg: 'rgba(233, 12, 89, 1)',
     brightBlue: 'rgba(70, 223, 240, 1)', // #46dff0
     exportTextareaColor: 'rgba(170, 170, 170, 1)', // #aaa, also used in anchorButton
-    inherit: 'inherit',
-    currentColor: 'currentColor',
   },
   light: {
     // Background colors in capacitor app needs to be in hexadecimal codes
@@ -130,8 +128,6 @@ const colors = {
     pinkAgainstFg: 'rgba(227, 179, 196, 1)',
     brightBlue: 'rgba(70, 223, 240, 1)', // #46dff0
     exportTextareaColor: 'rgba(85, 85, 85, 1)',
-    inherit: 'inherit',
-    currentColor: 'currentColor',
   },
 } as const
 

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -14,6 +14,8 @@ const CloseButton = ({ onClose, disableSwipeToDismiss }: { onClose: () => void; 
         upperRightRecipe(),
         css({
           fontSize: 'sm',
+          // inherit not yet supported by plugin
+          // eslint-disable-next-line @pandacss/no-hardcoded-color
           color: 'inherit',
           right: '0',
           textDecoration: 'none',

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -262,6 +262,8 @@ const ContextBreadcrumbs = ({
                   staticText={staticText}
                   linkCssRaw={css.raw(
                     {
+                      // inherit not yet supported by plugin
+                      // eslint-disable-next-line @pandacss/no-hardcoded-color
                       color: 'inherit',
                       textDecoration: 'none',
                       '&:active': { color: 'activeBreadCrumb', WebkitTextStrokeWidth: '0.05em' },

--- a/src/components/Tutorial/TutorialNavigation.tsx
+++ b/src/components/Tutorial/TutorialNavigation.tsx
@@ -53,6 +53,8 @@ const TutorialNavigation = ({
             return (
               <a
                 className={css({
+                  // inherit not yet supported by plugin
+                  // eslint-disable-next-line @pandacss/no-hardcoded-color
                   color: 'inherit',
                   textDecoration: 'none',
                   fontSize: '32px',

--- a/src/components/modals/ModalComponent.tsx
+++ b/src/components/modals/ModalComponent.tsx
@@ -90,6 +90,8 @@ class ModalComponent extends React.Component<ModalProps> {
               margin: '-10px -20px',
               position: 'fixed',
               right: '11px',
+              // inherit not yet supported by plugin
+              // eslint-disable-next-line @pandacss/no-hardcoded-color
               color: 'inherit',
               textDecoration: 'none',
               /* spacing.safeAreaTop applies for rounded screens */


### PR DESCRIPTION
Remove inherit + currentColor design tokens, use `// eslint-disable-next-line @pandacss/no-hardcoded-color`

Patch for this issue: https://github.com/chakra-ui/eslint-plugin-panda/issues/208