### PR TITLE
Note: remove asyncFocus, restore focus on create

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -11,8 +11,7 @@ import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
 import { setNoteFocusActionCreator as setNoteFocus } from '../actions/setNoteFocus'
 import { toggleNoteActionCreator as toggleNote } from '../actions/toggleNote'
-import { isTouch } from '../browser'
-import asyncFocus from '../device/asyncFocus'
+import { isSafari, isTouch } from '../browser'
 import * as selection from '../device/selection'
 import simplifyPath from '../selectors/simplifyPath'
 import store from '../stores/app'
@@ -50,6 +49,9 @@ const Note = React.memo(({ path }: { path: Path }) => {
     // cursor must be true if note is focused
     if (hasFocus) {
       selection.set(noteRef.current!, { end: true })
+      // deleting a note, then closing the keyboard, then creating a new note could result in lack of focus,
+      // perhaps related to iOS Safari's internal management of selection ranges and focus
+      if (isTouch && isSafari()) noteRef.current?.focus()
     }
   }, [hasFocus])
 
@@ -75,7 +77,6 @@ const Note = React.memo(({ path }: { path: Path }) => {
     else if (e.key === 'Backspace' && !note) {
       e.stopPropagation() // prevent delete thought
       e.preventDefault()
-      asyncFocus()
       dispatch(deleteAttribute({ path, value: '=note' }))
       dispatch(setNoteFocus({ value: false }))
     } else if (e.key === 'ArrowDown') {


### PR DESCRIPTION
Fixes #2691 

Calling `asyncFocus()` was blurring the editable, setting `editing` to `false` and triggering the whole editable's `onFocus` routine which calls `setCursorOnThought` with no offset. Without `asyncFocus()`, the caret pops back up to the end of the thought when a note is deleted.

Notes were also failing to focus in certain situations such as the following:

1. Delete an existing note (caret returns to main thought)
2. Close the keyboard
3. Create a note via gesture
4. No caret, keyboard stays closed

Explicitly calling `focus()` on the node causes it to focus regardless of how many previous notes have been edited or deleted.