### PR TITLE
LayoutTree: no hideCaret animation for 1st thought

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -937,7 +937,12 @@ const LayoutTree = () => {
   return (
     <div
       // the hideCaret animation must run every time the indent changes on iOS Safari, which necessitates replacing the animation with an identical substitute with a different name
-      className={cx(css({ marginTop: '0.501em' }), hideCaret({ animation: getHideCaretAnimationName(indentDepth) }))}
+      className={cx(
+        css({ marginTop: '0.501em' }),
+        hideCaret({
+          animation: treeThoughts.length > 1 ? getHideCaretAnimationName(indentDepth) : 'none',
+        }),
+      )}
       style={{
         // add a full viewport height's space above to ensure that there is room to scroll by the same amount as spaceAbove
         transform: `translateY(${-spaceAboveExtended + viewportHeight}px)`,

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -940,7 +940,7 @@ const LayoutTree = () => {
       className={cx(
         css({ marginTop: '0.501em' }),
         hideCaret({
-          animation: treeThoughts.length > 1 ? getHideCaretAnimationName(indentDepth) : 'none',
+          animation: getHideCaretAnimationName(indentDepth),
         }),
       )}
       style={{

--- a/src/util/getHideCaretAnimationName.ts
+++ b/src/util/getHideCaretAnimationName.ts
@@ -23,6 +23,9 @@ export const hideCaretAnimationNames = [
 
 const hideCaret = cva({
   base: {
+    // apply the animation to the LayoutTree in all circumstances so that it will not "change" when a new thought is added,
+    // but only "play" the animation if there are multiple thoughts
+    // the depth level will change as it always has, but the animation will not play at depth 0 when a new thought is added
     '&:has([aria-label=tree-node]:nth-child(2))': {
       animationDuration: 'layoutSlowShift',
     },

--- a/src/util/getHideCaretAnimationName.ts
+++ b/src/util/getHideCaretAnimationName.ts
@@ -23,7 +23,9 @@ export const hideCaretAnimationNames = [
 
 const hideCaret = cva({
   base: {
-    animationDuration: 'layoutSlowShift',
+    '&:has([aria-label=tree-node]:nth-child(2))': {
+      animationDuration: 'layoutSlowShift',
+    },
   },
   variants: {
     animation: hideCaretAnimationNames.reduce(


### PR DESCRIPTION
Fixes #2708 

Any `hideCaret` animation value will trigger the animation when it is first applied. If there's only one thought, use `'none'` as the animation value, which will not play an animation. There will not be any indentation changes while only one thought exists, so there will be no need to hide the caret.