### PR TITLE
cursorCleared: remove asyncFocus

### DIFF
--- a/src/actions/cursorCleared.ts
+++ b/src/actions/cursorCleared.ts
@@ -1,6 +1,5 @@
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
-import asyncFocus from '../device/asyncFocus'
 
 /**
  * Sets state.cursorCleared which controls a special state in which the cursor is rendered as an empty string. In this state the thought can be deleted or edited, but if the user navigates away the thought is restored to its previous value.
@@ -26,7 +25,6 @@ export const cursorClearedActionCreator =
     // This can occur when switching windows which triggers onBlur.
     // See: https://github.com/cybersemics/em/issues/1556
     if (getState().cursorCleared !== value) {
-      asyncFocus()
       dispatch({ type: 'cursorCleared', value })
     }
   }

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -51,6 +51,7 @@ const useEditMode = ({
           selection.clear()
         } else {
           selection.set(contentRef.current, { offset: editingCursorOffset || 0 })
+          if (isTouch && isSafari()) contentRef.current?.focus()
         }
       }
 


### PR DESCRIPTION
Fixes #2705 

Calling `asyncFocus()` after `clearThought` triggers the editable's `onBlur` which dispatches `cursorCleared({ value: false })`, which undoes the whole `clearThought` operation.

<img width="1152" alt="Screenshot 2025-01-15 at 10 23 33" src="https://github.com/user-attachments/assets/1fcd9a75-2f92-4f67-aea8-e22b30738a12" />

Without `asyncFocus()`, `clearThought` can proceed as intended.

<img width="1157" alt="Screenshot 2025-01-15 at 10 24 26" src="https://github.com/user-attachments/assets/7bf9324a-d58e-442f-991a-58b1d92ccee5" />

`asyncFocus()` was triggered on any `clearThought`, and the reason why it's failing in this specific case is because `selection.isText()` return `true` on a basic `clearThought`, and `false` after `cursorForward`. The reason for this is because the native selection sets `focusNode` to the text node within the editable, while `cursorForward` is setting `focusNode` to the editable `div`.