### PR TITLE
Re-render cursor thought on undo

### DIFF
--- a/src/e2e/puppeteer/__tests__/caret.ts
+++ b/src/e2e/puppeteer/__tests__/caret.ts
@@ -2,7 +2,6 @@ import { KnownDevices } from 'puppeteer'
 import click from '../helpers/click'
 import clickBullet from '../helpers/clickBullet'
 import clickThought from '../helpers/clickThought'
-import down from '../helpers/down'
 import emulate from '../helpers/emulate'
 import getEditingText from '../helpers/getEditingText'
 import getSelection from '../helpers/getSelection'
@@ -160,8 +159,7 @@ describe('all platforms', () => {
     // await press('Enter')
     await press('End')
     await press('Tab')
-    await down('Shift')
-    await press('Tab')
+    await press('Tab', { shift: true })
 
     const nodeType = await getSelection().focusNode?.nodeType
     expect(nodeType).toBe(Node.ELEMENT_NODE)

--- a/src/e2e/puppeteer/__tests__/commandPalette.ts
+++ b/src/e2e/puppeteer/__tests__/commandPalette.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { KnownDevices } from 'puppeteer'
-import { isMac } from '../../../browser'
 import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import paste from '../helpers/paste'
@@ -17,13 +16,7 @@ expect.extend({
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
 it('open with keyboard', async () => {
-  // Simulate pressing Ctrl + P or Command + P
-  //    process.platform === 'darwin'
-  const modifierKey = isMac ? 'Meta' : 'Control' // Use Meta for macOS, Control for others
-
-  await page.keyboard.down(modifierKey)
-  await press('P')
-  await page.keyboard.up(modifierKey)
+  await press('P', { meta: true })
 
   // TODO: Replace sleep with wait
   await sleep(200)

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -16,9 +16,7 @@ const pastePlainText = async (text: string) => {
     ])
   }, text)
 
-  await page.keyboard.down('Shift')
-  await page.keyboard.press('Insert')
-  await page.keyboard.up('Shift')
+  await press('Insert', { shift: true })
 }
 
 /** Custom helper for pasting HTML, avoiding the existing `paste` helper that uses `importText` internally. */
@@ -33,9 +31,7 @@ const pasteHTML = async (html: string) => {
     ])
   }, html)
 
-  await page.keyboard.down('Shift')
-  await page.keyboard.press('Insert')
-  await page.keyboard.up('Shift')
+  await press('Insert', { shift: true })
 }
 
 it('escapes typed HTML', async () => {

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import configureSnapshots from '../configureSnapshots'
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
+import down from '../helpers/down'
+import getEditingText from '../helpers/getEditingText'
 import hideHUD from '../helpers/hideHUD'
 import keyboard from '../helpers/keyboard'
 import paste from '../helpers/paste'
@@ -9,6 +11,7 @@ import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
+import { page } from '../setup'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -227,5 +230,32 @@ describe('Color Theme', () => {
     await hideHUD()
 
     expect(await screenshot()).toMatchImageSnapshot()
+  })
+})
+
+describe('Undo/Redo', () => {
+  it('Re-render cursor thought on undo', async () => {
+    // create a thought "hello"
+    await press('Enter')
+    await keyboard.type('hello')
+
+    // create a thought "a"
+    await press('Enter')
+    await keyboard.type('a')
+
+    // edit "hello" to "hello world"
+    await clickThought('hello')
+    await page.keyboard.down('Control')
+    await press('ArrowRight')
+    await page.keyboard.up('Control')
+    await keyboard.type(' world')
+
+    // undo
+    await page.keyboard.down('Control')
+    await press('z')
+    await page.keyboard.up('Control')
+
+    const thoughtValue = await getEditingText()
+    expect(thoughtValue).toBe('hello')
   })
 })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -2,7 +2,6 @@ import path from 'path'
 import configureSnapshots from '../configureSnapshots'
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
-import down from '../helpers/down'
 import getEditingText from '../helpers/getEditingText'
 import hideHUD from '../helpers/hideHUD'
 import keyboard from '../helpers/keyboard'
@@ -11,7 +10,6 @@ import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
-import { page } from '../setup'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -245,15 +243,11 @@ describe('Undo/Redo', () => {
 
     // edit "hello" to "hello world"
     await clickThought('hello')
-    await page.keyboard.down('Control')
-    await press('ArrowRight')
-    await page.keyboard.up('Control')
+    await press('ArrowRight', { ctrl: true })
     await keyboard.type(' world')
 
     // undo
-    await page.keyboard.down('Control')
-    await press('z')
-    await page.keyboard.up('Control')
+    await press('z', { meta: true })
 
     const thoughtValue = await getEditingText()
     expect(thoughtValue).toBe('hello')

--- a/src/e2e/puppeteer/helpers/down.ts
+++ b/src/e2e/puppeteer/helpers/down.ts
@@ -1,9 +1,0 @@
-import { KeyInput, Keyboard } from 'puppeteer'
-import { page } from '../setup'
-
-type Options = Parameters<Keyboard['down']>[1]
-
-/** Holds down a key on the keyboad. */
-const down = (key: KeyInput, options?: Options) => page.keyboard.down(key, options)
-
-export default down

--- a/src/e2e/puppeteer/helpers/keyboard.ts
+++ b/src/e2e/puppeteer/helpers/keyboard.ts
@@ -1,8 +1,8 @@
 import { page } from '../setup'
 
-/** Type text on the keyboard. */
+/** Type text on the keyboard. To press a key (optionally with modifiers), see the press helper. */
 const keyboard = {
-  // export keyboard object because 'type' is a reserved word
+  // export keyboard object because 'type' is a reserved word and cannot be used as a function name
   type: (text: string) => page.keyboard.type(text),
 }
 

--- a/src/e2e/puppeteer/helpers/newThought.ts
+++ b/src/e2e/puppeteer/helpers/newThought.ts
@@ -1,12 +1,13 @@
-import { page } from '../setup'
+import keyboard from './keyboard'
+import press from './press'
 import waitForEditable from './waitForEditable'
 
 /** Creates a new thought by hitting Enter and typing text. Waits for renders between each step. */
 const newThought = async (value?: string) => {
-  await page.keyboard.press('Enter')
+  await press('Enter')
   await waitForEditable('')
   if (value) {
-    await page.keyboard.type(value)
+    await keyboard.type(value)
     await waitForEditable(value)
   }
 }

--- a/src/e2e/puppeteer/helpers/press.ts
+++ b/src/e2e/puppeteer/helpers/press.ts
@@ -3,7 +3,20 @@ import { page } from '../setup'
 
 type Options = Parameters<Keyboard['press']>[1]
 
-/** Presses a key on the keyboad. */
-const press = (key: KeyInput, options?: Options) => page.keyboard.press(key, options)
+/** Presses a key on the keyboad. Extends page.keyboard.press options with meta, ctrl, and shift for easy modifier presses. */
+const press = async (
+  key: KeyInput,
+  { ctrl, meta, shift, ...options }: Options & { ctrl?: boolean; meta?: boolean; shift?: boolean } = {},
+) => {
+  if (ctrl) await page.keyboard.down('Control')
+  if (meta) await page.keyboard.down('Meta')
+  if (shift) await page.keyboard.down('Shift')
+
+  await page.keyboard.press(key, options)
+
+  if (ctrl) await page.keyboard.up('Control')
+  if (meta) await page.keyboard.up('Meta')
+  if (shift) await page.keyboard.up('Shift')
+}
 
 export default press

--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -8,6 +8,7 @@ import Lexeme from '../@types/Lexeme'
 import Patch from '../@types/Patch'
 import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
+import editableRender from '../actions/editableRender'
 import updateThoughts from '../actions/updateThoughts'
 import getThoughtById from '../selectors/getThoughtById'
 import headValue from '../util/headValue'
@@ -271,6 +272,7 @@ const undoReducer = (state: State, undoPatches: Patch[]) => {
     undoOneReducer,
     undoTwice ? undoOneReducer : null,
     newState => restorePushQueueFromPatches(newState, state, poppedUndoPatches.flat()),
+    editableRender,
   ])(state)
 }
 
@@ -290,6 +292,7 @@ const redoReducer = (state: State, redoPatches: Patch[]) => {
     redoTwice ? redoOneReducer : null,
     redoOneReducer,
     newState => restorePushQueueFromPatches(newState, state, poppedPatches.flat()),
+    editableRender,
   ])(state)
 }
 


### PR DESCRIPTION
ContentEditable does not re-render by default on value change when it has the focus in order to avoid interfering with typing. However, this causes the cursor thought to not re-render on undo.

This PR forces a re-render on undo and adds a puppeteer test.