### PR TITLE
Factor out useOnPaste logic into importData action creator

### DIFF
--- a/src/actions/importData.ts
+++ b/src/actions/importData.ts
@@ -1,0 +1,117 @@
+import SimplePath from '../@types/SimplePath'
+import Thunk from '../@types/Thunk'
+import * as selection from '../device/selection'
+import rootedParentOf from '../selectors/rootedParentOf'
+import isMarkdown from '../util/isMarkdown'
+import strip from '../util/strip'
+import timestamp from '../util/timestamp'
+import { importFilesActionCreator as importFiles } from './importFiles'
+import { importTextActionCreator as importText } from './importText'
+import { newThoughtActionCreator as newThought } from './newThought'
+
+interface ImportDataPayload {
+  path: SimplePath
+  text: string
+  html: string | null
+  rawDestValue: string
+  transient?: boolean
+  isEmText?: boolean
+}
+
+/** Action-creator for importData. This is an action that handles importing content
+ * into the application, choosing between importText and importFiles based on the content type.
+ *
+ * This action is primarily used when:
+ * - Pasting content (plain text, formatted text, or HTML) into the application.
+ * - Importing content from external sources.
+ * - Handling clipboard data with mixed formats.
+ *
+ * Key features:
+ * - Handles both single-line and multi-line content.
+ * - Supports markdown content.
+ * - Can preserve or strip text formatting based on configuration.
+ *
+ * Differences from other import actions:
+ * - importText: Used for single-line content or markdown. Handles inline text insertion and replacement.
+ * - importFiles: Used for multi-line, non-markdown content. Creates new thought structures for each line.
+ *
+ * @param payload - Configuration object for importing data.
+ * @param payload.path - The path where the data should be imported.
+ * @param payload.text - The plain text content to be imported.
+ * @param payload.html - HTML content to be imported, or null if importing plain text.
+ * @param payload.rawDestValue - The untrimmed destination value to preserve whitespace when combining with existing content.
+ * @param payload.transient - If true, creates a new empty thought before importing the text.
+ * @param payload.isEmText - If true, preserves formatting when stripping HTML. Default: false.
+ *
+ * @returns A Thunk that handles importing the data based on whether it is multiline or markdown.
+ */
+export const importDataActionCreator = ({
+  path,
+  text,
+  html,
+  rawDestValue,
+  transient,
+  isEmText = false,
+}: ImportDataPayload): Thunk => {
+  return (dispatch, getState) => {
+    const state = getState()
+
+    // If transient first add new thought and then import the text
+    if (transient) {
+      dispatch(
+        newThought({
+          at: rootedParentOf(state, path),
+          value: '',
+        }),
+      )
+    }
+
+    const processedText = html
+      ? strip(html, { preserveFormatting: isEmText, stripColors: !isEmText }).replace(/\n\s*\n+/g, '\n')
+      : text.trim()
+
+    const multiline = text.trim().includes('\n')
+    const markdown = isMarkdown(processedText)
+
+    if (!multiline || markdown) {
+      dispatch(
+        importText({
+          // use caret position to correctly track the last navigated point for caret
+          // calculated on the basis of node type we are currently focused on. `state.cursorOffset` doesn't really keep track of updated caret position when navigating within single thought. Hence selection.offset() is also used depending upon which node type we are on.
+          caretPosition: (selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0,
+          path,
+          text: processedText,
+          // text/plain may contain text that ultimately looks like html (contains <li>) and should be parsed as html
+          // pass the untrimmed old value to importText so that the whitespace is not loss when combining the existing value with the pasted value
+          rawDestValue,
+          // use selection start and end for importText to replace (if the imported thoughts are one line)
+          ...(selection.isActive() && !selection.isCollapsed()
+            ? {
+                replaceStart: selection.offsetStart()!,
+                replaceEnd: selection.offsetEnd()!,
+              }
+            : null),
+        }),
+      )
+    } else {
+      // importFiles passes preventSetCursor: true to newThought so the selection will stay disabled
+      selection.clear()
+
+      dispatch(
+        importFiles({
+          path,
+          files: [
+            {
+              lastModified: timestamp(),
+              name: 'from clipboard',
+              size: processedText.length * 8,
+              text: async () => processedText,
+            },
+          ],
+        }),
+      )
+    }
+  }
+}
+
+export default importDataActionCreator

--- a/src/actions/importData.ts
+++ b/src/actions/importData.ts
@@ -69,10 +69,14 @@ export const importDataActionCreator = ({
     const processedText = html
       ? strip(html, { preserveFormatting: isEmText, stripColors: !isEmText }).replace(/\n\s*\n+/g, '\n')
       : text.trim()
-
+    // Is this an adequate check if the thought is multiline, or do we need to use textToHtml like in importText?
     const multiline = text.trim().includes('\n')
+
+    // Check if the text is markdown, if so, prefer importText over importFiles
     const markdown = isMarkdown(processedText)
 
+    // Resumable imports (via importFiles) import thoughts one at a time and can be resumed if the page is refreshed or there is another interruption. They have a progress bar and they allow duplicates pending descendants to be loaded and merged.
+    // Non-resumable imports (via importText), in contrast, are atomic, fast, and preserve the browser selection. Due to the lack of support for duplicates pending descendants, they are only used for single line imports.
     if (!multiline || markdown) {
       dispatch(
         importText({

--- a/src/components/Editable/useOnPaste.ts
+++ b/src/components/Editable/useOnPaste.ts
@@ -62,7 +62,6 @@ const useOnPaste = ({
         )
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [simplePath, transient, contentRef, dispatch],
   )
 }

--- a/src/components/Editable/useOnPaste.ts
+++ b/src/components/Editable/useOnPaste.ts
@@ -2,16 +2,10 @@ import { escape as escapeHtml } from 'html-escaper'
 import React, { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 import SimplePath from '../../@types/SimplePath'
-import { importFilesActionCreator as importFiles } from '../../actions/importFiles'
-import { importTextActionCreator as importText } from '../../actions/importText'
-import { newThoughtActionCreator as newThought } from '../../actions/newThought'
-import * as selection from '../../device/selection'
-import rootedParentOf from '../../selectors/rootedParentOf'
+import { importDataActionCreator as importData } from '../../actions/importData'
 import store from '../../stores/app'
 import equalPath from '../../util/equalPath'
-import isMarkdown from '../../util/isMarkdown'
 import strip from '../../util/strip'
-import timestamp from '../../util/timestamp'
 
 /** Returns an onPaste handler that parses and inserts the pasted text or thoughts at the cursor. Handles plaintext and HTML, inline and nested paste. */
 const useOnPaste = ({
@@ -24,15 +18,14 @@ const useOnPaste = ({
   transient?: boolean
 }) => {
   const dispatch = useDispatch()
-  const onPaste = useCallback(
+
+  return useCallback(
     (e: React.ClipboardEvent) => {
-      // mobile Safari copies URLs as 'text/uri-list' when the share button is used
       const plainText = e.clipboardData.getData('text/plain') || e.clipboardData.getData('text/uri-list')
       const htmlText = e.clipboardData.getData('text/html')
-      // Puppeteer does not allow setData with other MIME types. If the browser is controlled by automation, or the clipboard comes from em, set true.
-      const emText = navigator.webdriver || !!e.clipboardData.getData('text/em')
+      const isEmText = navigator.webdriver || !!e.clipboardData.getData('text/em')
 
-      // import raw thoughts: confirm before overwriting state
+      // Handle raw thought import confirmation
       if (
         typeof window !== 'undefined' &&
         plainText.startsWith(`{
@@ -49,80 +42,26 @@ const useOnPaste = ({
       // See: https://github.com/cybersemics/em/issues/286
       if (plainText || htmlText) {
         e.preventDefault()
-
         // import into the live thoughts
         // neither ref.current is set here nor can newValue be stored from onChange
         // not sure exactly why, but it appears that the DOM node has been removed before the paste handler is called
-        const { cursor, cursorOffset: cursorOffsetState } = store.getState()
-        const path = cursor && equalPath(cursor, simplePath) ? cursor : simplePath
+        const { cursor } = store.getState()
+        const path = (cursor && equalPath(cursor, simplePath) ? cursor : simplePath) as SimplePath
 
-        // If transient first add new thought and then import the text
-        if (transient) {
-          dispatch(
-            newThought({
-              at: rootedParentOf(store.getState(), path),
-              value: '',
-            }),
-          )
-        }
-
-        const text = htmlText
-          ? strip(htmlText, { preserveFormatting: emText, stripColors: !emText }).replace(/\n\s*\n+/g, '\n') // Clean HTML from clipboard
-          : escapeHtml(plainText.trim()) // Escape plain text from clipboard
-
-        // Is this an adequate check if the thought is multiline, or do we need to use textToHtml like in importText?
-        const multiline = plainText.trim().includes('\n')
-
-        // Check if the text is markdown, if so, prefer importText over importFiles
-        const markdown = isMarkdown(text)
-        // Resumable imports (via importFiles) import thoughts one at a time and can be resumed if the page is refreshed or there is another interruption. They have a progress bar and they allow duplicates pending descendants to be loaded and merged.
-        // Non-resumable imports (via importText), in contrast, are atomic, fast, and preserve the browser selection. Due to the lack of support for duplicates pending descendants, they are only used for single line imports.
-        if (!multiline || markdown) {
-          dispatch(
-            importText({
-              // use caret position to correctly track the last navigated point for caret
-              // calculated on the basis of node type we are currently focused on. `state.cursorOffset` doesn't really keep track of updated caret position when navigating within single thought. Hence selection.offset() is also used depending upon which node type we are on.
-              caretPosition: (selection.isText() ? selection.offset() || 0 : cursorOffsetState) || 0,
-              path,
-              text,
-              // text/plain may contain text that ultimately looks like html (contains <li>) and should be parsed as html
-              // pass the untrimmed old value to importText so that the whitespace is not loss when combining the existing value with the pasted value
-              rawDestValue: strip(contentRef.current!.innerHTML, { preventTrim: true }),
-              // use selection start and end for importText to replace (if the imported thoughts are one line)
-              ...(selection.isActive() && !selection.isCollapsed()
-                ? {
-                    replaceStart: selection.offsetStart()!,
-                    replaceEnd: selection.offsetEnd()!,
-                  }
-                : null),
-            }),
-          )
-        } else {
-          // importFiles passes preventSetCursor: true to newThought so the selection will stay disabled
-          selection.clear()
-
-          dispatch(
-            importFiles({
-              path,
-              files: [
-                {
-                  lastModified: timestamp(),
-                  name: 'from clipboard',
-                  // approximate byte size of text
-                  size: text.length * 8,
-                  text: async () => text,
-                },
-              ],
-            }),
-          )
-        }
+        dispatch(
+          importData({
+            path,
+            text: escapeHtml(plainText),
+            html: htmlText,
+            rawDestValue: strip(contentRef.current!.innerHTML, { preventTrim: true }),
+            transient,
+            isEmText,
+          }),
+        )
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [simplePath, transient],
+    [simplePath, transient, contentRef, dispatch],
   )
-
-  return onPaste
 }
 
 export default useOnPaste

--- a/src/components/Editable/useOnPaste.ts
+++ b/src/components/Editable/useOnPaste.ts
@@ -21,8 +21,10 @@ const useOnPaste = ({
 
   return useCallback(
     (e: React.ClipboardEvent) => {
+      // mobile Safari copies URLs as 'text/uri-list' when the share button is used
       const plainText = e.clipboardData.getData('text/plain') || e.clipboardData.getData('text/uri-list')
       const htmlText = e.clipboardData.getData('text/html')
+      // Puppeteer does not allow setData with other MIME types. If the browser is controlled by automation, or the clipboard comes from em, set true.
       const isEmText = navigator.webdriver || !!e.clipboardData.getData('text/em')
 
       // Handle raw thought import confirmation
@@ -60,6 +62,7 @@ const useOnPaste = ({
         )
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [simplePath, transient, contentRef, dispatch],
   )
 }


### PR DESCRIPTION
In this PR, I have created a new action creator called importData.
And shift `useOnPaste`'s main logic into `importData` action creator.
