### PR TITLE
Fix notion nested bulleted list import error

### DIFF
--- a/src/actions/importData.ts
+++ b/src/actions/importData.ts
@@ -32,8 +32,7 @@ const processHtmlContent = (html: string, isEmText: boolean): string => {
   }
 
   // Otherwise strip the HTML
-  return strip(html, { preserveFormatting: isEmText, stripColors: !isEmText })
-    .replace(/\n\s*\n+/g, '\n')
+  return strip(html, { preserveFormatting: isEmText, stripColors: !isEmText }).replace(/\n\s*\n+/g, '\n')
 }
 
 /** Action-creator for importData. This is an action that handles importing content
@@ -84,9 +83,7 @@ export const importDataActionCreator = ({
       )
     }
 
-    const processedText = html
-      ? processHtmlContent(html, isEmText)
-      : text.trim()
+    const processedText = html ? processHtmlContent(html, isEmText) : text.trim()
     // Is this an adequate check if the thought is multiline, or do we need to use textToHtml like in importText?
     const multiline = text.trim().includes('\n')
 


### PR DESCRIPTION
This PR resolves the issue : https://github.com/cybersemics/em/issues/2747

This issue is occured because `strip` function removes the nested list and return a list.

So, in this PR, I added a new `processHtmlContent` function that checks if the HTML has nested list structure.
If it does, preserves the structure while only cleaning up unnecessary artifacts
If not, falls back to the original stripping behavior.

I use this function instead of directly calling `strip` on the HTML content.