### PR TITLE
fix sort error after edit

### DIFF
--- a/src/actions/editThought.ts
+++ b/src/actions/editThought.ts
@@ -144,7 +144,7 @@ const editThought = (state: State, { cursorOffset, force, oldValue, newValue, pa
     value: newValue,
     // store the last non-empty value to preserve the sort order of thoughts edited to empty
     // reset to undefined when newValue is non-empty
-    ...(newValue ? undefined : { sortValue: oldValue || editedThought.sortValue }),
+    ...(newValue ? { sortValue: undefined } : { sortValue: oldValue || editedThought.sortValue }),
     lastUpdated: timestamp(),
     updatedBy: clientId,
   }

--- a/src/actions/editThought.ts
+++ b/src/actions/editThought.ts
@@ -144,7 +144,7 @@ const editThought = (state: State, { cursorOffset, force, oldValue, newValue, pa
     value: newValue,
     // store the last non-empty value to preserve the sort order of thoughts edited to empty
     // reset to undefined when newValue is non-empty
-    ...(newValue ? { sortValue: undefined } : { sortValue: oldValue || editedThought.sortValue }),
+    sortValue: newValue ? undefined : oldValue || editedThought.sortValue,
     lastUpdated: timestamp(),
     updatedBy: clientId,
   }

--- a/src/commands/__tests__/toggleSort.ts
+++ b/src/commands/__tests__/toggleSort.ts
@@ -827,6 +827,54 @@ describe('store', () => {
   - a
   - b`)
     })
+
+    it('preserve sort order after multiple sort', async () => {
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - 1
+              - 2
+            `,
+          }),
+          setCursor(['1']),
+        ])
+      })
+
+      act(() => executeCommand(toggleSortCommand, { store }))
+      act(() =>
+        store.dispatch(
+          editThought({
+            oldValue: '1',
+            newValue: '3',
+            path: contextToPath(store.getState(), ['1']) as SimplePath,
+          }),
+        ),
+      )
+      const state = store.getState()
+      const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
+      expect(exported).toEqual(`- ${HOME_TOKEN}
+  - =sort
+    - Alphabetical
+      - Asc
+  - 2
+  - 3`)
+
+      act(() => executeCommand(toggleSortCommand, { store }))
+      act(() => executeCommand(toggleSortCommand, { store }))
+      act(() => executeCommand(toggleSortCommand, { store }))
+
+      // await act(() => vi.runOnlyPendingTimersAsync())
+
+      const newState = store.getState()
+      const lastExported = exportContext(newState, [HOME_TOKEN], 'text/plain')
+      expect(lastExported).toEqual(`- ${HOME_TOKEN}
+  - =sort
+    - Alphabetical
+      - Asc
+  - 2
+  - 3`)
+    })
   })
 
   describe('global sort', () => {

--- a/src/commands/__tests__/toggleSort.ts
+++ b/src/commands/__tests__/toggleSort.ts
@@ -829,27 +829,30 @@ describe('store', () => {
     })
 
     it('preserve sort order after multiple sort', async () => {
-      act(() => {
-        store.dispatch([
-          importText({
-            text: `
+      store.dispatch([
+        importText({
+          text: `
               - 1
               - 2
             `,
-          }),
-          setCursor(['1']),
-        ])
-      })
+        }),
+        setCursor(['1']),
+      ])
+      executeCommand(toggleSortCommand, { store })
 
-      act(() => executeCommand(toggleSortCommand, { store }))
-      act(() =>
-        store.dispatch(
-          editThought({
-            oldValue: '1',
-            newValue: '3',
-            path: contextToPath(store.getState(), ['1']) as SimplePath,
-          }),
-        ),
+      store.dispatch(
+        editThought({
+          oldValue: '1',
+          newValue: '',
+          path: contextToPath(store.getState(), ['1']) as SimplePath,
+        }),
+      )
+      store.dispatch(
+        editThought({
+          oldValue: '',
+          newValue: '3',
+          path: contextToPath(store.getState(), ['']) as SimplePath,
+        }),
       )
       const state = store.getState()
       const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
@@ -860,12 +863,9 @@ describe('store', () => {
   - 2
   - 3`)
 
-      act(() => executeCommand(toggleSortCommand, { store }))
-      act(() => executeCommand(toggleSortCommand, { store }))
-      act(() => executeCommand(toggleSortCommand, { store }))
-
-      // await act(() => vi.runOnlyPendingTimersAsync())
-
+      executeCommand(toggleSortCommand, { store })
+      executeCommand(toggleSortCommand, { store })
+      executeCommand(toggleSortCommand, { store })
       const newState = store.getState()
       const lastExported = exportContext(newState, [HOME_TOKEN], 'text/plain')
       expect(lastExported).toEqual(`- ${HOME_TOKEN}


### PR DESCRIPTION
This PR resolves the issue : Sort error after edit #2768

This error is caused because there was an issue in storing the last none-empty value.

So, in this PR, I have fixed the thoughtNew object to reset the sortValue to undefined when newValue is non-empty.
Like this.
`...(newValue ? { sortValue: undefined } : { sortValue: oldValue || editedThought.sortValue }),`