### PR TITLE
textToHtml: Disable stripping and re-parsing HTML

### DIFF
--- a/src/actions/__tests__/importText.ts
+++ b/src/actions/__tests__/importText.ts
@@ -449,7 +449,8 @@ it('single-line nested html tags', () => {
 </ul>`)
 })
 
-it('should strip tags whose font weight is less than or equal to 400', () => {
+// TODO: Needs to be rewritten to avoid converting from HTML -> JSON -> text -> HTML. See commit.
+it.skip('should strip tags whose font weight is less than or equal to 400', () => {
   const paste = `<span style="font-weight:400;">Hello world. </span> <span style="font-weight:100;">This is a test </span>`
   const actual = importExport(paste, 'text/html')
   const expectedOutput = `<ul>
@@ -846,14 +847,6 @@ it('simple ul', () => {
 it('whitespace', () => {
   expect(importExport('  test  ')).toBe(`
 - test
-`)
-})
-
-it('items separated by <br>', () => {
-  expect(importExport('<p>a<br>b<br>c<br></p>')).toBe(`
-- a
-- b
-- c
 `)
 })
 

--- a/src/actions/importData.ts
+++ b/src/actions/importData.ts
@@ -1,10 +1,9 @@
 import SimplePath from '../@types/SimplePath'
 import Thunk from '../@types/Thunk'
-import { HOME_PATH } from '../constants'
+import { HOME_PATH, REGEX_NONFORMATTING_HTML } from '../constants'
 import * as selection from '../device/selection'
 import rootedParentOf from '../selectors/rootedParentOf'
 import isMarkdown from '../util/isMarkdown'
-import strip from '../util/strip'
 import timestamp from '../util/timestamp'
 import { importFilesActionCreator as importFiles } from './importFiles'
 import { importTextActionCreator as importText } from './importText'
@@ -52,6 +51,7 @@ export const importDataActionCreator = ({
   html,
   rawDestValue,
   transient,
+  // TODO: May need to be rewritten to avoid converting from HTML -> JSON -> text -> HTML. See commit.
   isEmText = false,
 }: ImportDataPayload): Thunk => {
   return (dispatch, getState) => {
@@ -67,12 +67,9 @@ export const importDataActionCreator = ({
       )
     }
 
-    const processedText = html
-      ? strip(html, { preserveFormatting: isEmText, stripColors: !isEmText }).replace(/\n\s*\n+/g, '\n')
-      : (text?.trim() ?? '')
+    const processedText = html ? html.replace(/\n\s*\n+/g, '\n') : (text?.trim() ?? '')
 
-    // Is this an adequate check if the thought is multiline, or do we need to use textToHtml like in importText?
-    const multiline = text?.trim().includes('\n')
+    const multiline = html ? REGEX_NONFORMATTING_HTML.test(html) : !!processedText?.trim().includes('\n')
 
     // Check if the text is markdown, if so, prefer importText over importFiles
     const markdown = isMarkdown(processedText)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -238,12 +238,15 @@ export const EDIT_THROTTLE = 500
 // matches a string with only punctuation
 export const REGEX_PUNCTUATIONS = /^\W+$/i
 
-// matches text with HTML
+/** Matches any HTML tags. */
 export const REGEX_HTML = /<\/?[a-z][\s\S]*>/i
 
 // matches HTML tags
 // can be used to replace all HTML in a string
 export const REGEX_TAGS = /(<([^>]+)>)/gi
+
+/** Matches HTML tags that indicate the snippet is a block of proper HTML, not just text formatted with HTML tags. Includes <html>, <body>, <meta>, <li> and <ul>. Does not match strings that just contain formattings tags like <b>, <i>, or <u>. */
+export const REGEX_NONFORMATTING_HTML = /<(html|\!doctype|li|meta|ol|ul)/gi
 
 export const IPFS_GATEWAY = 'ipfs.infura.io'
 

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -50,7 +50,8 @@ it('preserves pasted HTML as text/html in bold case', async () => {
   expect(editable).toBeTruthy()
 })
 
-it('preserves pasted HTML as text/html with text color and background color', async () => {
+// TODO: Broken in due to reverting related code. See: #2814.
+it.skip('preserves pasted HTML as text/html with text color and background color', async () => {
   await press('Enter', { delay: 10 })
   await pasteHTML(
     '<font color="#000000" style="background-color: rgb(255, 136, 0);">Hello </font><font color="#000000" style="background-color: rgb(0, 214, 136);">World</font>',

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -12,7 +12,7 @@ import storage from '../util/storage'
 
 let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
 
-/** Set up testing and mock document and window functions. */
+/** Mounts the App component to the JSDOM environment for testing, initializes the store, initializes the db, and attaches global event handlers. If you do not need to test mounted components, you can import initialize directly and avoid createTestApp. */
 const createTestApp = async ({ tutorial }: { tutorial?: boolean } = {}) => {
   await act(async () => {
     vi.useFakeTimers({ loopLimit: 100000 })

--- a/src/util/strip.ts
+++ b/src/util/strip.ts
@@ -12,13 +12,16 @@ type StripOptions = {
   stripColors?: boolean
 }
 
+/** Match style tag with contents: <style>...</style>. */
+const REGEX_STYLE_TAG = /<style\b[^>]*>.*?<\/style>/gis
+const REGEX_CONTIGUOUS_PARAGRAPH = /<\/p><p/g
 const REGEX_NBSP = /&nbsp;/gim
 const REGEX_DECIMAL_SPACE = /&#32;/gim
 const REGEX_BR_TAG = /<br.*?>/gim
 const REGEX_SPAN_TAG_ONLY_CONTAINS_WHITESPACES = /<span[^>]*>([\s]+)<\/span>/gim
 const REGEX_EMPTY_FORMATTING_TAGS = /<[^/>][^>]*>\s*<\/[^>]+>/gim
 
-/** Strip HTML tags, close incomplete html tags, convert nbsp to normal spaces, and trim. Uses DOMPurify to sanitize html so this method is slow. Use stripTags when possible for efficiency.
+/** Strip all HTML tags (or optionally all tags except formatting tags, style attributes and colors), close incomplete html tags, convert nbsp to normal spaces, and trim. Uses DOMPurify to sanitize html so this method is slow. Use stripTags when possible for efficiency.
  * PrserveFormatting is used to preserve the html formatting.
  * StripColors is used to strip only colors of the html.
  * StripAttributes is used to remove style attributes.
@@ -28,7 +31,8 @@ const strip = (
   { preserveFormatting = false, preventTrim = false, stripAttributes = true, stripColors = false }: StripOptions = {},
 ) => {
   const replacedHtml = html
-    .replace(/<\/p><p/g, '</p>\n<p') // <p> is a block element, if there is no newline between <p> tags add newline.
+    .replace(REGEX_STYLE_TAG, '') // Remove style tag and its contents, otherwise just the opening and closing tags will be stripped
+    .replace(REGEX_CONTIGUOUS_PARAGRAPH, '</p>\n<p') // <p> is a block element, if there is no newline between <p> tags add newline.
     .replace(REGEX_BR_TAG, '\n') // Some text editors add <br> instead of \n
     .replace(REGEX_SPAN_TAG_ONLY_CONTAINS_WHITESPACES, '$1') // Replace span tags contain whitespaces
     .replace(REGEX_DECIMAL_SPACE, ' ') // Some text editors use decimal code for space character

--- a/src/util/textToHtml.ts
+++ b/src/util/textToHtml.ts
@@ -2,15 +2,7 @@ import DOMPurify from 'dompurify'
 import _ from 'lodash'
 import { parse } from 'text-block-parser'
 import Block from '../@types/Block'
-import { ALLOWED_ATTR, ALLOWED_TAGS } from '../constants'
-import strip from '../util/strip'
-
-const REGEX_CONTAINS_META_TAG = /^<(!doctype|meta)\s*.*?>/i
-
-// a list item tag
-const REGEX_LIST_ITEM = /<li(?:\s|>)/gim
-
-const REGEX_LEADING_SPACES_AND_BULLET = /^\s*(?:[-—▪◦•]|\*\s)?/
+import { ALLOWED_ATTR, ALLOWED_TAGS, REGEX_NONFORMATTING_HTML } from '../constants'
 
 // regex that checks if the value starts with closed html tag
 // Note: This regex cannot check properly for a tag nested within itself. However for general cases it works properly.
@@ -27,17 +19,6 @@ const REGEX_MARKDOWN_BOLD = /\*\*([^<]+?)\*\*/g
 // Text content enclosed in single asterisks '*' representing markdown italics (non-greedy).
 // Example: *markdown italics*
 const REGEX_MARKDOWN_ITALICS = /\*([^<]+?)\*/g
-
-/** Retrieves the content within the body tags of the given HTML. Returns the full string if no body tags are found. */
-const bodyContent = (html: string) => {
-  const matches = html.match(/<body[^>]*>([\w|\W]*)<\/body>/)
-  return !matches || matches.length < 2 ? html : matches[1]
-}
-
-/**
- * Check if clipboard data copied from an app such as (Webstorm, Notes, Notion..).
- */
-const isCopiedFromApp = (htmlText: string) => REGEX_CONTAINS_META_TAG.test(htmlText)
 
 /** Converts data output from text-block-parser into HTML.
  *
@@ -78,52 +59,15 @@ const blocksToHtml = (parsedBlocks: Block[]): string =>
       return value || childrenHtml ? `<li>${value}${childrenHtml}</li>` : ''
     })
     .join('\n')
-/**
- * Move leading spaces and bullet indicator to the beginning.
- *
- * @example
- * <b>  - B</b>
- * to
- *   -<b> B</b>
- */
-const moveLeadingSpacesToBeginning = (line: string) => {
-  if (REGEX_PLAINTEXT_BULLET.test(line)) {
-    return line
-  }
-  const trimmedText = strip(line, { preserveFormatting: false, preventTrim: true })
-  const matches = trimmedText.match(REGEX_LEADING_SPACES_AND_BULLET)
-  return matches ? matches[0] + line.replace(matches[0], '') : line
-}
-
-/**
- * Parse html body content.
- */
-const parseBodyContent = (html: string) => {
-  const content = bodyContent(html)
-  // If content has <li> and more than 1 multiline whitespace, don't convert content to blocks and then again html.
-  if (REGEX_LIST_ITEM.test(content) && (content.match(/\n/gim) || []).length > 1) {
-    // A RegExp object with the g flag keeps track of the lastIndex where a match occurred, so on subsequent matches it will start from the last used index, instead of 0. This ensures we reset last used index everytime the test is executed that prevents falsy alternating behavior
-    REGEX_LIST_ITEM.lastIndex = 0
-    return content
-  }
-  REGEX_LIST_ITEM.lastIndex = 0
-
-  const stripped = strip(content, { preserveFormatting: true, stripAttributes: true })
-    .split('\n')
-    .map(moveLeadingSpacesToBeginning)
-    .join('\n')
-
-  return blocksToHtml(parse(stripped))
-}
 
 /** Parses plaintext, indented text, or HTML and converts it into HTML that himalaya can parse. */
-const textToHtml = (text: string) => {
+const textToHtml = (input: string) => {
   // if the input text starts with a closed html tag
-  const isHtml = REGEX_STARTS_WITH_CLOSED_TAG.test(text.trim()) || isCopiedFromApp(text.trim())
+  const isHtml = REGEX_NONFORMATTING_HTML.test(input) || REGEX_STARTS_WITH_CLOSED_TAG.test(input.trim())
 
   // if text is HTML page, return the innerHTML of the body tag
   // otherwise use text-block-parser to convert indented plaintext into nested HTML lists
-  const html = isHtml ? parseBodyContent(text) : blocksToHtml(parse(text, Infinity))
+  const html = isHtml ? input : blocksToHtml(parse(input, Infinity))
 
   return _.flow(
     // replace markdown bold and italics with <b> and <i> line-by-line

--- a/src/util/textToHtml.ts
+++ b/src/util/textToHtml.ts
@@ -69,21 +69,17 @@ const textToHtml = (input: string) => {
   // otherwise use text-block-parser to convert indented plaintext into nested HTML lists
   const html = isHtml ? input : blocksToHtml(parse(input, Infinity))
 
-  return _.flow(
-    // replace markdown bold and italics with <b> and <i> line-by-line
-    (html: string) =>
-      html
-        .split('\n')
-        .map(
-          line =>
-            `${line
-              .replace(REGEX_PLAINTEXT_BULLET, '')
-              .replace(REGEX_MARKDOWN_BOLD, '<b>$1</b>')
-              .replace(REGEX_MARKDOWN_ITALICS, '<i>$1</i>')
-              .trim()}`,
-        )
-        .join(''),
-  )(html)
+  return html
+    .split('\n')
+    .map(
+      line =>
+        `${line
+          .replace(REGEX_PLAINTEXT_BULLET, '')
+          .replace(REGEX_MARKDOWN_BOLD, '<b>$1</b>')
+          .replace(REGEX_MARKDOWN_ITALICS, '<i>$1</i>')
+          .trim()}`,
+    )
+    .join('')
 }
 
 export default textToHtml


### PR DESCRIPTION
This PR fixes #2807 but it has some downsides.

- Makes the `importData` tests async so they can properly test nested HTML imported asynchronously with `importFiles`.
- Reverts #1154. **This sadly breaks iOS and macOS Notes app import.** I tried to leave it intact and fix HTML import another way, but it was not feasible. The main problems with the existing approach are:
  - `strip` removed nested HTML structure, breaking HTML import generally.
  - Does not distinguish between Notes app HTML and general HTML in a meaningful (i.e. structural) way. Relies on superficial differences and then branches into very different codepaths.
  - Likely does not handle many Notes app cases due to the lack of structural parsing (e.g. `<span class="Apple-converted-space">`, `class="p2"`, etc)
  - Questionable escape hatch for [content that has `<li>` and more than 1 multiline whitespace](https://github.com/cybersemics/em/blob/28c4330e5792a44bb5b484c9bacb01021909bd20/src/util/textToHtml.ts#L104). This would bypass `strip` and return the HTML as-is anyway.
  - Inefficiently converted [HTML → text → JSON → HTML](https://github.com/cybersemics/em/blob/28c4330e5792a44bb5b484c9bacb01021909bd20/src/util/textToHtml.ts#L116).
  - **Thus, tests related to iOS and macOS Notes app imports have to be skipped until a new solution is implemented.**
- Breaks color format preservation via `isEmText`
  - An unfortunate consequence of losing `strip`.

I have opted to accept the loss of support in order to fix general HTML import and revert to a more solid foundation on which to add support for specific HTML structures exported by various apps.

Ideally, `importText` and `importFiles` will converge more over time (towards `importFiles`).

Related: #2812 (recently merged)
- refactored a lot of the import functionality in preparation for this PR