### PR TITLE
LayoutTree: Move FadeTransition into TransitionGroup

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -477,38 +477,38 @@ const TreeNode = ({
     : `left {durations.layoutNodeAnimation} ease-out,top {durations.layoutNodeAnimation} ease-out`
 
   return (
-    <div
-      aria-label='tree-node'
-      // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
-      // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
-      className={css({
-        position: 'absolute',
-        transition,
-      })}
-      style={{
-        // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.
-        // Unfortunately left causes layout recalculation, so we may want to hoist DropChild into a parent and manually control the position.
-        left: x,
-        top: y,
-        // Table col1 uses its exact width since cannot extend to the right edge of the screen.
-        // All other thoughts extend to the right edge of the screen. We cannot use width auto as it causes the text to wrap continuously during the counter-indentation animation, which is jarring. Instead, use a fixed width of the available space so that it changes in a stepped fashion as depth changes and the word wrap will not be animated. Use x instead of depth in order to accommodate ancestor tables.
-        // 1em + 10px is an eyeball measurement at font sizes 14 and 18
-        // (Maybe the 10px is from .content padding-left?)
-        width: isTableCol1 ? width : `calc(100% - ${x}px + 1em + 10px)`,
-        ...style,
-        textAlign: isTableCol1 ? 'right' : undefined,
-      }}
+    <FadeTransition
+      id={thoughtKey}
+      // The FadeTransition is only responsible for fade out on unmount;
+      // or for fade in on mounting of a new thought.
+      // See autofocusChanged for normal opacity transition.
+      // Limit the fade/shrink/blur animation to the archive, delete, and collapseContext actions.
+      duration={isEmpty ? 'nodeFadeIn' : isLastActionDelete ? 'nodeDissolve' : 'nodeFadeOut'}
+      nodeRef={fadeThoughtRef}
+      in={transitionGroupsProps.in}
+      unmountOnExit
     >
-      <FadeTransition
-        id={thoughtKey}
-        // The FadeTransition is only responsible for fade out on unmount;
-        // or for fade in on mounting of a new thought.
-        // See autofocusChanged for normal opacity transition.
-        // Limit the fade/shrink/blur animation to the archive, delete, and collapseContext actions.
-        duration={isEmpty ? 'nodeFadeIn' : isLastActionDelete ? 'nodeDissolve' : 'nodeFadeOut'}
-        nodeRef={fadeThoughtRef}
-        in={transitionGroupsProps.in}
-        unmountOnExit
+      <div
+        aria-label='tree-node'
+        // The key must be unique to the thought, both in normal view and context view, in case they are both on screen.
+        // It should not be based on editable values such as Path, value, rank, etc, otherwise moving the thought would make it appear to be a completely new thought to React.
+        className={css({
+          position: 'absolute',
+          transition,
+        })}
+        style={{
+          // Cannot use transform because it creates a new stacking context, which causes later siblings' DropChild to be covered by previous siblings'.
+          // Unfortunately left causes layout recalculation, so we may want to hoist DropChild into a parent and manually control the position.
+          left: x,
+          top: y,
+          // Table col1 uses its exact width since cannot extend to the right edge of the screen.
+          // All other thoughts extend to the right edge of the screen. We cannot use width auto as it causes the text to wrap continuously during the counter-indentation animation, which is jarring. Instead, use a fixed width of the available space so that it changes in a stepped fashion as depth changes and the word wrap will not be animated. Use x instead of depth in order to accommodate ancestor tables.
+          // 1em + 10px is an eyeball measurement at font sizes 14 and 18
+          // (Maybe the 10px is from .content padding-left?)
+          width: isTableCol1 ? width : `calc(100% - ${x}px + 1em + 10px)`,
+          ...style,
+          textAlign: isTableCol1 ? 'right' : undefined,
+        }}
       >
         <div ref={fadeThoughtRef}>
           <VirtualThought
@@ -537,22 +537,22 @@ const TreeNode = ({
             marginRight={isTableCol1 ? marginRight : 0}
           />
         </div>
-      </FadeTransition>
 
-      {dragInProgress &&
-        // do not render hidden cliffs
-        // rough autofocus estimate
-        autofocusDepth - depth < 2 && (
-          <DropCliff
-            cliff={cliff}
-            depth={depth}
-            path={path}
-            isTableCol2={isTableCol2}
-            isLastVisible={isLastVisible}
-            prevWidth={treeThoughtsPositioned[index - 1]?.width}
-          />
-        )}
-    </div>
+        {dragInProgress &&
+          // do not render hidden cliffs
+          // rough autofocus estimate
+          autofocusDepth - depth < 2 && (
+            <DropCliff
+              cliff={cliff}
+              depth={depth}
+              path={path}
+              isTableCol2={isTableCol2}
+              isLastVisible={isLastVisible}
+              prevWidth={treeThoughtsPositioned[index - 1]?.width}
+            />
+          )}
+      </div>
+    </FadeTransition>
   )
 }
 

--- a/src/components/__tests__/LayoutTree.ts
+++ b/src/components/__tests__/LayoutTree.ts
@@ -1,0 +1,36 @@
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('unmount TreeNodes on collapse', async () => {
+  await dispatch(
+    importText({
+      text: `
+        - a
+          - b
+        - c
+      `,
+    }),
+  )
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // a is initially collapsed because cursor is set to c after import
+  expect(document.querySelectorAll('[aria-label="tree-node"]').length).toBe(2)
+
+  await dispatch(setCursor(['a']))
+
+  // expand a
+  expect(document.querySelectorAll('[aria-label="tree-node"]').length).toBe(3)
+
+  await dispatch(setCursor(['c']))
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // collapse a and unmount b
+  expect(document.querySelectorAll('[aria-label="tree-node"]').length).toBe(2)
+})


### PR DESCRIPTION
This PR makes a small change to the React component hierarchy, moving `FadeTransition` one level up in `TreeNode` so that it is a direct child of `TransitionGroup`.

Otherwise, the `TreeNode` div is never unmounted. Empty divs accumulate in the DOM. See the included unit test for an example.

Regression: #2581