### PR TITLE
Fix cursorUp

### DIFF
--- a/src/actions/__tests__/cursorUp.ts
+++ b/src/actions/__tests__/cursorUp.ts
@@ -202,6 +202,26 @@ describe('normal view', () => {
     const stateNew = cursorUp(store.getState())
     expectPathToEqual(stateNew, stateNew.cursor, ['x'])
   })
+
+  it('should move to the last visible thought of pinned thought', () => {
+    const text = `
+      - a
+        - b
+          - =pin
+          - b1
+        - c
+    `
+
+    const steps = [
+      importText({ text }),
+      setCursor(['a', 'b', 'b1']),
+      newThought({ value: '', insertBefore: true }),
+      setCursor(['a', 'c']),
+      cursorUp,
+    ]
+    const stateNew = reducerFlow(steps)(initialState())
+    expect(stateNew.cursor).toMatchObject(contextToPath(stateNew, ['a', 'b', 'b1'])!)
+  })
 })
 
 describe('context view', () => {

--- a/src/selectors/prevThought.ts
+++ b/src/selectors/prevThought.ts
@@ -1,6 +1,6 @@
 import Path from '../@types/Path'
 import State from '../@types/State'
-import getChildren from '../selectors/getChildren'
+import { getChildrenSorted } from '../selectors/getChildren'
 import isContextViewActive from '../selectors/isContextViewActive'
 import prevContext from '../selectors/prevContext'
 import prevSibling from '../selectors/prevSibling'
@@ -18,7 +18,7 @@ const lastVisibleDescendant = (state: State, path: Path): Path => {
   if (!state.expanded[hashPath(simplePath)]) return path
 
   // If no children, return current path
-  const children = getChildren(state, head(simplePath))
+  const children = getChildrenSorted(state, head(simplePath))
   if (children.length === 0) return path
 
   const lastChild = children[children.length - 1]


### PR DESCRIPTION
This PR resolves the issue : https://github.com/cybersemics/em/issues/2767

The cause of bug : When gets the last visible descendant of a thought, we used `getChildren` to get the children of thought.

So, in this PR, I have changed from `getChildren` to `getChildrenSorted` to get the children of thought.