### PR TITLE
Fix: Drag parent hover animation continues after canDrop returns false

### DIFF
--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -8,6 +8,7 @@ import SimplePath from '../@types/SimplePath'
 import { isTouch } from '../browser'
 import testFlags from '../e2e/testFlags'
 import useDragAndDropSubThought from '../hooks/useDragAndDropSubThought'
+import useDragLeave from '../hooks/useDragLeave'
 import useDropHoverColor from '../hooks/useDropHoverColor'
 import useHoveringPath from '../hooks/useHoveringPath'
 import { hasChildren } from '../selectors/getChildren'
@@ -32,8 +33,9 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
   const value = useSelector(state => getThoughtById(state, head(simplePath))?.value || '')
   const dropHoverColor = useDropHoverColor(depth || 0)
 
-  const { isHovering, dropTarget } = useDragAndDropSubThought({ path, simplePath })
+  const { isHovering, isDeepHovering, canDropThought, dropTarget } = useDragAndDropSubThought({ path, simplePath })
   useHoveringPath(path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
+  useDragLeave({ isDeepHovering, canDropThought })
 
   // Calculate the height for the child thought over cliff
   const dropTargetHeight = isLastVisible ? calculateCliffDropTargetHeight({ depth }) : 0

--- a/src/components/DropChild.tsx
+++ b/src/components/DropChild.tsx
@@ -2,15 +2,12 @@ import React from 'react'
 import { shallowEqual, useSelector } from 'react-redux'
 import { css, cx } from '../../styled-system/css'
 import { dropEndRecipe, dropHoverRecipe } from '../../styled-system/recipes'
-import DropThoughtZone from '../@types/DropThoughtZone'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import { isTouch } from '../browser'
 import testFlags from '../e2e/testFlags'
 import useDragAndDropSubThought from '../hooks/useDragAndDropSubThought'
-import useDragLeave from '../hooks/useDragLeave'
 import useDropHoverColor from '../hooks/useDropHoverColor'
-import useHoveringPath from '../hooks/useHoveringPath'
 import { hasChildren } from '../selectors/getChildren'
 import getThoughtById from '../selectors/getThoughtById'
 import calculateCliffDropTargetHeight from '../util/calculateCliffDropTargetHeight'
@@ -33,9 +30,7 @@ const DropChild = ({ depth, path, simplePath, isLastVisible }: DropChildProps) =
   const value = useSelector(state => getThoughtById(state, head(simplePath))?.value || '')
   const dropHoverColor = useDropHoverColor(depth || 0)
 
-  const { isHovering, isDeepHovering, canDropThought, dropTarget } = useDragAndDropSubThought({ path, simplePath })
-  useHoveringPath(path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
-  useDragLeave({ isDeepHovering, canDropThought })
+  const { isHovering, dropTarget } = useDragAndDropSubThought({ path, simplePath })
 
   // Calculate the height for the child thought over cliff
   const dropTargetHeight = isLastVisible ? calculateCliffDropTargetHeight({ depth }) : 0

--- a/src/components/DropEnd.tsx
+++ b/src/components/DropEnd.tsx
@@ -7,9 +7,7 @@ import Path from '../@types/Path'
 import { isTouch } from '../browser'
 import testFlags from '../e2e/testFlags'
 import useDragAndDropSubThought from '../hooks/useDragAndDropSubThought'
-import useDragLeave from '../hooks/useDragLeave'
 import useDropHoverColor from '../hooks/useDropHoverColor'
-import useHoveringPath from '../hooks/useHoveringPath'
 import { getChildrenSorted } from '../selectors/getChildren'
 import getSortPreference from '../selectors/getSortPreference'
 import getThoughtById from '../selectors/getThoughtById'
@@ -50,9 +48,7 @@ const DropEnd = ({
   const value = useSelector(state => getThoughtById(state, thoughtId)?.value) ?? ''
   const dropHoverColor = useDropHoverColor(depth + 1)
 
-  const { isHovering, isDeepHovering, canDropThought, dropTarget } = useDragAndDropSubThought({ path })
-  useHoveringPath(path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
-  useDragLeave({ isDeepHovering, canDropThought })
+  const { isHovering, dropTarget } = useDragAndDropSubThought({ path })
 
   // a boolean indicating if the drop-hover component is shown
   // true if hovering and the context is not sorted

--- a/src/components/DropEnd.tsx
+++ b/src/components/DropEnd.tsx
@@ -7,6 +7,7 @@ import Path from '../@types/Path'
 import { isTouch } from '../browser'
 import testFlags from '../e2e/testFlags'
 import useDragAndDropSubThought from '../hooks/useDragAndDropSubThought'
+import useDragLeave from '../hooks/useDragLeave'
 import useDropHoverColor from '../hooks/useDropHoverColor'
 import useHoveringPath from '../hooks/useHoveringPath'
 import { getChildrenSorted } from '../selectors/getChildren'
@@ -49,8 +50,9 @@ const DropEnd = ({
   const value = useSelector(state => getThoughtById(state, thoughtId)?.value) ?? ''
   const dropHoverColor = useDropHoverColor(depth + 1)
 
-  const { isHovering, dropTarget } = useDragAndDropSubThought({ path })
+  const { isHovering, isDeepHovering, canDropThought, dropTarget } = useDragAndDropSubThought({ path })
   useHoveringPath(path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
+  useDragLeave({ isDeepHovering, canDropThought })
 
   // a boolean indicating if the drop-hover component is shown
   // true if hovering and the context is not sorted

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -230,26 +230,45 @@ const ThoughtContainer = ({
 
   /** True if a dragged thought is hovering over a visible child of the current thought (ThoughtDrop or SubthoughtsDrop). This determines if the parent should be highlighted. */
   // TODO: It would be nice if we could reuse canDrop.
-  const isChildHovering = useSelector(
-    state =>
-      !!isVisible &&
-      !!state.hoveringPath &&
-      // Do not highlight parent of dragging thought (i.e. when simply reordering but not moving to a new parent).
-      // Reordering is a less destructive action that does not need to bring attention to the parent.
-      state.draggingThought &&
-      !equalPath(rootedParentOf(state, state.draggingThought), simplePath) &&
-      !isContextViewActive(state, path) &&
-      // SubthoughtsDrop
-      // Can drop on SubthoughtsDrop if this thought is being hovered over.
-      ((state.hoverZone === DropThoughtZone.SubthoughtsDrop && equalPath(simplePath, state.hoveringPath)) ||
-        // ThoughtDrop
-        // Can drop on ThoughtDrop if this thought is a parent of the hovered thought, and not a descendant of the dragging thought.
-        (state.hoverZone === DropThoughtZone.ThoughtDrop &&
-          equalPath(rootedParentOf(state, state.hoveringPath), simplePath) &&
-          !isDescendantPath(simplePath, state.draggingThought))) &&
-      state.alert?.alertType !== AlertType.DeleteDropHint &&
-      state.alert?.alertType !== AlertType.CopyOneDropHint,
-  )
+  const isChildHovering = useSelector(state => {
+    // Early return if essential conditions are not met
+    if (!isVisible || !state.hoveringPath || !state.draggingThought) {
+      return false
+    }
+
+    // Make sure we're not hovering over a thought that cannot be dropped on
+    // This is what fixes the bug when dragging a thought over its ancestor
+    if (isDescendantPath(state.hoveringPath, state.draggingThought)) {
+      return false
+    }
+
+    // Do not highlight parent of dragging thought (i.e. when simply reordering but not moving to a new parent)
+    if (equalPath(rootedParentOf(state, state.draggingThought), simplePath)) {
+      return false
+    }
+
+    // Do not highlight in context view
+    if (isContextViewActive(state, path)) {
+      return false
+    }
+
+    // Do not highlight during delete or copy alerts
+    if (state.alert?.alertType === AlertType.DeleteDropHint || state.alert?.alertType === AlertType.CopyOneDropHint) {
+      return false
+    }
+
+    // SubthoughtsDrop: Can drop on SubthoughtsDrop if this thought is being hovered over
+    const isSubthoughtsDropTarget =
+      state.hoverZone === DropThoughtZone.SubthoughtsDrop && equalPath(simplePath, state.hoveringPath)
+
+    // ThoughtDrop: Can drop on ThoughtDrop if this thought is a parent of the hovered thought
+    const isThoughtDropTarget =
+      state.hoverZone === DropThoughtZone.ThoughtDrop &&
+      equalPath(rootedParentOf(state, state.hoveringPath), simplePath) &&
+      !isDescendantPath(simplePath, state.draggingThought)
+
+    return isSubthoughtsDropTarget || isThoughtDropTarget
+  })
 
   // when the thought is edited on desktop, hide the top controls and breadcrumbs for distraction-free typing
   const onEdit = useCallback(({ newValue, oldValue }: { newValue: string; oldValue: string }) => {

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -237,7 +237,6 @@ const ThoughtContainer = ({
     }
 
     // Make sure we're not hovering over a thought that cannot be dropped on
-    // This is what fixes the bug when dragging a thought over its ancestor
     if (isDescendantPath(state.hoveringPath, state.draggingThought)) {
       return false
     }
@@ -261,7 +260,7 @@ const ThoughtContainer = ({
     const isSubthoughtsDropTarget =
       state.hoverZone === DropThoughtZone.SubthoughtsDrop && equalPath(simplePath, state.hoveringPath)
 
-    // ThoughtDrop: Can drop on ThoughtDrop if this thought is a parent of the hovered thought
+    // ThoughtDrop: Can drop on ThoughtDrop if this thought is a parent of the hovered thought and not a descendant of the dragging thought.
     const isThoughtDropTarget =
       state.hoverZone === DropThoughtZone.ThoughtDrop &&
       equalPath(rootedParentOf(state, state.hoveringPath), simplePath) &&

--- a/src/hooks/useDragAndDropSubThought.ts
+++ b/src/hooks/useDragAndDropSubThought.ts
@@ -38,7 +38,7 @@ import useHoveringPath from './useHoveringPath'
 
 interface DroppableSubthoughts {
   path: Path
-  simplePath: SimplePath
+  simplePath?: SimplePath
   showContexts?: boolean
 }
 
@@ -83,7 +83,7 @@ const canDrop = (props: DroppableSubthoughts, monitor: DropTargetMonitor): boole
   return (!isHidden || isClosestHiddenParent) && !isDescendant && !divider && !showContexts
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/** Moves a thought on drop, or imports a file on drop. */
 const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
   const state = store.getState()
 
@@ -146,7 +146,7 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
       const alertFrom = '"' + ellipsize(thoughtFrom.value) + '"'
       const alertTo = parentIdTo === HOME_TOKEN ? 'home' : '"' + ellipsize(thoughtTo.value) + '"'
       const inContext = props.showContexts
-        ? ` in the context of ${ellipsize(headValue(state, props.simplePath) ?? 'MISSING_CONTEXT')}`
+        ? ` in the context of ${ellipsize(headValue(state, props.simplePath ?? props.path) ?? 'MISSING_CONTEXT')}`
         : ''
 
       store.dispatch(
@@ -169,21 +169,16 @@ const dropCollect = (monitor: DropTargetMonitor) => ({
 })
 
 /** A draggable and droppable SubThought hook. */
-const useDragAndDropSubThought = (props: Partial<DroppableSubthoughts>) => {
-  const propsTypes = props as DroppableSubthoughts
-
+const useDragAndDropSubThought = (props: DroppableSubthoughts) => {
   const [{ isHovering, isBeingHoveredOver, isDeepHovering, canDropThought }, dropTarget] = useDrop({
     accept: [DragAndDropType.Thought, NativeTypes.FILE],
-    canDrop: (item, monitor) => canDrop(propsTypes, monitor),
-    drop: (item, monitor) => drop(propsTypes, monitor),
+    canDrop: (item, monitor) => canDrop(props, monitor),
+    drop: (item, monitor) => drop(props, monitor),
     collect: dropCollect,
   })
 
-  // Encapsulate the useHoveringPath and useDragLeave hooks
-  if (props.path) {
-    useHoveringPath(props.path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
-    useDragLeave({ isDeepHovering, canDropThought })
-  }
+  useHoveringPath(props.path, isHovering, DropThoughtZone.SubthoughtsDrop)
+  useDragLeave({ isDeepHovering, canDropThought })
 
   return { isHovering, isBeingHoveredOver, isDeepHovering, dropTarget }
 }

--- a/src/hooks/useDragAndDropSubThought.ts
+++ b/src/hooks/useDragAndDropSubThought.ts
@@ -162,20 +162,21 @@ const dropCollect = (monitor: DropTargetMonitor) => ({
   // is being hovered over current thought irrespective of whether the given item is droppable
   isBeingHoveredOver: monitor.isOver({ shallow: true }),
   isDeepHovering: monitor.isOver(),
+  canDropThought: monitor.canDrop(),
 })
 
 /** A draggable and droppable SubThought hook. */
 const useDragAndDropSubThought = (props: Partial<DroppableSubthoughts>) => {
   const propsTypes = props as DroppableSubthoughts
 
-  const [{ isHovering, isBeingHoveredOver, isDeepHovering }, dropTarget] = useDrop({
+  const [{ isHovering, isBeingHoveredOver, isDeepHovering, canDropThought }, dropTarget] = useDrop({
     accept: [DragAndDropType.Thought, NativeTypes.FILE],
     canDrop: (item, monitor) => canDrop(propsTypes, monitor),
     drop: (item, monitor) => drop(propsTypes, monitor),
     collect: dropCollect,
   })
 
-  return { isHovering, isBeingHoveredOver, isDeepHovering, dropTarget }
+  return { isHovering, isBeingHoveredOver, isDeepHovering, canDropThought, dropTarget }
 }
 
 export default useDragAndDropSubThought

--- a/src/hooks/useDragAndDropSubThought.ts
+++ b/src/hooks/useDragAndDropSubThought.ts
@@ -3,6 +3,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import DragAndDropType from '../@types/DragAndDropType'
 import DragThoughtItem from '../@types/DragThoughtItem'
 import DragThoughtOrFiles from '../@types/DragThoughtOrFiles'
+import DropThoughtZone from '../@types/DropThoughtZone'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
@@ -32,6 +33,8 @@ import isDivider from '../util/isDivider'
 import isDraggedFile from '../util/isDraggedFile'
 import isEM from '../util/isEM'
 import isRoot from '../util/isRoot'
+import useDragLeave from './useDragLeave'
+import useHoveringPath from './useHoveringPath'
 
 interface DroppableSubthoughts {
   path: Path
@@ -176,7 +179,13 @@ const useDragAndDropSubThought = (props: Partial<DroppableSubthoughts>) => {
     collect: dropCollect,
   })
 
-  return { isHovering, isBeingHoveredOver, isDeepHovering, canDropThought, dropTarget }
+  // Encapsulate the useHoveringPath and useDragLeave hooks
+  if (props.path) {
+    useHoveringPath(props.path, !!isHovering, DropThoughtZone.SubthoughtsDrop)
+    useDragLeave({ isDeepHovering, canDropThought })
+  }
+
+  return { isHovering, isBeingHoveredOver, isDeepHovering, dropTarget }
 }
 
 export default useDragAndDropSubThought

--- a/src/hooks/useDragLeave.ts
+++ b/src/hooks/useDragLeave.ts
@@ -23,7 +23,6 @@ const useDragLeave = ({ isDeepHovering, canDropThought }: { isDeepHovering: bool
   const hoverZone = useSelector(state => state.hoverZone)
   const prevIsDeepHoveringRef = useRef(isDeepHovering)
   const prevHoverZone = useRef(hoverZone)
-  const prevCanDropRef = useRef(canDropThought)
 
   // Initialize the debounced function if it hasn't been already
   if (!debouncedSetHoveringPath) {
@@ -41,17 +40,7 @@ const useDragLeave = ({ isDeepHovering, canDropThought }: { isDeepHovering: bool
       return
     }
 
-    // If canDrop changed from true to false, immediately clear the hovering path
-    if (!canDropThought && prevCanDropRef.current) {
-      dispatch(clearHoveringPath)
-      prevCanDropRef.current = canDropThought
-      return
-    }
-
-    // Update prevCanDropRef
-    prevCanDropRef.current = canDropThought
-
-    // If canDrop is false return
+    // If canDrop is false, clear hovering path and return
     if (!canDropThought) {
       dispatch(clearHoveringPath)
       return

--- a/src/hooks/useDragLeave.ts
+++ b/src/hooks/useDragLeave.ts
@@ -23,6 +23,7 @@ const useDragLeave = ({ isDeepHovering, canDropThought }: { isDeepHovering: bool
   const hoverZone = useSelector(state => state.hoverZone)
   const prevIsDeepHoveringRef = useRef(isDeepHovering)
   const prevHoverZone = useRef(hoverZone)
+  const prevCanDropRef = useRef(canDropThought)
 
   // Initialize the debounced function if it hasn't been already
   if (!debouncedSetHoveringPath) {
@@ -39,6 +40,16 @@ const useDragLeave = ({ isDeepHovering, canDropThought }: { isDeepHovering: bool
       debouncedSetHoveringPath?.cancel()
       return
     }
+
+    // If canDrop changed from true to false, immediately clear the hovering path
+    if (!canDropThought && prevCanDropRef.current) {
+      dispatch(clearHoveringPath)
+      prevCanDropRef.current = canDropThought
+      return
+    }
+
+    // Update prevCanDropRef
+    prevCanDropRef.current = canDropThought
 
     // If canDrop is false return
     if (!canDropThought) {


### PR DESCRIPTION
### **Issue** #2169 
When dragging a thought, the visual feedback for valid drop targets was inconsistent. Specifically:
- If a user dragged thought "b" below thought "c" and then attempted to drag thought "a" into "b"
- If the drop became invalid (e.g., "a" had children), the `DropHover` component correctly disappeared
- However, thought "c" continued to pulse/highlight, even though it was no longer a valid drop target


### **Root Cause**
- The `hoveringPath` in Redux wasn't cleared when a thought became an invalid drop target.
- The state only cleared on physical drag leave events but didn't respond to logical state changes (i.e., when `canDropThought` changed to `false`).
- Components responsible for pulsing did not check the latest `canDropThought` state before continuing the animation.

### **Solution**

#### **1. Enhanced `useDragLeave.ts`**
- Tracked `prevCanDropThought` to detect state changes.
- Cleared `hoveringPath` immediately when a drop target became invalid.

#### **2. Updated `Thought.tsx`**
- Adjusted `isChildHovering` selector to factor in `canDropThought`.
- Ensured pulsing only occurs when `canDropThought` is `true`.
- Refactored existing inline condition checks with descriptive comments.

#### **3. Improved `useDragAndDropSubThought.ts`**
- Updated `dropCollect` to return `canDropThought`, ensuring dependent components receive accurate drop validity.

#### **4. Updated `DropChild.tsx` and `DropEnd.tsx`**
- Integrated `useDragLeave` to clear hover states when `canDropThought` changes.
- Ensured components respond to both physical drag events and logical state changes.

