### PR TITLE
Option + ArrowLeft: Do not move caret to end of thought

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,7 @@ import { suppressExpansionActionCreator as suppressExpansion } from './actions/s
 import { isMac } from './browser'
 import * as commandsObject from './commands/index'
 import { AlertType, COMMAND_PALETTE_TIMEOUT, Settings } from './constants'
+import * as selection from './device/selection'
 import globals from './globals'
 import getUserSetting from './selectors/getUserSetting'
 import gestureStore from './stores/gesture'
@@ -320,6 +321,12 @@ export const inputHandlers = (store: Store<State, any>) => ({
     if (!(isMac ? e.metaKey : e.ctrlKey)) {
       // disable suppress expansion without triggering re-render
       globals.suppressExpansion = false
+    }
+
+    // Handle Alt+ArrowLeft when caret is at the beginning of a thought
+    if (e.altKey && e.key === 'ArrowLeft' && selection.offset() === 0 && selection.isThought()) {
+      e.preventDefault()
+      return
     }
 
     // disable if command palette is displayed

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -323,7 +323,8 @@ export const inputHandlers = (store: Store<State, any>) => ({
       globals.suppressExpansion = false
     }
 
-    // Handle Alt+ArrowLeft when caret is at the beginning of a thought
+    // For some reason, when the caret is at the beginning of the thought, alt + ArrowLeft sets the caret to the end.
+    // Prevent this default behavior, as the caret should have nowhere to go when it is already at the beginning.
     if (e.altKey && e.key === 'ArrowLeft' && selection.offset() === 0 && selection.isThought()) {
       e.preventDefault()
       return

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -585,16 +585,6 @@ const Editable = ({
     [disabled, isVisible, path, setCursorOnThought],
   )
 
-  /** Handle keydown events before they are passed to ContentEditable. */
-  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
-    // If Alt+ArrowLeft and selection is at the beginning of the thought, prevent default behavior
-    if (e.altKey && e.key === 'ArrowLeft' && selection.offset() === 0) {
-      e.preventDefault()
-      // No need to do anything else, just prevent the default behavior
-      // which would cause the caret to jump to the end
-    }
-  }, [])
-
   return (
     <ContentEditable
       disabled={disabled}
@@ -624,7 +614,6 @@ const Editable = ({
       onFocus={onFocus}
       onBlur={onBlur}
       onChange={onChangeHandler}
-      onKeyDown={onKeyDown}
       onCopy={onCopy}
       onCut={e => {
         // flush the last edit, otherwise if cut occurs in quick succession the new value can be overwritten by the throttled change

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -585,6 +585,16 @@ const Editable = ({
     [disabled, isVisible, path, setCursorOnThought],
   )
 
+  /** Handle keydown events before they are passed to ContentEditable. */
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // If Alt+ArrowLeft and selection is at the beginning of the thought, prevent default behavior
+    if (e.altKey && e.key === 'ArrowLeft' && selection.offset() === 0) {
+      e.preventDefault()
+      // No need to do anything else, just prevent the default behavior
+      // which would cause the caret to jump to the end
+    }
+  }, [])
+
   return (
     <ContentEditable
       disabled={disabled}
@@ -614,6 +624,7 @@ const Editable = ({
       onFocus={onFocus}
       onBlur={onBlur}
       onChange={onChangeHandler}
+      onKeyDown={onKeyDown}
       onCopy={onCopy}
       onCut={e => {
         // flush the last edit, otherwise if cut occurs in quick succession the new value can be overwritten by the throttled change


### PR DESCRIPTION
PR for #2855 

### Problem:

- The browser's default behavior for Alt+ArrowLeft in contentEditable elements is to jump to the previous word boundary When at the beginning of a thought, there's no previous word boundary within the current contentEditable element
This caused the browser to behave unexpectedly, jumping the caret to the end of the text.

### Solution

- added a prevent default behavior for alt/option + leftarrow in global keydown handler
