### PR TITLE
Refactor pickers: Create shared Popover component

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,20 +1,18 @@
 import { rgbToHex } from '@mui/material'
-import React, { FC, useRef } from 'react'
+import React, { FC } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import { token } from '../../styled-system/tokens'
-import { SystemStyleObject } from '../../styled-system/types'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import { isTouch } from '../browser'
 import { ColorToken } from '../colors.config'
 import * as selection from '../device/selection'
-import useWindowOverflow from '../hooks/useWindowOverflow'
 import getThoughtById from '../selectors/getThoughtById'
 import themeColors from '../selectors/themeColors'
 import commandStateStore from '../stores/commandStateStore'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
-import TriangleDown from './TriangleDown'
+import Popover from './Popover'
 import TextColorIcon from './icons/TextColor'
 
 /** A function that adds an alpha channel to a hex color. */
@@ -161,62 +159,39 @@ const ColorSwatch: FC<{
 }
 
 /** Text Color Picker component. */
-const ColorPicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = ({ fontSize, cssRaw }) => {
-  const ref = useRef<HTMLDivElement>(null)
-
-  const overflow = useWindowOverflow(ref)
+const ColorPicker: FC<{
+  size?: number
+}> = ({ size }) => {
+  const showColorPicker = useSelector(state => state.showColorPicker)
 
   return (
-    <div className={css({ userSelect: 'none' })}>
-      <div
-        className={css(
-          {
-            backgroundColor: 'fgOverlay90',
-            borderRadius: 3,
-            display: 'inline-block',
-            padding: '0.2em 0.25em 0.25em',
-            position: 'relative',
-          },
-          cssRaw,
-        )}
-        ref={ref}
-        style={{ ...(overflow.left ? { left: overflow.left } : { right: overflow.right }) }}
-      >
-        {/* Triangle */}
-        <TriangleDown
-          fill={token('colors.fgOverlay90')}
-          cssRaw={css.raw({ position: 'absolute', width: '100%' })}
-          size={fontSize}
-          style={{ ...(overflow.left ? { left: -overflow.left } : { right: -overflow.right }), top: -fontSize / 2 }}
-        />
-
-        {/* Text Color */}
-        <div aria-label='text color swatches' className={css({ whiteSpace: 'nowrap' })}>
-          <ColorSwatch color={'fg'} label='default' />
-          <ColorSwatch color={'gray'} label='gray' />
-          <ColorSwatch color={'orange'} label='orange' />
-          <ColorSwatch color={'yellow'} label='yellow' />
-          <ColorSwatch color={'green'} label='green' />
-          <ColorSwatch color={'blue'} label='blue' />
-          <ColorSwatch color={'purple'} label='purple' />
-          <ColorSwatch color={'pink'} label='pink' />
-          <ColorSwatch color={'red'} label='red' />
-        </div>
-
-        {/* Background Color */}
-        <div aria-label='background color swatches' className={css({ whiteSpace: 'nowrap' })}>
-          <ColorSwatch backgroundColor={'fg'} label='inverse' />
-          <ColorSwatch backgroundColor={'gray'} label='gray' />
-          <ColorSwatch backgroundColor={'orange'} label='orange' />
-          <ColorSwatch backgroundColor={'yellow'} label='yellow' />
-          <ColorSwatch backgroundColor={'green'} label='green' />
-          <ColorSwatch backgroundColor={'blue'} label='blue' />
-          <ColorSwatch backgroundColor={'purple'} label='purple' />
-          <ColorSwatch backgroundColor={'pink'} label='pink' />
-          <ColorSwatch backgroundColor={'red'} label='red' />
-        </div>
+    <Popover show={showColorPicker} size={size}>
+      {/* Text Color */}
+      <div aria-label='text color swatches' className={css({ whiteSpace: 'nowrap' })}>
+        <ColorSwatch color={'fg'} label='default' />
+        <ColorSwatch color={'gray'} label='gray' />
+        <ColorSwatch color={'orange'} label='orange' />
+        <ColorSwatch color={'yellow'} label='yellow' />
+        <ColorSwatch color={'green'} label='green' />
+        <ColorSwatch color={'blue'} label='blue' />
+        <ColorSwatch color={'purple'} label='purple' />
+        <ColorSwatch color={'pink'} label='pink' />
+        <ColorSwatch color={'red'} label='red' />
       </div>
-    </div>
+
+      {/* Background Color */}
+      <div aria-label='background color swatches' className={css({ whiteSpace: 'nowrap' })}>
+        <ColorSwatch backgroundColor={'fg'} label='inverse' />
+        <ColorSwatch backgroundColor={'gray'} label='gray' />
+        <ColorSwatch backgroundColor={'orange'} label='orange' />
+        <ColorSwatch backgroundColor={'yellow'} label='yellow' />
+        <ColorSwatch backgroundColor={'green'} label='green' />
+        <ColorSwatch backgroundColor={'blue'} label='blue' />
+        <ColorSwatch backgroundColor={'purple'} label='purple' />
+        <ColorSwatch backgroundColor={'pink'} label='pink' />
+        <ColorSwatch backgroundColor={'red'} label='red' />
+      </div>
+    </Popover>
   )
 }
 

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -159,9 +159,7 @@ const ColorSwatch: FC<{
 }
 
 /** Text Color Picker component. */
-const ColorPicker: FC<{
-  size?: number
-}> = ({ size }) => {
+const ColorPicker: FC<{ size?: number }> = ({ size }) => {
   const showColorPicker = useSelector(state => state.showColorPicker)
 
   return (

--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -1,27 +1,25 @@
-import React, { FC, memo, useRef } from 'react'
+import React, { FC, memo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
-import { token } from '../../styled-system/tokens'
-import { SystemStyleObject } from '../../styled-system/types'
 import LetterCaseType from '../@types/LetterCaseType'
 import { formatLetterCaseActionCreator as formatLetterCase } from '../actions/formatLetterCase'
 import { isTouch } from '../browser'
-import useWindowOverflow from '../hooks/useWindowOverflow'
 import getThoughtById from '../selectors/getThoughtById'
 import applyLetterCase from '../util/applyLetterCase'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
-import TriangleDown from './TriangleDown'
+import Popover from './Popover'
 import LowerCaseIcon from './icons/LowerCaseIcon'
 import SentenceCaseIcon from './icons/SentenceCaseIcon'
 import TitleCaseIcon from './icons/TitleCaseIcon'
 import UpperCaseIcon from './icons/UpperCaseIcon'
 
 /** Letter Case Picker component. */
-const LetterCasePicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = memo(({ fontSize, cssRaw }) => {
-  const ref = useRef<HTMLDivElement>(null)
+const LetterCasePicker: FC<{
+  size?: number
+}> = memo(({ size }) => {
   const dispatch = useDispatch()
-  const overflow = useWindowOverflow(ref)
+  const showLetterCase = useSelector(state => state.showLetterCase)
 
   /** Toggles the Letter Case to the clicked swatch. */
   const toggleLetterCase = (command: LetterCaseType, e: React.MouseEvent | React.TouchEvent) => {
@@ -40,52 +38,30 @@ const LetterCasePicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = m
   const casingTypes: LetterCaseType[] = ['LowerCase', 'UpperCase', 'SentenceCase', 'TitleCase']
 
   return (
-    <div className={css({ userSelect: 'none' })}>
-      <div
-        ref={ref}
-        style={{ ...(overflow.left ? { left: `${overflow.left}` } : { right: `${overflow.right}` }) }}
-        className={css(
-          {
-            background: 'pickerBg',
-            borderRadius: '3',
-            display: 'inline-block',
-            padding: '0.2em 0.25em 0.25em',
-            position: 'relative',
-          },
-          cssRaw,
-        )}
-      >
-        <TriangleDown
-          fill={token('colors.fgOverlay90')}
-          size={fontSize}
-          cssRaw={{ position: 'absolute', width: '100%' }}
-          style={{ ...(overflow.left ? { left: -overflow.left } : { right: -overflow.right }), top: -fontSize / 2 }}
-        />
-
-        <div aria-label='letter case swatches' className={css({ whiteSpace: 'wrap' })}>
-          {casingTypes.map(type => (
-            <div
-              key={type}
-              title={type}
-              className={css({
-                margin: '2px',
-                lineHeight: '0',
-                border: selected === type ? `solid 1px {colors.fg}` : `solid 1px {colors.transparent}`,
-              })}
-              aria-label={type}
-              {...fastClick(e => e.stopPropagation())}
-              onTouchStart={e => toggleLetterCase(type, e)}
-              onMouseDown={e => !isTouch && toggleLetterCase(type, e)}
-            >
-              {type === 'LowerCase' && <LowerCaseIcon />}
-              {type === 'UpperCase' && <UpperCaseIcon />}
-              {type === 'SentenceCase' && <SentenceCaseIcon />}
-              {type === 'TitleCase' && <TitleCaseIcon />}
-            </div>
-          ))}
-        </div>
+    <Popover show={showLetterCase} size={size}>
+      <div aria-label='letter case swatches' className={css({ whiteSpace: 'wrap' })}>
+        {casingTypes.map(type => (
+          <div
+            key={type}
+            title={type}
+            className={css({
+              margin: '2px',
+              lineHeight: '0',
+              border: selected === type ? `solid 1px {colors.fg}` : `solid 1px {colors.transparent}`,
+            })}
+            aria-label={type}
+            {...fastClick(e => e.stopPropagation())}
+            onTouchStart={e => toggleLetterCase(type, e)}
+            onMouseDown={e => !isTouch && toggleLetterCase(type, e)}
+          >
+            {type === 'LowerCase' && <LowerCaseIcon />}
+            {type === 'UpperCase' && <UpperCaseIcon />}
+            {type === 'SentenceCase' && <SentenceCaseIcon />}
+            {type === 'TitleCase' && <TitleCaseIcon />}
+          </div>
+        ))}
       </div>
-    </div>
+    </Popover>
   )
 })
 LetterCasePicker.displayName = 'LetterCasePicker'

--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -15,9 +15,7 @@ import TitleCaseIcon from './icons/TitleCaseIcon'
 import UpperCaseIcon from './icons/UpperCaseIcon'
 
 /** Letter Case Picker component. */
-const LetterCasePicker: FC<{
-  size?: number
-}> = memo(({ size }) => {
+const LetterCasePicker: FC<{ size?: number }> = memo(({ size }) => {
   const dispatch = useDispatch()
   const showLetterCase = useSelector(state => state.showLetterCase)
 

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,0 +1,67 @@
+import React, { FC, useRef } from 'react'
+import { useSelector } from 'react-redux'
+import { css } from '../../styled-system/css'
+import { token } from '../../styled-system/tokens'
+import useWindowOverflow from '../hooks/useWindowOverflow'
+import FadeTransition from './FadeTransition'
+import TriangleDown from './TriangleDown'
+
+interface PopoverProps {
+  children: React.ReactNode
+  show?: boolean
+  size?: number
+}
+
+/** A reusable popover component that handles positioning and styling for popup menus. */
+const Popover: FC<PopoverProps> = ({ children, show, size = 18 }) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const fontSize = useSelector(state => state.fontSize)
+  const overflow = useWindowOverflow(ref)
+
+  return (
+    <FadeTransition duration='fast' nodeRef={ref} in={show} exit={false} unmountOnExit>
+      <div
+        ref={ref}
+        className={css({
+          position: 'relative',
+          zIndex: 'stack',
+          // position fixed or absolute causes the ColorPicker to get clipped by the toolbar's overflow-x: scroll
+          // ideally we want overflow-x:scroll and overflow-y:visible, but Safari does not differing allow overflow-x and overflow-y
+          // instead, keep position:static but set the width to 0
+          // this will increase the height of the toolbar so the ColorPicker does not get clipped without taking up horizontal space
+          width: 0,
+        })}
+        style={{
+          // eyeballing it to get font sizes 14–24 to look right
+          left: (size * (size + 90)) / 200 + 600 / (size * size),
+          marginTop: size * 1.2 - 10,
+        }}
+      >
+        <div
+          className={css({
+            backgroundColor: 'pickerBg',
+            borderRadius: '3',
+            display: 'inline-block',
+            padding: '0.2em 0.25em 0.25em',
+            position: 'relative',
+            transform: 'translate(-50%)',
+            userSelect: 'none',
+          })}
+        >
+          <TriangleDown
+            fill={token('colors.fgOverlay90')}
+            size={fontSize}
+            cssRaw={{ position: 'absolute', width: '100%' }}
+            style={{
+              ...(overflow.left ? { left: -overflow.left } : { right: -overflow.right }),
+              top: -fontSize / 2,
+            }}
+          />
+          {children}
+        </div>
+      </div>
+    </FadeTransition>
+  )
+}
+
+export default Popover

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -25,10 +25,10 @@ const Popover: FC<PopoverProps> = ({ children, show, size = 18 }) => {
         className={css({
           position: 'relative',
           zIndex: 'stack',
-          // position fixed or absolute causes the ColorPicker to get clipped by the toolbar's overflow-x: scroll
+          // position fixed or absolute causes the Popover to get clipped by the toolbar's overflow-x: scroll
           // ideally we want overflow-x:scroll and overflow-y:visible, but Safari does not differing allow overflow-x and overflow-y
           // instead, keep position:static but set the width to 0
-          // this will increase the height of the toolbar so the ColorPicker does not get clipped without taking up horizontal space
+          // this will increase the height of the toolbar so the Popover does not get clipped without taking up horizontal space
           width: 0,
         })}
         style={{

--- a/src/components/SortPicker.tsx
+++ b/src/components/SortPicker.tsx
@@ -1,21 +1,18 @@
 import { isEqual } from 'lodash'
-import React, { FC, memo, useRef } from 'react'
+import React, { FC, memo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
-import { token } from '../../styled-system/tokens'
-import { SystemStyleObject } from '../../styled-system/types'
 import SortPreference from '../@types/SortPreference'
 import { setSortPreferenceActionCreator as setSortPreference } from '../actions/setSortPreference'
 import { toggleSortPickerActionCreator as toggleSortPicker } from '../actions/toggleSortPicker'
 import { isTouch } from '../browser'
-import useWindowOverflow from '../hooks/useWindowOverflow'
 import getSortPreference from '../selectors/getSortPreference'
 import rootedParentOf from '../selectors/rootedParentOf'
 import simplifyPath from '../selectors/simplifyPath'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
 import isRoot from '../util/isRoot'
-import TriangleDown from './TriangleDown'
+import Popover from './Popover'
 
 // Define the type for sort options
 type SortType = 'None' | 'Alphabetical'
@@ -69,10 +66,11 @@ const SortOption: FC<SortOptionProps> = ({ type, supportsDirection, label, sortP
 }
 
 /** Sort Picker component. */
-const SortPicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = memo(({ fontSize, cssRaw }) => {
-  const ref = useRef<HTMLDivElement>(null)
+const SortPicker: FC<{
+  size?: number
+}> = memo(({ size }) => {
   const dispatch = useDispatch()
-  const overflow = useWindowOverflow(ref)
+  const showSortPicker = useSelector(state => state.showSortPicker)
 
   const simplePath = useSelector(state =>
     state.cursor && !isRoot(state.cursor) ? simplifyPath(state, rootedParentOf(state, state.cursor)) : null,
@@ -111,46 +109,24 @@ const SortPicker: FC<{ fontSize: number; cssRaw?: SystemStyleObject }> = memo(({
   }
 
   return (
-    <div className={css({ userSelect: 'none' })}>
-      <div
-        ref={ref}
-        style={{ ...(overflow.left ? { left: `${overflow.left}` } : { right: `${overflow.right}` }) }}
-        className={css(
-          {
-            background: 'pickerBg',
-            borderRadius: '3',
-            display: 'inline-block',
-            padding: '0.2em 0.25em 0.25em',
-            position: 'relative',
-          },
-          cssRaw,
-        )}
-      >
-        <TriangleDown
-          fill={token('colors.fgOverlay90')}
-          size={fontSize}
-          cssRaw={{ position: 'absolute', width: '100%' }}
-          style={{ ...(overflow.left ? { left: -overflow.left } : { right: -overflow.right }), top: -fontSize / 2 }}
+    <Popover show={showSortPicker} size={size}>
+      <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
+        <SortOption
+          type='None'
+          supportsDirection={false}
+          label='None'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
         />
-
-        <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
-          <SortOption
-            type='None'
-            supportsDirection={false}
-            label='None'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-          <SortOption
-            type='Alphabetical'
-            supportsDirection={true}
-            label='Alphabetical'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-        </div>
+        <SortOption
+          type='Alphabetical'
+          supportsDirection={true}
+          label='Alphabetical'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
       </div>
-    </div>
+    </Popover>
   )
 })
 

--- a/src/components/SortPicker.tsx
+++ b/src/components/SortPicker.tsx
@@ -66,9 +66,7 @@ const SortOption: FC<SortOptionProps> = ({ type, supportsDirection, label, sortP
 }
 
 /** Sort Picker component. */
-const SortPicker: FC<{
-  size?: number
-}> = memo(({ size }) => {
+const SortPicker: FC<{ size?: number }> = memo(({ size }) => {
   const dispatch = useDispatch()
   const showSortPicker = useSelector(state => state.showSortPicker)
 

--- a/src/components/icons/LetterCaseWithPicker.tsx
+++ b/src/components/icons/LetterCaseWithPicker.tsx
@@ -1,40 +1,13 @@
-import { useRef } from 'react'
-import { useSelector } from 'react-redux'
-import { css } from '../../../styled-system/css'
 import IconType from '../../@types/IconType'
-import FadeTransition from '../FadeTransition'
 import LetterCasePicker from '../LetterCasePicker'
 import LetterCaseIcon from './LetterCaseIcon'
 
-/** Text Color Icon Component with popup ColorPicker. */
+/** Letter Case Icon Component with popup Picker. */
 const Icon = ({ size = 20, style, cssRaw }: IconType) => {
-  const showLetterCase = useSelector(state => state.showLetterCase)
-  const toolbarPopupRef = useRef<HTMLDivElement>(null)
-
   return (
     <div>
       <LetterCaseIcon size={size} style={style} cssRaw={cssRaw} />
-      <FadeTransition duration='fast' nodeRef={toolbarPopupRef} in={showLetterCase} exit={false} unmountOnExit>
-        <div
-          className={css({
-            position: 'relative',
-            zIndex: 'stack',
-            // position fixed or absolute causes the ColorPicker to get clipped by the toolbar's overflow-x: scroll
-            // ideally we want overflow-x:scroll and overflow-y:visible, but Safari does not differing allow overflow-x and overflow-y
-            // instead, keep position:static but set the width to 0
-            // this will increase the height of the toolbar so the ColorPicker does not get clipped without taking up horizontal space
-            width: 0,
-          })}
-          ref={toolbarPopupRef}
-          style={{
-            // eyeballing it to get font sizes 14–24 to look right
-            left: (size * (size + 90)) / 200 + 600 / (size * size),
-            marginTop: size * 1.2 - 10,
-          }}
-        >
-          <LetterCasePicker fontSize={size} cssRaw={css.raw({ transform: `translate(-50%)` })} />
-        </div>
-      </FadeTransition>
+      <LetterCasePicker size={size} />
     </div>
   )
 }

--- a/src/components/icons/SortWithPicker.tsx
+++ b/src/components/icons/SortWithPicker.tsx
@@ -1,40 +1,16 @@
-import { useRef } from 'react'
 import { useSelector } from 'react-redux'
-import { css } from '../../../styled-system/css'
 import IconType from '../../@types/IconType'
-import FadeTransition from '../FadeTransition'
 import SortPicker from '../SortPicker'
 import SortIcon from './Sort'
 
-/** Sort Icon Component with popup SortPicker. */
+/** Sort Icon Component with popup Picker. */
 const SortWithPicker = ({ size = 18, style, cssRaw }: IconType) => {
   const showSortPicker = useSelector(state => state.showSortPicker)
-  const toolbarPopupRef = useRef<HTMLDivElement>(null)
 
   return (
     <div>
       <SortIcon size={size} style={style} cssRaw={cssRaw} animated={showSortPicker} />
-      <FadeTransition duration='fast' nodeRef={toolbarPopupRef} in={showSortPicker} exit={false} unmountOnExit>
-        <div
-          ref={toolbarPopupRef}
-          className={css({
-            position: 'relative',
-            zIndex: 'stack',
-            // position fixed or absolute causes the SortPicker to get clipped by the toolbar's overflow-x: scroll
-            // ideally we want overflow-x:scroll and overflow-y:visible, but Safari does not differing allow overflow-x and overflow-y
-            // instead, keep position:static but set the width to 0
-            // this will increase the height of the toolbar so the SortPicker does not get clipped without taking up horizontal space
-            width: 0,
-          })}
-          style={{
-            // eyeballing it to get font sizes 14–24 to look right
-            left: (size * (size + 90)) / 200 + 600 / (size * size),
-            marginTop: size * 1.2 - 10,
-          }}
-        >
-          <SortPicker fontSize={size} cssRaw={css.raw({ transform: `translate(-50%)` })} />
-        </div>
-      </FadeTransition>
+      <SortPicker size={size} />
     </div>
   )
 }

--- a/src/components/icons/TextColorWithColorPicker.tsx
+++ b/src/components/icons/TextColorWithColorPicker.tsx
@@ -1,16 +1,12 @@
-import { useRef } from 'react'
 import { useSelector } from 'react-redux'
-import { css } from '../../../styled-system/css'
 import { token } from '../../../styled-system/tokens'
 import IconType from '../../@types/IconType'
 import ColorPicker from '../ColorPicker'
-import FadeTransition from '../FadeTransition'
 import TextColorIcon from './TextColor'
 
 /** Text Color Icon with popup ColorPicker. */
 const TextColorWithColorPicker = ({ size = 18, style, cssRaw }: IconType) => {
   const showColorPicker = useSelector(state => state.showColorPicker)
-  const toolbarPopupRef = useRef<HTMLDivElement>(null)
 
   return (
     <div>
@@ -21,27 +17,7 @@ const TextColorWithColorPicker = ({ size = 18, style, cssRaw }: IconType) => {
         animated={showColorPicker}
         fill={style?.fill || token('colors.fg')}
       />
-      <FadeTransition duration='fast' nodeRef={toolbarPopupRef} in={showColorPicker} exit={false} unmountOnExit>
-        <div
-          ref={toolbarPopupRef}
-          className={css({
-            zIndex: 'stack',
-            position: 'relative',
-            // position fixed or absolute causes the ColorPicker to get clipped by the toolbar's overflow-x: scroll
-            // ideally we want overflow-x:scroll and overflow-y:visible, but Safari does not differing allow overflow-x and overflow-y
-            // instead, keep position:static but set the width to 0
-            // this will increase the height of the toolbar so the ColorPicker does not get clipped without taking up horizontal space
-            width: 0,
-          })}
-          style={{
-            // eyeballing it to get font sizes 14–24 to look right
-            left: (size * (size + 90)) / 200 + 600 / (size * size),
-            marginTop: size * 1.2 - 10,
-          }}
-        >
-          <ColorPicker fontSize={size} cssRaw={css.raw({ transform: `translate(-50%)` })} />
-        </div>
-      </FadeTransition>
+      <ColorPicker size={size} />
     </div>
   )
 }

--- a/src/components/icons/TextColorWithColorPicker.tsx
+++ b/src/components/icons/TextColorWithColorPicker.tsx
@@ -4,7 +4,7 @@ import IconType from '../../@types/IconType'
 import ColorPicker from '../ColorPicker'
 import TextColorIcon from './TextColor'
 
-/** Text Color Icon with popup ColorPicker. */
+/** Text Color Icon with popup Picker. */
 const TextColorWithColorPicker = ({ size = 18, style, cssRaw }: IconType) => {
   const showColorPicker = useSelector(state => state.showColorPicker)
 


### PR DESCRIPTION
@raineorshine the exports design hasn't been finalized yet, but I thought I'd create the Popover shared component first.

Should I rename this to Picker instead of Popover?

<img width="177" alt="Screenshot 2025-03-30 at 4 31 40 PM" src="https://github.com/user-attachments/assets/a4ca839e-6591-4127-9880-90b0370e5bae" />
<img width="422" alt="Screenshot 2025-03-30 at 4 31 35 PM" src="https://github.com/user-attachments/assets/7e2e2d08-a340-449d-bede-3c3c867ad74c" />
<img width="191" alt="Screenshot 2025-03-30 at 4 31 55 PM" src="https://github.com/user-attachments/assets/683c6394-6997-4a00-a1be-4ca47705a420" />
