### PR TITLE
[Android] Virtual keyboard does not open on New Thought 

### DIFF
--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -8,7 +8,7 @@ import createThought from '../actions/createThought'
 import setCursor from '../actions/setCursor'
 import tutorialNext from '../actions/tutorialNext'
 import tutorialStepReducer from '../actions/tutorialStep'
-import { isSafari, isTouch } from '../browser'
+import { isTouch } from '../browser'
 import {
   ABSOLUTE_PATH,
   ABSOLUTE_TOKEN,
@@ -240,7 +240,7 @@ export const newThoughtActionCreator =
     // cancel if tutorial has just started
     if (tutorial && tutorialStep === TUTORIAL_STEP_START) return
 
-    if (!preventSetCursor && isTouch && isSafari()) {
+    if (!preventSetCursor && isTouch) {
       asyncFocus()
     }
 

--- a/src/device/asyncFocus.ts
+++ b/src/device/asyncFocus.ts
@@ -1,4 +1,4 @@
-import { isSafari, isTouch } from '../browser'
+import { isTouch } from '../browser'
 import { noop } from '../constants'
 import * as selection from './selection'
 
@@ -10,7 +10,7 @@ import * as selection from './selection'
  * See: https://stackoverflow.com/a/45703019/480608.
  */
 export const AsyncFocus: () => () => void = () => {
-  if (!isTouch || !isSafari()) return noop
+  if (!isTouch) return noop
 
   // create invisible dummy input to receive the focus
   const hiddenInput = document.createElement('input')


### PR DESCRIPTION
PR for issue #2821 

### Problem

On touch devices, the virtual keyboard was not appearing when users performed gestures to create new thoughts, new sub-thoughts and other similar actions. The root cause was that the asyncFocus() function, which is responsible for triggering the virtual keyboard, was conditionally called only for Safari browsers due to a check that looked like:

```ts
if (isTouch && isSafari()) {
  asyncFocus()
}
```
This meant that non-Safari mobile browsers (like Chrome on iOS or Android browsers) were not properly triggering the keyboard to appear after gesture commands completed.

### Solution

The solution was simply to remove the Safari browser check from the condition.

> NOTE: The Safari-only check was likely added historically because this workaround was primarily needed for Safari, but the same issue exists across mobile browsers. By removing the Safari-specific check, the virtual keyboard now appears properly across all mobile browsers when gesture commands complete.