### PR TITLE
Fix __ROOT__ token shouldnt be rendered on close context view

### DIFF
--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -115,7 +115,7 @@ const StaticThought = ({
   const showContexts = useSelector(state => isContextViewActive(state, rootedParentOf(state, path)))
   const fontSize = useSelector(state => state.fontSize)
   const dark = useSelector(state => theme(state) !== 'Light')
-  const homeContext = showContexts && isRoot(simplePath) && !isContextPending
+  const homeContext = isRoot(simplePath) && !isContextPending
   const value = useSelector(state => getThoughtById(state, head(simplePath))?.value) ?? ''
   // store ContentEditable ref to update DOM without re-rendering the Editable during editing
   const editableRef = React.useRef<HTMLInputElement>(null)


### PR DESCRIPTION
Close #2715 

## Overview
Looks like there’s a race condition in Redux between two components: ⁠ LayoutTree ⁠ and ⁠ StaticThought ⁠, both of which rely on ⁠ contextView ⁠ state.
- `LayoutTree` determines which nodes (thoughts) should be rendered, including handling visibility when contextView is active.
- `StaticThought` controls whether the `HomeIcon` should be displayed when contextView is active.

When closing context view of ⁠` m`⁠, ⁠ `LayoutTree` ⁠ updates the list of nodes to reflect that change. Since context view of ⁠ `m` ⁠ is now off, it removes the related nodes from the render tree. But at the same time, `StaticThought` is also reacting to the change, but it only sees that `contextView of m` has now become false without being aware that `LayoutTree` has already unmounted the context view nodes. And this results in a brief flicker where the HomeIcon shows up as `__ROOT__` before it disappears.

## Solution
To fix the issue, we decided to remove the usage of `showContext` inside `<StaticThought/>` to determine the value of `homeContext`. This avoids rendering the path `__ROOT__` as `__ROOT__` when the contextView state of `m` is false, while LayoutTree hasnt yet finished unmounting the context view nodes. By doing this, we will also render `__ROOT__` as homeIcon by default.


## Screenshots / Videos

https://github.com/user-attachments/assets/103dd88d-2899-477f-a12f-3a0c87ff9e2b


