### PR TITLE
Animate Bullet cursor overlay

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -297,8 +297,8 @@ const BulletLeaf = ({
       data-bullet='leaf'
       ry={radius}
       rx={radius}
-      cy='298'
-      cx='297'
+      cy='300'
+      cx='300'
       style={{
         // allow .gray to define fill when missing
         // allow .graypulse to define fill when pending
@@ -366,10 +366,9 @@ const BulletParent = ({
 }
 
 /** A larger circle that surrounds the bullet of the cursor thought. */
-const BulletCursorOverlay = ({
+const BulletHighlightOverlay = ({
   isHighlighted,
 }: {
-  isEditing: boolean
   isHighlighted?: boolean
   leaf?: boolean
   publish?: boolean
@@ -584,9 +583,8 @@ const Bullet = ({
         ref={svgElement}
       >
         <g>
-          {!(publish && (isRoot || isRootChildLeaf)) && (isEditing || isHighlighted) && !isQuickDropDeleteHovering && (
-            <BulletCursorOverlay
-              isEditing={isEditing}
+          {!(publish && (isRoot || isRootChildLeaf)) && isHighlighted && !isQuickDropDeleteHovering && (
+            <BulletHighlightOverlay
               isHighlighted={isHighlighted}
               leaf={leaf}
               publish={publish}

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -174,23 +174,6 @@ function PlaceholderContextBreadcrumbs({ simplePath }: { simplePath: SimplePath 
 }
 
 /**
- * PlaceholderSubThought is a component mimicking the behavior of SubThought.
- * Needed to prevent the overlay from covering the bullet.
- */
-function PlaceholderSubThought({ children }: { children?: React.ReactNode }) {
-  return (
-    <div
-      aria-label='placeholder-subthought'
-      className={css({
-        willChange: 'opacity',
-      })}
-    >
-      {children}
-    </div>
-  )
-}
-
-/**
  * PlaceholderTreeNode is a component used to mimic behavior of TreeNode.
  * Any position changes from one Thought to another will be animated within this component.
  */
@@ -361,25 +344,23 @@ export default function BulletCursorOverlay({
 
   return (
     <PlaceholderTreeNode width={width} x={x} y={y} isTableCol1={isTableCol1}>
-      <PlaceholderSubThought>
-        {showContexts && simplePath?.length > 1 && <PlaceholderContextBreadcrumbs simplePath={simplePath} />}
+      {showContexts && simplePath?.length > 1 && <PlaceholderContextBreadcrumbs simplePath={simplePath} />}
 
-        <div
-          aria-label='placeholder-thought-container'
-          className={css({
-            /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
-            /* must match value used in Editable useMultiline */
-            lineHeight: '2',
-            // ensure that ThoughtAnnotation is positioned correctly
-            position: 'relative',
-            ...(hideBullet ? { marginLeft: -12 } : null),
-          })}
-        >
-          <CursorOverlay simplePath={simplePath} path={path} leaf={leaf} isInContextView={isInContextView} />
+      <div
+        aria-label='placeholder-thought-container'
+        className={css({
+          /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
+          /* must match value used in Editable useMultiline */
+          lineHeight: '2',
+          // ensure that ThoughtAnnotation is positioned correctly
+          position: 'relative',
+          ...(hideBullet ? { marginLeft: -12 } : null),
+        })}
+      >
+        <CursorOverlay simplePath={simplePath} path={path} leaf={leaf} isInContextView={isInContextView} />
 
-          <PlaceholderThoughtAnnotation />
-        </div>
-      </PlaceholderSubThought>
+        <PlaceholderThoughtAnnotation />
+      </div>
     </PlaceholderTreeNode>
   )
 }

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -1,0 +1,385 @@
+import { useSelector } from 'react-redux'
+import { css } from '../../styled-system/css'
+import Path from '../@types/Path'
+import SimplePath from '../@types/SimplePath'
+import Thought from '../@types/Thought'
+import ThoughtId from '../@types/ThoughtId'
+import { isSafari, isTouch, isiPhone } from '../browser'
+import useHideBullet from '../hooks/useHideBullet'
+import attributeEquals from '../selectors/attributeEquals'
+import { findAnyChild, getChildrenRanked } from '../selectors/getChildren'
+import isContextViewActive from '../selectors/isContextViewActive'
+import rootedParentOf from '../selectors/rootedParentOf'
+import equalThoughtRanked from '../util/equalThoughtRanked'
+import getBulletWidth from '../util/getBulletWidth'
+import head from '../util/head'
+import isRoot from '../util/isRoot'
+import parentOf from '../util/parentOf'
+import FauxCaret from './FauxCaret'
+
+type BulletCursorOverlayProps = {
+  x: number
+  y: number
+  simplePath: SimplePath
+  path: Path
+  isTableCol1: boolean
+  width?: number
+  value?: string
+  parentId: ThoughtId
+  showContexts?: boolean
+  leaf?: boolean
+}
+
+const isIOSSafari = isTouch && isiPhone && isSafari()
+
+/** Returns true if two lists of children are equal. Deeply compares id, value, and rank. */
+const equalChildren = (a: Thought[], b: Thought[]) =>
+  a === b ||
+  (a && b && a.length === b.length && a.every((thought, i) => equalThoughtRanked(a[i], b[i]) && a[i].id === b[i].id))
+
+/**
+ * CursorOverlay is a component that renders the cursor overlay for a thought bullet.
+ * @param props - The props for the component.
+ * @returns The rendered cursor overlay.
+ */
+function CursorOverlay({
+  simplePath,
+  path,
+  leaf,
+  isInContextView,
+}: {
+  simplePath: SimplePath
+  path: Path
+  leaf?: boolean
+  isInContextView?: boolean
+}) {
+  const bulletOverlayRadius = isIOSSafari ? 300 : 245
+
+  // Bottom margin for bullet to align with thought text
+  const glyphBottomMargin = isIOSSafari ? '-0.2em' : '-0.3em'
+
+  const showContexts = useSelector(state => isContextViewActive(state, path))
+  const fontSize = useSelector(state => state.fontSize)
+
+  const lineHeight = fontSize * 1.25
+
+  const extendClickWidth = fontSize * 1.2
+  const extendClickHeight = fontSize / 3
+
+  const isTableCol1 = useSelector(state =>
+    attributeEquals(state, head(rootedParentOf(state, simplePath)), '=view', 'Table'),
+  )
+
+  // calculate position of bullet for different font sizes
+  // Table column 1 needs more space between the bullet and thought for some reason
+  const width = getBulletWidth(fontSize) + (!isInContextView && isTableCol1 ? fontSize / 4 : 0)
+  const marginLeft = -width
+
+  return (
+    <span
+      aria-label='placeholder-bullet'
+      style={{
+        top: -extendClickHeight,
+        left: -extendClickWidth + marginLeft,
+        paddingTop: extendClickHeight,
+        paddingLeft: extendClickWidth,
+        paddingBottom: extendClickHeight + 2,
+        width,
+        position: 'absolute',
+        verticalAlign: 'top',
+        zIndex: isIOSSafari ? 4 : undefined, // fix misalignment of cursor on iOS
+      }}
+    >
+      <svg
+        viewBox='0 0 600 600'
+        style={{
+          height: lineHeight,
+          width: lineHeight,
+          marginLeft: -lineHeight,
+          // required to make the distance between bullet and thought scale properly at all font sizes.
+          left: lineHeight * 0.317,
+          marginBottom: glyphBottomMargin,
+          willChange: 'transform',
+          position: 'relative',
+          // backgroundColor: 'red',
+          top: showContexts && leaf && isIOSSafari ? '-0.05em' : undefined,
+        }}
+      >
+        <g>
+          <ellipse
+            ry={bulletOverlayRadius}
+            rx={bulletOverlayRadius}
+            cy='300'
+            cx='300'
+            className={css({
+              stroke: 'highlight',
+              fillOpacity: 0.25,
+              fill: 'fg',
+            })}
+          />
+        </g>
+      </svg>
+    </span>
+  )
+}
+
+/**
+ * PlaceholderContextBreadcrumbs is a component that renders invisible breadcrumbs for context view.
+ * Used to maintain layout consistency when context breadcrumbs are present.
+ */
+function PlaceholderContextBreadcrumbs({ simplePath }: { simplePath: SimplePath; path: Path }) {
+  const ancestors = parentOf(simplePath)
+
+  const isHaveMultipleAncestors = ancestors.length > 1
+
+  return (
+    <div
+      aria-label='placeholder-ctx-breadcrumbs-outer-container'
+      className={css({
+        marginLeft: 'calc(1.3em - 14.5px)',
+        minHeight: '1em',
+        visibility: 'hidden',
+        marginBottom: '-0.25em', // Tighten up the space between the context-breadcrumbs and the thought (similar to the space above a note).
+        paddingTop: '0.5em', // Use padding-top instead of margin-top to ensure this gets included in the dynamic height of each thought. Otherwise the accumulated y value will not be correct.
+      })}
+      style={{
+        fontSize: '0.867em',
+        marginTop: '0.533em',
+      }}
+    >
+      {isRoot(simplePath) ? null : (
+        <span
+          style={{
+            wordBreak: 'break-word',
+            textDecoration: 'none',
+            WebkitTextStrokeWidth: '0.05em',
+
+            height: '1em',
+            margin: '-0.5em',
+            padding: '0.5em',
+            ...(isHaveMultipleAncestors
+              ? {
+                  lineHeight: '16px',
+                }
+              : {}),
+          }}
+          dangerouslySetInnerHTML={{ __html: '&ZeroWidthSpace;' }}
+        ></span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * PlaceholderSubThought is a component that renders a sub-thought in the thought tree.
+ * @param param0 - The props for the component.
+ * @returns The rendered component.
+ */
+function PlaceholderSubThought({ children }: { children?: React.ReactNode }) {
+  return (
+    <div
+      aria-label='placeholder-subthought'
+      className={css({
+        willChange: 'opacity',
+      })}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * PlaceholderTreeNode is a component used to mimic behavior of TreeNode.
+ * Any position changes from one Thought to another will be animated within this component.
+ */
+function PlaceholderTreeNode({
+  children,
+  isTableCol1 = false,
+  x,
+  y,
+  width,
+}: {
+  children?: React.ReactNode
+  isTableCol1?: boolean
+  x: number
+  y: number
+  width: number
+}) {
+  const outerDivStyle = {
+    left: x,
+    top: y,
+    // Table col1 uses its exact width since cannot extend to the right edge of the screen.
+    // All other thoughts extend to the right edge of the screen. We cannot use width auto as it causes the text to wrap continuously during the counter-indentation animation, which is jarring. Instead, use a fixed width of the available space so that it changes in a stepped fashion as depth changes and the word wrap will not be animated. Use x instead of depth in order to accommodate ancestor tables.
+    // 1em + 10px is an eyeball measurement at font sizes 14 and 18
+    // (Maybe the 10px is from .content padding-left?)
+    width: isTableCol1 ? width : 'calc(100% - ${x}px + 1em + 10px)',
+    textAlign: isTableCol1 ? ('right' as const) : undefined,
+  }
+
+  return (
+    <div
+      aria-label='placeholder-tree-node'
+      className={css({
+        transition: 'left {durations.layoutNodeAnimation} linear,top {durations.layoutNodeAnimation} ease-in-out',
+        ...(isTableCol1
+          ? {
+              position: 'relative',
+              width: 'auto',
+            }
+          : {
+              position: 'absolute',
+              width: '100%',
+            }),
+      })}
+      style={{
+        ...outerDivStyle,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * A placeholder component for the ThoughtAnnotation component.
+ * Used to maintain consistent positioning of the cursor and bullet in normal view on iOS.
+ */
+function PlaceholderThoughtAnnotation() {
+  return (
+    <div
+      aria-label='placeholder-thought-annotation-outer-container'
+      className={css({
+        opacity: 0,
+        position: 'absolute',
+        boxSizing: 'border-box',
+        width: '100%',
+        marginTop: '0',
+        display: 'inline-block',
+        verticalAlign: 'top',
+        whiteSpace: 'pre-wrap',
+        maxWidth: '100%',
+        '@media (max-width: 500px)': {
+          marginTop: { _android: '-2.1px' },
+          marginLeft: { _android: '0.5em' },
+        },
+        '@media (min-width: 560px) and (max-width: 1024px)': {
+          marginTop: { _android: '-0.1px' },
+          marginLeft: { _android: '0.5em' },
+        },
+      })}
+    >
+      <div
+        aria-label='placeholder-thought-annotation-inner-container'
+        className={css({
+          display: 'inline-block',
+          maxWidth: '100%',
+          boxSizing: 'border-box',
+          paddingRight: '0.333em',
+        })}
+        style={{
+          padding: '0 0.333em',
+          margin: '-0.5px 0 0 calc(1em - 18px)',
+        }}
+      >
+        <span
+          className={css({
+            fontSize: '1.25em',
+            margin: '-0.375em 0 0 -0.05em',
+            position: 'absolute',
+          })}
+        >
+          <FauxCaret caretType='thoughtStart' />
+        </span>
+        <span
+          className={css({
+            visibility: 'hidden',
+            position: 'relative',
+            clipPath: 'inset(0.001px 0 0.1em 0)',
+            wordBreak: 'break-word',
+          })}
+          dangerouslySetInnerHTML={{ __html: '&ZeroWidthSpace;' }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * BulletCursorOverlay is a component used to animate the cursor overlay from the bullet.
+ * This component also contains placeholders for other components to maintain consistency of cursor overlay position.
+ **/
+export default function BulletCursorOverlay({
+  x,
+  y,
+  simplePath,
+  path,
+  isTableCol1,
+  width = 0,
+  value,
+  parentId,
+  showContexts,
+  leaf,
+}: BulletCursorOverlayProps) {
+  const childrenAttributeId = useSelector(
+    state => (value !== '=children' && findAnyChild(state, parentId, child => child.value === '=children')?.id) || null,
+  )
+  const grandparentId = simplePath[simplePath.length - 3]
+
+  const grandchildrenAttributeId = useSelector(
+    state =>
+      (value !== '=style' && findAnyChild(state, grandparentId, child => child.value === '=grandchildren')?.id) || null,
+  )
+
+  const hideBulletProp = useSelector(state => {
+    const hideBulletsChildren = attributeEquals(state, childrenAttributeId, '=bullet', 'None')
+    if (hideBulletsChildren) return true
+    const hideBulletsGrandchildren =
+      value !== '=bullet' && attributeEquals(state, grandchildrenAttributeId, '=bullet', 'None')
+    if (hideBulletsGrandchildren) return true
+    return false
+  })
+
+  const children = useSelector<Thought[]>(
+    state => getChildrenRanked(state, head(simplePath)),
+    // only compare id, value, and rank for re-renders
+    equalChildren,
+  )
+
+  const isInContextView = useSelector(state => isContextViewActive(state, parentOf(path)))
+
+  const hideBullet = useHideBullet({
+    children,
+    env: {},
+    hideBulletProp,
+    isEditing: true,
+    simplePath,
+    isInContextView,
+    thoughtId: head(simplePath),
+  })
+
+  return (
+    <PlaceholderTreeNode width={width} x={x} y={y} isTableCol1={isTableCol1}>
+      <PlaceholderSubThought>
+        {showContexts && simplePath?.length > 1 && (
+          <PlaceholderContextBreadcrumbs simplePath={simplePath} path={path} />
+        )}
+
+        <div
+          aria-label='placeholder-thought-container'
+          className={css({
+            /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
+            /* must match value used in Editable useMultiline */
+            lineHeight: '2',
+            // ensure that ThoughtAnnotation is positioned correctly
+            position: 'relative',
+            ...(hideBullet ? { marginLeft: -12 } : null),
+          })}
+        >
+          <CursorOverlay simplePath={simplePath} path={path} leaf={leaf} isInContextView={isInContextView} />
+
+          <PlaceholderThoughtAnnotation />
+        </div>
+      </PlaceholderSubThought>
+    </PlaceholderTreeNode>
+  )
+}

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -39,8 +39,6 @@ const equalChildren = (a: Thought[], b: Thought[]) =>
 
 /**
  * CursorOverlay is a component that renders the cursor overlay for a thought bullet.
- * @param props - The props for the component.
- * @returns The rendered cursor overlay.
  */
 function CursorOverlay({
   simplePath,
@@ -101,8 +99,8 @@ function CursorOverlay({
           marginBottom: glyphBottomMargin,
           willChange: 'transform',
           position: 'relative',
-          // backgroundColor: 'red',
-          top: showContexts && leaf && isIOSSafari ? '-0.05em' : undefined,
+
+          top: showContexts && isIOSSafari ? '-0.05em' : undefined,
         }}
       >
         <g>
@@ -127,10 +125,8 @@ function CursorOverlay({
  * PlaceholderContextBreadcrumbs is a component that renders invisible breadcrumbs for context view.
  * Used to maintain layout consistency when context breadcrumbs are present.
  */
-function PlaceholderContextBreadcrumbs({ simplePath }: { simplePath: SimplePath; path: Path }) {
-  const ancestors = parentOf(simplePath)
-
-  const isHaveMultipleAncestors = ancestors.length > 1
+function PlaceholderContextBreadcrumbs({ simplePath }: { simplePath: SimplePath }) {
+  const isHaveMultipleAncestors = simplePath.length > 2
 
   return (
     <div
@@ -171,9 +167,8 @@ function PlaceholderContextBreadcrumbs({ simplePath }: { simplePath: SimplePath;
 }
 
 /**
- * PlaceholderSubThought is a component that renders a sub-thought in the thought tree.
- * @param param0 - The props for the component.
- * @returns The rendered component.
+ * PlaceholderSubThought is a component mimicking the behavior of SubThought.
+ * Needed to prevent the overlay from covering the bullet.
  */
 function PlaceholderSubThought({ children }: { children?: React.ReactNode }) {
   return (
@@ -212,7 +207,7 @@ function PlaceholderTreeNode({
     // All other thoughts extend to the right edge of the screen. We cannot use width auto as it causes the text to wrap continuously during the counter-indentation animation, which is jarring. Instead, use a fixed width of the available space so that it changes in a stepped fashion as depth changes and the word wrap will not be animated. Use x instead of depth in order to accommodate ancestor tables.
     // 1em + 10px is an eyeball measurement at font sizes 14 and 18
     // (Maybe the 10px is from .content padding-left?)
-    width: isTableCol1 ? width : 'calc(100% - ${x}px + 1em + 10px)',
+    width: isTableCol1 ? width : `calc(100% - ${x}px + 1em + 10px)`,
     textAlign: isTableCol1 ? ('right' as const) : undefined,
   }
 
@@ -360,9 +355,7 @@ export default function BulletCursorOverlay({
   return (
     <PlaceholderTreeNode width={width} x={x} y={y} isTableCol1={isTableCol1}>
       <PlaceholderSubThought>
-        {showContexts && simplePath?.length > 1 && (
-          <PlaceholderContextBreadcrumbs simplePath={simplePath} path={path} />
-        )}
+        {showContexts && simplePath?.length > 1 && <PlaceholderContextBreadcrumbs simplePath={simplePath} />}
 
         <div
           aria-label='placeholder-thought-container'

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -8,11 +8,13 @@ import { isSafari, isTouch, isiPhone } from '../browser'
 import useHideBullet from '../hooks/useHideBullet'
 import attributeEquals from '../selectors/attributeEquals'
 import { findAnyChild, getChildrenRanked } from '../selectors/getChildren'
+import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
 import rootedParentOf from '../selectors/rootedParentOf'
 import equalThoughtRanked from '../util/equalThoughtRanked'
 import getBulletWidth from '../util/getBulletWidth'
 import head from '../util/head'
+import isDivider from '../util/isDivider'
 import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
 import FauxCaret from './FauxCaret'
@@ -59,6 +61,10 @@ function CursorOverlay({
   const showContexts = useSelector(state => isContextViewActive(state, path))
   const fontSize = useSelector(state => state.fontSize)
 
+  const thoughtId = head(simplePath)
+
+  const bulletIsDivider = useSelector(state => isDivider(getThoughtById(state, thoughtId)?.value))
+
   const lineHeight = fontSize * 1.25
 
   const extendClickWidth = fontSize * 1.2
@@ -85,6 +91,7 @@ function CursorOverlay({
         width,
         position: 'absolute',
         verticalAlign: 'top',
+        display: bulletIsDivider ? 'none' : undefined,
         zIndex: isIOSSafari ? 4 : undefined, // fix misalignment of cursor on iOS
       }}
     >

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -16,8 +16,8 @@ import nextSibling from '../selectors/nextSibling'
 import reactMinistore from '../stores/react-ministore'
 import scrollTopStore from '../stores/scrollTop'
 import viewportStore from '../stores/viewport'
-import equalPath from '../util/equalPath'
 import head from '../util/head'
+import parentOf from '../util/parentOf'
 import BulletCursorOverlay from './BulletCursorOverlay'
 import HoverArrow from './HoverArrow'
 import TreeNode from './TreeNode'
@@ -218,9 +218,7 @@ const LayoutTree = () => {
   )
 
   // compare between state.cursor and the position of the thought
-  const cursorThoughtPositioned = useSelector(state =>
-    treeThoughtsPositioned.find(thought => equalPath(state.cursor, thought.path)),
-  )
+  const cursorThoughtPositioned = treeThoughtsPositioned.find(thought => thought.isCursor)
 
   // The indentDepth multipicand (0.9) causes the horizontal counter-indentation to fall short of the actual indentation, causing a progressive shifting right as the user navigates deeper. This provides an additional cue for the user's depth, which is helpful when autofocus obscures the actual depth, but it must stay small otherwise the thought width becomes too small.
   // The indentCursorAncestorTables multipicand (0.5) is smaller, since animating over by the entire width of column 1 is too abrupt.
@@ -274,7 +272,7 @@ const LayoutTree = () => {
             y={cursorThoughtPositioned.y}
             showContexts={cursorThoughtPositioned.showContexts}
             width={cursorThoughtPositioned.width}
-            parentId={cursorThoughtPositioned.path[cursorThoughtPositioned.path.length - 2] as ThoughtId}
+            parentId={head(parentOf(cursorThoughtPositioned.path))}
           />
         )}
         <TransitionGroup>

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -16,7 +16,9 @@ import nextSibling from '../selectors/nextSibling'
 import reactMinistore from '../stores/react-ministore'
 import scrollTopStore from '../stores/scrollTop'
 import viewportStore from '../stores/viewport'
+import equalPath from '../util/equalPath'
 import head from '../util/head'
+import BulletCursorOverlay from './BulletCursorOverlay'
 import HoverArrow from './HoverArrow'
 import TreeNode from './TreeNode'
 
@@ -215,6 +217,11 @@ const LayoutTree = () => {
     },
   )
 
+  // compare between state.cursor and the position of the thought
+  const cursorThoughtPositioned = useSelector(state =>
+    treeThoughtsPositioned.find(thought => equalPath(state.cursor, thought.path)),
+  )
+
   // The indentDepth multipicand (0.9) causes the horizontal counter-indentation to fall short of the actual indentation, causing a progressive shifting right as the user navigates deeper. This provides an additional cue for the user's depth, which is helpful when autofocus obscures the actual depth, but it must stay small otherwise the thought width becomes too small.
   // The indentCursorAncestorTables multipicand (0.5) is smaller, since animating over by the entire width of column 1 is too abrupt.
   // (The same multiplicand is applied to the vertical translation that crops hidden thoughts above the cursor.)
@@ -258,6 +265,18 @@ const LayoutTree = () => {
           marginRight: `${-indent + (isTouch ? 2 : -1)}em`,
         }}
       >
+        {cursorThoughtPositioned && (
+          <BulletCursorOverlay
+            isTableCol1={cursorThoughtPositioned.isTableCol1}
+            path={cursorThoughtPositioned.path}
+            simplePath={cursorThoughtPositioned.simplePath}
+            x={cursorThoughtPositioned.x}
+            y={cursorThoughtPositioned.y}
+            showContexts={cursorThoughtPositioned.showContexts}
+            width={cursorThoughtPositioned.width}
+            parentId={cursorThoughtPositioned.path[cursorThoughtPositioned.path.length - 2] as ThoughtId}
+          />
+        )}
         <TransitionGroup>
           {treeThoughtsPositioned.map((thought, index) => (
             <TreeNode


### PR DESCRIPTION
Close #2730 

## Description
The main goal of this PR is to animate the bullet cursor overlay whenever the cursor moves. However, to achieve this, I also made several related changes:

- Moved `BulletCursorOverlay` to the `LayoutTree` level.

- Separated the overlay for the active cursor (`BulletCursorOverlay`) and the highlighted cursor (`BulletHighlightOverlay`) when dragging the node

- Moved variables related to bullet and cursor position (mostly padding and margin) into a hook. This ensures that any changes affecting bullet and cursor positioning are automatically synchronized across all relevant components. Affected components: `BulletCursorOverlay`, `Bullet`, `ContextBreadcrumbs`, and `ThoughtAnnotation`.

## How the Position Calculation Works
The x and y positions of the cursor overlay are determined by the bullet’s position, which is affected by left-right alignment, margin, and padding across normal view, context view, and table view. Additionally, font size changes impact positioning since most margins and paddings use the em unit.

**Calculation Breakdown:**
```
X = X of active thought + left position + margin left -  padding left
```

```
Y = Y of active thought + margin top + padding top - margin bottom - padding bottom
```

There are also a few extra factors that affect the X position:
- When the thought is in **table view** and **it's in column 1**
- When the thought is in **context view** (adds extra pixels due to rendering ContextBreadcrumb)
The calculation follows the same logic as the X position adjustments mentioned earlier.



For the Y position with contextView , slight adjustments occur when the thought is in context view and has a breadcrumb. The Y position follows this formula:

```
Breadcrumb Y position = breadcrumb margin-top + Max(fontSize, breadcrumbFontSize + breadcrumb padding-top)
```

With
- `fontSize` is `1em`
- `breadcrumbFontSize` is `0.867em`

## Notes:
- The position of the cursor overlay may not always be perfectly centered, especially when using a small font size. However, I’ve adjusted it so that the bullet always remains within the overlay, even if it’s not perfectly centered.

- When Table View and Context View are active, there is a case where the cursor overlay highlights a blank space. I’ve verified that a node should be rendered in this blank space, but it's currently missing due to a duplicate key issue in the `TreeNode` component. This issue existed before these changes but was less noticeable because the cursor overlay was previously inside the TreeNode. So when the duplicate key issue happened, the cursor overlay didnt render, because the TreeNode with the duplicate key wasnt rendered either. (will be addressed in here: #2884 )

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/c94563e5-b31f-4b4a-a5a5-62221fbb12f2" />

## Results (Videos/Screenshots)
**Desktop Chrome (font size 18)**

https://github.com/user-attachments/assets/cba8713f-4403-4ff0-a34b-f87b64ab258f

---

**Context View active**

https://github.com/user-attachments/assets/d0125e51-7a34-4585-bd18-cdb23755f2e0


---
**When Table View and Context View is active**

https://github.com/user-attachments/assets/ceb68ba6-936f-472f-876f-5cf18f8ba9c0

---
**Font Size 32**


https://github.com/user-attachments/assets/8e0628a4-42af-4e4a-9def-6dc7b3619ff7



---
**Font Size 10**

https://github.com/user-attachments/assets/253fdc5d-d9a3-4328-b434-22d061cc42fa



---
**iOS App**

https://github.com/user-attachments/assets/8b6c5ba7-18c1-4889-ba43-5829e460af3a



---
**iOS Safari**

https://github.com/user-attachments/assets/42702f6f-cb23-49ae-a19f-ed9d0b117b15



---
**Android App**

https://github.com/user-attachments/assets/79f26c61-73d0-408f-a3cd-7bd218b14252


---
**Android Chrome**

https://github.com/user-attachments/assets/c2dfd285-fbdf-48b2-8510-b87ed3fb036d


