### PR TITLE
Remove Safari-specific positioning for empty thought

### DIFF
--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -202,7 +202,7 @@ const ThoughtAnnotation = React.memo(
           <span
             className={css({
               fontSize: '1.25em',
-              margin: textMarkup.length ? '-0.375em 0 0 -0.125em' : '-0.25em 0 0 -0.0875em',
+              margin: '-0.375em 0 0 -0.05em',
               position: 'absolute',
             })}
           >

--- a/src/recipes/editable.ts
+++ b/src/recipes/editable.ts
@@ -23,19 +23,6 @@ const editableRecipe = defineRecipe({
       _mobile: '-2px',
     },
     paddingBottom: { _mobile: '0' },
-    /* On Safari, the caret is not lined up with the placeholder text on empty thoughts (due to either negative margin or line-height).
-      Add padding-top to shift the caret down.
-      This bumps the placeholder text off, so we need to shift the placeholder text up by the same amount.
-    */
-    '&:empty': {
-      paddingTop: { _safari: '0.2em' },
-      marginBottom: { _safari: '-0.2em' } /* offset padding-top, otherwise next sibling will be bumped down */,
-    },
-    '&:empty::before': {
-      /* shift placeholder up to offset padding-top */
-      top: { _safari: '-0.2em' },
-      position: { _safari: 'relative' },
-    },
   },
 })
 


### PR DESCRIPTION
It appears that the Safari-specific styles in the editable recipe were responsible for the incorrect positioning of the placeholder relative to the caret. I wouldn't describe the result as perfectly-centered, but it looks pretty consistent with the positioning of text within a non-empty thought so let me know what you think.