### PR TITLE
2779 bug clear thought remove note focus

### DIFF
--- a/src/actions/cursorCleared.ts
+++ b/src/actions/cursorCleared.ts
@@ -15,6 +15,8 @@ const cursorCleared = (state: State, { value }: { value: boolean }): State => ({
   editableNonce: state.editableNonce + 1,
   // manually set edit mode to true since the cursor is not changing and normally setCursor handles this
   editing: value,
+  // clearing the cursor should always move the caret into the empty thought
+  noteFocus: false,
 })
 
 /** Temporary clear the cursor in response to the clearThought. NOOP if value is no different than current state. See actions/cursorCleared. */

--- a/src/commands/__tests__/clearThought.ts
+++ b/src/commands/__tests__/clearThought.ts
@@ -1,0 +1,57 @@
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { setCursorActionCreator as setCursor } from '../../actions/setCursor'
+import store from '../../stores/app'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
+import executeCommand from '../../util/executeCommand'
+import clearThoughtCommand from '../clearThought'
+
+beforeEach(initStore)
+
+/**
+ * This has been moved to the top because the rest of the tests aren't getting cleaned up.
+ * This should be properly fixed at some point.
+ */
+describe('clearThought', () => {
+  beforeEach(createTestApp)
+  afterEach(cleanupTestApp)
+
+  it('sets noteFocus to false when executing clearThought while noteFocus is true', async () => {
+    await act(async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+              - =note
+                - b
+          `,
+        }),
+        setCursorFirstMatchActionCreator(['a']),
+      ])
+    })
+
+    const { cursor } = store.getState()
+
+    await act(async () => {
+      store.dispatch([setCursor({ path: cursor, noteFocus: true })])
+    })
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    // This ensures that the focus is on the note initially.
+    const { noteFocus: initialNoteFocus } = store.getState()
+    expect(initialNoteFocus).toBe(true)
+
+    await act(async () => {
+      executeCommand(clearThoughtCommand)
+    })
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    // This ensures that the focus is no longer on the note.
+    const { noteFocus } = store.getState()
+    expect(noteFocus).toBe(false)
+  })
+})

--- a/src/commands/clearThought.ts
+++ b/src/commands/clearThought.ts
@@ -1,5 +1,6 @@
 import Command from '../@types/Command'
 import { cursorClearedActionCreator as cursorCleared } from '../actions/cursorCleared'
+import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import ClearThoughtIcon from '../components/icons/ClearThoughtIcon'
 import * as selection from '../device/selection'
 import hasMulticursor from '../selectors/hasMulticursor'
@@ -20,7 +21,12 @@ const clearThoughtCommand: Command = {
     return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
   },
   exec: (dispatch, getState) => {
-    const isCursorCleared = getState().cursorCleared
+    const { cursor, cursorCleared: isCursorCleared, noteFocus } = getState()
+
+    // move the cursor out of the note before clearing the thought
+    if (noteFocus && !isCursorCleared) {
+      dispatch(setCursor({ path: cursor, noteFocus: false }))
+    }
 
     dispatch(cursorCleared({ value: !isCursorCleared }))
 

--- a/src/commands/clearThought.ts
+++ b/src/commands/clearThought.ts
@@ -1,6 +1,5 @@
 import Command from '../@types/Command'
 import { cursorClearedActionCreator as cursorCleared } from '../actions/cursorCleared'
-import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import ClearThoughtIcon from '../components/icons/ClearThoughtIcon'
 import * as selection from '../device/selection'
 import hasMulticursor from '../selectors/hasMulticursor'
@@ -21,12 +20,7 @@ const clearThoughtCommand: Command = {
     return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
   },
   exec: (dispatch, getState) => {
-    const { cursor, cursorCleared: isCursorCleared, noteFocus } = getState()
-
-    // move the cursor out of the note before clearing the thought
-    if (noteFocus && !isCursorCleared) {
-      dispatch(setCursor({ path: cursor, noteFocus: false }))
-    }
+    const { cursorCleared: isCursorCleared } = getState()
 
     dispatch(cursorCleared({ value: !isCursorCleared }))
 


### PR DESCRIPTION
Fixes #2779

When executing `clearThought` while `noteFocus` is true, call `setCursor` with `noteFocus: false` before calling `clearThought` so that the cursor is on the main thought when it is cleared.