### PR TITLE
ThoughtAnnotation: fallback to zero-width space instead of empty string

### DIFF
--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -232,7 +232,7 @@ const ThoughtAnnotation = React.memo(
               cssRaw,
             )}
             style={style}
-            dangerouslySetInnerHTML={{ __html: textMarkup || placeholder || '' }}
+            dangerouslySetInnerHTML={{ __html: textMarkup || placeholder || '&ZeroWidthSpace;' }}
           />
           {
             // do not render url icon on root thoughts in publish mode


### PR DESCRIPTION
Fixes #2892

The empty span in the `ThoughtAnnotation` does not leave any room in the `inline-block` layout for the `thoughtEnd` faux caret to occupy. Adding a `&ZeroWidthSpace` entity to the span makes it participate in the layout.