### PR TITLE
Multiselect: Moving different groups of thoughts down and up breaks rank

### DIFF
--- a/src/selectors/__tests__/getDescendantThoughtIds.ts
+++ b/src/selectors/__tests__/getDescendantThoughtIds.ts
@@ -60,7 +60,7 @@ it('get descendants ordered by rank', () => {
     { value: 'a', rank: 0 },
     { value: 'b', rank: 1 },
     { value: 'c', rank: 2 },
-    { value: 'x', rank: 1.502 }, // rank is nudged towards the next sibling (see getRankBefore)
+    { value: 'x', rank: 1.5 },
   ])
 
   // ordered
@@ -69,7 +69,7 @@ it('get descendants ordered by rank', () => {
   expect(descendantsOrdered).toMatchObject([
     { value: 'a', rank: 0 },
     { value: 'b', rank: 1 },
-    { value: 'x', rank: 1.502 }, // rank is nudged towards the next sibling (see getRankBefore)
+    { value: 'x', rank: 1.5 },
     { value: 'c', rank: 2 },
   ])
 })

--- a/src/selectors/getRankAfter.ts
+++ b/src/selectors/getRankAfter.ts
@@ -48,9 +48,7 @@ const getRankAfter = (state: State, simplePath: SimplePath) => {
       prevSubthought.rank === nextSubthought.rank
       ? (console.warn('Duplicate ranks detected', prevSubthought, nextSubthought), prevSubthought.rank - Math.random()) // nudge into non-conflicting rank
       : // default case set the rank halfway between the prev and next thoughts
-        // set slightly closer to prev thought to allow sorting empty thoughts at the point of creation in alphabetically sorted contexts
-        // use a fraction of prevSubthought.rank in order to maintain a nearby order of magnitude without forcing the halving function to jump an order of magnitude
-        (prevSubthought.rank + nextSubthought.rank) / 2 - prevSubthought.rank * 10e-8
+        (prevSubthought.rank + nextSubthought.rank) / 2
     : // if there is no next thought (i.e. the thought is the last child) then simply increment the rank
       prevSubthought.rank + 1
 

--- a/src/selectors/getRankBefore.ts
+++ b/src/selectors/getRankBefore.ts
@@ -48,9 +48,7 @@ const getRankBefore = (state: State, simplePath: SimplePath) => {
       prevSubthought.rank === nextSubthought.rank
       ? (console.warn('Duplicate ranks detected', prevSubthought, nextSubthought), prevSubthought.rank - Math.random()) // nudge into non-conflicting rank
       : // default case set the rank halfway between the prev and next thoughts
-        // set slightly closer to next thought to allow sorting empty thoughts at the point of creation in alphabetically sorted contexts
-        // use a fraction of nextSubthought.rank in order to maintain a nearby order of magnitude without forcing the halving function to jump an order of magnitude
-        (prevSubthought.rank + nextSubthought.rank) / 2 + nextSubthought.rank * 0.001
+        (prevSubthought.rank + nextSubthought.rank) / 2
     : // if there is no previous thought (i.e. the thought is the first child) then simply decrement the rank
       nextSubthought.rank - 1
 


### PR DESCRIPTION
Close #2853 

## Root cause

The issue is noticeably seen with 7+ thoughts  that relates to how ranks accumulate and interact with the proportional nudge factor. Here's what's happening:

- Each thought has a rank value that determines its position.
- When we move thoughts, new ranks are calculated using `(prevRank + nextRank)/2 + nextRank*0.001
`.
- The nudge factor `(nextRank*0.001)` creates progressively larger gaps as ranks increase.

With 6 or fewer thoughts, the rank differences remain small enough that the proportional nudges don't cause noticeable issues. But once we have 7+ thoughts, especially after multiple move operations:

- The rank values spread out more.
- When we select non-adjacent thoughts (d, e, g), each gets a different proportional nudge.
- Thoughts with higher ranks (like g) get larger nudges.
- This causes g to drift more than d and e, breaking the expected grouping.

## Solution

The use of a fractional component of `prevSubthought.rank`originally added to maintain a nearby order of magnitude and prevent the halving function from jumping an order has been completely removed. This change is safe because the sorting algorithm has been updated from render-time to creation-time, meaning thought.rank is now directly modified during sorting.

 Thorough manual testing was performed, including scenarios with empty thoughts in sorted contexts. No regressions were found, confirming that the removal is safe.