### PR TITLE
Invalid cursor after uncategorize + categorize + cursorForward

### DIFF
--- a/src/actions/__tests__/cursorForward.ts
+++ b/src/actions/__tests__/cursorForward.ts
@@ -39,19 +39,12 @@ describe('normal view', () => {
   it('should use a valid path after uncategorize and categorize operations', () => {
     const steps = [
       newThought('a'),
-
       setCursor(['a']),
-
       categorize,
-
       cursorForward,
-
       cursorBack,
-
       uncategorize({}),
-
       categorize,
-
       cursorForward,
     ]
 

--- a/src/actions/cursorForward.ts
+++ b/src/actions/cursorForward.ts
@@ -13,8 +13,6 @@ import head from '../util/head'
 import headValue from '../util/headValue'
 import unroot from '../util/unroot'
 
-// import validatePath from '../util/validatePath'
-
 /** Moves the cursor forward in the cursorHistory. */
 const cursorForward = (state: State) => {
   const cursorFromHistory = last(state.cursorHistory)


### PR DESCRIPTION
Close #2750 

Root Cause:

The `cursorForward` action used an outdated path from cursorHistory. Its check was too basic as it only looked to see if the head thought in the path was still a child of the current thought, without checking the full structure of the path. After the thought was uncategorized and re-categorized, the structure changed and new thought IDs were created with different relationships. This led the cursor to follow a path that looked valid at the start but was no longer correct overall.

Solution:

If `validChild` exists and `cursorFromHistory` is not undefined, we now append the head thought from `cursorFromHistory` to the current cursor, rather than directly setting `cursorNew` to `cursorFromHistory`. This approach ensures that navigation after categorize/uncategorize actions uses only valid and up-to-date paths.