### PR TITLE
Refactor fastClick using onClick

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -7,7 +7,7 @@ import Loader from './Loader'
 
 interface ActionButtonProps {
   title: string
-  onClick?: (e: React.MouseEvent | React.TouchEvent) => void
+  onClick?: (e: React.MouseEvent) => void
   /** Render button with fg and bg colors inverted. */
   isLoading?: boolean
   isDisabled?: boolean

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -21,7 +21,7 @@ import getThoughtFill from '../selectors/getThoughtFill'
 import isContextViewActive from '../selectors/isContextViewActive'
 import isMulticursorPath from '../selectors/isMulticursorPath'
 import rootedParentOf from '../selectors/rootedParentOf'
-import fastClick, { type FastClickEvent } from '../util/fastClick'
+import fastClick from '../util/fastClick'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
 import isDivider from '../util/isDivider'
@@ -467,7 +467,7 @@ const Bullet = ({
   // expand or collapse on click
   // has some additional logic to make it work intuitively with pin true/false
   const clickHandler = useCallback(
-    (e: FastClickEvent) => {
+    (e: React.MouseEvent) => {
       // short circuit if dragHold
       // useLongPress stop is activated in onMouseUp but is delayed to ensure that dragHold is still true here
       // stopping propagation from useLongPress was not working either due to bubbling order or mismatched event type
@@ -499,6 +499,9 @@ const Bullet = ({
           setCursor({ path: shouldCollapse ? pathParent : path, preserveMulticursor: true }),
         ])
       })
+
+      e.stopPropagation()
+      // stop click event from bubbling up to Content.clickOnEmptySpace
     },
     [dispatch, dragHold, path, simplePath],
   )
@@ -540,8 +543,6 @@ const Bullet = ({
         width,
       }}
       {...fastClick(clickHandler, { enableHaptics: false })}
-      // stop click event from bubbling up to Content.clickOnEmptySpace
-      onClick={e => e.stopPropagation()}
     >
       <svg
         className={cx(

--- a/src/components/HomeLink.tsx
+++ b/src/components/HomeLink.tsx
@@ -22,8 +22,8 @@ const HomeLink = ({ color, size, iconStyle, className, breadcrumb }: HomeLinkPro
       <a
         tabIndex={-1}
         href='/'
-        onClick={e => e.preventDefault()}
-        {...fastClick(() => {
+        {...fastClick(e => {
+          e.preventDefault()
           dispatch(home())
         })}
       >

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -173,6 +173,7 @@ const Note = React.memo(
           }}
           onBlur={onBlur}
           onFocus={onFocus}
+          role='button'
         />
         <span className={css({ fontSize: '1.1em', position: 'absolute', margin: '-0.15em 0 0 -1.175em' })}>
           <FauxCaret caretType='noteEnd' />

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -37,6 +37,7 @@ const Tab = <T extends string>({
         }),
       })}
       onClick={onClick}
+      role='button'
     >
       <span
         className={css({

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -230,12 +230,12 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
         padding: `14px ${TOOLBAR_BUTTON_PADDING}px ${isDraggingAny ? '7em' : 0}px ${TOOLBAR_BUTTON_PADDING}px`,
       }}
       onMouseLeave={onMouseLeave}
-      {...fastClick(tapUp, {
-        // disable default haptics in favor of custom haptics on touchstart and touchend
-        enableHaptics: false,
-        tapDown,
-        touchMove,
-      })}
+      onMouseUp={tapUp}
+      onMouseDown={tapDown}
+      onTouchStart={tapDown}
+      onTouchMove={touchMove}
+      onTouchEnd={tapUp}
+      role='button'
     >
       {
         // selected top dash

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -14,6 +14,7 @@ import useToolbarLongPress from '../hooks/useToolbarLongPress'
 import store from '../stores/app'
 import commandStateStore from '../stores/commandStateStore'
 import { executeCommandWithMulticursor } from '../util/executeCommand'
+import fastClick from '../util/fastClick'
 import getCursorSortDirection from '../util/getCursorSortDirection'
 import haptics from '../util/haptics'
 
@@ -229,12 +230,7 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
         padding: `14px ${TOOLBAR_BUTTON_PADDING}px ${isDraggingAny ? '7em' : 0}px ${TOOLBAR_BUTTON_PADDING}px`,
       }}
       onMouseLeave={onMouseLeave}
-      onMouseUp={tapUp}
-      onMouseDown={tapDown}
-      onTouchStart={tapDown}
-      onTouchMove={touchMove}
-      onTouchEnd={tapUp}
-      role='button'
+      {...fastClick(tapUp, { enableHaptics: false, tapDown, touchMove })}
     >
       {
         // selected top dash

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -14,7 +14,6 @@ import useToolbarLongPress from '../hooks/useToolbarLongPress'
 import store from '../stores/app'
 import commandStateStore from '../stores/commandStateStore'
 import { executeCommandWithMulticursor } from '../util/executeCommand'
-import fastClick from '../util/fastClick'
 import getCursorSortDirection from '../util/getCursorSortDirection'
 import haptics from '../util/haptics'
 

--- a/src/e2e/puppeteer/setup.ts
+++ b/src/e2e/puppeteer/setup.ts
@@ -69,8 +69,7 @@ const setup = async ({
     await page.waitForSelector('#skip-tutorial')
 
     // click the skip tutorial link
-    // tap for mobile devices, since fastClick uses touch events
-    await page.tap('#skip-tutorial')
+    await page.click('#skip-tutorial')
 
     // wait for welcome modal to disappear
     await page.waitForFunction(() => !document.getElementById('skip-tutorial'))

--- a/src/test-helpers/click.ts
+++ b/src/test-helpers/click.ts
@@ -10,6 +10,9 @@ const click = async (selector: string) => {
   await act(async () => {
     fireEvent.mouseUp(el)
   })
+  await act(async () => {
+    fireEvent.click(el)
+  })
 }
 
 export default click

--- a/src/util/fastClick.ts
+++ b/src/util/fastClick.ts
@@ -3,89 +3,55 @@ import React from 'react'
 import { isTouch } from '../browser'
 import haptics from './haptics'
 
-export type FastClickEvent = React.TouchEvent<Element> | React.MouseEvent<Element, MouseEvent>
-
-// the number of pixels of scrolling or dragging from touchStart that is allowed to still trigger fastClick
-const MOVE_THRESHOLD = 15
-
-// track the touch start coordinates
-let touchStart: { x: number; y: number } | null = null
-
 /** A faster alternative to onClick or checkbox onChange. Activates on mouseUp/touchEnd to avoid interfering with mobile scroll. Returns onTouchStart/Move/End or onMouseUp handler depending on if touch is supported. Cancelled on scroll (with 15px error tolerance). */
 const fastClick = isTouch
   ? (
       // triggered on mouseup or touchend
       // cancelled if the user scroll or drags
-      tapUp: (e: FastClickEvent) => void,
+      tapUp: (e: React.MouseEvent<Element, MouseEvent>) => void,
       {
         // whether to trigger haptics on tap
         enableHaptics = true,
         // triggered on mousedown or touchstart
         tapDown,
-        // triggered when tapUp is cancelled due to scrolling or dragging
-        // does not work with drag-and-drop on desktop (onMouseUp does not trigger)
-        tapCancel,
         // triggered with touchMove, which can never be a MouseEvent
         touchMove,
       }: {
         enableHaptics?: boolean
-        tapDown?: (e: FastClickEvent) => void
-        tapCancel?: (e: FastClickEvent) => void
+        tapDown?: (e: React.TouchEvent) => void
         touchMove?: (e: React.TouchEvent) => void
       } = {},
     ) => ({
-      onTouchStart: (e: React.TouchEvent) => {
-        if (e.touches.length > 0) {
-          const x = e.touches[0].clientX
-          const y = e.touches[0].clientY
-          touchStart = { x, y }
-        }
-        tapDown?.(e)
-      },
-      // cancel tap if touchmove exceeds threshold (e.g. with scrolling or dragging)
-      onTouchMove: _.throttle((e: React.TouchEvent) => {
-        touchMove?.(e)
-        if (touchStart && e.changedTouches.length > 0) {
-          const x = e.changedTouches[0].clientX
-          const y = e.changedTouches[0].clientY
-          if (Math.abs(touchStart.x - x) > MOVE_THRESHOLD || Math.abs(touchStart.y - y) > MOVE_THRESHOLD) {
-            touchStart = null
-          }
-        }
-      }, 16.666),
-      onTouchEnd: (e: React.TouchEvent) => {
+      onTouchStart: tapDown,
+      onTouchMove: touchMove,
+      onClick: (e: React.MouseEvent) => {
         if (enableHaptics) {
           haptics.light()
         }
-        let cancel = !touchStart
 
-        if (touchStart && e.changedTouches.length > 0) {
-          const x = e.changedTouches[0].clientX
-          const y = e.changedTouches[0].clientY
-          if (Math.abs(touchStart.x - x) > MOVE_THRESHOLD || Math.abs(touchStart.y - y) > MOVE_THRESHOLD) {
-            cancel = true
-          }
-        }
-
-        if (cancel) {
-          tapCancel?.(e)
-        } else {
-          tapUp(e)
-        }
-
-        touchStart = null
+        tapUp(e)
       },
+      role: 'button',
     })
   : (
       tapUp: (e: React.MouseEvent) => void,
       {
+        enableHaptics = true,
         tapDown,
       }: {
+        enableHaptics?: boolean
         tapDown?: (e: React.MouseEvent) => void
       } = {},
     ) => ({
-      onMouseUp: tapUp,
+      onClick: (e: React.MouseEvent) => {
+        if (enableHaptics) {
+          haptics.light()
+        }
+
+        tapUp(e)
+      },
       ...(tapDown ? { onMouseDown: tapDown } : null),
+      role: 'button',
     })
 
 export default fastClick

--- a/src/util/fastClick.ts
+++ b/src/util/fastClick.ts
@@ -4,54 +4,34 @@ import { isTouch } from '../browser'
 import haptics from './haptics'
 
 /** A faster alternative to onClick or checkbox onChange. Activates on mouseUp/touchEnd to avoid interfering with mobile scroll. Returns onTouchStart/Move/End or onMouseUp handler depending on if touch is supported. Cancelled on scroll (with 15px error tolerance). */
-const fastClick = isTouch
-  ? (
-      // triggered on mouseup or touchend
-      // cancelled if the user scroll or drags
-      tapUp: (e: React.MouseEvent<Element, MouseEvent>) => void,
-      {
-        // whether to trigger haptics on tap
-        enableHaptics = true,
-        // triggered on mousedown or touchstart
-        tapDown,
-        // triggered with touchMove, which can never be a MouseEvent
-        touchMove,
-      }: {
-        enableHaptics?: boolean
-        tapDown?: (e: React.TouchEvent) => void
-        touchMove?: (e: React.TouchEvent) => void
-      } = {},
-    ) => ({
-      onTouchStart: tapDown,
-      onTouchMove: touchMove,
-      onClick: (e: React.MouseEvent) => {
-        if (enableHaptics) {
-          haptics.light()
-        }
+const fastClick = (
+  // triggered on mouseup or touchend
+  // cancelled if the user scroll or drags
+  tapUp: (e: React.MouseEvent<Element, MouseEvent>) => void,
+  {
+    // whether to trigger haptics on tap
+    enableHaptics = true,
+    // triggered on mousedown or touchstart
+    tapDown,
+    // triggered with touchMove, which can never be a MouseEvent
+    touchMove,
+  }: {
+    enableHaptics?: boolean
+    tapDown?: (e: React.MouseEvent | React.TouchEvent) => void
+    touchMove?: (e: React.TouchEvent) => void
+  } = {},
+) => ({
+  onMouseDown: isTouch ? undefined : tapDown,
+  onTouchStart: isTouch ? tapDown : undefined,
+  onTouchMove: isTouch ? touchMove : undefined,
+  onClick: (e: React.MouseEvent) => {
+    if (enableHaptics) {
+      haptics.light()
+    }
 
-        tapUp(e)
-      },
-      role: 'button',
-    })
-  : (
-      tapUp: (e: React.MouseEvent) => void,
-      {
-        enableHaptics = true,
-        tapDown,
-      }: {
-        enableHaptics?: boolean
-        tapDown?: (e: React.MouseEvent) => void
-      } = {},
-    ) => ({
-      onClick: (e: React.MouseEvent) => {
-        if (enableHaptics) {
-          haptics.light()
-        }
-
-        tapUp(e)
-      },
-      ...(tapDown ? { onMouseDown: tapDown } : null),
-      role: 'button',
-    })
+    tapUp(e)
+  },
+  role: 'button',
+})
 
 export default fastClick


### PR DESCRIPTION
Fixes #2776

Replaces the `onTouchEnd` method for `fastClick` with `onClick` and `role=button`. Preserves the haptics in `onClick`, and conditionally adds `tapDown` or `onMouseDown` handlers. Only adds `touchMove` for touch devices.