### PR TITLE
Note: don't set editing: false if relatedTarget is thought or note

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -116,11 +116,21 @@ const Note = React.memo(
     )
 
     /** Set editing to false onBlur, if keyboard is closed. */
-    const onBlur = useCallback(() => {
-      if (isTouch && !selection.isActive()) {
-        setTimeout(() => dispatch(editing({ value: false })))
-      }
-    }, [dispatch])
+    const onBlur = useCallback(
+      (e: React.FocusEvent) => {
+        if (isTouch && !selection.isActive()) {
+          // if we know that the focus is changing to another editable or note then do not set editing to false
+          // (does not work when clicking a bullet as it is set to null)
+          const isRelatedTargetEditableOrNote =
+            e.relatedTarget &&
+            ((e.relatedTarget as Element).hasAttribute?.('data-editable') ||
+              !!(e.relatedTarget as Element).matches('[aria-label="note-editable"]'))
+
+          if (!isRelatedTargetEditableOrNote) setTimeout(() => dispatch(editing({ value: false })))
+        }
+      },
+      [dispatch],
+    )
 
     if (note === null) return null
 


### PR DESCRIPTION
Fixes #2910 

If focus is moving from a note to a `relatedTarget` that is a thought or a note, don't dispatch `editing({ value: false })`.