### PR TITLE
Replace commandById with static import 

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,7 @@ import { commandPaletteActionCreator as commandPalette } from './actions/command
 import { showLatestCommandsActionCreator as showLatestCommands } from './actions/showLatestCommands'
 import { suppressExpansionActionCreator as suppressExpansion } from './actions/suppressExpansion'
 import { isMac } from './browser'
+import helpCommand from './commands/help'
 import * as commandsObject from './commands/index'
 import { AlertType, COMMAND_PALETTE_TIMEOUT, Settings } from './constants'
 import * as selection from './device/selection'
@@ -246,7 +247,6 @@ export const inputHandlers = (store: Store<State, any>) => ({
     // Get the command from the command gesture index.
     // When the command palette  is displayed, disable gesture aliases (i.e. gestures hidden from instructions). This is because the gesture hints are meant only as an aid when entering gestures quickly.
 
-    const helpCommand = commandById('help')
     const helpGesture = gestureString(helpCommand)
 
     // If sequence ends with help gesture, use help command

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -9,7 +9,9 @@ import Key from '../@types/Key'
 import State from '../@types/State'
 import { commandPaletteActionCreator as commandPalette } from '../actions/commandPalette'
 import { isTouch } from '../browser'
-import { commandById, formatKeyboardShortcut, gestureString, hashCommand, hashKeyDown } from '../commands'
+import { formatKeyboardShortcut, gestureString, hashCommand, hashKeyDown } from '../commands'
+import commandPaletteCommand from '../commands/commandPalette'
+import helpCommand from '../commands/help'
 import allowScroll from '../device/disableScroll'
 import * as selection from '../device/selection'
 import useFilteredCommands from '../hooks/useFilteredCommands'
@@ -27,8 +29,6 @@ import Popup from './Popup'
 
 /** The maximum number of recent commands to store for the command palette. */
 const MAX_RECENT_COMMANDS = 5
-
-const commandPaletteCommand = commandById('commandPalette')
 
 /**********************************************************************
  * Helper Functions
@@ -461,7 +461,6 @@ const CommandPalette: FC<{
               <>
                 {(() => {
                   const hasMatchingCommand = commands.some(cmd => gestureInProgress === cmd.gesture)
-                  const helpCommand = commandById('help')
 
                   return commands.map(command => {
                     // Check if the current gesture sequence ends with help gesture

--- a/src/components/EmptyThoughtspace.tsx
+++ b/src/components/EmptyThoughtspace.tsx
@@ -5,14 +5,13 @@ import { textNoteRecipe } from '../../styled-system/recipes'
 import { token } from '../../styled-system/tokens'
 import GesturePath from '../@types/GesturePath'
 import { isTouch } from '../browser'
-import { commandById, gestureString } from '../commands'
+import { gestureString } from '../commands'
+import newThoughtCommand from '../commands/newThought'
 import { TUTORIAL_STEP_FIRSTTHOUGHT } from '../constants'
 import getSetting from '../selectors/getSetting'
 import offlineStatusStore from '../stores/offlineStatusStore'
 import GestureDiagram from './GestureDiagram'
 import LoadingEllipsis from './LoadingEllipsis'
-
-const newThoughtCommand = commandById('newThought')
 
 /** Display platform-specific instructions of how to create a thought when a context has no thoughts. */
 const EmptyThoughtspace = ({ isTutorial }: { isTutorial?: boolean }) => {

--- a/src/components/NoOtherContexts.tsx
+++ b/src/components/NoOtherContexts.tsx
@@ -4,10 +4,9 @@ import { token } from '../../styled-system/tokens'
 import GesturePath from '../@types/GesturePath'
 import SimplePath from '../@types/SimplePath'
 import { isTouch } from '../browser'
-import { commandById, formatKeyboardShortcut, gestureString } from '../commands'
+import { formatKeyboardShortcut, gestureString } from '../commands'
+import toggleContextViewCommand from '../commands/toggleContextView'
 import GestureDiagram from '../components/GestureDiagram'
-
-const toggleContextViewCommand = commandById('toggleContextView')
 
 /** A message that explains that the thought is no other contexts and provides a hint for adding it to a context. */
 const NoOtherContexts = ({ allowSingleContext }: { allowSingleContext?: boolean; simplePath: SimplePath }) => {

--- a/src/components/Tutorial/Tutorial2StepContext1.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newSubthoughtCommand from '../../commands/newSubthought'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -49,7 +49,7 @@ const Tutorial2StepContext1 = () => {
             {readyToSelect ? `Select "${chosenTutorialText}". ` : null}
             {isTouch ? 'Trace the line below with your finger' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter`} to
             create a new thought <i>within</i> "{chosenTutorialText}". Then type "{TUTORIAL_CONTEXT[tutorialChoice]}".
-            {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
+            {!readyToSelect && <TutorialGestureDiagram gesture={newSubthoughtCommand.gesture} />}
           </TutorialHint>
         </p>
       ) : (

--- a/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1Parent.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash'
 import { useSelector } from 'react-redux'
 import { isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import { HOME_TOKEN, TUTORIAL_CONTEXT1_PARENT } from '../../constants'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
 import selectTutorialChoice from '../../selectors/selectTutorialChoice'
@@ -41,7 +41,7 @@ const Tutorial2StepContext1Parent = () => {
           ) : null}
           {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought. Then type "
           {TUTORIAL_CONTEXT1_PARENT[tutorialChoice]}".
-          <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
+          <TutorialGestureDiagram gesture={newThoughtCommand.gesture} />
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext1SubThought.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newSubthoughtCommand from '../../commands/newSubthought'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -75,7 +75,7 @@ const Tutorial2StepContext1SubThought = () => {
               {select ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
-              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
+              {!select && <TutorialGestureDiagram gesture={newSubthoughtCommand.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newSubthoughtCommand from '../../commands/newSubthought'
 import { HOME_TOKEN, TUTORIAL_CONTEXT, TUTORIAL_CONTEXT2_PARENT } from '../../constants'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
 import { getAllChildrenAsThoughts } from '../../selectors/getChildren'
@@ -52,7 +52,7 @@ const Tutorial2StepContext2 = () => {
                   to create a new thought <i>within</i> "{TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
                 </>
               )}
-              {!select && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
+              {!select && <TutorialGestureDiagram gesture={newSubthoughtCommand.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Parent.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import {
   TUTORIAL_CONTEXT,
   TUTORIAL_CONTEXT1_PARENT,
@@ -50,7 +50,7 @@ const Tutorial2StepContext2Parent = () => {
               {TUTORIAL_CONTEXT2_PARENT[tutorialChoice]}".
             </>
           )}
-          {!readyToSelect && <TutorialGestureDiagram gesture={commandById('newThought').gesture} />}
+          {!readyToSelect && <TutorialGestureDiagram gesture={newThoughtCommand.gesture} />}
         </TutorialHint>
       </p>
     </>

--- a/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
+++ b/src/components/Tutorial/Tutorial2StepContext2Subthought.tsx
@@ -1,7 +1,7 @@
 import pluralize from 'pluralize'
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newSubthoughtCommand from '../../commands/newSubthought'
 import {
   HOME_TOKEN,
   TUTORIAL_CONTEXT,
@@ -104,7 +104,7 @@ const Tutorial2StepContext2Subthought = () => {
               {selectChoice ? `Select "${TUTORIAL_CONTEXT[tutorialChoice]}". ` : null}
               {isTouch ? 'Trace the line below with your finger ' : `Hold ${isMac ? 'Command' : 'Ctrl'} and hit Enter `}
               to create a new thought <i>within</i> "{TUTORIAL_CONTEXT[tutorialChoice]}".
-              {!selectChoice && <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />}
+              {!selectChoice && <TutorialGestureDiagram gesture={newSubthoughtCommand.gesture} />}
             </TutorialHint>
           </p>
         ) : (

--- a/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
+++ b/src/components/Tutorial/Tutorial2StepContextViewToggle.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 import { isTouch } from '../../browser'
-import { commandById, formatKeyboardShortcut } from '../../commands'
+import { formatKeyboardShortcut } from '../../commands'
+import toggleContextViewCommand from '../../commands/toggleContextView'
 import { TUTORIAL_CONTEXT } from '../../constants'
 import getContexts from '../../selectors/getContexts'
 import getSetting from '../../selectors/getSetting'
@@ -35,12 +36,10 @@ const Tutorial2StepContextViewToggle = () => {
             </p>
           ) : null}
           <p>
-            {isTouch
-              ? 'Trace the line below'
-              : `Hit ${formatKeyboardShortcut(commandById('toggleContextView')!.keyboard!)}`}{' '}
-            to view the current thought's contexts.
+            {isTouch ? 'Trace the line below' : `Hit ${formatKeyboardShortcut(toggleContextViewCommand.keyboard!)}`} to
+            view the current thought's contexts.
           </p>
-          <TutorialGestureDiagram gesture={commandById('toggleContextView').gesture} />
+          <TutorialGestureDiagram gesture={toggleContextViewCommand.gesture} />
         </>
       )}
     </>

--- a/src/components/Tutorial/TutorialStepFirstThought.tsx
+++ b/src/components/Tutorial/TutorialStepFirstThought.tsx
@@ -1,5 +1,5 @@
 import { isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import TutorialGestureDiagram from './TutorialGestureDiagram'
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -11,7 +11,7 @@ const TutorialStepFirstThought = () => {
         {isTouch ? 'gesture' : 'keyboard shortcut'}. Just follow the instructions; this tutorial will stay open.
       </p>
       <p>{isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.</p>
-      <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
+      <TutorialGestureDiagram gesture={newThoughtCommand.gesture} />
     </>
   )
 }

--- a/src/components/Tutorial/TutorialStepSecondThought.tsx
+++ b/src/components/Tutorial/TutorialStepSecondThought.tsx
@@ -1,5 +1,5 @@
 import { isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import TutorialGestureDiagram from './TutorialGestureDiagram'
 import TutorialHint from './TutorialHint'
 
@@ -13,7 +13,7 @@ const TutorialStepSecondThought = () => (
         <br />
         <br />
         {isTouch ? 'Trace the line below with your finger' : 'Hit the Enter key'} to create a new thought.
-        <TutorialGestureDiagram gesture={commandById('newThought').gesture} />
+        <TutorialGestureDiagram gesture={newThoughtCommand.gesture} />
       </TutorialHint>
     </p>
   </>

--- a/src/components/Tutorial/TutorialStepSecondThoughtEnter.tsx
+++ b/src/components/Tutorial/TutorialStepSecondThoughtEnter.tsx
@@ -2,11 +2,10 @@ import { useSelector } from 'react-redux'
 import { css } from '../../../styled-system/css'
 import GesturePath from '../../@types/GesturePath'
 import { isTouch } from '../../browser'
-import { commandById, gestureString } from '../../commands'
+import { gestureString } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import headValue from '../../util/headValue'
 import GestureDiagram from '../GestureDiagram'
-
-const newThoughtCommand = commandById('newThought')!
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 const TutorialStepSecondThoughtEnter = () => {

--- a/src/components/Tutorial/TutorialStepSubThought.tsx
+++ b/src/components/Tutorial/TutorialStepSubThought.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 import { isMac, isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newSubthoughtCommand from '../../commands/newSubthought'
 import headValue from '../../util/headValue'
 import TutorialGestureDiagram from './TutorialGestureDiagram'
 
@@ -27,7 +27,7 @@ const TutorialStepSubThought = () => {
           .
         </p>
       )}
-      <TutorialGestureDiagram gesture={commandById('newSubthought').gesture} />
+      <TutorialGestureDiagram gesture={newSubthoughtCommand.gesture} />
     </>
   )
 }

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -4,7 +4,7 @@ import { TransitionGroup } from 'react-transition-group'
 import { css, cx } from '../../../styled-system/css'
 import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
 import { isTouch } from '../../browser'
-import { commandById } from '../../commands'
+import newThoughtCommand from '../../commands/newThought'
 import { TUTORIAL2_STEP_SUCCESS, TUTORIAL_STEP_SUCCESS } from '../../constants'
 import useIsVisible from '../../hooks/useIsVisible'
 import getSetting from '../../selectors/getSetting'
@@ -30,7 +30,6 @@ const WithCSSTransition = ({ component, transitionKey }: { component: FC; transi
 }
 
 // assert command at load time
-const newThoughtCommand = commandById('newThought')
 if (!newThoughtCommand) {
   throw new Error('newThought command not found.')
 }


### PR DESCRIPTION
Close #2929 

- [X] Replace all instances of commandById that use a string literal with a static import, which is more conventional. 
- [X] Reserve commandById for command ids that are only known at runtime.