### PR TITLE
[Mobile] Cancel gesture selected instead of New Thought 

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -162,7 +162,7 @@ const { commandKeyIndex, commandIdIndex, commandGestureIndex } = index()
 
 /** Gets the canonical gesture of the command as a string, ignoring aliases. Returns an empty string if the command does not have a gesture. */
 export const gestureString = (command: Command): string =>
-  (typeof command.gesture === 'string' ? command.gesture : command.gesture?.[0] || '') as string
+  (typeof command.gesture === 'string' ? command.gesture : command.gesture?.[0] || ' ') as string
 
 /** Get a command by its id. */
 export const commandById = (id: CommandId): Command => commandIdIndex[id]

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -249,7 +249,7 @@ const CommandRow: FC<{
               color: disabled
                 ? 'gray'
                 : isTouch
-                  ? selected || gestureInProgress === command.gesture
+                  ? selected || (gestureInProgress as string).startsWith(gestureString(command))
                     ? 'vividHighlight'
                     : 'fg'
                   : 'fg',
@@ -460,7 +460,9 @@ const CommandPalette: FC<{
             {commands.length > 0 ? (
               <>
                 {(() => {
-                  const hasMatchingCommand = commands.some(cmd => gestureInProgress === cmd.gesture)
+                  const hasMatchingCommand = commands.some(cmd =>
+                    (gestureInProgress as string).startsWith(gestureString(cmd)),
+                  )
 
                   return commands.map(command => {
                     // Check if the current gesture sequence ends with help gesture
@@ -483,7 +485,9 @@ const CommandPalette: FC<{
                         selected={
                           !isTouch
                             ? command === selectedCommand
-                            : isHelpMatch || gestureInProgress == command.gesture || isCancelMatch
+                            : isHelpMatch ||
+                              (gestureInProgress as string).startsWith(gestureString(command)) ||
+                              isCancelMatch
                         }
                         command={command}
                       />


### PR DESCRIPTION
Close #2938

### Regression

The issue was introduced as a regression in commit 320829c13f1f87f301c61189505bc41474999887. In pull request #2925, we removed all command aliases and consolidated them into their primary command definitions. Previously, the `command.gesture `property was treated as a string, and gesture comparisons relied on string equality checks. However, following the change, `command.gesture` may now be an array representing multiple possible gesture directions.

This led to an invalid comparison logic, causing the `hasMatchingCommand` flag to always evaluate to false. As a result, the fallback condition for `isCancelMatch `was triggered unconditionally, leading to the cancel command being selected regardless of the actual gesture input.

### Fix

Implemented proper handling of array-based gesture comparisons using `gestureString`