### PR TITLE
Add cycle detection to thoughtToPath 

### DIFF
--- a/src/selectors/thoughtToPath.ts
+++ b/src/selectors/thoughtToPath.ts
@@ -6,12 +6,21 @@ import getThoughtById from '../selectors/getThoughtById'
 import isRoot from '../util/isRoot'
 
 /** Generates the SimplePath for a Thought by traversing upwards to the root thought. Return null if any ancestors are missing, e.g. pending context. */
-const thoughtToPath = (state: State, thoughtId: ThoughtId): SimplePath => {
+const thoughtToPath = (state: State, thoughtId: ThoughtId, visited: Set<ThoughtId> = new Set()): SimplePath => {
+  // Detect cycles
+  if (visited.has(thoughtId)) {
+    console.error(`Cycle detected in parent chain for thought: ${thoughtId}`)
+    return HOME_PATH
+  }
+
+  // Add current thought to visited set
+  visited.add(thoughtId)
+
   if (isRoot([thoughtId]) || thoughtId === EM_TOKEN) return [thoughtId] as SimplePath
   const thought = getThoughtById(state, thoughtId)
   if (!thought) return HOME_PATH
   if (isRoot([thought.parentId])) return [thoughtId] as SimplePath
-  const pathSegment = thoughtToPath(state, thought.parentId)
+  const pathSegment = thoughtToPath(state, thought.parentId, visited)
   return [...pathSegment, thoughtId] as unknown as SimplePath
 }
 


### PR DESCRIPTION
Close #2932 

### Solution

Added a visited set that tracks the thought IDs encountered during the traversal. If a thought ID is revisited, a cycle is detected, and the function returns a safe default path to prevent infinite recursion.