### PR TITLE
Disable touch events on Editable

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -609,6 +609,14 @@ const Editable = ({
       // must call onMouseDown on mobile since onTap cannot preventDefault
       // otherwise gestures and scrolling can trigger cursorBack (#1054)
       onMouseDown={onTap}
+      onTouchEnd={e => {
+        e.stopPropagation()
+        e.preventDefault()
+      }}
+      onTouchStart={e => {
+        e.stopPropagation()
+        e.preventDefault()
+      }}
       onFocus={onFocus}
       onBlur={onBlur}
       onChange={onChangeHandler}


### PR DESCRIPTION
References #2837 

For this proof-of-concept, I wanted to add `onTouchEnd={e => e.preventDefault()}` in order to block all editable selection. This works in https://codesandbox.io/p/sandbox/hj2lk7, but not in em.

I didn't trust the result, so I added `e.stopPropagation()` to make sure that the event wasn't being handled by an upstream component. That broke multiselect and caused it to be difficult to verify the behavior, so I added

```
      onTouchStart={e => {
        e.stopPropagation()
        e.preventDefault()
      }}
```

as well, disabling touch events entirely. As you can see in this branch, it behaves exactly the same as before. Blocking `touchend` entirely in em does not appear to stop the selection (or change the aberrant double tap behavior), even though it does in the CodeSandbox.

I took it a little farther and commented out `onMouseDown` and `onClick`, which causes it to call `selection.set` inside of `useEditMode`, which makes sense. If I comment that out, I see some annoying autoscroll behavior and selection becomes impossible.

I commented out the new `onTouchStart` and `onTouchEnd` handlers, and selection is still impossible.

I commented out `onFocus` and now single tap will select an editable, so we're back to default browser behavior I think.

I put back

```
      onTouchEnd={e => {
        e.stopPropagation()
        e.preventDefault()
      }}
      onTouchStart={e => {
        e.stopPropagation()
        e.preventDefault()
      }}
```

and it still does not block single tap selection, even with everything else commented out.

The main issue that I see is that touch events aren't preventing default the way we expect, but there's also something weird going on in the `onFocus` handler apparently. I don't guess that the two are related, so uncovering what's wrong with touch events is probably more important.