### PR TITLE
Collapse expandHoverDownPath after delay

### DIFF
--- a/src/@types/State.ts
+++ b/src/@types/State.ts
@@ -80,7 +80,7 @@ interface State {
   /** A map of all Paths that are expanded. Recalculated whenever the cursor moves or the thoughts change. Keyed by hashPath(path). */
   expanded: Index<Path>
   /** Expand thoughts during drag-and-drop by hovering over them. Tracked separately from state.expanded so they can be toggled on/off independently from autoexpansion. */
-  expandHoverDownPaths: Index<Path>
+  expandHoverDownPath?: Path | null
   /** Make hidden ancestors visible during drag-and-drop by hovering over them. This allows a thought to be dragged anywhere, even to thoughts that are initially hidden by autofocus. */
   expandHoverUpPath?: Path | null
   fontSize: number

--- a/src/actions/clearExpandDown.ts
+++ b/src/actions/clearExpandDown.ts
@@ -7,7 +7,7 @@ import { registerActionMetadata } from '../util/actionMetadata.registry'
 const clearExpandDown = (state: State): State => ({
   ...state,
   expanded: expandThoughts(state, state.cursor),
-  expandHoverDownPaths: {},
+  expandHoverDownPath: null,
 })
 
 /** Action-creator for clearExpandDown. */

--- a/src/actions/expandHoverDown.ts
+++ b/src/actions/expandHoverDown.ts
@@ -5,6 +5,7 @@ import Thunk from '../@types/Thunk'
 import Timer from '../@types/Timer'
 import { clearExpandDownActionCreator as clearExpandDown } from '../actions/clearExpandDown'
 import { AlertType, EXPAND_HOVER_DELAY } from '../constants'
+import testFlags from '../e2e/testFlags'
 import expandThoughts from '../selectors/expandThoughts'
 import rootedParentOf from '../selectors/rootedParentOf'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
@@ -31,7 +32,7 @@ const expandHoverDownDebounced =
         return
       dispatch({ type: 'expandHoverDown', path })
       expandDownTimer = null
-    }, EXPAND_HOVER_DELAY)
+    }, testFlags.expandHoverDelay ?? EXPAND_HOVER_DELAY)
   }
 
 /** Calculates the expanded context due to hover expansion on empty child drop. */

--- a/src/actions/expandHoverDown.ts
+++ b/src/actions/expandHoverDown.ts
@@ -8,7 +8,7 @@ import { AlertType, EXPAND_HOVER_DELAY } from '../constants'
 import expandThoughts from '../selectors/expandThoughts'
 import getChildren from '../selectors/getChildren'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
-import hashPath from '../util/hashPath'
+import equalPath from '../util/equalPath'
 import head from '../util/head'
 import pathToContext from '../util/pathToContext'
 
@@ -40,14 +40,14 @@ const expandHoverDownDebounced =
 const expandDown = (state: State, { path }: { path: Path }): State => ({
   ...state,
   expanded: { ...state.expanded, ...expandThoughts(state, path) },
-  expandHoverDownPaths: { ...state.expandHoverDownPaths, [hashPath(path)]: path },
+  expandHoverDownPath: path,
 })
 
 /** Expands state.hoveringPath after a delay. Only expands if it is a valid Path with children and it is not already expanded. Expands using state.expandHoverDownPaths so that it can be toggled independently from autoexpansion with expandThoughts. */
 export const expandHoverDownActionCreator = (): Thunk => (dispatch, getState) => {
   const state = getState()
 
-  const { hoveringPath, hoverZone, expandHoverDownPaths, dragInProgress } = state
+  const { hoveringPath, hoverZone, expandHoverDownPath, dragInProgress } = state
 
   // true if hovering over a valid Path with children
   const shouldExpand =
@@ -64,7 +64,7 @@ export const expandHoverDownActionCreator = (): Thunk => (dispatch, getState) =>
 
   /** Check if current state.hoveringPath is already expanded. */
   const isAlreadyExpanded = () => {
-    return hoveringPath && pathToContext(state, hoveringPath) && expandHoverDownPaths[head(hoveringPath)]
+    return hoveringPath && pathToContext(state, hoveringPath) && equalPath(expandHoverDownPath, hoveringPath)
   }
 
   if (hoveringPath && !isAlreadyExpanded()) {

--- a/src/actions/expandHoverDown.ts
+++ b/src/actions/expandHoverDown.ts
@@ -39,7 +39,7 @@ const expandHoverDownDebounced =
 /** Calculates the expanded context due to hover expansion on empty child drop. */
 const expandDown = (state: State, { path }: { path: Path }): State => ({
   ...state,
-  expanded: { ...state.expanded, ...expandThoughts(state, path) },
+  expanded: expandThoughts(state, path),
   expandHoverDownPath: path,
 })
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ import emojiRegex from './emojiRegex'
 export const MAX_DISTANCE_FROM_CURSOR = 3
 export const MAX_DEPTH = 20
 
-// number of ms to wait after thought hover to expand it's children
+// Number of ms to wait after hovering over a thought before expanding, during drag-and-drop. Overriden by testFlags.expandHoverDelay during drag-and-drop tests.
 export const EXPAND_HOVER_DELAY = 1000
 
 // threshold for keyboard visibility detection (percentage of height change)

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -404,10 +404,7 @@ describe('hover expansion', () => {
         `)
 
     // Start dragging thought C
-    await dragAndDropThought('C', 'A', {
-      position: 'child',
-      mouseUp: false, // Don't complete the drag yet
-    })
+    await dragAndDropThought('C', 'A', { position: 'child' })
 
     // Wait for expansion to occur
     await sleep(MOCK_EXPAND_HOVER_DELAY)
@@ -429,10 +426,7 @@ describe('hover expansion', () => {
           - C
           `)
     // First expand thought A by dragging over it
-    await dragAndDropThought('C', 'A', {
-      position: 'child',
-      mouseUp: false,
-    })
+    await dragAndDropThought('C', 'A', { position: 'child' })
 
     // Wait for expansion to occur
     await sleep(MOCK_EXPAND_HOVER_DELAY)
@@ -445,11 +439,7 @@ describe('hover expansion', () => {
     expect(a2Editable).toBeTruthy()
 
     // Now drag to thought B instead
-    await dragAndDropThought('C', 'B', {
-      position: 'after',
-      mouseUp: false,
-      skipMouseDown: true,
-    })
+    await dragAndDropThought('C', 'B', { position: 'after', skipMouseDown: true })
 
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 
@@ -473,10 +463,7 @@ describe('hover expansion', () => {
     `)
 
     // First expand thought A by dragging over it
-    await dragAndDropThought('C', 'A', {
-      position: 'child',
-      mouseUp: false,
-    })
+    await dragAndDropThought('C', 'A', { position: 'child' })
 
     // Wait for expansion to occur
     await sleep(MOCK_EXPAND_HOVER_DELAY)
@@ -489,11 +476,7 @@ describe('hover expansion', () => {
     expect(a2Editable).toBeTruthy()
 
     // Now move to A1 using the dragAndDropThought function with skipMouseDown
-    await dragAndDropThought('C', 'A1', {
-      position: 'child',
-      mouseUp: false,
-      skipMouseDown: true, // Skip pressing the mouse button down again
-    })
+    await dragAndDropThought('C', 'A1', { position: 'child', skipMouseDown: true })
 
     // Wait for A1 to expand
     await sleep(MOCK_EXPAND_HOVER_DELAY)
@@ -506,11 +489,7 @@ describe('hover expansion', () => {
     expect(a12Editable).toBeTruthy()
 
     // Now drag to A2
-    await dragAndDropThought('C', 'A2', {
-      position: 'child',
-      mouseUp: false,
-      skipMouseDown: true, // Skip pressing the mouse button down again
-    })
+    await dragAndDropThought('C', 'A2', { position: 'child', skipMouseDown: true })
 
     // Wait for any state changes
     await sleep(MOCK_EXPAND_HOVER_DELAY)
@@ -523,11 +502,7 @@ describe('hover expansion', () => {
     expect(a12Visible).toBe(false)
 
     // Now drag completely away to B
-    await dragAndDropThought('C', 'B', {
-      position: 'after',
-      mouseUp: false,
-      skipMouseDown: true,
-    })
+    await dragAndDropThought('C', 'B', { position: 'after', skipMouseDown: true })
 
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -431,13 +431,6 @@ describe('hover expansion', () => {
     // Wait for expansion to occur
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 
-    // Verify that A1 and A2 are visible (A has expanded)
-    const a1Editable = await waitForEditable('A1')
-    const a2Editable = await waitForEditable('A2')
-
-    expect(a1Editable).toBeTruthy()
-    expect(a2Editable).toBeTruthy()
-
     // Now drag to thought B instead
     await dragAndDropThought('C', 'B', { position: 'after', skipMouseDown: true })
 
@@ -467,13 +460,6 @@ describe('hover expansion', () => {
 
     // Wait for expansion to occur
     await sleep(MOCK_EXPAND_HOVER_DELAY)
-
-    // Verify that A1 and A2 are visible (A has expanded)
-    const a1Editable = await waitForEditable('A1')
-    const a2Editable = await waitForEditable('A2')
-
-    expect(a1Editable).toBeTruthy()
-    expect(a2Editable).toBeTruthy()
 
     // Now move to A1 using the dragAndDropThought function with skipMouseDown
     await dragAndDropThought('C', 'A1', { position: 'child', skipMouseDown: true })

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -410,8 +410,8 @@ describe('hover expansion', () => {
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 
     // Verify that A1 and A2 are visible (A has expanded)
-    const a1Editable = await waitForEditable('A1', { timeout: 2000 })
-    const a2Editable = await waitForEditable('A2', { timeout: 2000 })
+    const a1Editable = await waitForEditable('A1')
+    const a2Editable = await waitForEditable('A2')
 
     expect(a1Editable).toBeTruthy()
     expect(a2Editable).toBeTruthy()
@@ -469,8 +469,8 @@ describe('hover expansion', () => {
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 
     // Verify that A1 and A2 are visible (A has expanded)
-    const a1Editable = await waitForEditable('A1', { timeout: 2000 })
-    const a2Editable = await waitForEditable('A2', { timeout: 2000 })
+    const a1Editable = await waitForEditable('A1')
+    const a2Editable = await waitForEditable('A2')
 
     expect(a1Editable).toBeTruthy()
     expect(a2Editable).toBeTruthy()
@@ -482,8 +482,8 @@ describe('hover expansion', () => {
     await sleep(MOCK_EXPAND_HOVER_DELAY)
 
     // Verify that A1-1 and A1-2 are visible (A1 has expanded)
-    const a11Editable = await waitForEditable('A1-1', { timeout: 2000 })
-    const a12Editable = await waitForEditable('A1-2', { timeout: 2000 })
+    const a11Editable = await waitForEditable('A1-1')
+    const a12Editable = await waitForEditable('A1-2')
 
     expect(a11Editable).toBeTruthy()
     expect(a12Editable).toBeTruthy()

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -20,8 +20,8 @@ import { page } from '../setup'
 const UNCLE_DIFF_THRESHOLD = 0.4
 
 // Override EXPAND_HOVER_DELAY
-// TODO: Fails intermittently with "Drag destination element not found" when set to 0.
-const MOCK_EXPAND_HOVER_DELAY = 10
+// TODO: Fails intermittently with "Drag destination element not found" when set to 10.
+const MOCK_EXPAND_HOVER_DELAY = 100
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -390,8 +390,8 @@ describe('hover expansion', () => {
     // Release mouse button if it's still down
     await page.mouse.up()
 
-    // TODO: "collapses nested thoughts when dragging away" fails intermittently when this is omitted
-    await sleep(10)
+    // TODO: "collapses nested thoughts when dragging away" fails intermittently with 10ms
+    await sleep(100)
   })
 
   it('expands a thought on hover down during drag', async () => {

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -16,6 +16,7 @@ const dragAndDropThought = async (
     position,
     showAlert,
     showQuickDropPanel,
+    skipMouseDown,
   }: {
     /** If true, the source thought is dropped as a sibling to the hidden uncle. */
     dropUncle?: boolean
@@ -32,6 +33,7 @@ const dragAndDropThought = async (
     showAlert?: boolean
     /** Show the QuickDropPanel. Hidden by default. */
     showQuickDropPanel?: boolean
+    skipMouseDown?: boolean
   },
 ) => {
   const sourceElement = await getEditable(sourceValue)
@@ -67,7 +69,10 @@ const dragAndDropThought = async (
 
   // move the mouse to the drag target, then press
   await page.mouse.move(dragPosition.x, dragPosition.y)
-  await page.mouse.down()
+
+  if (!skipMouseDown) {
+    await page.mouse.down()
+  }
 
   // move to the drop target, and release
   if (destValue) {

--- a/src/e2e/testFlags.ts
+++ b/src/e2e/testFlags.ts
@@ -1,9 +1,17 @@
 /** Test flags that are injected into window.em.testFlags. */
-const testFlags = {
+const testFlags: {
+  /** Delay in ms before expanding the hovering thought. */
+  expandHoverDelay: number | null
+  /** Render drop-hover elements as blocks of color. */
+  simulateDrag: boolean
+  /** Render drop targets as blocks of color. */
+  simulateDrop: boolean
+} = {
+  /** Delay in ms before expanding the hovering thought. Set in drag-and-drop test.  If null, EXPAND_HOVER_DELAY is use instead. */
+  expandHoverDelay: null,
   /** Render drop-hover elements as blocks of color. */
   simulateDrag: false,
   /** Render drop targets as blocks of color. */
   simulateDrop: false,
 }
-
 export default testFlags

--- a/src/selectors/calculateAutofocus.ts
+++ b/src/selectors/calculateAutofocus.ts
@@ -58,8 +58,7 @@ const calculateAutofocus = (state: State, path: Path) => {
     (isRoot(state.expandHoverUpPath) || isDescendantPath(path, state.expandHoverUpPath || null))
 
   /** Returns true if the thought is expanded by hovering below a thought. */
-  const isExpandedBottom = () =>
-    Object.values(state.expandHoverDownPaths).some(bottomPath => isDescendantPath(path, bottomPath || null))
+  const isExpandedBottom = () => isDescendantPath(path, state.expandHoverDownPath ?? null)
 
   return (isCursorLeaf && isParentOrSibling()) || isDescendantOfCursor()
     ? 'show'

--- a/src/selectors/linearizeTree.ts
+++ b/src/selectors/linearizeTree.ts
@@ -75,7 +75,7 @@ const linearizeTree = (
 ): TreeThought[] => {
   const path = basePath || HOME_PATH
   const hashedPath = hashPath(path)
-  if (!isRoot(path) && !state.expanded[hashedPath] && !state.expandHoverDownPaths[hashedPath]) return []
+  if (!isRoot(path) && !state.expanded[hashedPath] && !equalPath(state.expandHoverDownPath, path)) return []
 
   const thoughtId = head(path)
   const thought = getThoughtById(state, thoughtId)

--- a/src/util/initialState.ts
+++ b/src/util/initialState.ts
@@ -121,7 +121,6 @@ const initialState = (created: Timestamp = timestamp()) => {
     error: null,
     expanded: {},
     fontSize: storageModel.get('fontSize'),
-    expandHoverDownPaths: {},
     importThoughtPath: null,
     invalidState: false,
     isLoading: true,


### PR DESCRIPTION
Fixes #2846.
Supersedes #2851.

- Converts `state.expandHoverDownPaths` from `Index<Path>` to `Path`. There's no need for multiple paths when only one path can be hovered over at a time.
- Replaces `state.expandHoverDownPath` with the new hovering path rather than adding to it.
- If hovering over a `SubthoughtDrop` zone, expands the `hoveringPath`. If hovering over a `ThoughtDrop` zone, then hoveringPath points to a sibling thought and we need to expand the parent.