### PR TITLE
LayoutTree: userSelect: none, reset userSelect in editables

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -231,6 +231,7 @@ const LayoutTree = () => {
       className={cx(
         css({
           marginTop: '0.501em',
+          userSelect: 'none',
         }),
         fauxCaretTreeProvider(indent),
       )}

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -231,6 +231,9 @@ const LayoutTree = () => {
       className={cx(
         css({
           marginTop: '0.501em',
+          // Disallow text selection on the entire tree to prevent selection of scroll zone and other background elements when dragging.
+          // This is overriden by the editable recipe to enable text selection on editable thoughts.
+          // https://github.com/cybersemics/em/pull/2962
           userSelect: 'none',
         }),
         fauxCaretTreeProvider(indent),

--- a/src/recipes/editable.ts
+++ b/src/recipes/editable.ts
@@ -23,6 +23,7 @@ const editableRecipe = defineRecipe({
       _mobile: '-2px',
     },
     paddingBottom: { _mobile: '0' },
+    userSelect: 'text',
   },
 })
 

--- a/src/recipes/editable.ts
+++ b/src/recipes/editable.ts
@@ -23,6 +23,8 @@ const editableRecipe = defineRecipe({
       _mobile: '-2px',
     },
     paddingBottom: { _mobile: '0' },
+    // Re-enable text selection that was disabled on the LayoutTree.
+    // https://github.com/cybersemics/em/pull/2962
     userSelect: 'text',
   },
 })


### PR DESCRIPTION
Fixes #2961

It turns out that setting `user-select: none` on `LayoutTree` (and then re-enabling selection with `user-select: text` on the editables themselves) was enough to stop all of the highlighting. The `ScrollZone`, `QuickDropPanel` etc. don't get highlighted anymore either.

The only difference in functionality that I've noticed is that I no longer get haptic feedback (or the accompanying lens popover) when long-pressing on the bullet or the empty space to the right of the thought. I still get haptic feedback when long-pressing the thought itself. If the feedback was desirable, we will need to add it as part of `useDragHold`, probably.