### PR TITLE
Disable pointer-events on Editable while long-pressing

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -595,7 +595,11 @@ const Editable = ({
       innerRef={contentRef}
       aria-label={'editable-' + head(path)}
       data-editable
-      className={cx(multiline ? multilineRecipe() : null, editableRecipe(), className)}
+      className={cx(
+        multiline ? multilineRecipe() : null,
+        editableRecipe({ editing: disabled ? 'disabled' : undefined }),
+        className,
+      )}
       html={
         value === EM_TOKEN
           ? '<b>em</b>'

--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -140,7 +140,7 @@ const StaticThought = ({
   // Disable contenteditable on Mobile Safari during drag-and-drop, otherwise thought text will become selected.
   // This is restricted to Mobile Safari, because on Chrome it creates a small layout shift.
   // https://github.com/cybersemics/em/pull/2960
-  const dragInProgressSafari = useSelector(state => isTouch && isSafari() && state.dragInProgress)
+  const dragInProgressSafari = useSelector(state => isTouch && isSafari() && (state.dragHold || state.dragInProgress))
 
   const isTableCol1 = useSelector(state => attributeEquals(state, head(parentOf(simplePath)), '=view', 'Table'))
 

--- a/src/recipes/editable.ts
+++ b/src/recipes/editable.ts
@@ -27,6 +27,13 @@ const editableRecipe = defineRecipe({
     // https://github.com/cybersemics/em/pull/2962
     userSelect: 'text',
   },
+  variants: {
+    editing: {
+      disabled: {
+        pointerEvents: 'none',
+      },
+    },
+  },
 })
 
 export default editableRecipe


### PR DESCRIPTION
Fixes #2953

Setting `pointer-events: none` on editables while a long press is in progress does a pretty good job of preventing iOS Safari from triggering editing-related behavior. It still needs more work in order to be reliable.