### PR TITLE
Use HTML5 backend for drag-and-drop on iOS Safari

### DIFF
--- a/src/components/DragAndDropContext.tsx
+++ b/src/components/DragAndDropContext.tsx
@@ -1,10 +1,11 @@
 import { FC, PropsWithChildren } from 'react'
 import { HTML5Backend } from 'react-dnd-html5-backend'
-import { DndProvider, PointerTransition, TouchTransition } from 'react-dnd-multi-backend'
+import { DndProvider, MultiBackendOptions, PointerTransition, TouchTransition } from 'react-dnd-multi-backend'
 import { TouchBackend } from 'react-dnd-touch-backend'
+import { isSafari, isTouch } from '../browser'
 import { TIMEOUT_LONG_PRESS_THOUGHT } from '../constants'
 
-const options = {
+const options: MultiBackendOptions = {
   backends: [
     // HTML5 backend
     // https://react-dnd.github.io/react-dnd/docs/backends/html5
@@ -13,6 +14,11 @@ const options = {
       backend: HTML5Backend,
       transition: PointerTransition,
     },
+  ],
+}
+
+if (isTouch && !isSafari()) {
+  options.backends.push(
     // Touch backend
     // https://react-dnd.github.io/react-dnd/docs/backends/touch
     {
@@ -22,7 +28,7 @@ const options = {
       preview: true,
       transition: TouchTransition,
     },
-  ],
+  )
 }
 
 /** Drag and Drop Provider HOC. */

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -232,7 +232,7 @@ const useDragAndDropThought = (props: Partial<ThoughtContainerProps>) => {
   })
 
   useEffect(() => {
-    dragPreview(getEmptyImage(), { captureDraggingState: true })
+    dragPreview(getEmptyImage())
   }, [dragPreview])
 
   const [{ isHovering, isBeingHoveredOver, isDeepHovering, canDropThought }, dropTarget] = useDrop({

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -1,6 +1,7 @@
 import moize from 'moize'
+import { useEffect } from 'react'
 import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from 'react-dnd'
-import { NativeTypes } from 'react-dnd-html5-backend'
+import { NativeTypes, getEmptyImage } from 'react-dnd-html5-backend'
 import DragAndDropType from '../@types/DragAndDropType'
 import DragThoughtItem from '../@types/DragThoughtItem'
 import DragThoughtOrFiles from '../@types/DragThoughtOrFiles'
@@ -229,6 +230,10 @@ const useDragAndDropThought = (props: Partial<ThoughtContainerProps>) => {
     end: () => endDrag(),
     collect: dragCollect,
   })
+
+  useEffect(() => {
+    dragPreview(getEmptyImage(), { captureDraggingState: true })
+  }, [dragPreview])
 
   const [{ isHovering, isBeingHoveredOver, isDeepHovering, canDropThought }, dropTarget] = useDrop({
     accept: [DragAndDropType.Thought, NativeTypes.FILE],

--- a/src/hooks/useDragAndDropToolbarButton.ts
+++ b/src/hooks/useDragAndDropToolbarButton.ts
@@ -99,7 +99,7 @@ const useDragAndDropToolbarButton = ({ commandId, customize }: { commandId: Comm
   })
 
   useEffect(() => {
-    dragPreview(getEmptyImage(), { captureDraggingState: true })
+    dragPreview(getEmptyImage())
   }, [dragPreview])
 
   const [{ isHovering }, dropTarget] = useDrop({

--- a/src/hooks/useDragAndDropToolbarButton.ts
+++ b/src/hooks/useDragAndDropToolbarButton.ts
@@ -1,5 +1,6 @@
+import { useEffect } from 'react'
 import { DropTargetMonitor, useDrag, useDrop } from 'react-dnd'
-import { NativeTypes } from 'react-dnd-html5-backend'
+import { NativeTypes, getEmptyImage } from 'react-dnd-html5-backend'
 import Command from '../@types/Command'
 import CommandId from '../@types/CommandId'
 import DragAndDropType from '../@types/DragAndDropType'
@@ -96,6 +97,10 @@ const useDragAndDropToolbarButton = ({ commandId, customize }: { commandId: Comm
       isDragging: monitor.isDragging(),
     }),
   })
+
+  useEffect(() => {
+    dragPreview(getEmptyImage(), { captureDraggingState: true })
+  }, [dragPreview])
 
   const [{ isHovering }, dropTarget] = useDrop({
     accept: [DragAndDropType.ToolbarButton, NativeTypes.FILE],

--- a/src/hooks/useDragDropFavorites.ts
+++ b/src/hooks/useDragDropFavorites.ts
@@ -157,7 +157,7 @@ const useDragAndDropFavorites = (props: Partial<DragAndDropFavoriteReturnType>) 
   })
 
   useEffect(() => {
-    dragPreview(getEmptyImage(), { captureDraggingState: true })
+    dragPreview(getEmptyImage())
   }, [dragPreview])
 
   const [{ isHovering }, dropTarget] = useDrop({

--- a/src/hooks/useDragDropFavorites.ts
+++ b/src/hooks/useDragDropFavorites.ts
@@ -1,5 +1,6 @@
+import { useEffect } from 'react'
 import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from 'react-dnd'
-import { NativeTypes } from 'react-dnd-html5-backend'
+import { NativeTypes, getEmptyImage } from 'react-dnd-html5-backend'
 import DragAndDropType from '../@types/DragAndDropType'
 import DragThoughtItem from '../@types/DragThoughtItem'
 import DragThoughtZone from '../@types/DragThoughtZone'
@@ -154,6 +155,10 @@ const useDragAndDropFavorites = (props: Partial<DragAndDropFavoriteReturnType>) 
     end: () => endDrag(),
     collect: dragCollect,
   })
+
+  useEffect(() => {
+    dragPreview(getEmptyImage(), { captureDraggingState: true })
+  }, [dragPreview])
 
   const [{ isHovering }, dropTarget] = useDrop({
     accept: [DragAndDropType.Thought, NativeTypes.FILE],


### PR DESCRIPTION
Fixes #2953, #2931 and #2964

While trying to block `touchstart` events from reaching the editables, I ran into some very weird behavior where `onTouchStartCapture={e => e.stopPropagation()}` seemed to stop `touchstart` events in parents as well as children. Now that I'm typing this, I realize that stopping an event on the way down (capture) probably also stops it from bubbling back up and being caught by the `TouchBackend`.

In any case, I realized that `TouchBackend` was being disabled and drag-and-drop was falling back to `HTML5Backend` which uses native drag events and was working a lot better in iOS Safari. It doesn't trigger any of the long press behavior that we want to avoid, presumably because it understands that a native drag is underway. According to https://caniuse.com/?search=drag, native drag-and-drop has been supported in iOS Safari since September 2021, so we may need to add an additional check if we want to support devices that haven't updated since then.

I tested on Android Chrome, and `HTML5Backend` had a lot more problems, so I kept `TouchBackend` for them.

I tested with drag-and-drop favorites and toolbar buttons and it seems to work without issue. Drag-and-drop thoughts work well, but don't drag-and-drop at all for thoughts other than the cursor thought. The cursor thought seems to work flawlessly, so I'm optimistic that non-cursor thoughts are solvable.

Let me know if  you think it's feasible to get rid of `TouchBackend` on iOS Safari, because this feels like a pretty good solution to me.