### PR TITLE
Add interactable flag to Alert

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -68,6 +68,7 @@ const Alert: FC = () => {
       onClose={alert?.showCloseLink ? onClose : undefined}
       value={alert ? value : null}
       icon={Icon ? <Icon cssRaw={css.raw({ cursor: 'default' })} size={iconSize} fill={token('colors.fg')} /> : null}
+      interactable={alert?.alertType !== AlertType.DragAndDropHint}
       onMouseLeave={startTimer}
       onMouseOver={clearTimer}
     >

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -10,6 +10,8 @@ import PopupBase from './PopupBase'
 const Notification: FC<
   {
     icon?: ReactNode
+    /** A flag specifying whether the notification has interactable elements, or whether it should be ignored by the pointer or mouse. */
+    interactable?: boolean
     /** The content rendered with padding in the center of the notification. */
     value: ReactNode | null
     /* Specify a key to force the component to re-render and thus recalculate useSwipeToDismissProps when the alert changes. Otherwise the alert gets stuck off screen in the dismiss state. */

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -24,6 +24,8 @@ export type PopupBaseProps = PropsWithChildren<
     circledCloseButton?: boolean
     /** If true, the popup will take up the full width of the screen. */
     fullWidth?: boolean
+    /** If false, the popup will not interact with the pointer or mouse. */
+    interactable?: boolean
     /** If defined, will show a small x in the upper right corner. */
     onClose?: () => void
     padding?: string
@@ -44,6 +46,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
       children,
       circledCloseButton,
       fullWidth = false,
+      interactable = true,
       onClose,
       padding,
       showXOnHover,
@@ -103,6 +106,8 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
         }
       : {}
 
+    const pointerEventsStyles = interactable ? {} : { pointerEvents: 'none' }
+
     return (
       <div
         className={css({
@@ -114,6 +119,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           ...borderStyles,
           ...centerStyles,
           ...fullWidthStyles,
+          ...pointerEventsStyles,
           '&:hover': {
             '& [data-close-button]': {
               opacity: showXOnHover ? 1 : undefined,


### PR DESCRIPTION
Fixes #3012

The multiselect alert (which may have been superseded by the new multiselect drawer) and the import file alert both have "Cancel" buttons, so it may be necessary to allow interaction with some alerts.

The drag-and-drop alert, however, will only appear during drag interactions, and must be prevented from interfering with the pointer. The new `interactable` flag makes the alert ignore pointer events.