### PR TITLE
Use data-drag-hold attribute to disable pointer-events

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -455,6 +455,7 @@ export default defineConfig({
     android: '[data-platform=android] &',
     mac: '[data-platform=mac] &',
     iphone: '[data-platform=iphone] &',
+    dragHold: '[data-drag-hold=true] &',
     dragInProgress: '[data-drag-in-progress=true] &',
   },
 

--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -114,6 +114,7 @@ const AppComponent: FC = () => {
   const colors = useSelector(themeColors)
   const dark = useSelector(state => theme(state) !== 'Light')
   const dragInProgress = useSelector(state => state.dragInProgress)
+  const dragHold = useSelector(state => state.dragHold)
   const enableLatestCommandsDiagram = useSelector(state => state.enableLatestCommandsDiagram)
   const showTutorial = useSelector(state => isTutorial(state) && !state.isLoading)
   const fontSize = useSelector(state => state.fontSize)
@@ -134,6 +135,7 @@ const AppComponent: FC = () => {
     document.body.setAttribute('data-native', Capacitor.isNativePlatform() ? 'true' : 'false')
     document.body.setAttribute('data-platform', isAndroid ? 'android' : isMac ? 'mac' : isiPhone ? 'iphone' : 'other')
     document.body.setAttribute('data-drag-in-progress', dragInProgress.toString())
+    document.body.setAttribute('data-drag-hold', dragHold ? dragHold.toString() : 'false')
 
     document.body.setAttribute(
       'data-browser',
@@ -155,7 +157,7 @@ const AppComponent: FC = () => {
         })
       }
     }
-  }, [colors, dark, dragInProgress])
+  }, [colors, dark, dragInProgress, dragHold])
 
   if (showModal && !modals[showModal]) {
     throw new Error(`Missing component for Modal type: ${showModal}`)

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -119,6 +119,8 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
               opacity: showXOnHover ? 1 : undefined,
             },
           },
+          /** It should be possible to drag elements through a popup without interference. */
+          pointerEvents: { _dragHold: 'none' },
         })}
         // disable swipe-to-dismiss when multicursor is active
         {...(!multicursor && useSwipeToDismissProps)}


### PR DESCRIPTION
Fixes #3012, supersedes #3022

I wanted to use the existing `data-drag-in-progress` attribute, but it doesn't flip to true until after the user begins to move the pointer, which happens after the alert appears and so the alert can still interfere and cancel the drag. I added `data-drag-hold`, which is set as soon as the long press activates, and seems to work well as far as I can tell.

I left #3022 open in case we end up going that route, but this seems like a cleaner solution if it passes testing.