### PR TITLE
Move userSelect: none into Content

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -76,6 +76,10 @@ const Content: FC = () => {
           maxWidth: '60em',
           margin: '0 auto',
           minHeight: '100vh',
+          // Disallow text selection on the entire tree to prevent selection of scroll zone and other background elements when dragging.
+          // This is overriden by the editable recipe to enable text selection on editable thoughts.
+          // https://github.com/cybersemics/em/pull/2962
+          userSelect: 'none',
           zIndex: 'content',
           '@media (max-width: 960px)': {
             maxWidth: '80%',

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -231,10 +231,6 @@ const LayoutTree = () => {
       className={cx(
         css({
           marginTop: '0.501em',
-          // Disallow text selection on the entire tree to prevent selection of scroll zone and other background elements when dragging.
-          // This is overriden by the editable recipe to enable text selection on editable thoughts.
-          // https://github.com/cybersemics/em/pull/2962
-          userSelect: 'none',
         }),
         fauxCaretTreeProvider(indent),
       )}


### PR DESCRIPTION
Fixes #2895

The div in `LayoutTree` that had `userSelect: none` applied to it to fix #2961 doesn't cover the entire viewport, and is sized differently when there are thoughts in the thoughtspace vs when it is empty. Applying `userSelect: none` instead to the `Content` wrapper solves this and doesn't appear to impact anything else that should be selectable.