### PR TITLE
Move preventAutoscrollEnd in onFocus into setTimeout

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -493,7 +493,7 @@ const Editable = ({
    */
   const onFocus = useCallback(
     () => {
-      preventAutoscrollEnd(contentRef.current)
+      setTimeout(() => preventAutoscrollEnd(contentRef.current))
       if (suppressFocusStore.getState()) return
       // do not allow blur to setEditingValue when it is followed immediately by a focus
       blurring = false


### PR DESCRIPTION
Fixes #2969

It looks like if I remove `preventAutoscrollEnd` from `onFocus` in `Editable.tsx`, then the bug goes away. `preventAutoscrollEnd` runs after a 10ms timeout initiated in `preventAutoscroll`, there is the "noticeable blink" described in the comment, and the cursor shows correctly.

If I can figure out how to fix the blink, then this approach could work well.