### PR TITLE
Don't dispatch setCursorOnThought if dragInProgress

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -127,7 +127,6 @@ const Editable = ({
   const nullRef = useRef<HTMLInputElement>(null)
   const contentRef = editableRef || nullRef
   const editingOrOnCursor = useSelector(state => state.isKeyboardOpen || equalPath(path, state.cursor))
-  const dragInProgress = useSelector(state => state.dragInProgress)
 
   // console.info('<Editable> ' + prettyPath(store.getState(), simplePath))
   // useWhyDidYouUpdate('<Editable> ' + prettyPath(state, simplePath), {
@@ -570,31 +569,32 @@ const Editable = ({
         e.preventDefault()
       }
 
-      if (!dragInProgress)
-        dispatch((dispatch, getState) => {
-          const state = getState()
-          if (
-            // disable editing when multicursor is enabled
-            hasMulticursorSelector(state) ||
-            disabled ||
-            // do not set cursor on hidden thought
-            // dragInProgress: not sure if this can happen, but I observed some glitchy behavior with the cursor moving when a drag and drop is completed so check dragInProgress to be safe
-            (!globals.touching && !state.dragInProgress && !state.dragHold && (!editingOrOnCursor || !isVisible))
-          ) {
-            e.preventDefault()
+      dispatch((dispatch, getState) => {
+        const state = getState()
+        if (state.dragInProgress) return
 
-            if (!isVisible) {
-              selection.clear()
+        if (
+          // disable editing when multicursor is enabled
+          hasMulticursorSelector(state) ||
+          disabled ||
+          // do not set cursor on hidden thought
+          // dragInProgress: not sure if this can happen, but I observed some glitchy behavior with the cursor moving when a drag and drop is completed so check dragInProgress to be safe
+          (!globals.touching && !state.dragInProgress && !state.dragHold && (!editingOrOnCursor || !isVisible))
+        ) {
+          e.preventDefault()
 
-              // close all popups when clicking on a thought
-              dispatch(toggleDropdown())
-            } else {
-              setCursorOnThought()
-            }
+          if (!isVisible) {
+            selection.clear()
+
+            // close all popups when clicking on a thought
+            dispatch(toggleDropdown())
+          } else {
+            setCursorOnThought()
           }
-        })
+        }
+      })
     },
-    [disabled, dispatch, dragInProgress, editingOrOnCursor, isVisible, setCursorOnThought],
+    [disabled, dispatch, editingOrOnCursor, isVisible, setCursorOnThought],
   )
 
   return (


### PR DESCRIPTION
Fixes #3051

I'm not quite sure why the transition from calling `onTap` on `mousedown` to calling it on `touchend` altered the flow, but now `setCursorOnThought` was being called at the end of a long press. Checking `dragInProgress` before the dispatch (which is delayed until after `useDragHold` has set `state.dragInProgress` to false) allows us to avoid calling `setCursorOnThought` as the result of a long press.