### PR TITLE
Flaky test fix

### DIFF
--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -11,6 +11,7 @@ import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
 import testIfNotCI from '../helpers/testIfNotCI'
+import { page } from '../setup'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -70,7 +71,7 @@ const testSuite = () => {
 
     // TODO: Test intermittently fails with small differences in 'b'.
     // https://github.com/cybersemics/em/issues/2955
-    testIfNotCI('superscript', async () => {
+    it('superscript', async () => {
       await paste(`
     - a
       - m
@@ -86,7 +87,12 @@ const testSuite = () => {
       // - https://github.com/cybersemics/em/actions/runs/14236307211
       // - https://github.com/cybersemics/em/actions/runs/14783509675/job/41507408875?pr=2917
       // Waiting for requestAnimationFrame does not fix the issue.
-      await sleep(200)
+      await page.evaluate(() => {
+        return new Promise(resolve => {
+          // Wait for 2 frames to ensure RAF completion
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        })
+      })
 
       expect(await screenshot()).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -11,8 +11,7 @@ import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
 import testIfNotCI from '../helpers/testIfNotCI'
-
-// import { page } from '../setup'
+import waitForFrames from '../helpers/waitForFrames'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -88,13 +87,7 @@ const testSuite = () => {
       // - https://github.com/cybersemics/em/actions/runs/14236307211
       // - https://github.com/cybersemics/em/actions/runs/14783509675/job/41507408875?pr=2917
       // Waiting for requestAnimationFrame does not fix the issue.
-      // await page.evaluate(() => {
-      //   return new Promise(resolve => {
-      //     // Wait for 2 frames to ensure RAF completion
-      //     requestAnimationFrame(() => requestAnimationFrame(resolve))
-      //   })
-      // })
-      await sleep(200)
+      await waitForFrames()
 
       expect(await screenshot()).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -11,7 +11,8 @@ import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
 import testIfNotCI from '../helpers/testIfNotCI'
-import { page } from '../setup'
+
+// import { page } from '../setup'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -87,12 +88,13 @@ const testSuite = () => {
       // - https://github.com/cybersemics/em/actions/runs/14236307211
       // - https://github.com/cybersemics/em/actions/runs/14783509675/job/41507408875?pr=2917
       // Waiting for requestAnimationFrame does not fix the issue.
-      await page.evaluate(() => {
-        return new Promise(resolve => {
-          // Wait for 2 frames to ensure RAF completion
-          requestAnimationFrame(() => requestAnimationFrame(resolve))
-        })
-      })
+      // await page.evaluate(() => {
+      //   return new Promise(resolve => {
+      //     // Wait for 2 frames to ensure RAF completion
+      //     requestAnimationFrame(() => requestAnimationFrame(resolve))
+      //   })
+      // })
+      await sleep(200)
 
       expect(await screenshot()).toMatchImageSnapshot()
     })

--- a/src/e2e/puppeteer/__tests__/url.ts
+++ b/src/e2e/puppeteer/__tests__/url.ts
@@ -9,6 +9,7 @@ import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import testIfNotCI from '../helpers/testIfNotCI'
+import waitForFrames from '../helpers/waitForFrames'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -113,6 +114,8 @@ it('collapsed thought with url child', async () => {
   `)
 
   await press('Escape')
+
+  await waitForFrames()
 
   const image = await screenshot()
   expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/__tests__/url.ts
+++ b/src/e2e/puppeteer/__tests__/url.ts
@@ -9,7 +9,6 @@ import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import testIfNotCI from '../helpers/testIfNotCI'
-import waitForFrames from '../helpers/waitForFrames'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -114,8 +113,6 @@ it('collapsed thought with url child', async () => {
   `)
 
   await press('Escape')
-
-  await waitForFrames()
 
   const image = await screenshot()
   expect(image).toMatchImageSnapshot()

--- a/src/e2e/puppeteer/helpers/waitForFrames.ts
+++ b/src/e2e/puppeteer/helpers/waitForFrames.ts
@@ -1,8 +1,8 @@
 import { page } from '../setup'
 
 /** Wait for 2 frames to ensure RAF completion, ensures final layout and paint occur. */
-const waitForFrames = async () =>
-  await page.evaluate(() => {
+const waitForFrames = () =>
+  page.evaluate(() => {
     return new Promise(resolve => {
       requestAnimationFrame(() => requestAnimationFrame(resolve))
     })

--- a/src/e2e/puppeteer/helpers/waitForFrames.ts
+++ b/src/e2e/puppeteer/helpers/waitForFrames.ts
@@ -1,0 +1,11 @@
+import { page } from '../setup'
+
+/** Wait for 2 frames to ensure RAF completion, ensures final layout and paint occur. */
+const waitForFrames = async () =>
+  await page.evaluate(() => {
+    return new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    })
+  })
+
+export default waitForFrames

--- a/src/e2e/puppeteer/helpers/waitForFrames.ts
+++ b/src/e2e/puppeteer/helpers/waitForFrames.ts
@@ -1,6 +1,18 @@
 import { page } from '../setup'
 
-/** Wait for 2 frames to ensure RAF completion, ensures final layout and paint occur. */
+/**
+ * Waits for two consecutive animation frames to ensure complete rendering.
+ *
+ * This technique guarantees:
+ * 1. All pending `requestAnimationFrame` callbacks execute (first frame).
+ * 2. Resulting DOM updates process through style/layout/paint (second frame).
+ * 3. Browser reaches stable visual state for screenshots.
+ *
+ * Essential for eliminating flaky tests where:
+ * - Components use rAF for state updates (e.g., Superscript calculations).
+ * - CI environments have slower frame rates (20-30 FPS vs local 60 FPS).
+ * - Fixed timeouts (e.g., `sleep(200)`) fail to capture final render.
+ */
 const waitForFrames = () =>
   page.evaluate(() => {
     return new Promise(resolve => {


### PR DESCRIPTION
### Potential root cause:

My speculation for this problem related with #2955 is purely on the basis of difference in frame rate that could affect which frame gets captured by the snapshot. Likely cause of the inconsistency appears to be timing issues related to React's asynchronous rendering and animation frame handling. The subtle differences in pixel is likely to be seen intermittently when screenshot is taken before the browser rendering pipeline process ends. There is a noticeably high chances of this flakiness occuring in CI because of comparative slow fps in CI environment. 

Here is a discussion on [frame rates for browser rendering](https://stackoverflow.com/questions/29192559/is-it-safe-to-assume-60-fps-for-browser-rendering)

The `sleep(200)` waits for 200ms of real time, but `requestAnimationFrame` callbacks execute based on the browser's refresh rate and rendering pipeline. In [Superscript component](https://github.com/cybersemics/em/blob/main/src/components/Superscript.tsx#L42-L47) the superscript count calculation is intentionally deferred to `requestAnimationFrame` for performance. There is a probable chance that screenshot can be taken at different points relative to when the rAF callback executes.

### Fix:

By replacing arbitrary `sleep()` with [double rAF](https://stackoverflow.com/questions/44145740/how-does-double-requestanimationframe-work) ensures all pending DOM updates complete and guarantees final layout and paint. I have tested this fix for numerous time via the github cli script and [results](https://github.com/karunkop/em/actions/workflows/puppeteer.yml) seem promising.

> Note: This should allow us to generalize to other similar cases where flakiness is observed
