### PR TITLE
Remove focusNode.focus from selection.set

### DIFF
--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -2,7 +2,6 @@
 
 /** Wraps the browser Selection API in a device-agnostic interface. */
 import SplitResult from '../@types/SplitResult'
-import { isSafari, isTouch } from '../browser'
 
 export type SelectionOptionsType = {
   offset?: number
@@ -369,12 +368,6 @@ export const set = (
   range.collapse(true)
   sel.removeAllRanges()
   sel.addRange(range)
-
-  // deleting a note, then closing the keyboard, then creating a new note could result in lack of focus,
-  // perhaps related to iOS Safari's internal management of selection ranges and focus
-  // this also occurs when activating clearThought, closing the keyboard, and activating clearThought again
-  if (isTouch && isSafari() && focusNode instanceof HTMLElement && document.activeElement !== focusNode)
-    focusNode.focus()
 }
 
 /**


### PR DESCRIPTION
References #3080 

There are 3 test cases for reproducing bugs that are fixed by calling `focusNode.focus()` in `selection.set`:

https://github.com/cybersemics/em/pull/2752#discussion_r1902247165
https://github.com/cybersemics/em/issues/2705

and then this comment, which I can't find documented elsewhere:

```
  // deleting a note, then closing the keyboard, then creating a new note could result in lack of focus
```

I have verified that all 3 behave normally now without the bug fix.