### PR TITLE
Remove whitespace from multline thought test

### DIFF
--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -140,12 +140,10 @@ describe('multiline', () => {
   beforeEach(hideHUD)
 
   it('multiline thought', async () => {
-    await paste(`
-        - a
-        - External objects (bodies) are merely appearances, hence also nothing other than a species of my representations, whose objects are something only through these representations, but are nothing separated from them.
-        - b
-        - c
-      `)
+    await paste(`- a
+- External objects (bodies) are merely appearances, hence also nothing other than a species of my representations, whose objects are something only through these representations, but are nothing separated from them.
+- b
+- c`)
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()


### PR DESCRIPTION
References #3080 

This is not related to refactoring that we've discussed, but I noticed that the multiline thought test is failing fairly consistently in CI and locally. Many of the tests use whitespace for readability, but I verified that pasting text into desktop Chrome leads to unexpected indentation:

![Screenshot 2025-06-28 143446](https://github.com/user-attachments/assets/4f1dece2-096a-49f8-8ae3-169d112b5680)

and I verified that removing the whitespace causes this particular test to pass.

It may be worth revisiting this and digging deeper into the `importText` action, although I will wait for you to weigh in, and I'll most likely work on other stuff first.