### PR TITLE
Remove setTimeout from long press stop handler

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -21,7 +21,6 @@ import getThoughtFill from '../selectors/getThoughtFill'
 import isContextViewActive from '../selectors/isContextViewActive'
 import isMulticursorPath from '../selectors/isMulticursorPath'
 import rootedParentOf from '../selectors/rootedParentOf'
-import fastClick from '../util/fastClick'
 import getBulletWidth from '../util/getBulletWidth'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
@@ -476,9 +475,9 @@ const Bullet = ({
   // expand or collapse on click
   // has some additional logic to make it work intuitively with pin true/false
   const clickHandler = useCallback(
-    (e: React.MouseEvent) => {
+    (e: React.MouseEvent | React.TouchEvent) => {
+      console.info(`clickHandler=${dragHold}`)
       // short circuit if dragHold
-      // useLongPress stop is activated in onMouseUp but is delayed to ensure that dragHold is still true here
       // stopping propagation from useLongPress was not working either due to bubbling order or mismatched event type
       if (dragHold) return
 
@@ -508,9 +507,6 @@ const Bullet = ({
           setCursor({ path: shouldCollapse ? pathParent : path, preserveMulticursor: true }),
         ])
       })
-
-      e.stopPropagation()
-      // stop click event from bubbling up to Content.clickOnEmptySpace
     },
     [dispatch, dragHold, path, simplePath],
   )
@@ -551,7 +547,11 @@ const Bullet = ({
         paddingBottom: extendClickHeight + 2,
         width,
       }}
-      {...fastClick(clickHandler, { enableHaptics: false })}
+      onMouseUp={isTouch ? undefined : clickHandler}
+      onTouchEnd={isTouch ? clickHandler : undefined}
+      // stop click event from bubbling up to Content.clickOnEmptySpace
+      onClick={e => e.stopPropagation()}
+      role='button'
     >
       <svg
         className={cx(

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -476,7 +476,6 @@ const Bullet = ({
   // has some additional logic to make it work intuitively with pin true/false
   const clickHandler = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
-      console.info(`clickHandler=${dragHold}`)
       // short circuit if dragHold
       // stopping propagation from useLongPress was not working either due to bubbling order or mismatched event type
       if (dragHold) return

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { keyboardOpenActionCreator as keyboardOpen } from '../actions/keyboardOpen'
 import { isTouch } from '../browser'
@@ -64,27 +64,23 @@ const useLongPress = (
   // TODO: Maybe an unmount handler would be better?
   const stop = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
-      // Delay setPressed(false) to ensure that onLongPressEnd is not called until bubbled events complete.
-      // This gives other components a chance to short circuit.
       // We can't stop propagation here without messing up other components like Bullet.
-      setTimeout(() => {
-        clearTimeout(timerIdRef.current)
-        timerIdRef.current = 0
-        longPressStore.unlock()
+      clearTimeout(timerIdRef.current)
+      timerIdRef.current = 0
+      longPressStore.unlock()
 
-        // If not longpressing, it means that the long press was canceled by a move event.
-        // in this case, onLongPressEnd should not be called, since it was already called by the move event.
-        if (!globals.longpressing) return
+      // If not longpressing, it means that the long press was canceled by a move event.
+      // in this case, onLongPressEnd should not be called, since it was already called by the move event.
+      if (!globals.longpressing) return
 
-        globals.longpressing = false
+      globals.longpressing = false
 
-        // If a long press occurred, mark it as not canceled
-        onLongPressEnd?.({ canceled: false })
+      // If a long press occurred, mark it as not canceled
+      onLongPressEnd?.({ canceled: false })
 
-        if (!unmounted.current) {
-          setPressed(false)
-        }
-      }, 10)
+      if (!unmounted.current) {
+        setPressed(false)
+      }
     },
     [onLongPressEnd],
   )


### PR DESCRIPTION
References #3080

In an effort to remove `setTimeout` from the `stop` function in `useLongPress`, I moved `clickHandler` in `Bullet` so that it fires `onMouseUp`/`onTouchEnd` rather than `onClick`. This worked OK on desktop, aside from needing to duplicate `fastClick` functionality in `Bullet` in kind of a messy way.

However, it seems that on iOS Safari, it will move the cursor on long press. I'm not quite sure why this is happening yet, maybe it has to do with `TouchBackend` in drag and drop. I can probably resolve it if you think it's worthwhile, but I feel like this has gone beyond a simple refactor task and maybe it should be abandoned for now.