### PR TITLE
Maintain dragHold onTouchMove

### DIFF
--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -76,6 +76,7 @@ const shouldCancelGesture = (
   const distance = state.fontSize * 2
   return (
     (x && y && selection.isNear(x, y, distance)) ||
+    state.dragHold ||
     state.dragInProgress ||
     !!state.showModal ||
     state.showSidebar ||

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -7,7 +7,6 @@ import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/
 import { dragHoldActionCreator as dragHold } from '../actions/dragHold'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
 import hasMulticursor from '../selectors/hasMulticursor'
-import longPressStore from '../stores/longPressStore'
 import useLongPress from './useLongPress'
 
 /** Adds event handlers to detect long press and set state.dragHold while the user is long pressing a thought in preparation for a drag. */
@@ -65,16 +64,10 @@ const useDragHold = ({
 
       if (isDragging || state.dragHold) {
         setIsPressed(false)
-        dispatch([dragHold({ value: false }), alert(null)])
 
         if (hasMulticursor(state)) {
           dispatch(clearMulticursors())
         }
-      }
-      // If we were dragging but now we're not, make sure to reset the lock
-      if (!isDragging && state.dragHold) {
-        // Reset the lock to allow immediate long press after drag ends
-        longPressStore.unlock()
       }
     })
   }, [dispatch, isDragging])

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -51,6 +51,7 @@ const useLongPress = (
         haptics.light()
         onLongPressStart?.()
         longPressStore.lock()
+        timerIdRef.current = 0
         if (!unmounted.current) {
           setPressed(true)
         }


### PR DESCRIPTION
Fixes #3072 and #3073 and #3074

I can prevent the gesture from showing after the  `dragHold` action fires by adding that condition to `shouldCancelGesture`. Additionally, if I clear `timerIdRef` after the timeout fires and activates the long press, I can prevent `dragHold` from getting reset `onTouchMove`.

However, drag-and-drop does not activate, most likely because

```
setTimeout(
  this.handleTopMoveStart.bind(this, e as any),
  delay,
)
```

in `TouchBackendImpl.ts` does not fire at the exact same time as

```
      timerIdRef.current = setTimeout(() => {
        globals.longpressing = true
        haptics.light()
        onLongPressStart?.()
        longPressStore.lock()
        timerIdRef.current = 0
        if (!unmounted.current) {
          setPressed(true)
        }
      }, delay)
```

in `useLongPress`.

So the result is that, after executing this type of quick move at the correct time:

1. the gesture does not start
2. the bullet does highlight
3. drag-and-drop never responds to any `touchmove` events
4. the multiselect command pane does appear `onTouchEnd`

https://github.com/user-attachments/assets/5d8f64a5-c085-4bdc-8ccf-55da9244c6a4

I'm still looking at `TouchBackendImpl` to try to verify that this is related to `setTimeout`. Would you be open to subtracting a few milliseconds from `TIMEOUT_LONG_PRESS_THOUGHT` in:

```
<DndProvider
    backend={isTouch ? TouchBackend : HTML5Backend}
    options={{ delayTouchStart: TIMEOUT_LONG_PRESS_THOUGHT, preview: true }}
  >
```

in order to guarantee that drag-and-drop activates before long press, so that quick movements don't get discarded?