### PR TITLE
Set =pin/false on root thought when tapping bullet

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -500,7 +500,8 @@ const Bullet = ({
         dispatch([
           // set pin false on expanded only child
           ...(isExpanded &&
-          (parentChildren?.length === 1 ||
+          (!pathParent ||
+            parentChildren?.length === 1 ||
             findDescendant(state, pathParent && head(pathParent), ['=children', '=pin', 'true']))
             ? [setDescendant({ path: simplePath, values: ['=pin', 'false'] })]
             : [deleteAttribute({ path: simplePath, value: '=pin' })]),


### PR DESCRIPTION
Fixes #3101

I changed `Bullet.tsx` so that it sets `=pin/false` on a thought that has no `pathParent`. In works well in all cases that I tested.