### PR TITLE
StaticThought: Remove isPressed prop from

### DIFF
--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -58,7 +58,6 @@ export interface ThoughtProps {
   styleContainer?: React.CSSProperties
   styleThought?: React.CSSProperties
   view?: string | null
-  isPressed: boolean
 }
 
 /** Returns true if a color is white, in rgb, rgba, hex, or color name. */
@@ -109,7 +108,6 @@ const StaticThought = ({
   styleThought,
   styleAnnotation,
   updateSize,
-  isPressed,
 }: ThoughtProps) => {
   const showContexts = useSelector(state => isContextViewActive(state, rootedParentOf(state, path)))
   const fontSize = useSelector(state => state.fontSize)
@@ -212,7 +210,6 @@ const StaticThought = ({
                       https://stackoverflow.com/questions/20310690/overflowhidden-on-inline-block-adds-height-to-parent
                     */
                   verticalAlign: 'top',
-                  userSelect: isPressed ? 'none' : undefined,
                 }),
               },
               cssRaw,

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -625,7 +625,6 @@ const ThoughtContainer = ({
             styleThought={styleThought}
             updateSize={updateSize}
             view={view}
-            isPressed={dragHoldResult.isPressed}
           />
         </div>
         <Note path={path} disabled={!isVisible} />


### PR DESCRIPTION
References #3080 

Changing `userSelect` on an editable doesn't fully fix browser selection behavior, plus this has been superseded by https://github.com/cybersemics/em/pull/3023.

I thought it might be possible to do away with `isPressed` as a prop returned by `useDragHold`, which would allow me to get rid of `const [isPressed, setIsPressed] = useState(false)` and possibly the entire `useEffect` block, since the other values are reset in both `onLongPressEnd` and in `endDrag` in `useDragAndDropThought`.

```
  // react-dnd stops propagation so onLongPressEnd sometimes doesn't get called.
  // Therefore, disable dragHold and isPressed as soon as we are dragging or if no longer dragging and dragHold never got cleared.
  useEffect(() => {
    dispatch((dispatch, getState) => {
      const state = getState()

      if (isDragging || state.dragHold) {
        setIsPressed(false)
        dispatch([dragHold({ value: false }), alert(null)])

        if (hasMulticursor(state)) {
          dispatch(clearMulticursors())
        }
      }
      // If we were dragging but now we're not, make sure to reset the lock
      if (!isDragging && state.dragHold) {
        // Reset the lock to allow immediate long press after drag ends
        longPressStore.unlock()
      }
    })
  }, [dispatch, isDragging])
```

However, `isPressed` is also used by `Favorites`:

```
      <ThoughtLink
        hideContext={hideContext}
        path={simplePath}
        styleLink={{
          ...(!disableDragAndDrop &&
            (isDragging || dragHoldResult.isPressed
              ? {
                  color: token('colors.highlight'),
                  fontWeight: 'bold',
                }
              : undefined)),
        }}
      />
```

so I abandoned that plan and simply removed `isPressed` as a prop in `StaticThought`.