### PR TITLE
newThought: skip asyncFocus if selection.isThought

### DIFF
--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -29,6 +29,7 @@ import {
 } from '../constants'
 import asyncFocus from '../device/asyncFocus'
 import getTextContentFromHTML from '../device/getTextContentFromHTML'
+import * as selection from '../device/selection'
 import { getChildrenSorted } from '../selectors/getChildren'
 import getNextRank from '../selectors/getNextRank'
 import getPrevRank from '../selectors/getPrevRank'
@@ -241,7 +242,9 @@ export const newThoughtActionCreator =
     // cancel if tutorial has just started
     if (tutorial && tutorialStep === TUTORIAL_STEP_START) return
 
-    if (!preventSetCursor && isTouch) {
+    // asyncFocus can cause disruptive autoscroll behavior, so it's important to avoid it when the selection is already on a thought.
+    // If the selection is already on a thought, then it follows that focus will not be blocked. (#2748, #3075)
+    if (!preventSetCursor && isTouch && !selection.isThought()) {
       asyncFocus()
     }
 

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -83,12 +83,15 @@ const useEditMode = ({
 
         setTimeout fixes it, however it introduces an infinite loop when a nested empty thought is created.
         Not calling asyncFocus when the selection is already on a thought prevents the infinite loop.
+        Also, setTimeout creates a large enough delay that the keyboard will intermittently close on iOS Safari.
+        Replacing setTimeout with requestAnimationFrame closes that gap sufficiently and keeps the keyboard open
+        while rapidly deleting thoughts. (#3129)
       */
         if (isTouch && isSafari()) {
           if (!selection.isThought()) {
             asyncFocus()
           }
-          setTimeout(setSelectionToCursorOffset)
+          requestAnimationFrame(setSelectionToCursorOffset)
         } else {
           setSelectionToCursorOffset()
         }

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -83,9 +83,9 @@ const useEditMode = ({
 
         setTimeout fixes it, however it introduces an infinite loop when a nested empty thought is created.
         Not calling asyncFocus when the selection is already on a thought prevents the infinite loop.
-        Also, setTimeout creates a large enough delay that the keyboard will intermittently close on iOS Safari.
-        Replacing setTimeout with requestAnimationFrame closes that gap sufficiently and keeps the keyboard open
-        while rapidly deleting thoughts. (#3129)
+        Also, setTimeout is frequently pushed into the next frame and the keyboard will intermittently close on iOS Safari.
+        Replacing setTimeout with requestAnimationFrame guarantees (hopefully?) that it will be processed before the next repaint,
+        keeping the keyboard open while rapidly deleting thoughts. (#3129)
       */
         if (isTouch && isSafari()) {
           if (!selection.isThought()) {


### PR DESCRIPTION
Fixes #2748, #3075 and #3076

[asyncFocus](https://github.com/ethan-james/em/blob/7a51ebcb9c7263a0f306016f56d08fedf56c6c0a/src/actions/newThought.ts#L245)  was being called in the `newThought` action, which would usually trigger [dispatch(keyboardOpenActionCreator({ value: false }))](https://github.com/ethan-james/em/blob/7a51ebcb9c7263a0f306016f56d08fedf56c6c0a/src/components/Editable/useEditMode.ts#L123) in `useEditMode`. `newThought` would immediately dispatch a `setCursor` action that would generally cause the keyboard to stay open, but not always. Hypothetically, it would have more trouble when exceeding a frame's render budget, which would potentially explain why it's more common with longer lists.

`asyncFocus` is always called, but it doesn't trigger `keyboardOpen` if the following conditions are both true:
1. The thought has text in it
2. This is the first invocation of `newThought` after the app is reloaded
 
This doesn't exactly explain why the keyboard *only* ever closes when creating a new thought from an empty thought. It is possible to get `keyboardOpen: false` to fire by doing the following, starting from #3075:

1. Double-tap `Alabama` to edit
2. Hit enter
3. No `dispatch(keyboardOpenActionCreator({ value: false }))`
4. Hit backspace
5. Hit enter
6. Yes `dispatch(keyboardOpenActionCreator({ value: false }))`

...and yet I have never seen the keyboard close when starting from a thought with text in it. In #3075 you say `(sometimes it takes multiple times)` so maybe you have seen it when creating the first new thought. Although, presumably, not the *first* new thought because `keyboardOpen: false` would not fire if you started from `Alabama` and created a single new thought.

There is also another issue when deleting all of the empty thoughts created during testing, especially now that I've fixed the closing keyboard so it's possible to generate an enormous number of empty thoughts quickly. Start with the repro steps for #3076, then rapidly hit backspace to clear out all of the test thoughts. You should see the keyboard close because it's scrolling too quickly upward.

https://github.com/user-attachments/assets/fa5b46c6-7cf1-4028-bf30-196d1eaa4be0

~This also appears to be related to `asyncFocus`, [but a different use of asyncFocus](https://github.com/ethan-james/em/blob/f9a3d765950528e326c40a8ffe3ad762ace6a24c/src/components/Editable/useEditMode.ts#L89), and one which is already checking for `selection.isThought` so I will need to dig a little deeper and try to fix that as well.~

This appears to be related to delaying [setSelectionToCursorOffset](https://github.com/ethan-james/em/blob/f9a3d765950528e326c40a8ffe3ad762ace6a24c/src/components/Editable/useEditMode.ts#L92), which intermittently allows the keyboard to close before calling `setCursor`. Replacing `setTimeout` with `requestAnimationFrame` presumably shortens that delay and fixes the problem for reasons that I do not sufficiently understand and for now will refer to as "magic".