### PR TITLE
Fix 3064: `Gesture menu should sort by gesture length`

### DIFF
--- a/src/hooks/useFilteredCommands.ts
+++ b/src/hooks/useFilteredCommands.ts
@@ -89,7 +89,11 @@ const useFilteredCommands = (
       else if (sortActiveCommandsFirst && !isExecutable(store.getState(), command)) return `\x98${label}`
       // sort gesture by length and then label
       // no padding of length needed since no gesture exceeds a single digit
-      else if (gestureInProgress) return `\x01${label}`
+      // Commands with fewer swipes appear first (e.g., "New Thought" with 'rd' before "New Subthought" with 'rdr') by adding length number before the label
+      else if (gestureInProgress) {
+        const gestureLength = gestureString(command).length
+        return `\x01${gestureLength}${label}`
+      }
 
       return (
         // prepend \x01 to sort after exact match and before inactive commands


### PR DESCRIPTION
Issue: https://github.com/cybersemics/em/issues/3064

In previous approach, it's been sorted by `x01${label}` - and this doesn't consider the command length at all.
I changed the sorting key text as `x01${getstureLength}${label}` by adding gesture length before label.
So that it can compare the length first and then, label name.

Below image is the result of fixing:
<img width="513" height="824" alt="image" src="https://github.com/user-attachments/assets/75e46b24-6586-4760-b538-08a1b43c15f2" />
