### PR TITLE
clearTimeout in handleTopMoveEndCapture

### DIFF
--- a/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch
+++ b/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch
@@ -1,0 +1,25 @@
+diff --git a/dist/TouchBackendImpl.js b/dist/TouchBackendImpl.js
+index 30900a8dd268827f2ed313b3cc3c68265151450b..725715a382d5ac19718cfbdca6732a0d1ddc5092 100644
+--- a/dist/TouchBackendImpl.js
++++ b/dist/TouchBackendImpl.js
+@@ -372,6 +372,7 @@ export class TouchBackendImpl {
+             if (!eventShouldEndDrag(e)) {
+                 return;
+             }
++            if (this.timeout) clearTimeout(this.timeout);
+             if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+                 this.moveStartSourceIds = undefined;
+                 return;
+diff --git a/src/TouchBackendImpl.ts b/src/TouchBackendImpl.ts
+index a85cd1845fe02f7731cc1afaf67c97f573a4ccee..6650cf98fdb08bca5fa450853cb7907c380fe13e 100644
+--- a/src/TouchBackendImpl.ts
++++ b/src/TouchBackendImpl.ts
+@@ -578,6 +578,8 @@ export class TouchBackendImpl implements Backend {
+ 			return
+ 		}
+ 
++		if (this.timeout) clearTimeout(this.timeout);
++
+ 		if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+ 			this.moveStartSourceIds = undefined
+ 			return

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-contenteditable": "^3.3.7",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
-    "react-dnd-touch-backend": "patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch",
+    "react-dnd-touch-backend": "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch",
     "react-dom": "18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-gravatar": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8784,7 +8784,7 @@ __metadata:
     react-dnd-html5-backend: "npm:^16.0.1"
     react-dnd-test-backend: "npm:^16.0.1"
     react-dnd-test-utils: "npm:^16.0.1"
-    react-dnd-touch-backend: "patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch"
+    react-dnd-touch-backend: "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:^4.1.2"
     react-gravatar: "npm:^2.6.3"
@@ -16615,13 +16615,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dnd-touch-backend@patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch":
+"react-dnd-touch-backend@patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch::version=16.0.1&hash=77964d":
   version: 16.0.1
   resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch::version=16.0.1&hash=77964d"
   dependencies:
     "@react-dnd/invariant": "npm:^4.0.1"
     dnd-core: "npm:^16.0.1"
   checksum: 10c0/99d175ed9e7bb61936014699312348dd9686d85d6a286cc9b9acea0015740f830adf727b562eaca516aab8027f7ec8aa571f18c08994c34ebc6b5c2fe7cd6d7e
+  languageName: node
+  linkType: hard
+
+"react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch":
+  version: 16.0.1
+  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch::version=16.0.1&hash=33fdd5"
+  dependencies:
+    "@react-dnd/invariant": "npm:^4.0.1"
+    dnd-core: "npm:^16.0.1"
+  checksum: 10c0/79a25736ac8e21c94169b5e7c5cc9c50ee9552adf598e411a8cf39f5164d5a2fed7a55bf57f53e8f8ceb6d591f051b2720a34f991bcc56ffe8dbe90598323b71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #3137

The timeout wasn't being cleared when ending a touch, so two touches in rapid succession could trigger drag-and-drop behavior. Now it's calling `clearTimeout` in `handleTopMoveEndCapture`.