### PR TITLE
asyncFocus: Replace isText with isThought

### DIFF
--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -29,7 +29,6 @@ import {
 } from '../constants'
 import asyncFocus from '../device/asyncFocus'
 import getTextContentFromHTML from '../device/getTextContentFromHTML'
-import * as selection from '../device/selection'
 import { getChildrenSorted } from '../selectors/getChildren'
 import getNextRank from '../selectors/getNextRank'
 import getPrevRank from '../selectors/getPrevRank'
@@ -242,9 +241,7 @@ export const newThoughtActionCreator =
     // cancel if tutorial has just started
     if (tutorial && tutorialStep === TUTORIAL_STEP_START) return
 
-    // asyncFocus can cause disruptive autoscroll behavior, so it's important to avoid it when the selection is already on a thought.
-    // If the selection is already on a thought, then it follows that focus will not be blocked. (#2748, #3075)
-    if (!preventSetCursor && isTouch && !selection.isThought()) {
+    if (!preventSetCursor && isTouch) {
       asyncFocus()
     }
 

--- a/src/device/asyncFocus.ts
+++ b/src/device/asyncFocus.ts
@@ -32,8 +32,8 @@ export const AsyncFocus: () => () => void = () => {
 
   document.body.prepend(hiddenInput)
   return () => {
-    // do not set the selection if it is already on a text node
-    if (!selection.isText()) {
+    // do not set the selection if it is already on a thought or a note
+    if (!selection.isThought()) {
       hiddenInput.disabled = false
       hiddenInput.focus()
       // the hidden input should not be a valid focus target unless this function was invoked


### PR DESCRIPTION
Fixes #3132

This seems to work fine, preserving the fixed behavior of #2748 and #3075. `selection.isThought` correctly identifies both thoughts and notes.