### PR TITLE
Note: use preventAutoscroll

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -12,6 +12,7 @@ import { setDescendantActionCreator as setDescendant } from '../actions/setDesce
 import { setNoteFocusActionCreator as setNoteFocus } from '../actions/setNoteFocus'
 import { toggleNoteActionCreator as toggleNote } from '../actions/toggleNote'
 import { isTouch } from '../browser'
+import preventAutoscroll, { preventAutoscrollEnd } from '../device/preventAutoscroll'
 import * as selection from '../device/selection'
 import useFreshCallback from '../hooks/useFreshCallback'
 import getThoughtById from '../selectors/getThoughtById'
@@ -45,6 +46,7 @@ const Note = React.memo(
 
     /** Focus Handling with useFreshCallback. */
     const onFocus = useFreshCallback(() => {
+      preventAutoscrollEnd(noteRef.current)
       dispatch(
         setCursor({
           path,
@@ -144,6 +146,8 @@ const Note = React.memo(
       [dispatch],
     )
 
+    const onMouseDown = useCallback(() => preventAutoscroll(noteRef.current), [noteRef])
+
     if (note === null) return null
 
     return (
@@ -197,6 +201,7 @@ const Note = React.memo(
           }}
           onBlur={onBlur}
           onFocus={onFocus}
+          onMouseDown={onMouseDown}
           role='button'
         />
         <span className={css({ fontSize: '1.1em', position: 'absolute', margin: '-0.15em 0 0 -1.175em' })}>


### PR DESCRIPTION
Fixes #3128 

Notes should use `preventAutoscroll` in `onMouseDown` and `preventAutoscrollEnd` in `onFocus` to replicate the same behavior as editables.

I think this is working well. If the note is very close to the top of the viewport then I see it scroll up to the top, but I believe a different, intentional mechanism is causing that. Let me know.