### PR TITLE
Hide positioned faux caret by default

### DIFF
--- a/src/components/FauxCaret.tsx
+++ b/src/components/FauxCaret.tsx
@@ -43,7 +43,7 @@ const FauxCaret = ({
     fontSize?: Property.FontSize
     top?: Property.Top
     left?: Property.Left
-  }>({})
+  }>({ display: caretType === 'positioned' ? 'none' : undefined })
 
   const isEditingCursor = useSelector(state => state.isKeyboardOpen && equalPath(path, state.cursor))
   const isTableCol1 = useSelector(state => path && attributeEquals(state, head(path), '=view', 'Table'))

--- a/src/components/FauxCaret.tsx
+++ b/src/components/FauxCaret.tsx
@@ -43,7 +43,7 @@ const FauxCaret = ({
     fontSize?: Property.FontSize
     top?: Property.Top
     left?: Property.Left
-  }>({ display: caretType === 'positioned' ? 'none' : undefined })
+  }>(() => (isTouch && isSafari() && caretType === 'positioned' ? { display: 'none' } : {}))
 
   const isEditingCursor = useSelector(state => state.isKeyboardOpen && equalPath(path, state.cursor))
   const isTableCol1 = useSelector(state => path && attributeEquals(state, head(path), '=view', 'Table'))


### PR DESCRIPTION
Fixes #3095 

The faux caret, specifically the positioned faux caret, had an empty `styles` object by default. The props would be analyzed and the styles would be set inside of a `useEffect`. Since `useEffect` runs asynchronously, presumably it gets pushed into a later frame under heavier load. Now the positioned faux caret is hidden when it is mounted, and the styles are set in the `useEffect` as before.

I did a bit of ad-hoc testing and can see that yes, in a thoughtspace with a single thought, render and `useEffect` are executed within a few milliseconds of each other, while in a much larger thoughtspace, renders come first and most `useEffect` calls happen more like 20-40ms later.