### PR TITLE
Fix macOS Safari error by duck-typing touch event

### DIFF
--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -66,11 +66,7 @@ const useLongPress = (
    * we will know which element is being long-pressed. */
   const start = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
-      if (
-        (typeof TouchEvent !== 'undefined' && e.nativeEvent instanceof TouchEvent) ||
-        (e.nativeEvent instanceof MouseEvent && e.nativeEvent.button !== 2)
-      )
-        setPressing(true)
+      if ('touches' in e.nativeEvent || e.nativeEvent.button !== 2) setPressing(true)
     },
     [setPressing],
   )

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -66,7 +66,11 @@ const useLongPress = (
    * we will know which element is being long-pressed. */
   const start = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
-      if (e.nativeEvent instanceof TouchEvent || e.nativeEvent.button !== 2) setPressing(true)
+      if (
+        (typeof TouchEvent !== 'undefined' && e.nativeEvent instanceof TouchEvent) ||
+        (e.nativeEvent instanceof MouseEvent && e.nativeEvent.button !== 2)
+      )
+        setPressing(true)
     },
     [setPressing],
   )


### PR DESCRIPTION
Fixes #3149

macOS Safari doesn't have `TouchEvent` defined as a class, so checking `e.nativeEvent instanceof TouchEvent` throws an error. Now it duck-types by checking `'touches' in e.nativeEvent`, which seems to remove the need to later disambiguate the mouse event.