### PR TITLE
Skipped Flaky Tests As Intermediary Solution Until Actual Fix

### DIFF
--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -10,7 +10,6 @@ import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import setTheme from '../helpers/setTheme'
-import testIfNotCI from '../helpers/testIfNotCI'
 import waitForFrames from '../helpers/waitForFrames'
 
 expect.extend({
@@ -71,7 +70,8 @@ const testSuite = () => {
 
     // TODO: Test intermittently fails with small differences in 'b'.
     // https://github.com/cybersemics/em/issues/2955
-    it('superscript', async () => {
+    // temporarily disabled to fix flakiness
+    it.skip('superscript', async () => {
       await paste(`
     - a
       - m
@@ -153,7 +153,8 @@ describe('multiline', () => {
     expect(image).toMatchImageSnapshot()
   })
 
-  it('multiline thought expanded', async () => {
+  // temporarily disabled to fix flakiness
+  it.skip('multiline thought expanded', async () => {
     await paste(`
         - a
         - External objects (bodies) are merely appearances, hence also nothing other than a species of my representations, whose objects are something only through these representations, but are nothing separated from them.
@@ -174,7 +175,8 @@ describe('multiline', () => {
     expect(image).toMatchImageSnapshot()
   })
 
-  it('superscript on multiline thought', async () => {
+  // temporarily disabled to fix flakiness
+  it.skip('superscript on multiline thought', async () => {
     await paste(`
         - a
           - External objects (bodies) are merely appearances, hence also nothing other than a species of my representations, whose objects are something only through these representations, but are nothing separated from them.
@@ -198,7 +200,8 @@ describe('multiline', () => {
 describe('Color Theme', () => {
   // TODO: Flaky test
   // https://github.com/cybersemics/em/issues/2955
-  testIfNotCI('superscript on light theme', async () => {
+  // temporarily disabled to fix flakiness
+  it.skip('superscript on light theme', async () => {
     await setTheme('Light')
 
     await hideHUD()

--- a/src/e2e/puppeteer/helpers/longPressThought.ts
+++ b/src/e2e/puppeteer/helpers/longPressThought.ts
@@ -35,7 +35,7 @@ const longPressThought = async (
   }
 
   await page.touchscreen.touchStart(coordinate.x, coordinate.y)
-  await thoughtContainer.waitForSelector('[aria-label=bullet][data-highlighted=true')
+  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted=true]')
   await page.touchscreen.touchEnd()
 }
 


### PR DESCRIPTION
Following tests are skipped temporarily

1. https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/__tests__/render-thoughts.ts#L74-L94
2. https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/__tests__/render-thoughts.ts#L177-L196
3. https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/__tests__/render-thoughts.ts#L201-L224
4. https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/__tests__/render-thoughts.ts#L156-L175

As discussed these are skipped temporarily for the time being unless a permanent fix is made.

Fixed flakiness for [mutiselect > mobile only](https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/__tests__/multiselect.ts#L32-L55)