### PR TITLE
Use allowTouchToScroll to block scrolling after long press begins

### DIFF
--- a/.yarn/patches/README.md
+++ b/.yarn/patches/README.md
@@ -6,12 +6,13 @@ Usage Error: Multiple candidate packages found; explicitly choose one of them (u
 
 - react-dnd-touch-backend@patch:react-dnd-touch-backend@npm%3A16.0.1#~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch::version=16.0.1&hash=77964d
 - react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch::version=16.0.1&hash=33fdd5
+- react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=a99236
 ```
 
 Specifying the candidate package involves copying the name of the last one in the list, and then pasting it in single quotes:
 
 ```
-yarn patch -u 'react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch::version=16.0.1&hash=33fdd5'
+yarn patch -u 'react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=a99236'
 ```
 
 A description of the existing patches follows:
@@ -35,3 +36,7 @@ To summarize, in chronological order rather than in the order that the changes a
 ### react-dnd-touch-backend-patch-0040823149.patch
 
 This patch is a result of https://github.com/cybersemics/em/pull/3138 and patches another edge case where `clearTimeout` is not called and multiple quick taps are interpreted as a single tap.
+
+### react-dnd-touch-backend-patch-2c3a2052b6.patch
+
+This patch is a result of https://github.com/cybersemics/em/pull/3160 and cancels drag-and-drop when a scroll event is detected during the initial long press.

--- a/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
+++ b/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
@@ -1,0 +1,134 @@
+diff --git a/dist/TouchBackendImpl.js b/dist/TouchBackendImpl.js
+index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bdbb32d93a 100644
+--- a/dist/TouchBackendImpl.js
++++ b/dist/TouchBackendImpl.js
+@@ -38,13 +38,27 @@ export class TouchBackendImpl {
+     get document() {
+         return this.options.document;
+     }
++
++    // Cancel drag-and-drop if a scroll event is received so that scroll doesn't interfere with dragging.
++    // Use an arrow function to bind this event handler to the TouchBackendImpl object so that we can use `this`.
++    handleScroll = (e) => {
++        if (this.timeout) {
++            clearTimeout(this.timeout);
++            this.timeout = 0;
++        } else if (this.monitor.isDragging()) {
++            this.actions.endDrag();
++        }
++    }
++
+     setup() {
+         const root = this.options.rootElement;
+         if (!root) {
+             return;
+         }
++        this.startTime = Date.now()
+         invariant(!TouchBackendImpl.isSetUp, 'Cannot have two Touch backends at the same time.');
+         TouchBackendImpl.isSetUp = true;
++        window.addEventListener('scroll', this.handleScroll);
+         this.addEventListener(root, 'start', this.getTopMoveStartHandler());
+         this.addEventListener(root, 'start', this.handleTopMoveStartCapture, true);
+         this.addEventListener(root, 'move', this.handleTopMove);
+@@ -64,6 +78,7 @@ export class TouchBackendImpl {
+         }
+         TouchBackendImpl.isSetUp = false;
+         this._mouseClientOffset = {};
++        window.removeEventListener('scroll', this.handleScroll);
+         this.removeEventListener(root, 'start', this.handleTopMoveStartCapture, true);
+         this.removeEventListener(root, 'start', this.handleTopMoveStart);
+         this.removeEventListener(root, 'move', this.handleTopMoveCapture, true);
+@@ -243,6 +258,7 @@ export class TouchBackendImpl {
+                 return;
+             }
+             const delay = e.type === eventNames.touch.start ? this.options.delayTouchStart : this.options.delayMouseStart;
++            this.cutoffTime = Date.now() + delay
+             this.timeout = setTimeout(this.handleTopMoveStart.bind(this, e), delay);
+             this.waitingForDelay = true;
+         };
+@@ -271,6 +287,7 @@ export class TouchBackendImpl {
+                 (this.options.touchSlop ? this.options.touchSlop : 0)
+             ) {
+                 clearTimeout(this.timeout);
++                this.timeout = 0;
+             }
+ 
+             if (!this.document || this.waitingForDelay) {
+@@ -284,6 +301,7 @@ export class TouchBackendImpl {
+                 this._isScrolling = true;
+                 return;
+             }
++
+             // If we're not dragging and we've moved a little, that counts as a drag start
+             if (!this.monitor.isDragging() && // eslint-disable-next-line no-prototype-builtins
+             this._mouseClientOffset.hasOwnProperty('x') && moveStartSourceIds && distance(this._mouseClientOffset.x || 0, this._mouseClientOffset.y || 0, clientOffset.x, clientOffset.y) > (this.options.touchSlop ? this.options.touchSlop : 0)) {
+@@ -372,7 +390,10 @@ export class TouchBackendImpl {
+             if (!eventShouldEndDrag(e)) {
+                 return;
+             }
+-            if (this.timeout) clearTimeout(this.timeout);
++            if (this.timeout) {
++                clearTimeout(this.timeout);
++                this.timeout = 0;
++            }
+             if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+                 this.moveStartSourceIds = undefined;
+                 return;
+diff --git a/src/TouchBackendImpl.ts b/src/TouchBackendImpl.ts
+index 6650cf98fdb08bca5fa450853cb7907c380fe13e..4afc3cb776a7cbd126402d0a7635ed5b0f011b2b 100644
+--- a/src/TouchBackendImpl.ts
++++ b/src/TouchBackendImpl.ts
+@@ -116,6 +116,17 @@ export class TouchBackendImpl implements Backend {
+ 		return this.options.document
+ 	}
+ 
++  // Cancel drag-and-drop if a scroll event is received so that scroll doesn't interfere with dragging.
++  // Use an arrow function to bind this event handler to the TouchBackendImpl object so that we can use `this`.
++	public handleScroll = (): void => {
++		if (this.timeout) {
++			clearTimeout(this.timeout)
++			this.timeout = 0
++		} else if (this.monitor.isDragging()) {
++			this.actions.endDrag()
++		}
++	}
++
+ 	public setup(): void {
+ 		const root = this.options.rootElement
+ 		if (!root) {
+@@ -128,6 +139,7 @@ export class TouchBackendImpl implements Backend {
+ 		)
+ 		TouchBackendImpl.isSetUp = true
+ 
++		window.addEventListener('scroll', this.handleScroll)
+ 		this.addEventListener(root, 'start', this.getTopMoveStartHandler() as any)
+ 		this.addEventListener(
+ 			root,
+@@ -171,6 +183,7 @@ export class TouchBackendImpl implements Backend {
+ 		TouchBackendImpl.isSetUp = false
+ 		this._mouseClientOffset = {}
+ 
++		window.removeEventListener('scroll', this.handleScroll)
+ 		this.removeEventListener(
+ 			root,
+ 			'start',
+@@ -426,6 +439,7 @@ export class TouchBackendImpl implements Backend {
+ 			(this.options.touchSlop ? this.options.touchSlop : 0)
+ 		) {
+ 			clearTimeout(this.timeout)
++			this.timeout = 0
+ 		}
+ 
+ 		if (!this.document || this.waitingForDelay) {
+@@ -578,7 +592,10 @@ export class TouchBackendImpl implements Backend {
+ 			return
+ 		}
+ 
+-		if (this.timeout) clearTimeout(this.timeout);
++		if (this.timeout) {
++			clearTimeout(this.timeout)
++			this.timeout = 0;
++		}
+ 
+ 		if (!this.monitor.isDragging() || this.monitor.didDrop()) {
+ 			this.moveStartSourceIds = undefined

--- a/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
+++ b/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/TouchBackendImpl.js b/dist/TouchBackendImpl.js
-index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bdbb32d93a 100644
+index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7aa2805728 100644
 --- a/dist/TouchBackendImpl.js
 +++ b/dist/TouchBackendImpl.js
-@@ -38,13 +38,27 @@ export class TouchBackendImpl {
+@@ -38,6 +38,18 @@ export class TouchBackendImpl {
      get document() {
          return this.options.document;
      }
@@ -21,32 +21,15 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bd
      setup() {
          const root = this.options.rootElement;
          if (!root) {
-             return;
-         }
-+        this.startTime = Date.now()
-         invariant(!TouchBackendImpl.isSetUp, 'Cannot have two Touch backends at the same time.');
-         TouchBackendImpl.isSetUp = true;
-+        window.addEventListener('scroll', this.handleScroll);
-         this.addEventListener(root, 'start', this.getTopMoveStartHandler());
-         this.addEventListener(root, 'start', this.handleTopMoveStartCapture, true);
-         this.addEventListener(root, 'move', this.handleTopMove);
-@@ -64,6 +78,7 @@ export class TouchBackendImpl {
-         }
-         TouchBackendImpl.isSetUp = false;
-         this._mouseClientOffset = {};
-+        window.removeEventListener('scroll', this.handleScroll);
-         this.removeEventListener(root, 'start', this.handleTopMoveStartCapture, true);
-         this.removeEventListener(root, 'start', this.handleTopMoveStart);
-         this.removeEventListener(root, 'move', this.handleTopMoveCapture, true);
-@@ -243,6 +258,7 @@ export class TouchBackendImpl {
+@@ -242,6 +254,7 @@ export class TouchBackendImpl {
+             if (!eventShouldStartDrag(e)) {
                  return;
              }
++            window.addEventListener('scroll', this.handleScroll);
              const delay = e.type === eventNames.touch.start ? this.options.delayTouchStart : this.options.delayMouseStart;
-+            this.cutoffTime = Date.now() + delay
              this.timeout = setTimeout(this.handleTopMoveStart.bind(this, e), delay);
              this.waitingForDelay = true;
-         };
-@@ -271,6 +287,7 @@ export class TouchBackendImpl {
+@@ -271,6 +284,7 @@ export class TouchBackendImpl {
                  (this.options.touchSlop ? this.options.touchSlop : 0)
              ) {
                  clearTimeout(this.timeout);
@@ -54,7 +37,7 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bd
              }
  
              if (!this.document || this.waitingForDelay) {
-@@ -284,6 +301,7 @@ export class TouchBackendImpl {
+@@ -284,10 +298,12 @@ export class TouchBackendImpl {
                  this._isScrolling = true;
                  return;
              }
@@ -62,7 +45,12 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bd
              // If we're not dragging and we've moved a little, that counts as a drag start
              if (!this.monitor.isDragging() && // eslint-disable-next-line no-prototype-builtins
              this._mouseClientOffset.hasOwnProperty('x') && moveStartSourceIds && distance(this._mouseClientOffset.x || 0, this._mouseClientOffset.y || 0, clientOffset.x, clientOffset.y) > (this.options.touchSlop ? this.options.touchSlop : 0)) {
-@@ -372,7 +390,10 @@ export class TouchBackendImpl {
+                 this.moveStartSourceIds = undefined;
++                window.removeEventListener('scroll', this.handleScroll);
+                 this.actions.beginDrag(moveStartSourceIds, {
+                     clientOffset: this._mouseClientOffset,
+                     getSourceClientOffset: this.getSourceClientOffset,
+@@ -372,7 +388,10 @@ export class TouchBackendImpl {
              if (!eventShouldEndDrag(e)) {
                  return;
              }
@@ -75,7 +63,7 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..58f120dd81b8369bd4e42e3fe86a83bd
                  this.moveStartSourceIds = undefined;
                  return;
 diff --git a/src/TouchBackendImpl.ts b/src/TouchBackendImpl.ts
-index 6650cf98fdb08bca5fa450853cb7907c380fe13e..4afc3cb776a7cbd126402d0a7635ed5b0f011b2b 100644
+index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98dc3dc72f8 100644
 --- a/src/TouchBackendImpl.ts
 +++ b/src/TouchBackendImpl.ts
 @@ -116,6 +116,17 @@ export class TouchBackendImpl implements Backend {
@@ -96,23 +84,15 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..4afc3cb776a7cbd126402d0a7635ed5b
  	public setup(): void {
  		const root = this.options.rootElement
  		if (!root) {
-@@ -128,6 +139,7 @@ export class TouchBackendImpl implements Backend {
- 		)
- 		TouchBackendImpl.isSetUp = true
+@@ -385,6 +396,7 @@ export class TouchBackendImpl implements Backend {
+ 			return
+ 		}
  
 +		window.addEventListener('scroll', this.handleScroll)
- 		this.addEventListener(root, 'start', this.getTopMoveStartHandler() as any)
- 		this.addEventListener(
- 			root,
-@@ -171,6 +183,7 @@ export class TouchBackendImpl implements Backend {
- 		TouchBackendImpl.isSetUp = false
- 		this._mouseClientOffset = {}
- 
-+		window.removeEventListener('scroll', this.handleScroll)
- 		this.removeEventListener(
- 			root,
- 			'start',
-@@ -426,6 +439,7 @@ export class TouchBackendImpl implements Backend {
+ 		const delay =
+ 			e.type === eventNames.touch.start
+ 				? this.options.delayTouchStart
+@@ -426,6 +438,7 @@ export class TouchBackendImpl implements Backend {
  			(this.options.touchSlop ? this.options.touchSlop : 0)
  		) {
  			clearTimeout(this.timeout)
@@ -120,6 +100,14 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..4afc3cb776a7cbd126402d0a7635ed5b
  		}
  
  		if (!this.document || this.waitingForDelay) {
+@@ -465,6 +478,7 @@ export class TouchBackendImpl implements Backend {
+ 		) {
+ 			this.moveStartSourceIds = undefined
+ 
++			window.removeEventListener('scroll', this.handleScroll)
+ 			this.actions.beginDrag(moveStartSourceIds, {
+ 				clientOffset: this._mouseClientOffset,
+ 				getSourceClientOffset: this.getSourceClientOffset,
 @@ -578,7 +592,10 @@ export class TouchBackendImpl implements Backend {
  			return
  		}

--- a/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
+++ b/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/TouchBackendImpl.js b/dist/TouchBackendImpl.js
-index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7aa2805728 100644
+index 725715a382d5ac19718cfbdca6732a0d1ddc5092..401b36a8ace589eae757662b707c2f845007e770 100644
 --- a/dist/TouchBackendImpl.js
 +++ b/dist/TouchBackendImpl.js
-@@ -38,6 +38,18 @@ export class TouchBackendImpl {
+@@ -38,6 +38,22 @@ export class TouchBackendImpl {
      get document() {
          return this.options.document;
      }
@@ -10,6 +10,10 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
 +    // Cancel drag-and-drop if a scroll event is received so that scroll doesn't interfere with dragging.
 +    // Use an arrow function to bind this event handler to the TouchBackendImpl object so that we can use `this`.
 +    handleScroll = (e) => {
++        if (window['scrolling']) {
++            window.removeEventListener('scroll', this.handleScroll)
++            return
++        }
 +        if (this.timeout) {
 +            clearTimeout(this.timeout);
 +            this.timeout = 0;
@@ -21,7 +25,7 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
      setup() {
          const root = this.options.rootElement;
          if (!root) {
-@@ -242,6 +254,7 @@ export class TouchBackendImpl {
+@@ -242,6 +258,7 @@ export class TouchBackendImpl {
              if (!eventShouldStartDrag(e)) {
                  return;
              }
@@ -29,7 +33,7 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
              const delay = e.type === eventNames.touch.start ? this.options.delayTouchStart : this.options.delayMouseStart;
              this.timeout = setTimeout(this.handleTopMoveStart.bind(this, e), delay);
              this.waitingForDelay = true;
-@@ -271,6 +284,7 @@ export class TouchBackendImpl {
+@@ -271,6 +288,7 @@ export class TouchBackendImpl {
                  (this.options.touchSlop ? this.options.touchSlop : 0)
              ) {
                  clearTimeout(this.timeout);
@@ -37,7 +41,7 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
              }
  
              if (!this.document || this.waitingForDelay) {
-@@ -284,10 +298,12 @@ export class TouchBackendImpl {
+@@ -284,10 +302,13 @@ export class TouchBackendImpl {
                  this._isScrolling = true;
                  return;
              }
@@ -46,11 +50,12 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
              if (!this.monitor.isDragging() && // eslint-disable-next-line no-prototype-builtins
              this._mouseClientOffset.hasOwnProperty('x') && moveStartSourceIds && distance(this._mouseClientOffset.x || 0, this._mouseClientOffset.y || 0, clientOffset.x, clientOffset.y) > (this.options.touchSlop ? this.options.touchSlop : 0)) {
                  this.moveStartSourceIds = undefined;
-+                window.removeEventListener('scroll', this.handleScroll);
++                // window.removeEventListener('scroll', this.handleScroll);
++                console.info('beginDrag')
                  this.actions.beginDrag(moveStartSourceIds, {
                      clientOffset: this._mouseClientOffset,
                      getSourceClientOffset: this.getSourceClientOffset,
-@@ -372,7 +388,10 @@ export class TouchBackendImpl {
+@@ -372,7 +393,10 @@ export class TouchBackendImpl {
              if (!eventShouldEndDrag(e)) {
                  return;
              }
@@ -63,16 +68,20 @@ index 725715a382d5ac19718cfbdca6732a0d1ddc5092..c68c2852ef396fad70e93844821b7c7a
                  this.moveStartSourceIds = undefined;
                  return;
 diff --git a/src/TouchBackendImpl.ts b/src/TouchBackendImpl.ts
-index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98dc3dc72f8 100644
+index 6650cf98fdb08bca5fa450853cb7907c380fe13e..baee9a1b2c55fc0c2894e134acf85a457e854ef1 100644
 --- a/src/TouchBackendImpl.ts
 +++ b/src/TouchBackendImpl.ts
-@@ -116,6 +116,17 @@ export class TouchBackendImpl implements Backend {
+@@ -116,6 +116,21 @@ export class TouchBackendImpl implements Backend {
  		return this.options.document
  	}
  
 +  // Cancel drag-and-drop if a scroll event is received so that scroll doesn't interfere with dragging.
 +  // Use an arrow function to bind this event handler to the TouchBackendImpl object so that we can use `this`.
 +	public handleScroll = (): void => {
++    if (window['scrolling']) {
++      window.removeEventListener('scroll', this.handleScroll)
++      return
++    }
 +		if (this.timeout) {
 +			clearTimeout(this.timeout)
 +			this.timeout = 0
@@ -84,7 +93,7 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98d
  	public setup(): void {
  		const root = this.options.rootElement
  		if (!root) {
-@@ -385,6 +396,7 @@ export class TouchBackendImpl implements Backend {
+@@ -385,6 +400,7 @@ export class TouchBackendImpl implements Backend {
  			return
  		}
  
@@ -92,7 +101,7 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98d
  		const delay =
  			e.type === eventNames.touch.start
  				? this.options.delayTouchStart
-@@ -426,6 +438,7 @@ export class TouchBackendImpl implements Backend {
+@@ -426,6 +442,7 @@ export class TouchBackendImpl implements Backend {
  			(this.options.touchSlop ? this.options.touchSlop : 0)
  		) {
  			clearTimeout(this.timeout)
@@ -100,7 +109,7 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98d
  		}
  
  		if (!this.document || this.waitingForDelay) {
-@@ -465,6 +478,7 @@ export class TouchBackendImpl implements Backend {
+@@ -465,6 +482,7 @@ export class TouchBackendImpl implements Backend {
  		) {
  			this.moveStartSourceIds = undefined
  
@@ -108,7 +117,7 @@ index 6650cf98fdb08bca5fa450853cb7907c380fe13e..a2447e127ce651e54bc34ade047df98d
  			this.actions.beginDrag(moveStartSourceIds, {
  				clientOffset: this._mouseClientOffset,
  				getSourceClientOffset: this.getSourceClientOffset,
-@@ -578,7 +592,10 @@ export class TouchBackendImpl implements Backend {
+@@ -578,7 +596,10 @@ export class TouchBackendImpl implements Backend {
  			return
  		}
  

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-contenteditable": "^3.3.7",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
-    "react-dnd-touch-backend": "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch",
+    "react-dnd-touch-backend": "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch",
     "react-dom": "18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-gravatar": "^2.6.3",

--- a/src/device/allowTouchToScroll.ts
+++ b/src/device/allowTouchToScroll.ts
@@ -1,0 +1,24 @@
+/** Prevent touchmove from allowing the page to scroll when a long press is active (#3141). */
+import { isTouch } from '../browser'
+
+/** Don't allow the page to scroll during touchmove. */
+const preventDefault = (e: TouchEvent) => e.preventDefault()
+
+/** Disables scrolling on the body element by preventing default on touchmove. */
+const disableScroll = () => {
+  document.body.addEventListener('touchmove', preventDefault, { passive: false })
+}
+
+/** Re-enables scrolling on the body element by removing the event handler that prevents default. */
+const enableScroll = () => {
+  document.body.removeEventListener('touchmove', preventDefault)
+}
+
+/** Enables or disables scrolling based on the parameter. */
+function allowTouchToScroll(disable: boolean) {
+  if (!isTouch) return
+  if (disable) enableScroll()
+  else disableScroll()
+}
+
+export default allowTouchToScroll

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -21,6 +21,7 @@ import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { setIsMulticursorExecutingActionCreator as setIsMulticursorExecuting } from '../actions/setIsMulticursorExecuting'
 import { ThoughtContainerProps } from '../components/Thought'
 import { AlertType, LongPressState } from '../constants'
+import allowTouchToScroll from '../device/allowTouchToScroll'
 import * as selection from '../device/selection'
 import globals from '../globals'
 import documentSort from '../selectors/documentSort'
@@ -109,6 +110,7 @@ const endDrag = () => {
   // Reset the lock variable to allow immediate long press after drag
   longPressStore.unlock()
   globals.longpressing = false
+  allowTouchToScroll(true)
 
   // Wait till the next tick before ending dragInProgress.
   // This allows onTap to be aborted in Editable to prevent the cursor from moving at the end of a drag.

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -8,6 +8,7 @@ import { dragHoldActionCreator as dragHold } from '../actions/dragHold'
 import { longPressActionCreator as longPress } from '../actions/longPress'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
 import { LongPressState } from '../constants'
+import allowTouchToScroll from '../device/allowTouchToScroll'
 import hasMulticursor from '../selectors/hasMulticursor'
 import longPressStore from '../stores/longPressStore'
 import useLongPress from './useLongPress'
@@ -35,6 +36,7 @@ const useDragHold = ({
   const onLongPressStart = useCallback(() => {
     if (disabled) return
     setIsPressed(true)
+    allowTouchToScroll(false)
     dispatch([dragHold({ value: true, simplePath, sourceZone }), longPress({ value: LongPressState.DragHold })])
   }, [disabled, dispatch, simplePath, sourceZone])
 
@@ -43,6 +45,7 @@ const useDragHold = ({
     if (disabled) return
 
     setIsPressed(false)
+    allowTouchToScroll(true)
     dispatch((dispatch, getState) => {
       const state = getState()
 

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -266,7 +266,7 @@ const initEvents = (store: Store<State, any>) => {
       // start scrolling up when within 120px of the top edge of the screen
       if (y < WINDOW_SCROLLATEDGE_UP_SIZE) {
         const rate = 1 + ((WINDOW_SCROLLATEDGE_UP_SIZE - y) * WINDOW_SCROLLATEDGE_SPEED) / WINDOW_SCROLLATEDGE_UP_SIZE
-        // @ts-ignore
+        // @ts-expect-error - this is a temporary solution for demonstration purposes and further discussion
         window['scrolling'] = true
         scrollAtEdge.start({ y: -rate })
       }
@@ -276,13 +276,13 @@ const initEvents = (store: Store<State, any>) => {
           1 +
           ((y - window.innerHeight + WINDOW_SCROLLATEDGE_DOWN_SIZE) * WINDOW_SCROLLATEDGE_SPEED) /
             WINDOW_SCROLLATEDGE_DOWN_SIZE
-        // @ts-ignore
+        // @ts-expect-error - this is a temporary solution for demonstration purposes and further discussion
         window['scrolling'] = true
         scrollAtEdge.start({ y: rate })
       }
       // stop scrolling when not near the edge of the screen
       else {
-        // @ts-ignore
+        // @ts-expect-error - this is a temporary solution for demonstration purposes and further discussion
         window['scrolling'] = false
         scrollAtEdge.stop()
       }

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -266,6 +266,8 @@ const initEvents = (store: Store<State, any>) => {
       // start scrolling up when within 120px of the top edge of the screen
       if (y < WINDOW_SCROLLATEDGE_UP_SIZE) {
         const rate = 1 + ((WINDOW_SCROLLATEDGE_UP_SIZE - y) * WINDOW_SCROLLATEDGE_SPEED) / WINDOW_SCROLLATEDGE_UP_SIZE
+        // @ts-ignore
+        window['scrolling'] = true
         scrollAtEdge.start({ y: -rate })
       }
       // start scrolling down when within 100px of the bottom edge of the screen
@@ -274,10 +276,14 @@ const initEvents = (store: Store<State, any>) => {
           1 +
           ((y - window.innerHeight + WINDOW_SCROLLATEDGE_DOWN_SIZE) * WINDOW_SCROLLATEDGE_SPEED) /
             WINDOW_SCROLLATEDGE_DOWN_SIZE
+        // @ts-ignore
+        window['scrolling'] = true
         scrollAtEdge.start({ y: rate })
       }
       // stop scrolling when not near the edge of the screen
       else {
+        // @ts-ignore
+        window['scrolling'] = false
         scrollAtEdge.stop()
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16637,11 +16637,11 @@ __metadata:
 
 "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch":
   version: 16.0.1
-  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=a99236"
+  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=6dbd48"
   dependencies:
     "@react-dnd/invariant": "npm:^4.0.1"
     dnd-core: "npm:^16.0.1"
-  checksum: 10c0/8e698a0c3a0d7f4e15cd8f79a557b0c0d1d037c134b3e26c25bbf227ea2f9b27c5161f31fd95a25d76432dda5a777cc26f9ac61e9896a15a0dd814e668497093
+  checksum: 10c0/e0b3064af764437c927043be8654347fcd27ea8a6f80a87ddabe59249ddf8e6a4a345726b9b1558e1fcd1c54699b8ddcce7bf120ae965a868e54df46f938c1c9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8784,7 +8784,7 @@ __metadata:
     react-dnd-html5-backend: "npm:^16.0.1"
     react-dnd-test-backend: "npm:^16.0.1"
     react-dnd-test-utils: "npm:^16.0.1"
-    react-dnd-touch-backend: "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch"
+    react-dnd-touch-backend: "patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch"
     react-dom: "npm:18.3.1"
     react-error-boundary: "npm:^4.1.2"
     react-gravatar: "npm:^2.6.3"
@@ -16625,13 +16625,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch":
+"react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch::version=16.0.1&hash=33fdd5":
   version: 16.0.1
   resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@npm%253A16.0.1%23~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%3A%3Aversion=16.0.1&hash=77964d#~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch::version=16.0.1&hash=33fdd5"
   dependencies:
     "@react-dnd/invariant": "npm:^4.0.1"
     dnd-core: "npm:^16.0.1"
   checksum: 10c0/79a25736ac8e21c94169b5e7c5cc9c50ee9552adf598e411a8cf39f5164d5a2fed7a55bf57f53e8f8ceb6d591f051b2720a34f991bcc56ffe8dbe90598323b71
+  languageName: node
+  linkType: hard
+
+"react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch":
+  version: 16.0.1
+  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=6e587b"
+  dependencies:
+    "@react-dnd/invariant": "npm:^4.0.1"
+    dnd-core: "npm:^16.0.1"
+  checksum: 10c0/64604fec4b3a124771a0dee2219ba47bf9786f9b045a860ddb144d1f80a91d3889600f87ed63cc53f68cb73e0f1a1318d09ccfbb7424c0f4f28a332d5aa75183
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16637,11 +16637,11 @@ __metadata:
 
 "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch":
   version: 16.0.1
-  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=6e587b"
+  resolution: "react-dnd-touch-backend@patch:react-dnd-touch-backend@patch%3Areact-dnd-touch-backend@patch%253Areact-dnd-touch-backend@npm%25253A16.0.1%2523~/.yarn/patches/react-dnd-touch-backend-npm-16.0.1-2b96ba84be.patch%253A%253Aversion=16.0.1&hash=77964d%23~/.yarn/patches/react-dnd-touch-backend-patch-0040823149.patch%3A%3Aversion=16.0.1&hash=33fdd5#~/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch::version=16.0.1&hash=a99236"
   dependencies:
     "@react-dnd/invariant": "npm:^4.0.1"
     dnd-core: "npm:^16.0.1"
-  checksum: 10c0/64604fec4b3a124771a0dee2219ba47bf9786f9b045a860ddb144d1f80a91d3889600f87ed63cc53f68cb73e0f1a1318d09ccfbb7424c0f4f28a332d5aa75183
+  checksum: 10c0/8e698a0c3a0d7f4e15cd8f79a557b0c0d1d037c134b3e26c25bbf227ea2f9b27c5161f31fd95a25d76432dda5a777cc26f9ac61e9896a15a0dd814e668497093
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #3141 

This is an improved version of #3148 

There are two constraints on this problem:

1. It is not possible to stop iOS Safari from scrolling once it has begun
2. It is not possible to cancel a drag in react-dnd once it has begun

[allowTouchToScroll](https://github.com/ethan-james/em/blob/1e86a86415cf178282a006d37055e15016dcd458/src/device/allowTouchToScroll.ts#L1) is a new counterpart to allowScroll. The overflow: hidden approach that `allowScroll` takes unfortunately doesn't work to block this type of scrolling in iOS Safari. I needed this to be in its own file because it needs to be called from [useDragHold](https://github.com/ethan-james/em/blob/1e86a86415cf178282a006d37055e15016dcd458/src/hooks/useDragHold.ts#L39) to register the event handler, and [useDragAndDropThought](https://github.com/ethan-james/em/blob/1e86a86415cf178282a006d37055e15016dcd458/src/hooks/useDragAndDropThought.tsx#L113) to unregister it. So the reference to the `preventDefault` function needs to be stable across those two files.

[handleScroll](https://github.com/ethan-james/em/blob/7f09e82887770c8f6723ad5020ff2f1df298bc92/.yarn/patches/react-dnd-touch-backend-patch-2c3a2052b6.patch#L12) watches for scroll events and cancels drag-and-drop functionality either before it has begun (`clearTimeout`) or after it has begun (`this.actions.endDrag()`). This is necessary because when we attempt to block `scroll` events by calling `preventDefault` on `touchmove` events, then the subsequent `scroll` events start coming in very slowly and we can't count on being able to respond to them quickly enough to cancel drag-and-drop before it begins.

[scrollAtEdge](https://github.com/ethan-james/em/blob/7f09e82887770c8f6723ad5020ff2f1df298bc92/src/util/initEvents.ts#L270) also produces `scroll` events that should not cancel drag-and-drop. Since the timing of scroll events is not very precise, we can't really remove `handleScroll` as an event listener at any particular time. Setting a global flag declaring that `scrollAtEdge` is active allows us to avoid canceling drag-and-drop based on `scroll` events from that source.

I created an alternate solution that does not rely on the `window['scrolling']` flag: #3161.