### PR TITLE
Fix 3070: Fix `Sort non-dates after dates`

### DIFF
--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -242,7 +242,7 @@ describe('isDatePattern', () => {
     expect(isDatePattern('12/1')).toBe(true)
     expect(isDatePattern('1/31')).toBe(true)
     expect(isDatePattern('12/31')).toBe(true)
-    expect(isDatePattern(' 6/21 ')).toBe(true) // Should trim spaces
+    expect(isDatePattern(' 6/21 ')).toBe(false) // Trimming is now handled at call site
 
     // Valid full date patterns with year
     expect(isDatePattern('6/21/2025')).toBe(true)
@@ -250,14 +250,14 @@ describe('isDatePattern', () => {
     expect(isDatePattern('12/1/2024')).toBe(true)
     expect(isDatePattern('1/31/2023')).toBe(true)
     expect(isDatePattern('12/31/2026')).toBe(true)
-    expect(isDatePattern(' 6/21/2025 ')).toBe(true) // Should trim spaces
+    expect(isDatePattern(' 6/21/2025 ')).toBe(false) // Trimming is now handled at call site
 
     // Valid written date patterns
     expect(isDatePattern('March 3, 2020')).toBe(true)
     expect(isDatePattern('December 3, 2020')).toBe(true)
     expect(isDatePattern('March 3')).toBe(true)
     expect(isDatePattern('December 3')).toBe(true)
-    expect(isDatePattern(' March 3, 2020 ')).toBe(true) // Should trim spaces
+    expect(isDatePattern(' March 3, 2020 ')).toBe(false) // Trimming is now handled at call site
     expect(isDatePattern('march 3, 2020')).toBe(true) // Case-insensitive
     expect(isDatePattern('MARCH 3, 2020')).toBe(true) // Case-insensitive
   })

--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -1,5 +1,6 @@
 import Thought from '../../@types/Thought'
 import { HOME_TOKEN } from '../../constants'
+import timestamp from '../../util/timestamp'
 import {
   compare,
   compareDateStrings,
@@ -11,9 +12,9 @@ import {
   compareReasonable,
   compareStringsWithEmoji,
   compareThoughtDescending,
+  isDatePattern,
   makeOrderedComparator,
-} from '../../util/compareThought'
-import timestamp from '../../util/timestamp'
+} from '../compareThought'
 import createId from '../createId'
 
 /** Build a test thought with the given value. */
@@ -230,5 +231,108 @@ describe('compareThought', () => {
       expect(compareThoughtDescending(thought('🍍 the apple'), thought('🍍 book'))).toBe(1)
       expect(compareThoughtDescending(thought('🍍 the apple'), thought('🍍 apple'))).toBe(0)
     })
+  })
+})
+
+describe('isDatePattern', () => {
+  it('identifies valid date patterns', () => {
+    // Valid short date patterns
+    expect(isDatePattern('6/21')).toBe(true)
+    expect(isDatePattern('6-21')).toBe(true)
+    expect(isDatePattern('12/1')).toBe(true)
+    expect(isDatePattern('1/31')).toBe(true)
+    expect(isDatePattern('12/31')).toBe(true)
+    expect(isDatePattern(' 6/21 ')).toBe(true) // Should trim spaces
+
+    // Valid full date patterns with year
+    expect(isDatePattern('6/21/2025')).toBe(true)
+    expect(isDatePattern('6-21-2025')).toBe(true)
+    expect(isDatePattern('12/1/2024')).toBe(true)
+    expect(isDatePattern('1/31/2023')).toBe(true)
+    expect(isDatePattern('12/31/2026')).toBe(true)
+    expect(isDatePattern(' 6/21/2025 ')).toBe(true) // Should trim spaces
+
+    // Valid written date patterns
+    expect(isDatePattern('March 3, 2020')).toBe(true)
+    expect(isDatePattern('December 3, 2020')).toBe(true)
+    expect(isDatePattern('March 3')).toBe(true)
+    expect(isDatePattern('December 3')).toBe(true)
+    expect(isDatePattern(' March 3, 2020 ')).toBe(true) // Should trim spaces
+    expect(isDatePattern('march 3, 2020')).toBe(true) // Case-insensitive
+    expect(isDatePattern('MARCH 3, 2020')).toBe(true) // Case-insensitive
+  })
+
+  it('rejects invalid date patterns', () => {
+    // Invalid patterns
+    expect(isDatePattern('6')).toBe(false)
+    expect(isDatePattern('6/')).toBe(false)
+    expect(isDatePattern('/21')).toBe(false)
+    expect(isDatePattern('6/21/')).toBe(false)
+    expect(isDatePattern('6-21-')).toBe(false)
+    expect(isDatePattern('abc')).toBe(false)
+    expect(isDatePattern('6.21')).toBe(false)
+    expect(isDatePattern('6_21')).toBe(false)
+    expect(isDatePattern('')).toBe(false)
+
+    // Invalid year formats
+    expect(isDatePattern('6/21/25')).toBe(false) // 2-digit year
+    expect(isDatePattern('6/21/202')).toBe(false) // 3-digit year
+    expect(isDatePattern('6/21/20255')).toBe(false) // 5-digit year
+    expect(isDatePattern('6/21/abc')).toBe(false) // Non-numeric year
+    expect(isDatePattern('6/21/2025/')).toBe(false) // Extra separator
+    expect(isDatePattern('6-21-2025-')).toBe(false) // Extra separator
+
+    // Mixed separators (invalid)
+    expect(isDatePattern('6/21-2025')).toBe(false) // Slash then dash
+    expect(isDatePattern('6-21/2025')).toBe(false) // Dash then slash
+    expect(isDatePattern('6/21-')).toBe(false) // Slash then dash (incomplete)
+    expect(isDatePattern('6-21/')).toBe(false) // Dash then slash (incomplete)
+
+    // Invalid written formats
+    expect(isDatePattern('March')).toBe(false) // Missing day
+    expect(isDatePattern('March 3rd')).toBe(false) // Ordinal not supported
+    expect(isDatePattern('March 3, 2020,')).toBe(false) // Extra comma
+    expect(isDatePattern('March 3 2020')).toBe(false) // Missing comma
+    expect(isDatePattern('March 3, 25')).toBe(false) // 2-digit year not supported
+    expect(isDatePattern('Mar 3, 2020')).toBe(false) // Abbreviated month not supported
+  })
+})
+
+describe('compareDateStrings', () => {
+  it('only handles date vs date comparisons, returns 0 for others', () => {
+    expect(compareDateStrings('6/1', '6')).toBe(0) // Let other comparators handle date vs non-date
+    expect(compareDateStrings('6/1', '6/')).toBe(0) // Let other comparators handle date vs non-date
+    expect(compareDateStrings('6', '6/1')).toBe(0) // Let other comparators handle non-date vs date
+    expect(compareDateStrings('6/', '6/1')).toBe(0) // Let other comparators handle non-date vs date
+  })
+
+  it('sorts valid dates correctly among themselves', () => {
+    expect(compareDateStrings('6/1', '6/2')).toBe(-1) // 6/1 comes before 6/2
+    expect(compareDateStrings('6/2', '6/1')).toBe(1) // 6/2 comes after 6/1
+    expect(compareDateStrings('6/1', '6/1')).toBe(0) // Same dates are equal
+
+    // Written dates
+    expect(compareDateStrings('March 3', 'March 4')).toBe(-1) // March 3 comes before March 4
+    expect(compareDateStrings('March 4', 'March 3')).toBe(1) // March 4 comes after March 3
+    expect(compareDateStrings('March 3, 2020', 'March 3, 2021')).toBe(-1) // 2020 comes before 2021
+    expect(compareDateStrings('March 3, 2021', 'March 3, 2020')).toBe(1) // 2021 comes after 2020
+
+    // Mixed numeric and written dates (both are valid dates, so they should be compared)
+    expect(compareDateStrings('3/3', 'March 3')).toBe(0) // Both represent March 3rd, so they're equal
+    expect(compareDateStrings('March 3', '3/3')).toBe(0) // Both represent March 3rd, so they're equal
+  })
+
+  it('returns 0 for non-date strings to let other comparators handle them', () => {
+    expect(compareDateStrings('6', '6/')).toBe(0) // Let other comparators handle non-dates
+    expect(compareDateStrings('6/', '6')).toBe(0) // Let other comparators handle non-dates
+    expect(compareDateStrings('5', '6')).toBe(0) // Let other comparators handle non-dates
+  })
+
+  it('handles edge cases correctly', () => {
+    expect(compareDateStrings('12/31', '1/1')).toBe(1) // 12/31 comes after 1/1
+    expect(compareDateStrings('1/1', '12/31')).toBe(-1) // 1/1 comes before 12/31
+    expect(compareDateStrings('abc', '6/1')).toBe(0) // Let other comparators handle non-date vs date
+    expect(compareDateStrings('6/1', 'abc')).toBe(0) // Let other comparators handle date vs non-date
+    expect(compareDateStrings('abc', 'def')).toBe(0) // Let other comparators handle non-dates
   })
 })

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -87,6 +87,7 @@ const toNumber = (x: number | string): number =>
 
 /** Returns trure if the given string is an integer or decimal number. Recognizes prefixed number strings like "#1" and "$1" as numbers. */
 const isNumber = (x: number | string): boolean => !isNaN(toNumber(x))
+
 /** Checks if a string matches a date pattern like "M/d", "M-d", "M/d/yyyy", "M-d-yyyy", or written formats.
  * Accepts 1-2 digits for month and day, optionally followed by year
  * Also accepts written month names like "March 3, 2020" or "December 3, 2020"

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -74,19 +74,10 @@ const parseDate = (s: string): number => {
   // Use pre-compiled regex for optimal performance
   const shortDateMatch = s.match(REGEX_SHORT_DATE_PARSE)
 
-  let dateString = s
-
-  if (shortDateMatch) {
-    // Handle short dates by adding current year
-    if (s.includes('/')) {
-      dateString = `${s}/${CURRENT_YEAR}`
-    } else if (s.includes('-')) {
-      dateString = `${s}-${CURRENT_YEAR}`
-    } else {
-      // Written format
-      dateString = `${s}, ${CURRENT_YEAR}`
-    }
-  }
+  // Build the complete date string
+  const dateString = shortDateMatch
+    ? `${s}${s.includes('/') ? '/' : s.includes('-') ? '-' : ', '}${CURRENT_YEAR}`
+    : s
 
   // Single Date.parse call for optimal performance
   return Date.parse(dateString)

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -75,9 +75,7 @@ const parseDate = (s: string): number => {
   const shortDateMatch = s.match(REGEX_SHORT_DATE_PARSE)
 
   // Build the complete date string
-  const dateString = shortDateMatch
-    ? `${s}${s.includes('/') ? '/' : s.includes('-') ? '-' : ', '}${CURRENT_YEAR}`
-    : s
+  const dateString = shortDateMatch ? `${s}${s.includes('/') ? '/' : s.includes('-') ? '-' : ', '}${CURRENT_YEAR}` : s
 
   // Single Date.parse call for optimal performance
   return Date.parse(dateString)
@@ -89,7 +87,6 @@ const toNumber = (x: number | string): number =>
 
 /** Returns trure if the given string is an integer or decimal number. Recognizes prefixed number strings like "#1" and "$1" as numbers. */
 const isNumber = (x: number | string): boolean => !isNaN(toNumber(x))
-
 /** Checks if a string matches a date pattern like "M/d", "M-d", "M/d/yyyy", "M-d-yyyy", or written formats.
  * Accepts 1-2 digits for month and day, optionally followed by year
  * Also accepts written month names like "March 3, 2020" or "December 3, 2020"


### PR DESCRIPTION
Fixes: https://github.com/cybersemics/em/issues/3070

`isDatePattern` is created for checking if text is date formatted or not.
And I more prioritized the date formatted text than non-dates text.
Also I added test cases for updated logic.