### PR TITLE
Bypass clickOnEmptySpace if event target isEditable, remove stopPropagation

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -524,9 +524,6 @@ const Editable = ({
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      // stop propagation to prevent the event from propagating down to the Content component and triggering clickOnEmptySpace
-      e.stopPropagation()
-
       // If editing or the cursor is on the thought, allow the default browser selection so the offset is correct.
       // Otherwise useEditMode will programmatically set the selection to the beginning of the thought.
       // See: #981

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -57,7 +57,7 @@ export const isCollapsed = (): boolean => !!window.getSelection()?.isCollapsed
 export const isActive = (): boolean => !!window.getSelection()?.focusNode
 
 /** Returns true if the Node is an editable. */
-const isEditable = (node?: Node | null) => {
+export const isEditable = (node?: Node | EventTarget | null) => {
   const element = node as HTMLElement
   return (
     !!element &&


### PR DESCRIPTION
Fixes #3174 

Instead of controlling `clickOnEmptySpace` by detecting `mousedown` events (and calling `stopPropagation` on them to avoid triggering `clickOnEmptySpace`) we can check whether the event target `isEditable` and decide whether it qualifies as empty space based on that.