### PR TITLE
Remove selection.clear when ending long press

### DIFF
--- a/src/actions/dragInProgress.ts
+++ b/src/actions/dragInProgress.ts
@@ -8,7 +8,6 @@ import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import { isSafari } from '../browser'
 import { AlertText, AlertType, LongPressState } from '../constants'
-import * as selection from '../device/selection'
 import globals from '../globals'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import haptics from '../util/haptics'
@@ -121,11 +120,6 @@ export const dragInProgressActionCreator =
     // react-dnd stops propagation of the TouchMonitor's touchend event, so we need to turn off globals.touching here
     else {
       globals.touching = false
-
-      // clear selection after drag ends just in case browser made a selection
-      // Mobile Safari long-press-to-select is difficult to stop
-      // See: https://github.com/cybersemics/em/issues/1704
-      setTimeout(selection.clear)
     }
 
     dispatch({ type: 'dragInProgress', ...payload })


### PR DESCRIPTION
References #3175

Thanks to #3023, tap-to-select no longer activates during a long press. Now this workaround is unnecessary. I tested against #1704 to make sure. I also added this change to #3177 since I moved `dragInProgress.ts` into `longPress.ts`. So we may not end up merging this if that PR gets approved soon.