### PR TITLE
fix2142: extractThought

### DIFF
--- a/src/commands/__tests__/extractThought.ts
+++ b/src/commands/__tests__/extractThought.ts
@@ -1,4 +1,4 @@
-import { findAllByPlaceholderText, screen } from '@testing-library/react'
+import { findAllByLabelText, screen } from '@testing-library/react'
 import { extractThoughtActionCreator as extractThought } from '../../actions/extractThought'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
@@ -68,10 +68,10 @@ describe.skip('Extract thought', () => {
     expect(createdThought).toBeTruthy()
 
     // created thought gets appended to the end
-    const thoughtChildrenWrapper = thought!.closest('li')?.lastElementChild as HTMLElement
-    const thoughtChildren = await findAllByPlaceholderText(thoughtChildrenWrapper, 'Add a thought')
+    const thoughtChildrenWrapper = thought!.closest('div[aria-label=tree-node]')?.lastElementChild as HTMLElement
+    const thoughtChildren = await findAllByLabelText(thoughtChildrenWrapper, 'thought')
 
-    expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['sub-thought', 'thought'])
+    expect(thoughtChildren.map((child: HTMLElement) => child.textContent)).toMatchObject(['this is a'])
   })
 
   it('the cursor does not get updated on child creation', async () => {


### PR DESCRIPTION
- Added fix to get list of elements with the of tree-node attribute as per your suggestion.

- Added verification to get element by label as thought and verify it last child thought.