### PR TITLE
Remove globals.longpressing

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -2,10 +2,6 @@
 
 /** THE BAD PLACE where mutable globals are defined. */
 
-// globally tracks when a long press starts and ends
-// this is useful to prevent long-tap-to-select on mobile safari
-let longpressing = false
-
 // track whether the user is touchmoving so that we can distinguish touchend events from tap or drag
 // not related to react-dnd
 let touching = false
@@ -39,7 +35,6 @@ const globals = {
   freeThoughtsThreshold,
   errorTimer,
   offlineTimer,
-  longpressing,
   rendered,
   suppressExpansion,
   touching,

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -23,7 +23,6 @@ import { ThoughtContainerProps } from '../components/Thought'
 import { AlertType, LongPressState } from '../constants'
 import allowTouchToScroll from '../device/allowTouchToScroll'
 import * as selection from '../device/selection'
-import globals from '../globals'
 import documentSort from '../selectors/documentSort'
 import findDescendant from '../selectors/findDescendant'
 import getNextRank from '../selectors/getNextRank'
@@ -109,7 +108,6 @@ const beginDrag = ({ path, simplePath }: ThoughtContainerProps): DragThoughtItem
 const endDrag = () => {
   // Reset the lock variable to allow immediate long press after drag
   longPressStore.unlock()
-  globals.longpressing = false
 
   // react-dnd-touch-backend will call preventDefault on touchmove events once a drag has begun, but since there is a touchSlop threshold of 10px,
   // we can get iOS Safari to initiate a scroll before drag-and-drop begins. It is then impossible to cancel the scroll programatically. (#3141)

--- a/src/hooks/useDragAndDropToolbarButton.ts
+++ b/src/hooks/useDragAndDropToolbarButton.ts
@@ -10,7 +10,6 @@ import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { newThoughtActionCreator as newThought } from '../actions/newThought'
 import { commandById } from '../commands'
 import { EM_TOKEN } from '../constants'
-import globals from '../globals'
 import contextToPath from '../selectors/contextToPath'
 import findDescendant from '../selectors/findDescendant'
 import { getChildrenRanked } from '../selectors/getChildren'
@@ -89,7 +88,6 @@ const useDragAndDropToolbarButton = ({ commandId, customize }: { commandId: Comm
     end: () => {
       // Reset the lock to allow immediate long press after drag ends
       longPressStore.unlock()
-      globals.longpressing = false
       store.dispatch(dragCommand(null))
     },
     collect: monitor => ({

--- a/src/hooks/useDragDropFavorites.ts
+++ b/src/hooks/useDragDropFavorites.ts
@@ -11,7 +11,6 @@ import { dragInProgressActionCreator as dragInProgress } from '../actions/dragIn
 import { updateThoughtsActionCreator as updateThoughts } from '../actions/updateThoughts'
 import { AlertType } from '../constants'
 import * as selection from '../device/selection'
-import globals from '../globals'
 import { getLexeme } from '../selectors/getLexeme'
 import getThoughtById from '../selectors/getThoughtById'
 import store from '../stores/app'
@@ -43,7 +42,6 @@ const beginDrag = ({ path, simplePath }: DragThoughtItem): DragThoughtItem => {
 /** Handles drag end. */
 const endDrag = () => {
   longPressStore.unlock()
-  globals.longpressing = false
   store.dispatch([
     dragInProgress({ value: false }),
     dragHold({ value: false }),

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -58,10 +58,10 @@ const useDragHold = ({
 
       if (state.dragHold) {
         dispatch([dragHold({ value: false }), !hasMulticursor(state) ? alert(null) : null])
+        if (toggleMulticursorOnLongPress) dispatch(toggleMulticursor({ path: simplePath }))
       }
 
       dispatch(longPress({ value: LongPressState.Inactive }))
-      if (toggleMulticursorOnLongPress) dispatch(toggleMulticursor({ path: simplePath }))
     })
   }, [disabled, dispatch, simplePath, toggleMulticursorOnLongPress])
 

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -5,7 +5,6 @@ import { keyboardOpenActionCreator as keyboardOpen } from '../actions/keyboardOp
 import { isTouch } from '../browser'
 import { TIMEOUT_LONG_PRESS_THOUGHT, noop } from '../constants'
 import * as selection from '../device/selection'
-import globals from '../globals'
 import longPressStore from '../stores/longPressStore'
 import haptics from '../util/haptics'
 
@@ -35,11 +34,10 @@ const useLongPress = (
   }, [isLocked, setPressing])
 
   useEffect(() => {
-    /** Begin a long press, after the timer elapses on desktop, or the dragStart event is fired by TouchBackned in react-dnd. */
+    /** Begin a long press, after the timer elapses on desktop, or the dragStart event is fired by TouchBackend in react-dnd. */
     const onStart = () => {
       if (isLocked || !pressing) return
 
-      globals.longpressing = true
       haptics.light()
       onLongPressStart?.()
       longPressStore.lock()
@@ -83,12 +81,6 @@ const useLongPress = (
       clearTimeout(timerIdRef.current)
       timerIdRef.current = 0
       longPressStore.unlock()
-
-      // If not longpressing, it means that the long press was canceled by a move event.
-      // in this case, onLongPressEnd should not be called, since it was already called by the move event.
-      if (!globals.longpressing) return
-
-      globals.longpressing = false
 
       // If a long press occurred, mark it as not canceled
       onLongPressEnd?.()


### PR DESCRIPTION
References #3175

There is only [one place](https://github.com/ethan-james/em/blob/80a075ffba1c268d2ae77aff7c3fa0ed14120a08/src/hooks/useLongPress.ts#L89) where `globals.longpressing` was being tested, and the main reason for that was to check if the long press had been canceled by our `touchmove` handler, which is now gone.

There is now significant redundancy between [onLongPressEnd](https://github.com/ethan-james/em/blob/77f854d559f95ea8147484ada69f9e52a708d56b/src/hooks/useDragHold.ts#L48) and [endDrag](https://github.com/ethan-james/em/blob/77f854d559f95ea8147484ada69f9e52a708d56b/src/hooks/useDragAndDropThought.tsx#L108). I'm pretty confident that I can do away with `endDrag` entirely, since in my testing I always see [stop](https://github.com/ethan-james/em/blob/77f854d559f95ea8147484ada69f9e52a708d56b/src/hooks/useLongPress.ts#L75) getting called at the end of any long press, including a drag.

I figured it would be best to start small and work toward eliminating `endDrag` and even [the useEffect in useDragHold](https://github.com/ethan-james/em/blob/77f854d559f95ea8147484ada69f9e52a708d56b/src/hooks/useDragHold.ts#L70), especially due to this comment:

```
// react-dnd stops propagation so onLongPressEnd sometimes doesn't get called.
```

I don't think that `react-dnd` is still stopping propagation, but please let me know if there are drag-and-drop edge cases that I might need to test.