### PR TITLE
Remove scrollTo when drag begins at scrollY position 0

### DIFF
--- a/src/actions/longPress.ts
+++ b/src/actions/longPress.ts
@@ -5,7 +5,6 @@ import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
-import { isSafari } from '../browser'
 import { AlertText, AlertType, LongPressState } from '../constants'
 import globals from '../globals'
 import hasMulticursor from '../selectors/hasMulticursor'
@@ -151,12 +150,6 @@ export const longPressActionCreator =
     }
 
     if (value === LongPressState.DragInProgress || previousValue === LongPressState.DragInProgress) {
-      // when at the top of the viewport, bump the scroll bar to prevent gitching in Safari mobile
-      // TODO: It still glitches out if you scroll back to the top during a drag
-      if (isSafari() && document.documentElement.scrollTop === 0) {
-        window.scrollTo(0, 1)
-      }
-
       dispatch(expandHoverUp())
       dispatch(expandHoverDown())
     }


### PR DESCRIPTION
References #3175

This band-aid originated in https://github.com/cybersemics/em/commit/16971ff08b3eb84b66f8f49b3dff1e657283e4a1, which I can't install due to a dependency that has disappeared from the internet. Based on my testing, though, drag appears to behave well while scroll is at the top. There is also a comment stating `It still glitches out if you scroll back to the top during a drag`, and I don't see any glitching while using `scrollAtEdge` to scroll back to the top.

The `scrollTo` behavior doesn't seem to cause any issues other than a tiny layout shift at the beginning of the drag, so of course we can keep it if we feel that removing it might still cause problems.