### PR TITLE
useDragHold: remove isDragging effect, clearMulticursors in beginDrag instead

### DIFF
--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -11,6 +11,7 @@ import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import { addMulticursorActionCreator as addMulticursor } from '../actions/addMulticursor'
 import { alertActionCreator as alert } from '../actions/alert'
+import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/clearMulticursors'
 import { createThoughtActionCreator as createThought } from '../actions/createThought'
 import { errorActionCreator as error } from '../actions/error'
 import { importFilesActionCreator as importFiles } from '../actions/importFiles'
@@ -89,14 +90,15 @@ const beginDrag = ({ path, simplePath }: ThoughtContainerProps): DragThoughtItem
     zone: DragThoughtZone.Thoughts,
   }))
 
-  store.dispatch(
+  store.dispatch([
     longPress({
       value: LongPressState.DragInProgress,
       draggingThoughts: draggingThoughts.map(item => item.simplePath),
       sourceZone: DragThoughtZone.Thoughts,
       ...(offset != null ? { offset } : null),
     }),
-  )
+    ...(hasMulticursor(state) ? [clearMulticursors()] : []),
+  ])
 
   return draggingThoughts
 }

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -1,15 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import DragThoughtZone from '../@types/DragThoughtZone'
 import SimplePath from '../@types/SimplePath'
 import { alertActionCreator as alert } from '../actions/alert'
-import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/clearMulticursors'
 import { longPressActionCreator as longPress } from '../actions/longPress'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
 import { LongPressState } from '../constants'
 import allowTouchToScroll from '../device/allowTouchToScroll'
 import hasMulticursor from '../selectors/hasMulticursor'
-import longPressStore from '../stores/longPressStore'
 import useLongPress from './useLongPress'
 
 /** Adds event handlers to detect long press and set state.dragHold while the user is long pressing a thought in preparation for a drag. */
@@ -63,28 +61,6 @@ const useDragHold = ({
       dispatch(longPress({ value: LongPressState.Inactive }))
     })
   }, [disabled, dispatch, simplePath, toggleMulticursorOnLongPress])
-
-  // react-dnd stops propagation so onLongPressEnd sometimes doesn't get called.
-  // Therefore, disable isPressed as soon as we are dragging.
-  useEffect(() => {
-    dispatch((dispatch, getState) => {
-      const state = getState()
-
-      if (isDragging || state.longPress === LongPressState.DragHold) {
-        setIsPressed(false)
-        dispatch([alert(null)])
-
-        if (hasMulticursor(state)) {
-          dispatch(clearMulticursors())
-        }
-      }
-      // If we were dragging but now we're not, make sure to reset the lock
-      if (!isDragging && state.longPress === LongPressState.DragHold) {
-        // Reset the lock to allow immediate long press after drag ends
-        longPressStore.unlock()
-      }
-    })
-  }, [dispatch, isDragging])
 
   const props = useLongPress(onLongPressStart, onLongPressEnd)
 


### PR DESCRIPTION
References #3175 

The effect handler in `useDragHold` was performing 4 functions:

1. `setIsPressed(false)` when a drag began
2. `dispatch([alert(null)])` when a drag began
3. `dispatch(clearMulticursors())` when a drag began
4. `longPressStore.unlock()`, probably never (thankfully)

Now that `globals.longpressing` was removed in #3184, `onLongPressEnd` will always run and the local state `isPressed` can be cleared directly rather than relying on the `isDragging` side effect.

[dispatch(alert(null))](https://github.com/ethan-james/em/blob/14c356fa8255f72fc5a62f3339ed03583d41040a/src/hooks/useDragAndDropThought.tsx#L123) already runs in `endDrag`, which is the only place where the alert needs to be cleared. Running it in `useDragHold` was redundant.

I moved `dispatch(clearMulticursors())` into [beginDrag](https://github.com/ethan-james/em/blob/14c356fa8255f72fc5a62f3339ed03583d41040a/src/hooks/useDragAndDropThought.tsx#L100).

The condition `if (!isDragging && state.longPress === LongPressState.DragHold)` was probably never true because `state.longPress` wasn't part of the dependency array. This is good because running `longPressStore.unlock()` as soon as a drag begins seems much earlier than it would run in any other context.