### PR TITLE
Move clearMulticursors from beginDrag into longPressActionCreator

### DIFF
--- a/src/actions/longPress.ts
+++ b/src/actions/longPress.ts
@@ -5,6 +5,7 @@ import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
+import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/clearMulticursors'
 import { AlertText, AlertType, LongPressState } from '../constants'
 import globals from '../globals'
 import hasMulticursor from '../selectors/hasMulticursor'
@@ -127,7 +128,8 @@ const longPress = (state: State, payload: Payload) => {
 export const longPressActionCreator =
   (payload: Parameters<typeof longPress>[1]): Thunk =>
   (dispatch, getState) => {
-    const { longPress: previousValue } = getState()
+    const state = getState()
+    const { longPress: previousValue } = state
     const { value } = payload
 
     switch (value) {
@@ -152,6 +154,14 @@ export const longPressActionCreator =
     if (value === LongPressState.DragInProgress || previousValue === LongPressState.DragInProgress) {
       dispatch(expandHoverUp())
       dispatch(expandHoverDown())
+    }
+
+    if (
+      previousValue === LongPressState.DragInProgress &&
+      value !== LongPressState.DragInProgress &&
+      hasMulticursor(state)
+    ) {
+      dispatch(clearMulticursors())
     }
   }
 

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -11,7 +11,6 @@ import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import { addMulticursorActionCreator as addMulticursor } from '../actions/addMulticursor'
 import { alertActionCreator as alert } from '../actions/alert'
-import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/clearMulticursors'
 import { createThoughtActionCreator as createThought } from '../actions/createThought'
 import { errorActionCreator as error } from '../actions/error'
 import { importFilesActionCreator as importFiles } from '../actions/importFiles'
@@ -95,7 +94,6 @@ const beginDrag = ({ path }: ThoughtContainerProps): DragThoughtItem[] => {
       sourceZone: DragThoughtZone.Thoughts,
       ...(offset != null ? { offset } : null),
     }),
-    ...(hasMulticursor(state) ? [clearMulticursors()] : []),
   ])
 
   return draggingThoughts


### PR DESCRIPTION
Dispatching `clearMulticursors` in `beginDrag` would not affect the bullet highlighting or drag-and-drop functionality, but it was impacting `multicursorAlertMiddleware`. That middleware would update or hide the multicursor alert while the drag was still in progress. Now it waits until `state.longPress` transitions away from `DragInProgress` to dispatch `clearMulticursors`.