### PR TITLE
Fix for multiselect mobile thoughts flakiness

### DIFF
--- a/src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts
@@ -5,6 +5,8 @@ import hideHUD from '../helpers/hideHUD'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 
+vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
+
 describe('drag and drop multiple thoughts', () => {
   beforeEach(async () => {
     await hideHUD()

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -4,7 +4,6 @@ import longPressThought from '../helpers/longPressThought'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
-import waitUntil from '../helpers/waitUntil'
 import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -44,11 +43,10 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    // Wait for both bullets to be highlighted and command menu to update
-    await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent
-      return highlightedBullets === 2 && commandMenuText?.includes('2 thoughts selected')
-    })
+    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
+    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
+
+    expect(highlightedBullets.length).toBe(2)
+    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -27,7 +27,7 @@ describe('multiselect', () => {
 
 describe('mobile only', () => {
   beforeEach(async () => {
-    await emulate(KnownDevices['iPhone 11'])
+    await emulate(KnownDevices['iPhone 15 Pro'])
   }, 10000)
 
   it('should multiselect two thoughts at once', async () => {
@@ -41,6 +41,9 @@ describe('mobile only', () => {
     const b = await waitForEditable('b')
 
     await longPressThought(a, { edge: 'right', x: 100 })
+
+    // Wait for the first bullet to be highlighted
+    await waitUntil(() => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 1)
     await longPressThought(b, { edge: 'right', x: 100 })
 
     // Wait for both bullets to be highlighted and command menu to update

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -6,7 +6,7 @@ import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
 import waitUntil from '../helpers/waitUntil'
 
-vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
 describe('multiselect', () => {
   it('should multiselect two thoughts at once', async () => {
@@ -19,7 +19,7 @@ describe('multiselect', () => {
 
     await waitUntil(() => {
       const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid=alert-content]')?.textContent || ''
+      const commandMenuText = document.querySelector('[data-testid="alert-content"]')?.textContent || ''
       return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
     })
   })
@@ -41,16 +41,12 @@ describe('mobile only', () => {
     const b = await waitForEditable('b')
 
     await longPressThought(a, { edge: 'right', x: 100 })
-
-    // Wait for first bullet to be highlighted before proceeding
-    await waitUntil(() => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 1)
-
     await longPressThought(b, { edge: 'right', x: 100 })
 
     // Wait for both bullets to be highlighted and command menu to update
     await waitUntil(() => {
       const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid=command-menu-panel]')?.textContent || ''
+      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent || ''
       return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
     })
   })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -45,12 +45,15 @@ describe('mobile only', () => {
     const b = await waitForEditable('b')
 
     await longPressThought(a, { edge: 'right', x: 100 })
-    await longPressThought(b, { edge: 'right', x: 100 })
+    // Wait for first bullet to be highlighted before proceeding
+    await page.waitForFunction(() => document.querySelectorAll('.bullet[data-highlighted=true]').length === 1)
 
-    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
+    await longPressThought(b, { edge: 'right', x: 100 })
+    // Wait for both bullets to be highlighted
+    await page.waitForFunction(() => document.querySelectorAll('.bullet[data-highlighted=true]').length === 2)
+
     const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
 
-    expect(highlightedBullets.length).toBe(2)
     expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -4,7 +4,6 @@ import longPressThought from '../helpers/longPressThought'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
-import waitUntil from '../helpers/waitUntil'
 import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -44,11 +43,10 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    // Wait for both bullets to be highlighted and command menu to update
-    await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent || ''
-      return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
-    })
+    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
+    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
+
+    expect(highlightedBullets.length).toBe(2)
+    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -4,6 +4,7 @@ import longPressThought from '../helpers/longPressThought'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
+import waitUntil from '../helpers/waitUntil'
 import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -43,10 +44,11 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
-    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
-
-    expect(highlightedBullets.length).toBe(2)
-    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
+    // Wait for both bullets to be highlighted and command menu to update
+    await waitUntil(() => {
+      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
+      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent
+      return highlightedBullets === 2 && commandMenuText?.includes('2 thoughts selected')
+    })
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -4,7 +4,7 @@ import longPressThought from '../helpers/longPressThought'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
-import waitUntil from '../helpers/waitUntil'
+import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
@@ -17,17 +17,17 @@ describe('multiselect', () => {
 
     await multiselectThoughts(['a', 'b'])
 
-    await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid="alert-content"]')?.textContent || ''
-      return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
-    })
+    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
+    const alertContent = await page.$eval('[data-testid=alert-content]', el => el.textContent)
+
+    expect(highlightedBullets.length).toBe(2)
+    expect(alertContent).toContain('2 thoughts selected')
   })
 })
 
 describe('mobile only', () => {
   beforeEach(async () => {
-    await emulate(KnownDevices['iPhone 15 Pro'])
+    await emulate(KnownDevices['iPhone 11'])
   }, 10000)
 
   it('should multiselect two thoughts at once', async () => {
@@ -41,16 +41,12 @@ describe('mobile only', () => {
     const b = await waitForEditable('b')
 
     await longPressThought(a, { edge: 'right', x: 100 })
-
-    // Wait for the first bullet to be highlighted
-    await waitUntil(() => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 1)
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    // Wait for both bullets to be highlighted and command menu to update
-    await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
-      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent || ''
-      return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
-    })
+    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
+    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
+
+    expect(highlightedBullets.length).toBe(2)
+    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -4,6 +4,7 @@ import longPressThought from '../helpers/longPressThought'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
+import waitUntil from '../helpers/waitUntil'
 import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -27,7 +28,7 @@ describe('multiselect', () => {
 
 describe('mobile only', () => {
   beforeEach(async () => {
-    await emulate(KnownDevices['iPhone 11'])
+    await emulate(KnownDevices['iPhone 15 Pro'])
   }, 10000)
 
   it('should multiselect two thoughts at once', async () => {
@@ -43,10 +44,11 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    const highlightedBullets = await page.$$('.bullet[data-highlighted=true]')
-    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
-
-    expect(highlightedBullets.length).toBe(2)
-    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
+    // Wait for both bullets to be highlighted and command menu to update
+    await waitUntil(() => {
+      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
+      const commandMenuText = document.querySelector('[data-testid="command-menu-panel"]')?.textContent || ''
+      return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
+    })
   })
 })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -18,7 +18,7 @@ describe('multiselect', () => {
     await multiselectThoughts(['a', 'b'])
 
     await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('.bullet[data-highlighted=true]').length
+      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
       const commandMenuText = document.querySelector('[data-testid=alert-content]')?.textContent || ''
       return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
     })
@@ -43,13 +43,13 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
 
     // Wait for first bullet to be highlighted before proceeding
-    await waitUntil(() => document.querySelectorAll('.bullet[data-highlighted=true]').length === 1)
+    await waitUntil(() => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 1)
 
     await longPressThought(b, { edge: 'right', x: 100 })
 
     // Wait for both bullets to be highlighted and command menu to update
     await waitUntil(() => {
-      const highlightedBullets = document.querySelectorAll('.bullet[data-highlighted=true]').length
+      const highlightedBullets = document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length
       const commandMenuText = document.querySelector('[data-testid=command-menu-panel]')?.textContent || ''
       return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
     })

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -45,15 +45,17 @@ describe('mobile only', () => {
     const b = await waitForEditable('b')
 
     await longPressThought(a, { edge: 'right', x: 100 })
+
     // Wait for first bullet to be highlighted before proceeding
     await page.waitForFunction(() => document.querySelectorAll('.bullet[data-highlighted=true]').length === 1)
 
     await longPressThought(b, { edge: 'right', x: 100 })
-    // Wait for both bullets to be highlighted
-    await page.waitForFunction(() => document.querySelectorAll('.bullet[data-highlighted=true]').length === 2)
 
-    const commandMenuPanelTextContent = await page.$eval('[data-testid=command-menu-panel]', el => el.textContent)
-
-    expect(commandMenuPanelTextContent).toContain('2 thoughts selected')
+    // Wait for both bullets to be highlighted and command menu to update
+    await page.waitForFunction(() => {
+      const highlightedBullets = document.querySelectorAll('.bullet[data-highlighted=true]').length
+      const commandMenuText = document.querySelector('[data-testid=command-menu-panel]')?.textContent || ''
+      return highlightedBullets === 2 && commandMenuText.includes('2 thoughts selected')
+    })
   })
 })

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -97,7 +97,22 @@ const dragAndDropThought = async (
 
   if (mouseUp) {
     await page.mouse.up()
-    await waitUntil(() => !document.querySelector('[data-drag-in-progress="true"]'))
+
+    // Wait for drag operation to fully complete by checking:
+    // 1. data-drag-in-progress attribute is removed (longPress !== DragInProgress)
+    // 2. data-drag-hold attribute is removed (longPress !== DragHold)
+    // 3. DragAndDropHint alert is dismissed (happens in endDrag after setTimeout)
+    await waitUntil(() => {
+      const dragInProgress = document.querySelector('[data-drag-in-progress="true"]')
+      const dragHold = document.querySelector('[data-drag-hold="true"]')
+
+      // Check if drag-and-drop alert is still showing
+      const alertElement = document.querySelector('[data-testid="alert-content"]')
+      const isDragAlert = alertElement?.textContent?.includes('Drag and drop')
+
+      // Drag is complete when all drag-related states are cleared
+      return !dragInProgress && !dragHold && !isDragAlert
+    })
   }
 
   // Hide Alert by default.

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -1,4 +1,3 @@
-import sleep from '../../../util/sleep'
 import { page } from '../setup'
 import getEditable from './getEditable'
 import hide from './hide'
@@ -99,10 +98,6 @@ const dragAndDropThought = async (
   if (mouseUp) {
     await page.mouse.up()
     await waitUntil(() => !document.querySelector('[data-drag-in-progress="true"]'))
-
-    // TODO: Why does drop/DragAndDropThought test fails intermittently without a small delay?
-    // Bullet highlight is visible.
-    await sleep(500)
   }
 
   // Hide Alert by default.

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -106,12 +106,8 @@ const dragAndDropThought = async (
       const dragInProgress = document.querySelector('[data-drag-in-progress="true"]')
       const dragHold = document.querySelector('[data-drag-hold="true"]')
 
-      // Check if drag-and-drop alert is still showing
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      const isDragAlert = alertElement?.textContent?.includes('Drag and drop')
-
       // Drag is complete when all drag-related states are cleared
-      return !dragInProgress && !dragHold && !isDragAlert
+      return !dragInProgress && !dragHold
     })
   }
 

--- a/src/e2e/puppeteer/helpers/dragAndDropThought.ts
+++ b/src/e2e/puppeteer/helpers/dragAndDropThought.ts
@@ -101,7 +101,6 @@ const dragAndDropThought = async (
     // Wait for drag operation to fully complete by checking:
     // 1. data-drag-in-progress attribute is removed (longPress !== DragInProgress)
     // 2. data-drag-hold attribute is removed (longPress !== DragHold)
-    // 3. DragAndDropHint alert is dismissed (happens in endDrag after setTimeout)
     await waitUntil(() => {
       const dragInProgress = document.querySelector('[data-drag-in-progress="true"]')
       const dragHold = document.querySelector('[data-drag-hold="true"]')

--- a/src/e2e/puppeteer/helpers/longPressThought.ts
+++ b/src/e2e/puppeteer/helpers/longPressThought.ts
@@ -41,7 +41,7 @@ const longPressThought = async (
   // Wait for the long press duration to elapse before checking for highlight
   await sleep(TIMEOUT_LONG_PRESS_THOUGHT)
 
-  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]', { timeout: 2000 })
+  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]')
 
   await page.touchscreen.touchEnd()
 }

--- a/src/e2e/puppeteer/helpers/longPressThought.ts
+++ b/src/e2e/puppeteer/helpers/longPressThought.ts
@@ -35,7 +35,7 @@ const longPressThought = async (
   }
 
   await page.touchscreen.touchStart(coordinate.x, coordinate.y)
-  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted=true]')
+  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]')
   await page.touchscreen.touchEnd()
 }
 

--- a/src/e2e/puppeteer/helpers/longPressThought.ts
+++ b/src/e2e/puppeteer/helpers/longPressThought.ts
@@ -39,7 +39,7 @@ const longPressThought = async (
   await page.touchscreen.touchStart(coordinate.x, coordinate.y)
 
   // Wait for the long press duration to elapse before checking for highlight
-  await sleep(TIMEOUT_LONG_PRESS_THOUGHT)
+  await sleep(TIMEOUT_LONG_PRESS_THOUGHT + 100)
 
   await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]')
 

--- a/src/e2e/puppeteer/helpers/longPressThought.ts
+++ b/src/e2e/puppeteer/helpers/longPressThought.ts
@@ -1,6 +1,7 @@
 import { ElementHandle } from 'puppeteer'
 import { JSHandle } from 'puppeteer'
 import { TIMEOUT_LONG_PRESS_THOUGHT } from '../../../constants'
+import sleep from '../../../util/sleep'
 import { page } from '../setup'
 
 interface Options {
@@ -38,16 +39,9 @@ const longPressThought = async (
   await page.touchscreen.touchStart(coordinate.x, coordinate.y)
 
   // Wait for the long press duration to elapse before checking for highlight
-  await new Promise(resolve => setTimeout(resolve, TIMEOUT_LONG_PRESS_THOUGHT + 100))
+  await sleep(TIMEOUT_LONG_PRESS_THOUGHT)
 
-  // Then check if the bullet was highlighted
-  try {
-    await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]', { timeout: 2000 })
-  } catch (error) {
-    // If the bullet wasn't highlighted, end the touch and throw a more helpful error
-    await page.touchscreen.touchEnd()
-    throw new Error(`Long press did not trigger bullet highlighting. Original error: ${error}`)
-  }
+  await thoughtContainer.waitForSelector('[aria-label="bullet"][data-highlighted="true"]', { timeout: 2000 })
 
   await page.touchscreen.touchEnd()
 }

--- a/src/e2e/puppeteer/helpers/multiselectThoughts.ts
+++ b/src/e2e/puppeteer/helpers/multiselectThoughts.ts
@@ -1,5 +1,4 @@
 import { isMac } from '../../../browser'
-import sleep from '../../../util/sleep'
 import { page } from '../setup'
 import clickThought from './clickThought'
 
@@ -23,9 +22,6 @@ const multiselectThoughts = async (
     // Click each thought while holding the modifier
     for (const value of thoughtValues) {
       await clickThought(value)
-
-      // Small delay between clicks to ensure proper registration
-      await sleep(50)
     }
   } catch (error) {
     // Always release modifier key on error

--- a/src/e2e/puppeteer/helpers/multiselectThoughts.ts
+++ b/src/e2e/puppeteer/helpers/multiselectThoughts.ts
@@ -1,4 +1,5 @@
 import { isMac } from '../../../browser'
+import sleep from '../../../util/sleep'
 import { page } from '../setup'
 import clickThought from './clickThought'
 
@@ -22,6 +23,9 @@ const multiselectThoughts = async (
     // Click each thought while holding the modifier
     for (const value of thoughtValues) {
       await clickThought(value)
+
+      // Small delay between clicks to ensure proper registration
+      await sleep(50)
     }
   } catch (error) {
     // Always release modifier key on error


### PR DESCRIPTION
Close #3192, #3193.

Cause of flakiness for #3192 

In the previous version, the `longPressThought` function was using closest('[aria-label="thought-container"]') which might not be reliable for targeting the specific bullet that should be highlighted specifically in the CI environment and mobile emulation.

Fix:

I have updated the function by targeting the actual bullet element. Instead of searching generically within a thought container, the function now identifies the specific container that holds the long-pressed editable node and then locates its corresponding bullet, ensuring the correct element is being tracked. In addition, the waiting mechanism has been refined: rather than using a broad `waitForSelector` on the container, it now uses `waitForFunction` on the exact bullet element, checking its `data-highlighted` attribute. 

As for the fix for #3193, @ethan-james's latest PR (https://github.com/cybersemics/em/pull/3195) seems to have eliminated this timing issue. I have verified this multiple times in CI.

[Here](https://github.com/karunkop/em/actions?query=branch%3Amultiselect-mobile) is the check result after the fixes.