### PR TITLE
Track appComponentHeight, don't let alerts overflow that height

### DIFF
--- a/src/stores/viewport.ts
+++ b/src/stores/viewport.ts
@@ -10,7 +10,6 @@ let virtualKeyboardHeightPortrait = isTouch ? window.innerHeight / 2.275 : 0
 let virtualKeyboardHeightLandscape = isTouch ? window.innerWidth / 1.7 : 0
 
 export interface ViewportState {
-  scrollHeight: number
   contentWidth: number
   innerWidth: number
   innerHeight: number
@@ -29,8 +28,6 @@ const viewportStore = reactMinistore<ViewportState>({
     window.innerHeight > window.innerWidth ? virtualKeyboardHeightPortrait : virtualKeyboardHeightLandscape,
   /** Width of the content element. */
   contentWidth: 0,
-  /** Height of the body scroll area. */
-  scrollHeight: 0,
 })
 
 /** Throttled update of viewport height. Invoked on window resize. */


### PR DESCRIPTION
Fixes #3196?

An alert showing along the bottom of the viewport has its position calculated like [scrollTop + innerHeight - safariKeyboard.height](https://github.com/ethan-james/em/blob/aa504b7d1113f4ea9a2307d61d68b87c9a4a1baf/src/hooks/usePositionFixed.ts#L30). `innerHeight` is the height of the viewport and doesn't change if the viewport extends beyond the lower bound of the page. This shouldn't be able to happen, except that it's a [very common iOS Safari bug](https://medium.com/@nareshpingle/safari-the-new-internet-explorer-for-web-developers-the-battle-with-mobile-safaris-33444a9f2331) that affects every site that I've checked.

Since `scrollTop + innerHeight` can be greater than the height of the page, positioning an element there will extend the height of the page, which will cause the alert to be re-positioned lower and lower. Cutting off its position based on the height of the `AppComponent` div will prevent this infinite scroll.

Now it sort of sticks to the footer:

https://github.com/user-attachments/assets/08936368-ef79-4bb5-8997-accee87c054f

And as you may have noticed in that video, there's some unpredictable behavior where the alert sort of skips around while scrolling, and at one point starts sticking to the top rather than the bottom. Maybe some of that is intentional. I couldn't quite tell. I could definitely dive deeper into that in order to see what's going on, but I checked in `main` and I see similar behavior:

https://github.com/user-attachments/assets/4f16e90a-c21f-4439-98de-740d82f3830b