### PR TITLE
Remove toggleMulticursor and stopPropagation from Bullet click handler

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -9,7 +9,6 @@ import ThoughtId from '../@types/ThoughtId'
 import { deleteAttributeActionCreator as deleteAttribute } from '../actions/deleteAttribute'
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
-import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
 import { isMac, isSafari, isTouch, isiPhone } from '../browser'
 import { AlertType, LongPressState } from '../constants'
 import attributeEquals from '../selectors/attributeEquals'
@@ -483,7 +482,6 @@ const Bullet = ({
 
       // short circuit if toggling multiselect
       if (!isTouch && (isMac ? e.metaKey : e.ctrlKey)) {
-        dispatch(toggleMulticursor({ path }))
         return
       }
 
@@ -508,9 +506,6 @@ const Bullet = ({
           setCursor({ path: shouldCollapse ? pathParent : path, preserveMulticursor: true }),
         ])
       })
-
-      e.stopPropagation()
-      // stop click event from bubbling up to Content.clickOnEmptySpace
     },
     [dispatch, dragHold, path, simplePath],
   )


### PR DESCRIPTION
Fixes #3066

`toggleMulticursor` was being dispatched in `Bullet` and again in `Thought`, and they were canceling each other out. Now `Thought` can handle ctrl-click actions for both `Editable` and `Bullet`.

Also, `Bullet` was still calling `stopPropagation` to prevent `Content.clickOnEmptySpace`. This is no longer necessary after #3178.