### PR TITLE
Add bias to MultiGesture, Render perpendicular segments in GestureDiagram 20 degrees more acute

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -133,8 +133,11 @@ const GestureDiagram = ({
     // Don't skew a line segment that comes immediately after a skewed segment.
     // In the case of multiple perpendicular segments in a row, only skew every other segment.
     // Also don't skew 'rddl'.
-    const skew = path !== 'rddl' && path !== 'lddr'
-    isPerpendicular(dir, prev) && (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
+    const skew =
+      path !== 'rddl' &&
+      path !== 'lddr' &&
+      isPerpendicular(dir, prev) &&
+      (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
 
     // If the new segment is perpendicular to the previous segment, then special cases like reversals don't apply.
     // Draw the new segment 20 degrees more acute than an otherwise perpendicular line. (#1983)

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -128,14 +128,13 @@ const GestureDiagram = ({
     const next = pathDirs[i + 1]
     const afterNext = pathDirs[i + 2]
     const horizontal = dir === 'l' || dir === 'r'
+    const path = pathDirs.join('')
 
     // Don't skew a line segment that comes immediately after a skewed segment.
     // In the case of multiple perpendicular segments in a row, only skew every other segment.
     // Also don't skew 'rddl'.
-    const skew =
-      pathDirs.join('') !== 'rddl' &&
-      isPerpendicular(dir, prev) &&
-      (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
+    const skew = path !== 'rddl' && path !== 'lddr'
+    isPerpendicular(dir, prev) && (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
 
     // If the new segment is perpendicular to the previous segment, then special cases like reversals don't apply.
     // Draw the new segment 20 degrees more acute than an otherwise perpendicular line. (#1983)

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -130,14 +130,11 @@ const GestureDiagram = ({
     const horizontal = dir === 'l' || dir === 'r'
     const path = pathDirs.join('')
 
-    // Don't skew a line segment that comes immediately after a skewed segment.
-    // In the case of multiple perpendicular segments in a row, only skew every other segment.
-    // Also don't skew 'rddl'.
+    // Only skew line segments if they are perpendicular to both the previous and next segments, e.g. `rdr`.
     const skew =
-      path !== 'rddl' &&
-      path !== 'lddr' &&
       isPerpendicular(dir, prev) &&
-      (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
+      (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3])) &&
+      prev === next
 
     const negative = dir === 'l' || dir === 'd' // negative movement along the respective axis
 

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -139,34 +139,6 @@ const GestureDiagram = ({
       isPerpendicular(dir, prev) &&
       (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3]))
 
-    // If the new segment is perpendicular to the previous segment, then special cases like reversals don't apply.
-    // Draw the new segment 20 degrees more acute than an otherwise perpendicular line. (#1983)
-    if (skew) {
-      return horizontal
-        ? // horizontal, skewed upward
-          prev === 'u'
-          ? {
-              dx: Math.cos(Math.PI / 9) * size * (dir === 'l' ? -1 : 1),
-              dy: Math.sin(Math.PI / 9) * size,
-            }
-          : // horizontal, skewed downward
-            {
-              dx: Math.cos(Math.PI / 9) * size * (dir === 'l' ? -1 : 1),
-              dy: Math.sin(Math.PI / -9) * size,
-            }
-        : // vertical, skewed left
-          prev === 'r'
-          ? {
-              dx: Math.sin(Math.PI / -9) * size,
-              dy: Math.cos(Math.PI / 9) * size * (dir === 'u' ? -1 : 1),
-            }
-          : // vertical, skewed right
-            {
-              dx: Math.sin(Math.PI / 9) * size,
-              dy: Math.cos(Math.PI / 9) * size * (dir === 'u' ? -1 : 1),
-            }
-    }
-
     const negative = dir === 'l' || dir === 'd' // negative movement along the respective axis
 
     const clockwisePrev = rotateClockwise(prev) === dir
@@ -186,10 +158,10 @@ const GestureDiagram = ({
     // when there is a reversal of direction, instead of moving 0 on the orthogonal plane, offset the vertex to avoid segment overlap
     const dx = horizontal
       ? (size - shorten) * (negative ? -1 : 1)
-      : (reversal ? reversalOffset! : 0) * (flipOffset ? -1 : 1) // the negative multiplier here ensures the offset is moving away from the previous segment so it doesn't trace backwards
+      : (reversal ? reversalOffset! : skew ? Math.sin(Math.PI / -9) * size : 0) * (flipOffset ? -1 : 1) // the negative multiplier here ensures the offset is moving away from the previous segment so it doesn't trace backwards
     const dy = !horizontal
       ? (size - shorten) * (!negative ? -1 : 1)
-      : (reversal ? reversalOffset! : 0) * (flipOffset ? -1 : 1)
+      : (reversal ? reversalOffset! : skew ? Math.sin(Math.PI / -9) * size : 0) * (flipOffset ? -1 : 1)
 
     return { dx, dy }
   }

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -36,11 +36,6 @@ interface GestureDiagramProps {
   arrowhead?: 'filled' | 'outlined'
 }
 
-/** Determines if the new segment is perpendicular to the previous segment. */
-const isPerpendicular = (dir: Direction, prev: Direction) => {
-  return dir === 'r' || dir === 'l' ? prev === 'u' || prev === 'd' : prev === 'r' || prev === 'l'
-}
-
 /** Returns the direction resulting from a 90 degree clockwise rotation. */
 const rotateClockwise = (dir: Direction) =>
   ({
@@ -130,12 +125,6 @@ const GestureDiagram = ({
     const horizontal = dir === 'l' || dir === 'r'
     const path = pathDirs.join('')
 
-    // Only skew line segments if they are perpendicular to both the previous and next segments, e.g. `rdr`.
-    const skew =
-      isPerpendicular(dir, prev) &&
-      (!isPerpendicular(prev, beforePrev) || isPerpendicular(beforePrev, pathDirs[i - 3])) &&
-      prev === next
-
     const negative = dir === 'l' || dir === 'd' // negative movement along the respective axis
 
     const clockwisePrev = rotateClockwise(prev) === dir
@@ -155,10 +144,10 @@ const GestureDiagram = ({
     // when there is a reversal of direction, instead of moving 0 on the orthogonal plane, offset the vertex to avoid segment overlap
     const dx = horizontal
       ? (size - shorten) * (negative ? -1 : 1)
-      : (reversal ? reversalOffset! : skew ? Math.sin(Math.PI / -9) * size : 0) * (flipOffset ? -1 : 1) // the negative multiplier here ensures the offset is moving away from the previous segment so it doesn't trace backwards
+      : (reversal ? reversalOffset! : 0) * (flipOffset ? -1 : 1) // the negative multiplier here ensures the offset is moving away from the previous segment so it doesn't trace backwards
     const dy = !horizontal
       ? (size - shorten) * (!negative ? -1 : 1)
-      : (reversal ? reversalOffset! : skew ? Math.sin(Math.PI / -9) * size : 0) * (flipOffset ? -1 : 1)
+      : (reversal ? reversalOffset! : 0) * (flipOffset ? -1 : 1)
 
     return { dx, dy }
   }

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -36,7 +36,7 @@ interface GestureDiagramProps {
   arrowhead?: 'filled' | 'outlined'
 }
 
-/** Determines if the new segment is perpendicular to the previous segment */
+/** Determines if the new segment is perpendicular to the previous segment. */
 const isPerpendicular = (dir: Direction, prev: Direction) => {
   return dir === 'r' || dir === 'l' ? prev === 'u' || prev === 'd' : prev === 'r' || prev === 'l'
 }

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -59,13 +59,13 @@ const dirToRad = {
     SE: Math.PI / 4,
     SW: Math.PI * (3 / 4),
   },
-  LongitudinalBias: {
+  VerticalBias: {
     NW: -Math.PI * (31 / 36),
     NE: -Math.PI * (5 / 36),
     SE: Math.PI * (5 / 36),
     SW: Math.PI * (31 / 36),
   },
-  LatitudinalBias: {
+  HorizontalBias: {
     NW: -Math.PI * (23 / 36),
     NE: -Math.PI * (13 / 36),
     SE: Math.PI * (13 / 36),
@@ -215,8 +215,8 @@ class MultiGesture extends React.Component<MultiGestureProps> {
           // The new sequence will be appended as soon as it is detected, so we need to base the bias on the second-to-last letter in the sequence
           this.sequence.length > 1
             ? ['u', 'd'].includes(this.sequence[this.sequence.length - 2])
-              ? 'LatitudinalBias'
-              : 'LongitudinalBias'
+              ? 'HorizontalBias'
+              : 'VerticalBias'
             : 'NoBias',
         )
 

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -53,14 +53,30 @@ type MultiGestureProps = PropsWithChildren<{
 
 /** Static mapping of intercardinal directions to radians. Used to determine the closest gesture to an angle. Range: -π to π. */
 const dirToRad = {
-  NW: -Math.PI * (3 / 4),
-  NE: -Math.PI / 4,
-  SE: Math.PI / 4,
-  SW: Math.PI * (3 / 4),
+  NoBias: {
+    NW: -Math.PI * (3 / 4),
+    NE: -Math.PI / 4,
+    SE: Math.PI / 4,
+    SW: Math.PI * (3 / 4),
+  },
+  LongitudinalBias: {
+    NW: -Math.PI * (31 / 36),
+    NE: -Math.PI * (5 / 36),
+    SE: Math.PI * (5 / 36),
+    SW: Math.PI * (31 / 36),
+  },
+  LatitudinalBias: {
+    NW: -Math.PI * (23 / 36),
+    NE: -Math.PI * (13 / 36),
+    SE: Math.PI * (13 / 36),
+    SW: Math.PI * (23 / 36),
+  },
 }
 
+type BiasType = keyof typeof dirToRad
+
 /** Return the closest gesture based on the angle between two points. See: https://github.com/cybersemics/em/issues/1379. */
-const gesture = (p1: Point, p2: Point, minDistanceSquared: number): Direction | null => {
+const gesture = (p1: Point, p2: Point, minDistanceSquared: number, bias: BiasType = 'NoBias'): Direction | null => {
   // Instead of calculating the actual distance, calculate distance squared.
   // Then we can compare it directly to minDistanceSquared and avoid the Math.sqrt call completely.
   const distanceSquared = Math.pow(p2.x - p1.x, 2) + Math.pow(p2.y - p1.y, 2)
@@ -68,11 +84,11 @@ const gesture = (p1: Point, p2: Point, minDistanceSquared: number): Direction | 
 
   // Math.atan2 returns 0 to 180deg as 0 to π, and 180 to 360deg as -π to 0 (clockwise starting due right)
   const angle = Math.atan2(p2.y - p1.y, p2.x - p1.x)
-  return angle >= dirToRad.NW && angle < dirToRad.NE
+  return angle >= dirToRad[bias].NW && angle < dirToRad[bias].NE
     ? 'u'
-    : angle >= dirToRad.NE && angle < dirToRad.SE
+    : angle >= dirToRad[bias].NE && angle < dirToRad[bias].SE
       ? 'r'
-      : angle >= dirToRad.SE && angle < dirToRad.SW
+      : angle >= dirToRad[bias].SE && angle < dirToRad[bias].SW
         ? 'd'
         : 'l'
 }
@@ -196,6 +212,12 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             y: gestureState.moveY,
           },
           this.minDistanceSquared,
+          // The new sequence will be appended as soon as it is detected, so we need to base the bias on the second-to-last letter in the sequence
+          this.sequence.length > 1
+            ? ['u', 'd'].includes(this.sequence[this.sequence.length - 2])
+              ? 'LatitudinalBias'
+              : 'LongitudinalBias'
+            : 'NoBias',
         )
 
         if (g) {


### PR DESCRIPTION
Fixes #1983

`MultiGesture`: Calculate the new 25/65 degree bias for both horizontal and vertical gesture segments. Switch between biased or unbiased mappings based on the direction of the previous segment.

`GestureDiagram`: New logic in `pathSegmentDelta` for drawing path segments that are perpendicular to the previous segment at an angle 20 degrees more acute than a right angle. Ignore perpendicular segments that come after other perpendicular segments so that we don't lose 20 degrees repeatedly and draw a weird lightning bolt. Also ignore `rddl` because it's a special shape that doesn't look right if it is skewed.