### PR TITLE
Scale tall gestures

### DIFF
--- a/src/components/CommandItem.tsx
+++ b/src/components/CommandItem.tsx
@@ -302,6 +302,7 @@ const CommandItem: FC<{
         >
           <GestureDiagram
             color={disabled ? token('colors.gray') : undefined}
+            scaleTallGestures
             styleCancelAsRegularGesture
             highlight={gestureHighlight}
             path={command.id === 'cancel' ? null : gestureString(command)}

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -30,6 +30,9 @@ interface GestureDiagramProps {
   cssRaw?: SystemStyleObject
   /** Whether to render the gesture with rounded corners. */
   rounded?: boolean
+  /** The command palette doesn't have enough room for tall gestures at their natural height, but Customize Toolbar does.
+   * Allow the implementation to specify whether tall gestures should be scaled (#3210). */
+  scaleTallGestures?: boolean
   /** If true, the cancel gesture will have the same styling as the other gestures. Otherwise, there are additional sizing and margin styles applied. */
   styleCancelAsRegularGesture?: boolean
   /** Which kind of arrowhead to draw gesture diagrams with. By default, the arrowhead is filled. */
@@ -77,6 +80,7 @@ const GestureDiagram = ({
   inGestureContainer,
   cssRaw,
   rounded,
+  scaleTallGestures,
   styleCancelAsRegularGesture,
   arrowhead = 'filled',
 }: GestureDiagramProps) => {
@@ -215,7 +219,7 @@ const GestureDiagram = ({
     // use size if sumWidth is ~0, eg. for the path 'rl'
     // sumWidth will not be exactly 0 due to the reversal offset
     if (!width) {
-      const elementSize = sumHeight > size && sumHeight > sumWidth ? size * 0.75 : size
+      const elementSize = scaleTallGestures && sumHeight > sumWidth ? size * 0.75 : size
       el.setAttribute('width', (flexibleSize ? Math.max(sumWidth, size) : elementSize) + 'px')
       el.setAttribute('height', (flexibleSize ? Math.max(sumHeight, size) : elementSize) + 'px')
     }

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -215,8 +215,9 @@ const GestureDiagram = ({
     // use size if sumWidth is ~0, eg. for the path 'rl'
     // sumWidth will not be exactly 0 due to the reversal offset
     if (!width) {
-      el.setAttribute('width', (flexibleSize ? Math.max(sumWidth, size) : size) + 'px')
-      el.setAttribute('height', (flexibleSize ? Math.max(sumHeight, size) : size) + 'px')
+      const elementSize = sumHeight > size && sumHeight > sumWidth ? size * 0.75 : size
+      el.setAttribute('width', (flexibleSize ? Math.max(sumWidth, size) : elementSize) + 'px')
+      el.setAttribute('height', (flexibleSize ? Math.max(sumHeight, size) : elementSize) + 'px')
     }
   }
 


### PR DESCRIPTION
Fixes #3210

The wrinkle that makes this difficult is that, depending on the height of the text in the gesture's row, it may or may not be necessary to scale tall gestures. The "Customize Toolbar" table has plenty of room, while the command palette does not.

Therefore, I introduced the `scaleTallGestures` flag to let the parent control whether or not to attempt scaling. I also introduced a static `0.75` scaling factor because that looks pretty good in this case.

It may be worthwhile to revisit the [cell](https://github.com/ethan-james/em/blob/e3d4d046b638d00dd8895ca46b0250ff239376ab/src/components/CommandItem.tsx#L301) where the command palette gesture diagram resides, since a 32px by 32px cell with an absolutely-positioned 70px diagram in it is limiting our flexibility. However, for solving a one-off problem where one or two gestures need to be scaled, this is pretty straightforward and effective.

There are potentially some alignment quirks. It looks like it right-justifies pretty well in most cases, but it looks good next to some gestures, and less good next to others like "New Grandchild".

<img width="1170" height="2532" alt="image0 (4)" src="https://github.com/user-attachments/assets/0ebfdb0f-fe0b-407d-a9a9-173894a91712" />
<img width="1170" height="2532" alt="image1" src="https://github.com/user-attachments/assets/03064d4e-4b46-47a3-bcc7-f0ce8a89aa99" />
