### PR TITLE
GestureDiagram: Scale arrowhead and stroke width

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -258,7 +258,7 @@ const GestureDiagram = ({
     return `M ${startX} ${startY} A ${radius} ${radius} 0 0 ${sweepFlag} ${endX} ${endY}`
   }
 
-  const scale = Math.max(1, Math.max(sumWidth, sumHeight) / 100)
+  const scale = Math.max(1, (sumWidth * 2) / (size * 3))
 
   return (
     <svg


### PR DESCRIPTION
Fixes #3057

I have two unanswered questions about this approach:

1. Why does scale only need to be applied to wide gestures and not to tall gestures as well?
2. Why does 4/3 scale look so much better than 2x scale?

The SVG is drawn with path segments that are each `size` in length, and then each gesture is scaled down to a square that is `${size}px` on each side. In order to make the arrow and line size the same across different gestures, a scaling factor can be applied to them based on how wide the SVG is before it is scaled down to fit into the square.

I see discussion in #3057 about scaling down the path segments first, and then applying a uniform `arrowSize` and `strokeWidth` across the entire diagram. That also seems like a good approach, possibly more consistent than scaling the `strokeWidth` of each segment, and I think the core of that approach would be to change [M ${x} ${y} l ${segment.dx} ${segment.dy}](https://github.com/ethan-james/em/blob/2257fd3f93a3710baa2af2507277f6bc9823be30/src/components/GestureDiagram.tsx#L321) to account for the total width/height of the diagram, like:

```
M ${x} ${y} l ${segment.dx * size / sumWidth} ${segment.dy * size / sumHeight}
```