### PR TITLE
GestureDiagram: scale SVG by width/height or size

### DIFF
--- a/src/components/CommandItem.tsx
+++ b/src/components/CommandItem.tsx
@@ -305,7 +305,8 @@ const CommandItem: FC<{
             styleCancelAsRegularGesture
             highlight={gestureHighlight}
             path={command.id === 'cancel' ? null : gestureString(command)}
-            size={70}
+            width={70}
+            height={50}
             arrowSize={18 - strokeWidth * 0.3}
             strokeWidth={strokeWidth}
             rounded={command.rounded}


### PR DESCRIPTION
Fixes #3210

This approach creates a flexible container whose size is controlled by `width` and `height`, or `size` if it should be square. Currently this is a relatively small change, but it opens the door for addressing #3057 by creating fixed-size (e.g. 1px by 1px) diagrams that can have a constant `strokeWidth` and `arrowSize` applied to them without causing those sizes to appear different as the differently-sized diagrams scale to fit their containers.