### PR TITLE
PopupBase: disable margin-block: auto when absolutely-positioned

### DIFF
--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -20,7 +20,7 @@ export type PopupBaseProps = PropsWithChildren<
     /** If true, a border will be added to the popup. */
     border?: boolean
     circledCloseButton?: boolean
-    /** If true, the popup will take up the full width of the screen. */
+    /** If true, the popup will take up the full width and height of the screen. */
     fullScreen?: boolean
     /** If defined, will show a small x in the upper right corner. */
     onClose?: () => void
@@ -80,7 +80,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
         }
       : {}
 
-    const fullWidthStyles = fullScreen
+    const fullScreenStyles = fullScreen
       ? {
           boxShadow: 'none',
           border: 'none',
@@ -108,7 +108,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           right: 0,
           width: 'max-content',
           ...borderStyles,
-          ...fullWidthStyles,
+          ...fullScreenStyles,
           '&:hover': {
             '& [data-close-button]': {
               opacity: showXOnHover ? 1 : undefined,


### PR DESCRIPTION
Fixes #3222 

When the `fullScreen` prop is provided to `PopupBase`, it has `margin-block: auto` applied to it in order to vertically-center the popup. I could maybe remove that entirely because it also has `height: 100%` applied to it, making it truly full-screen. I left it for now, because it only causes a problem when `usePositionFixed` causes the popup to have `position: absolute` due to the keyboard being open. In that case, `margin-block: auto` uses the full height of the content div, so it pushes the popup off-screen in order to vertically-center it within that scrolling div. Currently this only impacts `CommandPalette` because it's the only `fullScreen` popup.