### PR TITLE
Quick drop panel test

### DIFF
--- a/src/e2e/puppeteer/__tests__/quickdrop-panel.ts
+++ b/src/e2e/puppeteer/__tests__/quickdrop-panel.ts
@@ -1,14 +1,12 @@
 import { KnownDevices } from 'puppeteer'
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
-import dragAndDropThought from '../helpers/dragAndDropThought'
+import dragToQuickDropPanel from '../helpers/dragToQuickDropPanel'
 import emulate from '../helpers/emulate'
 import getEditable from '../helpers/getEditable'
-import longPressThought from '../helpers/longPressThought'
 import paste from '../helpers/paste'
+import waitForAlertContent from '../helpers/waitForAlertContent'
 import waitForEditable from '../helpers/waitForEditable'
-import waitUntil from '../helpers/waitUntil'
-import { page } from '../setup'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
@@ -19,100 +17,7 @@ const isThoughtInDOM = async (value: string) => {
   return thoughtElementExists
 }
 
-/** Move mouse to QuickDropPanel area (right edge, 2em width ≈ 32px). */
-const dropOnQuickDropPanel = async () => {
-  // Get viewport dimensions to calculate QuickDropPanel position (right edge)
-  const viewport = await page.viewport()
-  if (!viewport) throw new Error('Viewport not available')
-
-  const position = {
-    x: viewport.width - 16, // Center of the 2em (32px) drop zone
-    y: viewport.height / 2, // Middle of the screen vertically
-  }
-
-  await page.mouse.move(position.x, position.y)
-}
-
-describe('Quick Drop Panel', () => {
-  it('should remove favorite thought when dropped on QuickDropPanel', async () => {
-    await paste(`
-      - a
-    `)
-
-    // Assert that the thought element exists
-    expect(await isThoughtInDOM('a')).toBe(true)
-
-    await clickThought('a')
-    await click('[aria-label="Add to Favorites"]')
-
-    // wait until the favorite alert appears
-    await waitUntil(() => {
-      const favoriteAlertContent = document.querySelector('[data-testid="alert-content"]')
-      return favoriteAlertContent?.textContent?.includes('Added a to favorites')
-    })
-
-    // trigger long press and show invisible QuickDropPanel
-    await dragAndDropThought('a', null, {
-      position: 'none',
-      mouseUp: false,
-      showAlert: true,
-    })
-
-    await dropOnQuickDropPanel()
-
-    await waitUntil(() => {
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      return alertElement?.textContent?.includes('Drop to remove a')
-    })
-
-    // Complete the drop
-    await page.mouse.up()
-
-    await waitUntil(() => {
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      return alertElement?.textContent?.includes('Removed 1 thought')
-    })
-
-    // Assert that the thought element no longer exists
-    expect(await isThoughtInDOM('a')).toBe(false)
-  })
-
-  it('should delete regular thought when dropped on QuickDropPanel', async () => {
-    await paste(`
-      - a
-    `)
-
-    // Assert that the thought element exists
-    expect(await isThoughtInDOM('a')).toBe(true)
-
-    // trigger long press and show invisible QuickDropPanel
-    await dragAndDropThought('a', null, {
-      position: 'none',
-      mouseUp: false,
-      showAlert: true,
-    })
-
-    await dropOnQuickDropPanel()
-
-    await waitUntil(() => {
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      return alertElement?.textContent?.includes('Drop to remove a')
-    })
-
-    // Complete the drop
-    await page.mouse.up()
-
-    await waitUntil(() => {
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      return alertElement?.textContent?.includes('Removed 1 thought')
-    })
-
-    // Assert that the thought element no longer exists
-    expect(await isThoughtInDOM('a')).toBe(false)
-  })
-})
-
-describe('mobile only', () => {
+describe('QuickDropPanel: mobile only', () => {
   beforeEach(async () => {
     await emulate(KnownDevices['iPhone 15 Pro'])
   }, 10000)
@@ -128,17 +33,32 @@ describe('mobile only', () => {
     await click('[aria-label="Add to Favorites"]')
 
     // wait until the favorite alert appears
-    await waitUntil(() => {
-      const favoriteAlertContent = document.querySelector('[data-testid="alert-content"]')
-      return favoriteAlertContent?.textContent?.includes('Added a to favorites')
-    })
+    await waitForAlertContent('Added a to favorites')
 
-    await longPressThought(await waitForEditable('a'), { quickDrop: true })
+    await dragToQuickDropPanel(await waitForEditable('a'))
 
-    await waitUntil(() => {
-      const alertElement = document.querySelector('[data-testid="alert-content"]')
-      return alertElement?.textContent?.includes('Removed 1 thought')
-    })
+    await waitForAlertContent('Removed 1 thought')
+
+    // Assert that the thought element no longer exists
+    expect(await isThoughtInDOM('a')).toBe(false)
+
+    // Assert that other thoughts still exist
+    expect(await isThoughtInDOM('b')).toBe(true)
+    expect(await isThoughtInDOM('c')).toBe(true)
+  })
+
+  it('should remove normal thought when dropped on QuickDropPanel', async () => {
+    await paste(`
+        - a
+        - b
+        - c
+        `)
+
+    await clickThought('a')
+
+    await dragToQuickDropPanel(await waitForEditable('a'))
+
+    await waitForAlertContent('Removed 1 thought')
 
     // Assert that the thought element no longer exists
     expect(await isThoughtInDOM('a')).toBe(false)

--- a/src/e2e/puppeteer/helpers/waitForAlertContent.ts
+++ b/src/e2e/puppeteer/helpers/waitForAlertContent.ts
@@ -1,0 +1,22 @@
+import { page } from '../setup'
+
+interface Options {
+  timeout?: number
+}
+
+/**
+ * Wait for alert content that includes the given text.
+ */
+const waitForAlertContent = async (text: string, { timeout }: Options = { timeout: 6000 }) =>
+  await page.waitForFunction(
+    (text: string) => {
+      const alertElement = document.querySelector('[data-testid="alert-content"]')
+      return alertElement?.textContent?.includes(text)
+    },
+    {
+      timeout,
+    },
+    text,
+  )
+
+export default waitForAlertContent


### PR DESCRIPTION
Close #3145 

I have added e2e puppeteer behavioral test for quick drop on the invisible panel. This PR covers both desktop and mobile emulation for the same behavior. In the test I have added this specific function
```ts
/** Check if a thought is in the DOM. */
const isThoughtInDOM = async (value: string) => {
  const thoughtElement = await getEditable(value)
  const thoughtElementExists = await thoughtElement.evaluate(element => element !== null)
  return thoughtElementExists
}
```
Not sure if this is a correct way to check thoughts in the DOM. Looking forward for your feedback.

[Here](https://github.com/karunkop/em/actions?query=branch%3Aquick-drop-panel-test) is the CI result to ensure that the newly added test is not flaky.