### PR TITLE
Add canLongPress to global touchState

### DIFF
--- a/src/actions/longPress.ts
+++ b/src/actions/longPress.ts
@@ -137,7 +137,7 @@ export const longPressActionCreator =
         haptics.light()
         break
       case LongPressState.Inactive:
-        globals.touching = false
+        globals.touchState.moving = false
         break
     }
 

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -576,7 +576,7 @@ const Editable = ({
       // when the MultiGesture is below the gesture threshold it is possible that onTap and onTouchEnd are both triggered
       // in this case, we need to prevent onTap from being called a second time via onTouchEnd
       // https://github.com/cybersemics/em/issues/1268
-      else if (globals.touching && e.cancelable) {
+      else if (globals.touchState.moving && e.cancelable) {
         e.preventDefault()
       }
 
@@ -595,7 +595,7 @@ const Editable = ({
           disabled ||
           // do not set cursor on hidden thought
           // dragInProgress: not sure if this can happen, but I observed some glitchy behavior with the cursor moving when a drag and drop is completed so check dragInProgress to be safe
-          (!globals.touching && (!editingOrOnCursor || !isVisible))
+          (!globals.touchState.moving && (!editingOrOnCursor || !isVisible))
         ) {
           e.preventDefault()
 

--- a/src/components/ScrollZone.tsx
+++ b/src/components/ScrollZone.tsx
@@ -19,7 +19,7 @@ const ScrollZone = ({ leftHanded }: { leftHanded?: boolean } = {}) => {
   useEffect(() => {
     const hapticScrollDifference = Math.abs(lastHapticScrollPosition.current - scrollTop)
     if (hapticScrollDifference >= 5) {
-      if (globals.touching) {
+      if (globals.touchState.moving) {
         haptics.light()
       }
       lastHapticScrollPosition.current = scrollTop

--- a/src/components/TouchMonitor.tsx
+++ b/src/components/TouchMonitor.tsx
@@ -1,16 +1,23 @@
 import lifecycle from 'page-lifecycle'
 import { FC, PropsWithChildren, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { Settings } from '../constants'
 import globals from '../globals'
+import getUserSetting from '../selectors/getUserSetting'
+import isInGestureZone from '../util/isInGestureZone'
 
 /** Turns off touching when app becomes hidden. */
 const onStateChange = ({ newState }: { oldState: string; newState: string }) => {
   if (newState === 'hidden') {
-    globals.touching = false
+    globals.touchState.moving = false
+    globals.touchState.canLongPress = true
   }
 }
 
 /** A higher-order component that monitors whether the user is touching the screen or not. */
 const TouchMonitor: FC<PropsWithChildren> = ({ children }) => {
+  const leftHanded = useSelector(getUserSetting(Settings.leftHanded))
+
   // turn off touching when app becomes hidden
   useEffect(() => {
     lifecycle.addEventListener('statechange', onStateChange)
@@ -19,11 +26,14 @@ const TouchMonitor: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <div
+      onTouchStartCapture={({ nativeEvent: { touches } }) => {
+        globals.touchState.canLongPress = isInGestureZone(touches[0].pageX, touches[0].pageY, leftHanded)
+      }}
       onTouchMove={() => {
-        globals.touching = true
+        globals.touchState.moving = true
       }}
       onTouchEnd={() => {
-        globals.touching = false
+        globals.touchState.moving = false
       }}
     >
       {children}

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -3,8 +3,9 @@
 /** THE BAD PLACE where mutable globals are defined. */
 
 // track whether the user is touchmoving so that we can distinguish touchend events from tap or drag
+// canLongPress is true if the touch did not begin in the scroll zone (#3085)
 // not related to react-dnd
-let touching = false
+let touchState = { moving: false, canLongPress: true }
 
 // track whether the page has rendered yet to simulate onload event
 let rendered = false
@@ -37,7 +38,7 @@ const globals = {
   offlineTimer,
   rendered,
   suppressExpansion,
-  touching,
+  touchState,
 }
 
 export default globals

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -20,6 +20,7 @@ import { setIsMulticursorExecutingActionCreator as setIsMulticursorExecuting } f
 import { ThoughtContainerProps } from '../components/Thought'
 import { LongPressState } from '../constants'
 import * as selection from '../device/selection'
+import globals from '../globals'
 import documentSort from '../selectors/documentSort'
 import findDescendant from '../selectors/findDescendant'
 import getNextRank from '../selectors/getNextRank'
@@ -58,6 +59,7 @@ const canDrag = (props: ThoughtContainerProps) => {
   const isDraggable = props.isVisible || props.isCursorParent
 
   return (
+    globals.touchState.canLongPress &&
     isDocumentEditable() &&
     !!isDraggable &&
     !findDescendant(state, thoughtId, '=immovable') &&

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -7,6 +7,7 @@ import { isTouch } from '../browser'
 import { LongPressState, TIMEOUT_LONG_PRESS_THOUGHT, noop } from '../constants'
 import allowTouchToScroll from '../device/allowTouchToScroll'
 import * as selection from '../device/selection'
+import globals from '../globals'
 import haptics from '../util/haptics'
 
 /** Custom hook to manage long press.
@@ -69,7 +70,8 @@ const useLongPress = (
    * we will know which element is being long-pressed. */
   const start = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
-      if ('touches' in e.nativeEvent || e.nativeEvent.button !== 2) setPressing(true)
+      if (globals.touchState.canLongPress && ('touches' in e.nativeEvent || e.nativeEvent.button !== 2))
+        setPressing(true)
     },
     [setPressing],
   )


### PR DESCRIPTION
Fixes #3085

After considering how to track whether a touch began in the scroll zone, I decided that it should be tracked in `TouchMonitor`, and that `globals.touching` wasn't actually tracking `touchStart`, only `touchMove`. I thought that it made sense to expand it into `globals.touchState`, which could more accurately track whether the touch was `moving`, and whether its start position made it eligible for long press or drag-and-drop.