### PR TITLE
Store cliff in setSize so that isNewCliff can check whether it's actually replacing a previous cliff

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -295,7 +295,7 @@ const TreeNode = ({
               indexDescendant={indexDescendant}
               isMultiColumnTable={false}
               leaf={leaf}
-              onResize={setSize}
+              onResize={props => setSize({ ...props, cliff })}
               path={path}
               prevChildId={prevChild?.id}
               showContexts={showContexts}

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -33,6 +33,8 @@ export type OnResize = (args: {
   id: ThoughtId
   /** Used by the LayoutTree to crop hidden thoughts below the cursor without disrupting the autofocus animation when parents fade in. */
   isVisible: boolean
+  /** Trying to store the cliff in the size object so that it can be referenced in treeThoughtsPositioned in subsequent passes. */
+  cliff?: number
   /** A key that uniquely identifies the thought across context views. */
   key: string
 }) => void

--- a/src/hooks/usePositionedThoughts.ts
+++ b/src/hooks/usePositionedThoughts.ts
@@ -21,7 +21,7 @@ const usePositionedThoughts = (
   }: {
     maxVisibleY: number
     singleLineHeight: number
-    sizes: Index<{ height: number; width?: number; isVisible: boolean }>
+    sizes: Index<{ height: number; width?: number; isVisible: boolean; cliff?: number }>
   },
 ): {
   indentCursorAncestorTables: number
@@ -100,6 +100,7 @@ const usePositionedThoughts = (
 
     const treeThoughtsPositioned = treeThoughts.map((node, i) => {
       const prev = treeThoughts[i - 1] as TreeThought | undefined
+      const prevCliff = prev ? sizes[prev.key].cliff || 0 : 0
       const next = treeThoughts[i + 1] as TreeThought | undefined
 
       // cliff is the number of levels that drop off after the last thought at a given depth. Increase in depth is ignored.
@@ -177,7 +178,7 @@ const usePositionedThoughts = (
           - a
           - [empty]
       */
-      const isNewCliff = !sizes[node.key] && cliff < 0 && prev && node.depth >= prev.depth
+      const isNewCliff = !sizes[node.key] && cliff < 0 && prev && node.depth >= prev.depth && prevCliff < 0
 
       // Capture the y position of the current thought before it is incremented by its own height for the next thought.
       const y = yaccum - (isNewCliff ? cliffPadding : 0)

--- a/src/hooks/useSizeTracking.ts
+++ b/src/hooks/useSizeTracking.ts
@@ -36,11 +36,13 @@ const useSizeTracking = () => {
   /** Update the size record of a single thought. Make sure to use a key that is unique across thoughts and context views. This should be called whenever the size of a thought changes to ensure that y positions are updated accordingly and thoughts are animated into place. Otherwise, y positions will be out of sync and thoughts will start to overlap. */
   const setSize = useCallback(
     ({
+      cliff,
       height,
       width,
       isVisible,
       key,
     }: {
+      cliff?: number
       height: number | null
       width?: number | null
       id: ThoughtId
@@ -67,6 +69,7 @@ const useSizeTracking = () => {
                 [key]: {
                   height: heightClipped,
                   width: width || undefined,
+                  cliff,
                   isVisible,
                 },
               },


### PR DESCRIPTION
Fixes #3097

As per [this comment](https://github.com/ethan-james/em/blob/6b7d5ae04f4b21e4b3e3a1d64e4dca7f755a856a/src/hooks/usePositionedThoughts.ts#L175), it is probably necessary to store the previous thought's cliff so that we can tell if it's losing it. The `isNewCliff` check was introduced in order to fix https://github.com/cybersemics/em/issues/2783, and now we have the opposite problem where it's compensating for a cliff that doesn't exist. The two cases,

```
- A
- B
```

and

```
- A
  - AA
- B
```

look pretty similar, from the standpoint of `treeThoughtsPositioned`, once `AA` collapses. So I added a `cliff` property to the `sizes` store, because that's the same store that is causing the new thought to overcorrect on its height, and it's the same store that is lagging behind `treeThoughtsPositioned` so it contains useful, consistently-outdated information at the time when `treeThoughtsPositioned` is being recalculated.

I am trying to convince myself that this is a pretty good solution, although it definitely needs more cleanup. Mostly I wanted to get it out of my brain before the end of the week so that you could let me know if you think it's viable before I finish fleshing it out.