### PR TITLE
Fix y value when moving thought up/down

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -234,10 +234,7 @@ const TreeNode = ({
           top: y,
           left: 0,
         }
-      : moveDivStyle
-
-  // Flag when moveThought animation is active so children (e.g., size measurement) can adjust behavior.
-  const isMoveAnimating = !!moveDivStyle && !isSwap && !isLastActionSort
+      : {}
 
   return (
     <FadeTransition
@@ -269,7 +266,6 @@ const TreeNode = ({
         style={outerDivStyle}
       >
         <div
-          data-move-animating={isMoveAnimating ? 'true' : undefined}
           className={css({
             ...(isTableCol1
               ? {
@@ -314,6 +310,7 @@ const TreeNode = ({
               prevCliff={treeThoughtsPositioned[index - 1]?.cliff}
               isLastVisible={isLastVisible}
               autofocus={autofocus}
+              moveStyle={moveDivStyle}
             />
           </div>
           {dragInProgress &&

--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -236,6 +236,9 @@ const TreeNode = ({
         }
       : moveDivStyle
 
+  // Flag when moveThought animation is active so children (e.g., size measurement) can adjust behavior.
+  const isMoveAnimating = !!moveDivStyle && !isSwap && !isLastActionSort
+
   return (
     <FadeTransition
       id={thoughtKey}
@@ -266,6 +269,7 @@ const TreeNode = ({
         style={outerDivStyle}
       >
         <div
+          data-move-animating={isMoveAnimating ? 'true' : undefined}
           className={css({
             ...(isTableCol1
               ? {

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -140,8 +140,10 @@ const VirtualThought = ({
 
     // Need to grab max height between .thought and .thought-annotation since the annotation height might be bigger (due to wrapping link icon).
     // Use offsetHeight to avoid transform-induced fractional measurements (Safari mobile) and ensure layout height is used.
-    const annotationEl = ref.current.querySelector('[aria-label="thought-annotation"]') as HTMLElement | null
-    const heightNew = Math.max(ref.current.offsetHeight, annotationEl?.offsetHeight || 0)
+    const heightNew = Math.max(
+      ref.current.getBoundingClientRect().height,
+      ref.current.querySelector('[aria-label="thought-annotation"]')?.getBoundingClientRect().height || 0,
+    )
     const widthNew = ref.current.querySelector(`[data-editable]`)?.getBoundingClientRect().width
 
     // skip updating height when preventAutoscroll is enabled, as it modifies the element's height in order to trick Safari into not scrolling

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -65,6 +65,7 @@ const VirtualThought = ({
   prevCliff,
   isLastVisible,
   autofocus,
+  moveStyle,
 }: {
   // contextChain is needed to uniquely identify thoughts across context views
   debugIndex?: number
@@ -88,6 +89,8 @@ const VirtualThought = ({
   prevCliff?: number
   isLastVisible?: boolean
   autofocus: Autofocus
+  /** Optional animation styles for moveThought animations. Applied to a child wrapper so height measurement is unaffected. */
+  moveStyle?: React.CSSProperties
 }) => {
   // TODO: Why re-render the thought when its height changes? This information should be passively passed up to LayoutTree.
   const [height, setHeight] = useState<number | null>(singleLineHeight)
@@ -100,7 +103,6 @@ const VirtualThought = ({
   const fontSize = useSelector(state => state.fontSize)
   const note = useSelector(state => noteValue(state, simplePath))
   const ref = useRef<HTMLDivElement>(null)
-  const moveAnimTimeoutRef = useRef<number | null>(null)
 
   /***************************
    * VirtualThought properties
@@ -136,25 +138,10 @@ const VirtualThought = ({
   const updateSize = useCallback(() => {
     if (!ref.current) return
 
-    // If a moveThought animation is active on an ancestor, skip measuring since
-    // transform: scale will distort getBoundingClientRect and yield incorrect heights.
-    // Re-measure after the animation completes.
-    const isMoveAnimating = !!ref.current.closest('[data-move-animating="true"]')
-    if (isMoveAnimating) {
-      if (moveAnimTimeoutRef.current) return
-      moveAnimTimeoutRef.current = setTimeout(() => {
-        moveAnimTimeoutRef.current = null
-        // re-check and measure
-        updateSize()
-      }, durations.get('layoutNodeAnimation')) as unknown as number
-      return
-    }
-
     // Need to grab max height between .thought and .thought-annotation since the annotation height might be bigger (due to wrapping link icon).
-    const heightNew = Math.max(
-      ref.current.getBoundingClientRect().height,
-      ref.current.querySelector('[aria-label="thought-annotation"]')?.getBoundingClientRect().height || 0,
-    )
+    // Use offsetHeight to avoid transform-induced fractional measurements (Safari mobile) and ensure layout height is used.
+    const annotationEl = ref.current.querySelector('[aria-label="thought-annotation"]') as HTMLElement | null
+    const heightNew = Math.max(ref.current.offsetHeight, annotationEl?.offsetHeight || 0)
     const widthNew = ref.current.querySelector(`[data-editable]`)?.getBoundingClientRect().width
 
     // skip updating height when preventAutoscroll is enabled, as it modifies the element's height in order to trick Safari into not scrolling
@@ -218,10 +205,6 @@ const VirtualThought = ({
   useEffect(
     () => {
       return () => {
-        if (moveAnimTimeoutRef.current) {
-          clearTimeout(moveAnimTimeoutRef.current)
-          moveAnimTimeoutRef.current = null
-        }
         onResize?.({ height: null, width: null, id: id, isVisible: true, key: crossContextualKey })
       }
     },
@@ -238,51 +221,53 @@ const VirtualThought = ({
         height: shimHiddenThought && height != null ? height : undefined,
       }}
     >
-      {
-        /* Since no drop target is rendered when thoughts are hidden/shimmed, we need to create a drop target after a hidden parent.
-             e.g. Below, a is hidden and all of b's siblings are hidden, but we still want to be able to drop before e. Therefore we must insert DropUncle when e would not be rendered.
-               - a
-                - b
-                  - c [cursor]
-                    - x
-                  - d
-                - e
-           */
-        !isVisible && dropUncle && <DropUncle depth={depth} path={path} simplePath={simplePath} cliff={prevCliff} />
-      }
+      <div style={moveStyle}>
+        {
+          /* Since no drop target is rendered when thoughts are hidden/shimmed, we need to create a drop target after a hidden parent.
+               e.g. Below, a is hidden and all of b's siblings are hidden, but we still want to be able to drop before e. Therefore we must insert DropUncle when e would not be rendered.
+                 - a
+                  - b
+                    - c [cursor]
+                      - x
+                    - d
+                  - e
+             */
+          !isVisible && dropUncle && <DropUncle depth={depth} path={path} simplePath={simplePath} cliff={prevCliff} />
+        }
 
-      {!shimHiddenThought && (
-        <Subthought
-          autofocus={autofocus}
-          debugIndex={debugIndex}
-          depth={depth + 1}
-          dropUncle={dropUncle}
-          env={env}
-          indexDescendant={indexDescendant}
-          isMultiColumnTable={isMultiColumnTable}
-          leaf={leaf}
-          updateSize={updateSize}
-          path={path}
-          prevChildId={prevChildId}
-          showContexts={showContexts}
-          simplePath={simplePath}
-          style={style}
-          zoomCursor={zoomCursor}
-        />
-      )}
+        {!shimHiddenThought && (
+          <Subthought
+            autofocus={autofocus}
+            debugIndex={debugIndex}
+            depth={depth + 1}
+            dropUncle={dropUncle}
+            env={env}
+            indexDescendant={indexDescendant}
+            isMultiColumnTable={isMultiColumnTable}
+            leaf={leaf}
+            updateSize={updateSize}
+            path={path}
+            prevChildId={prevChildId}
+            showContexts={showContexts}
+            simplePath={simplePath}
+            style={style}
+            zoomCursor={zoomCursor}
+          />
+        )}
 
-      {isVisible && (
-        <DropChild
-          depth={depth}
-          // In context view, we need to pass the source simplePath in order to add dragged thoughts to the correct lexeme instance.
-          // For example, when dropping a thought onto a/m~/b, drop should be triggered with the props of m/b.
-          // TODO: DragAndDropSubthoughts should be able to handle this.
-          path={path}
-          simplePath={simplePath}
-          cliff={cliff}
-          isLastVisible={isLastVisible}
-        />
-      )}
+        {isVisible && (
+          <DropChild
+            depth={depth}
+            // In context view, we need to pass the source simplePath in order to add dragged thoughts to the correct lexeme instance.
+            // For example, when dropping a thought onto a/m~/b, drop should be triggered with the props of m/b.
+            // TODO: DragAndDropSubthoughts should be able to handle this.
+            path={path}
+            simplePath={simplePath}
+            cliff={cliff}
+            isLastVisible={isLastVisible}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -7,6 +7,7 @@ import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
+import { isTouch } from '../browser'
 import useDelayedAutofocus from '../hooks/useDelayedAutofocus'
 import useLayoutAnimationFrameEffect from '../hooks/useLayoutAnimationFrameEffect'
 import useSelectorEffect from '../hooks/useSelectorEffect'
@@ -139,11 +140,16 @@ const VirtualThought = ({
     if (!ref.current) return
 
     // Need to grab max height between .thought and .thought-annotation since the annotation height might be bigger (due to wrapping link icon).
-    // Use offsetHeight to avoid transform-induced fractional measurements (Safari mobile) and ensure layout height is used.
-    const heightNew = Math.max(
-      ref.current.getBoundingClientRect().height,
-      ref.current.querySelector('[aria-label="thought-annotation"]')?.getBoundingClientRect().height || 0,
-    )
+    // On touch devices, use offsetHeight to avoid transform-induced fractional measurements and ensure layout height is used.
+    const heightNew = isTouch
+      ? Math.max(
+          ref.current.offsetHeight,
+          (ref.current.querySelector('[aria-label="thought-annotation"]') as HTMLElement | null)?.offsetHeight || 0,
+        )
+      : Math.max(
+          ref.current.getBoundingClientRect().height,
+          ref.current.querySelector('[aria-label="thought-annotation"]')?.getBoundingClientRect().height || 0,
+        )
     const widthNew = ref.current.querySelector(`[data-editable]`)?.getBoundingClientRect().width
 
     // skip updating height when preventAutoscroll is enabled, as it modifies the element's height in order to trick Safari into not scrolling

--- a/src/durations.config.ts
+++ b/src/durations.config.ts
@@ -26,6 +26,8 @@ const durationsConfig = {
   layoutSlowShift: 750,
   /** The animation duration of a node in the LayoutTree component. This animates thought positions when they are moved. */
   layoutNodeAnimation: 150,
+  /** The animation duration for the moveThought animation. */
+  moveThoughtAnimation: 250,
   /* A fade in animation that is triggered for new thoughts. */
   nodeFadeIn: 150,
   /* A fade out animation that is triggered when a node unmounts. See autofocusChanged for normal opacity animations. */

--- a/src/hooks/useMoveThoughtAnimation.ts
+++ b/src/hooks/useMoveThoughtAnimation.ts
@@ -119,7 +119,7 @@ const useMoveThoughtAnimation = (
   // leading: false means the clear won't happen immediately - it waits for the full
   // animation duration before clearing, allowing the CSS animation to complete.
   const clearMoveAnimation = useMemo(() => {
-    return throttle(() => setMoveAnimation(null), durations.get('layoutNodeAnimation'), {
+    return throttle(() => setMoveAnimation(null), durations.get('moveThoughtAnimation'), {
       leading: false,
     })
   }, [setMoveAnimation])
@@ -146,7 +146,7 @@ const useMoveThoughtAnimation = (
     // Common style props
     const base: React.CSSProperties = {
       transformOrigin: 'left',
-      animationDuration: `${durations.get('layoutNodeAnimation')}ms`,
+      animationDuration: `${durations.get('moveThoughtAnimation')}ms`,
       animationTimingFunction: 'ease-out',
       animationFillMode: 'none',
     }


### PR DESCRIPTION
This fixes regression in #2531 

During `moveThought` animations we scale via transform: scale3d(...): https://github.com/cybersemics/em/blob/345bca476e8573427fafb936fac52468108b7a8f/panda.config.ts#L167-L171

So measuring heights mid-animation yields distorted values which interferes with y accumulation. 

Added `data-move-animating="true"` on the inner animated container only when `moveThought` animation is active.
In `VirtualThought`, `updateSize` now checks for an ancestor with the attribute above. If present, it skips measurement and schedules a re-measure after the animation duration. This prevents capturing scaled bounding boxes.

It cleans up the scheduled timeout on unmount.