### PR TITLE
Connect dragSource to StaticThought, not Thought

### DIFF
--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import React from 'react'
+import { ConnectDragSource } from 'react-dnd'
 import { useSelector } from 'react-redux'
 import { css, cx } from '../../styled-system/css'
 import { thoughtRecipe } from '../../styled-system/recipes'
@@ -7,6 +8,7 @@ import { SystemStyleObject } from '../../styled-system/types'
 import LazyEnv from '../@types/LazyEnv'
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
+import { isSafari, isTouch } from '../browser'
 import { MIN_CONTENT_WIDTH_EM } from '../constants'
 import useLayoutAnimationFrameEffect from '../hooks/useLayoutAnimationFrameEffect'
 import attributeEquals from '../selectors/attributeEquals'
@@ -30,6 +32,7 @@ import HomeIcon from './icons/HomeIcon'
 export interface ThoughtProps {
   allowSingleContext?: boolean
   debugIndex?: number
+  dragSource: ConnectDragSource
   editing?: boolean | null
   env?: LazyEnv
   // When context view is activated, some contexts may be pending
@@ -91,6 +94,7 @@ const isBlack = (color: string | undefined) => {
 /** A static thought element with overlay bullet, context breadcrumbs, editable, and superscript. */
 const StaticThought = ({
   allowSingleContext,
+  dragSource,
   // See: ThoughtProps['isContextPending']
   env,
   isContextPending,
@@ -174,6 +178,11 @@ const StaticThought = ({
             inverse: (dark && isBlack(styleAnnotation?.color)) || (!dark && isWhite(styleAnnotation?.color)),
           }),
         )}
+        // HTML5Backend will override this to be "true" on platforms that use it.
+        // iOS Safari needs it to be true to disable native long press behavior. (#2953, #2931, #2964)
+        // Android works better if draggable is false.
+        draggable={isTouch && isSafari()}
+        ref={node => dragSource(node)}
         style={{ minWidth: `${MIN_CONTENT_WIDTH_EM}em` }}
       >
         {homeContext ? (

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -13,7 +13,7 @@ import State from '../@types/State'
 import Thought from '../@types/Thought'
 import ThoughtId from '../@types/ThoughtId'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
-import { isMac, isSafari, isTouch } from '../browser'
+import { isMac, isTouch } from '../browser'
 import { AlertType, REGEX_TAGS } from '../constants'
 import { MIN_CONTENT_WIDTH_EM } from '../constants'
 import testFlags from '../e2e/testFlags'
@@ -528,14 +528,10 @@ const ThoughtContainer = ({
   return (
     <div
       {...dragHoldResult.props}
-      ref={node => dragSource(dropTarget(node))}
+      ref={node => dropTarget(node)}
       aria-label='child'
       data-divider={isDivider(value)}
       data-editing={isEditing}
-      // HTML5Backend will override this to be "true" on platforms that use it.
-      // iOS Safari needs it to be true to disable native long press behavior. (#2953, #2931, #2964)
-      // Android works better if draggable is false.
-      draggable={isTouch && isSafari()}
       onClick={isTouch ? undefined : handleMultiselect}
       style={{
         transition: `transform ${token('durations.layoutSlowShift')} ease-out, opacity ${token('durations.layoutSlowShift')} ease-out`,
@@ -609,6 +605,7 @@ const ThoughtContainer = ({
         <div style={alignmentTransition.editable}>
           <StaticThought
             allowSingleContext={allowSingleContext}
+            dragSource={dragSource}
             env={env}
             isContextPending={isContextPending}
             isEditing={isEditing}


### PR DESCRIPTION
Fixes #3239

I wanted to fix this by shrinking the actual `ThoughtContainer` so that it would fit the width of the editable inside. That didn't work well with empty thoughts, since the placeholder would wrap inside a narrow editable, and `ThoughtAnnotation` is absolutely-positioned which prevents a wrapper from exploiting its width. I remember that you mentioned possibly revisiting thought annotations, so maybe this can be revisited at that time.

I ended up passing the `dragSource` parameter down from the full-width `Thought` into the restricted-width `StaticThought`. This has two differences compared to shrinking the width of the `ThoughtContainer`:

1. Long press is still possible in the empty space. My feeling was that long press and drag-and-drop behavior should mirror each other as much as possible, but of course long press doesn't cause any harm in the scroll area so maybe it's better this way.
2. The full-width `Thought` still serves as the drop target, which seems like a good thing.

TODO: fix `dragAndDropThought` test helper to keep touches contained within the new draggable area