### PR TITLE
Move dragSource into thought-container, use flexbox to shrink to fit content

### DIFF
--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -528,7 +528,7 @@ const ThoughtContainer = ({
   return (
     <div
       {...dragHoldResult.props}
-      ref={node => dragSource(dropTarget(node))}
+      ref={node => dropTarget(node)}
       aria-label='child'
       data-divider={isDivider(value)}
       data-editing={isEditing}
@@ -538,6 +538,7 @@ const ThoughtContainer = ({
       draggable={isTouch && isSafari()}
       onClick={isTouch ? undefined : handleMultiselect}
       style={{
+        display: 'flex',
         transition: `transform ${token('durations.layoutSlowShift')} ease-out, opacity ${token('durations.layoutSlowShift')} ease-out`,
         ...style,
         ...styleContainer,
@@ -577,6 +578,7 @@ const ThoughtContainer = ({
       <div
         aria-label='thought-container'
         data-testid={'thought-' + hashPath(path)}
+        ref={node => dragSource(node)}
         className={css({
           /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
           /* must match value used in Editable useMultiline */

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -527,7 +527,6 @@ const ThoughtContainer = ({
 
   return (
     <div
-      {...dragHoldResult.props}
       ref={node => dropTarget(node)}
       aria-label='child'
       data-divider={isDivider(value)}
@@ -576,6 +575,7 @@ const ThoughtContainer = ({
       )}
 
       <div
+        {...dragHoldResult.props}
         aria-label='thought-container'
         data-testid={'thought-' + hashPath(path)}
         ref={node => dragSource(node)}


### PR DESCRIPTION
Fixes #3239 

Back on the container-shrinking approach, I was able to split up the `dragSource` and `dropTarget` in order to keep the drop target on the full-width container (`[aria-label=child]`) while using `display: flex` to shrink the drag source (`[aria-label=thought-container]`) to fit its content.

TODO: Lots of failing tests to look into.