### PR TITLE
Ignore the upgrading modules which have github dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: 'page-lifecycle'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
+      - dependency-name: 'y-indexeddb'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']


### PR DESCRIPTION
I added ignore section to `dependabot.yml`.
I configured Dependabot to ignore updates for:
- page-lifecycle (custom fork with TypeScript types)
- y-indexeddb (custom fork with multiplexing features)

Because, as I investigated the error log, those modules which have github dependencies are causing error.
Also, this update can be reasonable to be kept further, since it is meaninless to update the modules like above.