### PR TITLE
Add key to ArcGradient

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -393,7 +393,7 @@ const GestureDiagram = ({
           ) : (
             pathSegments.map((segment, i) => {
               return rounded ? (
-                <ArcGradient index={i} extendedPath={extendedPath} size={size} />
+                <ArcGradient key={`${extendedPath}-gradient-${i}`} index={i} extendedPath={extendedPath} size={size} />
               ) : (
                 <linearGradient
                   id={`${extendedPath}-gradient-${i}`}


### PR DESCRIPTION
Fixes bug introduced by #3227, which fixed #2727

Taking the same key that was applied to `<linearGradient>` and adding it to `<ArcGradient>` should fix warnings about missing keys.