### PR TITLE
Add git based dependencies into .ncurc configuration

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -27,5 +27,10 @@ module.exports = {
     // Error running image diff: Unknown Error
     // https://github.com/vitest-dev/vitest/releases/tag/v2.0.0
     'puppeteer',
+
+    // Git-based dependencies that cause Dependabot issues
+    // These packages use Git URLs instead of npm registry, causing CI/CD failures
+    'page-lifecycle',
+    'y-indexeddb',
   ],
 }


### PR DESCRIPTION
I've added both `page-lifecycle` and `y-indexeddb` to the `.ncurc.js` file's reject array. This will tell Dependabot to ignore updates for these packages, which should resolve the Dependabot errors you're experiencing.