### PR TITLE
Update page-lifecycle and y-indexeddb with tarball links

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: 'page-lifecycle'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']
-      - dependency-name: 'y-indexeddb'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor', 'version-update:semver-patch']

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -27,10 +27,5 @@ module.exports = {
     // Error running image diff: Unknown Error
     // https://github.com/vitest-dev/vitest/releases/tag/v2.0.0
     'puppeteer',
-
-    // Git-based dependencies that cause Dependabot issues
-    // These packages use Git URLs instead of npm registry, causing CI/CD failures
-    'page-lifecycle',
-    'y-indexeddb',
   ],
 }

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -27,5 +27,10 @@ module.exports = {
     // Error running image diff: Unknown Error
     // https://github.com/vitest-dev/vitest/releases/tag/v2.0.0
     'puppeteer',
+
+    // Git-based dependencies that cause Dependabot issues
+    // These packages use Git URLs instead of npm registry, causing CI/CD failures
+    'page-lifecycle',
+    'y-indexeddb',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
       "workspace:"
     ],
     "allowed-hosts": [
+      "codeload.github.com",
       "github.com",
       "npm",
       "yarn"
@@ -71,7 +72,9 @@
     "resetMocks": false
   },
   "resolutions": {
-    "@pandacss/node@npm:0.47.0": "patch:@pandacss/node@npm%3A0.47.0#~/.yarn/patches/@pandacss-node-npm-0.47.0.patch"
+    "@pandacss/node@npm:0.47.0": "patch:@pandacss/node@npm%3A0.47.0#~/.yarn/patches/@pandacss-node-npm-0.47.0.patch",
+    "page-lifecycle": "https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0",
+    "y-indexeddb": "https://codeload.github.com/raineorshine/y-indexeddb/tar.gz/60b960009085b1a988b5064ee35703229231531f"
   },
   "workspaces": [
     "packages/*"
@@ -110,7 +113,7 @@
     "murmurhash3js": "^3.0.1",
     "nanoid": "^5.1.5",
     "openai": "^5.20.3",
-    "page-lifecycle": "git+https://github.com/magic-akari/page-lifecycle#feat/add-types",
+    "page-lifecycle": "^0.1.2",
     "pluralize": "^8.0.0",
     "qrcode.react": "^4.2.0",
     "rc-slider": "^11.1.9",
@@ -144,7 +147,7 @@
     "workbox-strategies": "^7.3.0",
     "workbox-window": "^7.3.0",
     "xhtml-purifier": "^0.4.1",
-    "y-indexeddb": "https://github.com/raineorshine/y-indexeddb#y-indexeddb-multiplex",
+    "y-indexeddb": "^9.0.11-multiplex.0",
     "y-protocols": "^1.0.6",
     "yallist": "^5.0.0",
     "yjs": "^13.6.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8887,7 +8887,7 @@ __metadata:
     nanoid: "npm:^5.1.5"
     npm-run-all2: "npm:^8.0.4"
     openai: "npm:^5.20.3"
-    page-lifecycle: "git+https://github.com/magic-akari/page-lifecycle#feat/add-types"
+    page-lifecycle: "npm:^0.1.2"
     pluralize: "npm:^8.0.0"
     postinstall-postinstall: "npm:^2.1.0"
     prettier: "npm:^3.6.2"
@@ -8936,7 +8936,7 @@ __metadata:
     workbox-strategies: "npm:^7.3.0"
     workbox-window: "npm:^7.3.0"
     xhtml-purifier: "npm:^0.4.1"
-    y-indexeddb: "https://github.com/raineorshine/y-indexeddb#y-indexeddb-multiplex"
+    y-indexeddb: "npm:^9.0.11-multiplex.0"
     y-protocols: "npm:^1.0.6"
     yallist: "npm:^5.0.0"
     yjs: "npm:^13.6.27"
@@ -15424,10 +15424,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"page-lifecycle@git+https://github.com/magic-akari/page-lifecycle#feat/add-types":
+"page-lifecycle@https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0":
   version: 0.1.2
-  resolution: "page-lifecycle@https://github.com/magic-akari/page-lifecycle.git#commit=50b50421bdeab3d211a57e81a277f699638373b0"
-  checksum: 10c0/e949c425e0da95197890f80f9163e882e482005f6ed1d67a1f257869f413e3e1b814fd8af1dd092d8957190f869734f8e760d3088ffbd993379a0f5af375016b
+  resolution: "page-lifecycle@https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0"
+  checksum: 10c0/ddf01b57da4e67db36aa00085476caa7291918e83baab5501443441125b106231b447a143eed786e3bffab1ea3556146f9ab15ce40d0512244ea2778c310972d
   languageName: node
   linkType: hard
 
@@ -20814,14 +20814,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y-indexeddb@https://github.com/raineorshine/y-indexeddb#y-indexeddb-multiplex":
+"y-indexeddb@https://codeload.github.com/raineorshine/y-indexeddb/tar.gz/60b960009085b1a988b5064ee35703229231531f":
   version: 9.0.11-multiplex.0
-  resolution: "y-indexeddb@https://github.com/raineorshine/y-indexeddb.git#commit=60b960009085b1a988b5064ee35703229231531f"
+  resolution: "y-indexeddb@https://codeload.github.com/raineorshine/y-indexeddb/tar.gz/60b960009085b1a988b5064ee35703229231531f"
   dependencies:
     lib0: "npm:^0.2.74"
   peerDependencies:
     yjs: ^13.0.0
-  checksum: 10c0/fce364bd0c537726703a5febc47f5a0866876335b65397e5dcc4f3c3bcd71fe0f85eb89520aeaef2ba92afa3a3ea4c94898225b2d2a96de4fb1fd6be4a7cc3ac
+  checksum: 10c0/fa4ba1b81f2c5e1fcee7445a1ff7a108947f83b1fea75a6bbf2efba925279726f0acc6b9c9c9f1e7f40642a1e34c9712e71ff3a528ca2890d42297ac82d92e43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I assumed the reason is because of upgraded yarn version.
So I replcaed git dependency url to tarball link.

1. `page-lifecycle` - from `git+https://github.com/magic-akari/page-lifecycle#feat/add-types` to `https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0`
2. `y-indexeddb` - from `https://github.com/raineorshine/y-indexeddb#y-indexeddb-multiplex` to `https://codeload.github.com/raineorshine/y-indexeddb/tar.gz/60b960009085b1a988b5064ee35703229231531f`

This will work because
- Yarn downloads a pre-packed .tar.gz directly from GitHub’s codeload service instead of trying to git clone + pack.
- No race conditions with tmp directories.
- Dependabot’s environment handles tarball URLs consistently.

And regarding other updates, I reverted all of them.

Also I added `codeload.github.com` to allowed host list.