### PR TITLE
Add packages/webview/.build to .gitignore and eslint ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ __diff_output__
 ## PandaCSS
 styled-system
 styled-system-studio
-
-# build files from webview package
-packages/webview/.build

--- a/packages/webview/.gitignore
+++ b/packages/webview/.gitignore
@@ -12,3 +12,6 @@ DerivedData
 swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+# build artifacts
+.build


### PR DESCRIPTION
After running `yarn build` (or a script that calls it, like `yarn cap:ios:static`), the `webview` package builds and stores artifacts in `packages/webview/.build`.

Currently these artifacts:

- get picked up as _unstaged changes_ in git, making it harder to review actual changes in PRs
- trigger ESLint errors (because they're minified files), which blocks commits without `--force`

This PR adds the `.build` directory to both git and ESLint ignore lists so build artifacts are no longer committed or linted.
