### PR TITLE
Test for scrollCursorIntoView after thought replication

### DIFF
--- a/src/e2e/puppeteer/__tests__/scroll-cursor-into-view.ts
+++ b/src/e2e/puppeteer/__tests__/scroll-cursor-into-view.ts
@@ -1,0 +1,77 @@
+import clickThought from '../helpers/clickThought'
+import getEditingText from '../helpers/getEditingText'
+import paste from '../helpers/paste'
+import refresh from '../helpers/refresh'
+import waitForEditable from '../helpers/waitForEditable'
+import waitForThoughtExistInDb from '../helpers/waitForThoughtExistInDb'
+import waitUntil from '../helpers/waitUntil'
+import { page } from '../setup'
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
+describe('scrollCursorIntoView', () => {
+  it('should scroll cursor into view after page refresh when cursor thought is outside viewport', async () => {
+    const importText = `
+- a
+  - =pin
+  - b
+  - c
+  - d
+  - e
+  - f
+  - g
+  - h
+  - i
+  - j
+  - k
+  - l
+  - m
+  - n
+  - o
+  - p
+  - q
+  - r
+  - s
+  - u
+  - v
+- t
+    `
+    await paste(importText)
+
+    // Verify the initial scroll position is 0
+    const initialScrollY = await page.evaluate(() => window.scrollY)
+    expect(initialScrollY).toBe(0)
+
+    await clickThought('t')
+
+    await waitForThoughtExistInDb('t')
+    await refresh()
+
+    // Wait for the cursor to be restored to thought 't'
+    await waitForEditable('t')
+
+    // Verify the editing thought is still 't'
+    const editingText = await getEditingText()
+    expect(editingText).toBe('t')
+
+    // Verify the cursor was scrolled into view after refresh
+    await waitUntil(() => {
+      const el = document.querySelector('[data-editing=true]')
+      if (!el) return false
+
+      const rect = el.getBoundingClientRect()
+      const toolbarRect = document.getElementById('toolbar')?.getBoundingClientRect()
+      const toolbarBottom = toolbarRect ? toolbarRect.bottom : 0
+
+      const viewport = {
+        top: toolbarBottom,
+        bottom: window.innerHeight,
+      }
+
+      const isInViewport = rect.top >= viewport.top && rect.bottom <= viewport.bottom
+
+      // Ensure the cursor is scrolled into view
+      return isInViewport && window.scrollY > 0
+    })
+  })
+})


### PR DESCRIPTION
Close #3261 

This test looks for the cursor thought and checks whether the scroll has occurred and is inside the viewport. If, because of some regression, `scrollCursorIntoView` is not activated, then the test will timeout as the cursor thought is not inside the viewport and the scrollY will remain 0 as well.