### PR TITLE
Ignore hoveringPath behavior after drag is canceled

### DIFF
--- a/src/hooks/useHoveringPath.ts
+++ b/src/hooks/useHoveringPath.ts
@@ -17,6 +17,9 @@ const useHoveringPath = (path: Path, isHovering: boolean, hoverZone: DropThought
         dispatch((dispatch, getState) => {
           const state = getState()
 
+          // If the drag has been canceled, ignore hoveringPath behavior
+          if (state.longPress === LongPressState.DragCanceled) return
+
           dispatch(
             longPress({
               value: LongPressState.DragInProgress,


### PR DESCRIPTION
Fixes #3270

The `isHovering` property on `useDragAndDropThought` will be false if `state.longPress` is `DragCanceled`. However, there's another property, `isBeingHoveredOver` that is used for `useHoveringPath` so that children will still be expanded even if the user is hovering over a context view. It doesn't take into account whether the drag has already been canceled, so I'm short-circuiting it so that `hoveringPath` does not update.

This could instead be handled in [useDragAndDropThought](https://github.com/ethan-james/em/blob/fd5f90bdb858dce6f9f8f63757c4932e25bdeac4/src/hooks/useDragAndDropThought.tsx#L275) to set `isBeingHoveredOver` to false in the event that `state.longPress === LongPressState.DragCanceled`. It would then be necessary to fetch the state in a context where it is not already being fetched.