### PR TITLE
Refactor BulletCursorOverlay through abstraction

### DIFF
--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -160,6 +160,8 @@ const ContextBreadcrumbs = ({
   staticText,
   thoughtsLimit,
   linkCssRaw,
+  asPlaceholder = false,
+  ariaLabel,
 }: {
   charLimit?: number
   cssRaw?: SystemStyleObject
@@ -176,6 +178,8 @@ const ContextBreadcrumbs = ({
   staticText?: boolean
   thoughtsLimit?: number
   linkCssRaw?: SystemStyleObject
+  asPlaceholder?: boolean
+  ariaLabel?: string
 }) => {
   const [disabled, setDisabled] = React.useState(false)
   const simplePath = useSelector(state => simplifyPath(state, path), shallowEqual)
@@ -202,17 +206,19 @@ const ContextBreadcrumbs = ({
 
   const homeIconStyle: React.CSSProperties = { position: 'relative', left: -1, top: 2 }
 
+  const label = hidden ? undefined : (ariaLabel ?? 'context-breadcrumbs')
+
   return (
     <div
-      aria-label={hidden ? undefined : 'context-breadcrumbs'}
+      aria-label={label}
       className={css(
         {
           fontSize: '0.867em',
-          color: 'gray66',
+          ...(!asPlaceholder ? { color: 'gray66' } : {}),
           marginLeft: 'calc(1.3em - 14.5px)',
           marginTop: '0.533em',
           minHeight: '1em',
-          visibility: hidden ? 'hidden' : undefined,
+          visibility: hidden || asPlaceholder ? 'hidden' : undefined,
         },
         cssRaw,
       )}

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -239,6 +239,40 @@ const useCol1Alignment = ({ path, value, isTableCol1 }: UseCol1AlignParams) => {
  * Components
  **********************************************************************/
 
+/**
+ * Thought wrapper used inside the Thought component and BulletCursorOverlay.
+ */
+export const ThoughtWrapper = ({
+  children,
+  path,
+  ariaLabel,
+  asPlaceholder = false,
+  hideBullet,
+}: {
+  children: React.ReactNode
+  path: Path
+  ariaLabel?: string
+  asPlaceholder?: boolean
+  hideBullet?: boolean
+}) => {
+  return (
+    <div
+      aria-label={ariaLabel || 'thought-container'}
+      data-testid={`${asPlaceholder ? 'placeholder-' : ''}thought-${hashPath(path)}`}
+      className={css({
+        /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
+        /* must match value used in Editable useMultiline */
+        lineHeight: '2',
+        // ensure that ThoughtAnnotation is positioned correctly
+        position: 'relative',
+        ...(hideBullet ? { marginLeft: -12 } : null),
+      })}
+    >
+      {children}
+    </div>
+  )
+}
+
 /** A thought container with bullet, thought annotation, thought, and subthoughts.
  *
   @param allowSingleContext  Pass through to Subthoughts since the SearchSubthoughts component does not have direct access to the Subthoughts of the Subthoughts of the search. Default: false.
@@ -584,18 +618,7 @@ const ThoughtContainer = ({
         />
       )}
 
-      <div
-        aria-label='thought-container'
-        data-testid={'thought-' + hashPath(path)}
-        className={css({
-          /* Use line-height to vertically center the text and bullet. We cannot use padding since it messes up the selection. This needs to be overwritten on multiline elements. See ".child .editable" below. */
-          /* must match value used in Editable useMultiline */
-          lineHeight: '2',
-          // ensure that ThoughtAnnotation is positioned correctly
-          position: 'relative',
-          ...(hideBullet ? { marginLeft: -12 } : null),
-        })}
-      >
+      <ThoughtWrapper path={path} hideBullet={hideBullet} asPlaceholder={false}>
         {!(publish && simplePath.length === 0) && (!leaf || !isPublishChild) && !hideBullet && (
           <div style={alignmentTransition.bullet}>
             <Bullet
@@ -640,7 +663,7 @@ const ThoughtContainer = ({
           />
         </div>
         <Note path={path} disabled={!isVisible} />
-      </div>
+      </ThoughtWrapper>
 
       {publish && simplePath.length === 0 && <Byline id={head(parentOf(simplePath))} />}
 

--- a/src/components/ThoughtAnnotationWrapper.tsx
+++ b/src/components/ThoughtAnnotationWrapper.tsx
@@ -1,0 +1,163 @@
+import { css, cx } from '../../styled-system/css'
+import { multilineRecipe } from '../../styled-system/recipes'
+import { SystemStyleObject } from '../../styled-system/types'
+import { MIN_CONTENT_WIDTH_EM } from '../constants'
+import isAttribute from '../util/isAttribute'
+import FauxCaret from './FauxCaret'
+
+type ThoughtAnnotationWrapperPlaceholderProps = {
+  asPlaceholder: true
+  children?: never
+  ellipsizedUrl?: undefined
+  multiline?: undefined
+  value?: undefined
+  styleAnnotation?: undefined
+  cssRaw?: undefined
+  style?: undefined
+  isTableCol1: boolean
+  textMarkup?: undefined
+  placeholder?: undefined
+}
+
+type ThoughtAnnotationWrapperVisibleProps = {
+  asPlaceholder?: false
+  ellipsizedUrl?: boolean
+  multiline?: boolean
+  value: string
+  styleAnnotation?: React.CSSProperties
+  cssRaw?: SystemStyleObject
+  style?: React.CSSProperties
+  children: React.ReactNode
+  isTableCol1: boolean
+  textMarkup: string
+  placeholder?: string
+}
+
+type ThoughtAnnotationWrapperProps = ThoughtAnnotationWrapperPlaceholderProps | ThoughtAnnotationWrapperVisibleProps
+
+/**
+ * Shared component used by ThoughtAnnotation and BulletCursorOverlay.
+ * In BulletCursorOverlay, it mirrors the real thought position to compute the overlay cursor position.
+ */
+export default function ThoughtAnnotationWrapper({
+  asPlaceholder = false,
+  ellipsizedUrl,
+  multiline,
+  value,
+  styleAnnotation,
+  cssRaw,
+  style,
+  children,
+  isTableCol1,
+  textMarkup,
+  placeholder,
+}: ThoughtAnnotationWrapperProps) {
+  return (
+    <div
+      aria-label='thought-annotation'
+      className={css({
+        position: 'absolute',
+        pointerEvents: 'none',
+        userSelect: 'none',
+        boxSizing: 'border-box',
+        width: '100%',
+        // maxWidth: '100%',
+        marginTop: '0',
+        display: 'inline-block',
+        textAlign: 'left',
+        verticalAlign: 'top',
+        whiteSpace: 'pre-wrap',
+        /* override editable-annotation's single line to have same width with .editable. 100% - 1em since .editable has padding-right 1em */
+        maxWidth: multiline ? 'calc(100% - 2em)' : '100%',
+        '@media (max-width: 500px)': {
+          marginTop: { _android: '-2.1px' },
+          marginLeft: { _android: '0.5em' },
+        },
+        '@media (min-width: 560px) and (max-width: 1024px)': {
+          marginTop: { _android: '-0.1px' },
+          marginLeft: { _android: '0.5em' },
+        },
+      })}
+      style={{
+        ...(asPlaceholder
+          ? {
+              visibility: 'hidden',
+            }
+          : {}),
+      }}
+    >
+      <div
+        className={
+          cx(
+            multiline ? multilineRecipe() : null,
+            css({
+              ...(value &&
+                isAttribute(value) && {
+                  backgroundColor: 'thoughtAnnotation',
+                  fontFamily: 'monospace',
+                }),
+              display: 'inline-block',
+              maxWidth: '100%',
+              padding: '0 0.333em',
+              boxSizing: 'border-box',
+              whiteSpace: ellipsizedUrl ? 'nowrap' : undefined,
+              /*
+                    Since .editable-annotation-text is display: inline the margin only gets applied to its first line, and not later lines.
+                    To make sure all lines are aligned need to apply the margin here, and remove margin from the .editable-annotation-text
+                  */
+              margin: '-0.5px 0 0 calc(1em - 18px)',
+              paddingRight: multiline ? '1em' : '0.333em',
+              textAlign: isTableCol1 ? 'right' : 'left',
+            }),
+          )
+          // disable intrathought linking until add, edit, delete, and expansion can be implemented
+          // 'subthought-highlight': isEditing && focusOffset != null && subthought.contexts.length > (subthought.text === value ? 1 : 0) && subthoughtUnderSelection() && subthought.text === subthoughtUnderSelection().text
+          // .subthought-highlight {
+          //   border-bottom: solid 1px;
+          // }
+        }
+        style={{
+          ...styleAnnotation,
+          minWidth: `${MIN_CONTENT_WIDTH_EM - 0.333 - 0.333}em`, // min width of thought (3em) - 0.333em left padding - 0.333em right padding
+        }}
+      >
+        <span
+          className={css({
+            fontSize: '1.25em',
+            margin: '-0.375em 0 0 -0.05em',
+            position: 'absolute',
+          })}
+        >
+          <FauxCaret caretType='thoughtStart' />
+        </span>
+        <span
+          className={css(
+            {
+              visibility: 'hidden',
+              position: 'relative',
+              clipPath: 'inset(0.001px 0 0.1em 0)',
+              wordBreak: 'break-word',
+              ...(ellipsizedUrl && {
+                display: 'inline-block',
+                textOverflow: 'ellipsis',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                maxWidth: '100%',
+                /*
+                      vertical-align: top; - This fixes the height difference problem of .thought-annotation and .thought
+                      Here is the reference to the reason.
+                      https://stackoverflow.com/questions/20310690/overflowhidden-on-inline-block-adds-height-to-parent
+                  */
+                verticalAlign: 'top',
+              }),
+            },
+            cssRaw,
+          )}
+          style={style}
+          dangerouslySetInnerHTML={{ __html: textMarkup || placeholder || '&ZeroWidthSpace;' }}
+        />
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/TreeNodeWrapper.tsx
+++ b/src/components/TreeNodeWrapper.tsx
@@ -1,0 +1,90 @@
+import { CSSProperties, ReactNode } from 'react'
+import { css } from '../../styled-system/css'
+
+type TreeNodeWrapperBaseProps = {
+  isTableCol1?: boolean
+  x: number
+  y: number
+  width: number
+  children?: ReactNode
+  ariaLabel?: string
+}
+type TreeNodeWrapperPlaceholderProps = {
+  asPlaceholder: true
+  outerTransition?: undefined
+  innerTransition?: undefined
+  outerStyle?: undefined
+  innerStyle?: undefined
+} & TreeNodeWrapperBaseProps
+type TreeNodeWrapperVisibleProps = {
+  asPlaceholder?: false
+
+  outerTransition?: string
+  innerTransition?: string
+  outerStyle?: CSSProperties
+  innerStyle?: CSSProperties
+} & TreeNodeWrapperBaseProps
+
+type TreeNodeWrapperProps = TreeNodeWrapperPlaceholderProps | TreeNodeWrapperVisibleProps
+/**
+ * A reusable positioned container that mirrors the outer/inner layout and transitions
+ * used by `TreeNode`, while remaining lightweight for wrapper use in BulletCursorOverlay to mimic the real thought layout.
+ */
+export default function TreeNodeWrapper({
+  children,
+  isTableCol1 = false,
+  x,
+  y,
+  width,
+  outerTransition,
+  innerTransition,
+  outerStyle,
+  innerStyle,
+  ariaLabel,
+  asPlaceholder,
+}: TreeNodeWrapperProps) {
+  const baseOuterStyle = {
+    left: x,
+    top: y,
+    // Table col1 uses its exact width since cannot extend to the right edge of the screen.
+    // All other thoughts extend to the right edge of the screen. We cannot use width auto as it causes the text to wrap continuously during the counter-indentation animation, which is jarring. Instead, use a fixed width of the available space so that it changes in a stepped fashion as depth changes and the word wrap will not be animated. Use x instead of depth in order to accommodate ancestor tables.
+    // 1em + 10px is an eyeball measurement at font sizes 14 and 18
+    // (Maybe the 10px is from .content padding-left?)
+    width: isTableCol1 ? (width ?? 0) : (`calc(100% - ${x}px + 1em + 10px)` as const),
+    ...(asPlaceholder && isTableCol1 ? { textAlign: 'right' as const } : {}),
+  }
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={css({
+        position: 'absolute',
+        transition:
+          outerTransition ??
+          'left {durations.layoutNodeAnimation} linear,top {durations.layoutNodeAnimation} ease-in-out',
+      })}
+      style={{
+        ...baseOuterStyle,
+        ...(outerStyle || {}),
+      }}
+    >
+      <div
+        className={css({
+          ...(isTableCol1
+            ? {
+                position: 'relative',
+                width: 'auto',
+              }
+            : {
+                position: 'absolute',
+                width: '100%',
+              }),
+          ...(innerTransition ? { transition: innerTransition! } : {}),
+        })}
+        style={innerStyle}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Fix #3162 with first approach.
---

Refactor BulletCursorOverlay by abstracting the shared pieces needed to compute the bullet position, eliminating the duplication that existed before.

This refactor touches
- TreeNode
- ThoughtAnnotation
-  Thought
- ContextBreadcrumb
- BulletCursorOverlay

Each abstracted component now accepts a new prop `asPlaceholder` to indicate whether it should render in hidden/placeholder mode.



### MacOS Safari
https://github.com/user-attachments/assets/d529cb03-65fc-4703-9339-01c621bc9e09

### iOS Safari

https://github.com/user-attachments/assets/3961c7b1-bdf4-4ca6-8823-45d9d94bf48e


