### PR TITLE
Set shimHiddenThought if autofocus is hide-parent

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -43,7 +43,7 @@ const useSingleLineHeight = (sizes: Index<{ height: number; width?: number; isVi
   const singleLineHeight = useMemo(() => {
     // The estimatedHeight calculation is ostensibly related to the font size, line height, and padding, though the process of determination was guess-and-check. This formula appears to work across font sizes.
     // If estimatedHeight is off, then totalHeight will fluctuate as actual sizes are saved (due to estimatedHeight differing from the actual single-line height).
-    const estimatedHeight = fontSize * 2 - 2
+    const estimatedHeight = fontSize * 2
 
     const singleLineHeightMeasured = Object.values(sizes).find(
       // TODO: This does not differentiate between leaves, non-leaves, cliff thoughts, which all have different sizes.

--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -121,7 +121,7 @@ const VirtualThought = ({
   const isVisible = zoomCursor || autofocus === 'show' || autofocus === 'dim'
   const shimHiddenThought = useDelayedAutofocus(autofocus, {
     delay: durations.get('layoutSlowShift'),
-    selector: autofocusNew => autofocus.startsWith('hide') && autofocusNew.startsWith('hide') && !!height,
+    selector: autofocusNew => autofocus === 'hide' && autofocusNew === 'hide' && !!height,
   })
 
   // console.info('<VirtualThought>', prettyPath(childPath))


### PR DESCRIPTION
Fixes #3256

Changing the cursor thought resulted in a hidden thought (`a` in this case) going from `autofocus=hide` to [autofocus=hide-parent](https://github.com/ethan-james/em/blob/827dbc69f38300a234baa38cb21b9535a176817f/src/selectors/calculateAutofocus.ts#L74). As a result, [shimHiddenThought](https://github.com/ethan-james/em/blob/827dbc69f38300a234baa38cb21b9535a176817f/src/components/VirtualThought.tsx#L122) would become false, and this would [remove the height](https://github.com/ethan-james/em/blob/827dbc69f38300a234baa38cb21b9535a176817f/src/components/VirtualThought.tsx#L235) from that hidden thought. Removing the height changed it from its designed value of 34px to its default value of 36px.

I assumed that it was an oversight that `hide-parent` was not being treated the same as `hide`. Let me know if that's not the case!