### PR TITLE
Flaky Test: Modal Snapshot

### DIFF
--- a/src/components/LoadingEllipsis.tsx
+++ b/src/components/LoadingEllipsis.tsx
@@ -14,6 +14,7 @@ const LoadingEllipsis = ({
   text?: string
 }) => (
   <span
+    data-loading-indicator
     className={
       center
         ? css({

--- a/src/e2e/puppeteer/helpers/openModal.ts
+++ b/src/e2e/puppeteer/helpers/openModal.ts
@@ -12,15 +12,14 @@ const openModal = async (id: ModalType): Promise<void> => {
   }, id)
 
   // Wait for any loading indicators to disappear
-  // This checks if a "Loading" text is present within the modal and waits for it to be removed
+  // Check for elements with data-loading-indicator attribute (LoadingEllipsis component)
   await waitUntil(() => {
     const modalContent = document.querySelector('[aria-label="modal-content"]')
     if (!modalContent) return false
 
-    const textContent = modalContent.textContent
-    const hasLoading = textContent.includes('Loading')
+    const hasLoadingIndicator = modalContent.querySelector('[data-loading-indicator]') !== null
 
-    return !hasLoading
+    return !hasLoadingIndicator
   })
 }
 


### PR DESCRIPTION
Closes #3320

### Cause:

For some reason, sometimes in CI, when dispatching a `showModal` action, the export content may not be available at the time. When this happens, `LoadingEllipsis.tsx` component is shown in `Export.tsx` component. And the snapshot taken now would have no export content but rather a `Loading..` content due to which the visual regression test fails. However this is very rare in CI itself.

### Fix:

I have added a proper waiting condition to wait for export content before snapshot in `openModal.ts` helper file. This will prevent the snapshot to reflect the rare `Loading..` condition and waits for sufficient time to show the export content.

[Here](https://github.com/karunkop/em/actions?query=branch%3Atest-flakiness-modal) is the result for the CI checks.
