### PR TITLE
Update estimatedHeight to fix height of shimmed hidden thought on first render

### DIFF
--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -43,7 +43,7 @@ const useSingleLineHeight = (sizes: Index<{ height: number; width?: number; isVi
   const singleLineHeight = useMemo(() => {
     // The estimatedHeight calculation is ostensibly related to the font size, line height, and padding, though the process of determination was guess-and-check. This formula appears to work across font sizes.
     // If estimatedHeight is off, then totalHeight will fluctuate as actual sizes are saved (due to estimatedHeight differing from the actual single-line height).
-    const estimatedHeight = fontSize * 2 - 2
+    const estimatedHeight = fontSize * 2
 
     const singleLineHeightMeasured = Object.values(sizes).find(
       // TODO: This does not differentiate between leaves, non-leaves, cliff thoughts, which all have different sizes.


### PR DESCRIPTION
Fixes #3256 

Updating the value of `estimatedHeight` used by `useSingleLineHeight` before it has measured any DOM elements fixes the hidden thought layout shift issue. I can collect more test cases tomorrow in order to make sure that it doesn't have any adverse impact.

After [shimHiddenThought](https://github.com/ethan-james/em/blob/c9d116ecff72a80f5c10c56caa680f853d3e52d3/src/components/VirtualThought.tsx#L235) is removed and the thought is measured, its height will be set to 36px. So I think that must be the correct value to use from the start.