### PR TITLE
importText: Force editable to re-render on paste

### DIFF
--- a/src/actions/importText.ts
+++ b/src/actions/importText.ts
@@ -29,6 +29,7 @@ import roamJsonToBlocks, { RoamPage } from '../util/roamJsonToBlocks'
 import textToHtml from '../util/textToHtml'
 import unroot from '../util/unroot'
 import validateRoam from '../util/validateRoam'
+import editableRender from './editableRender'
 import newThought from './newThought'
 import uncategorize from './uncategorize'
 
@@ -118,6 +119,10 @@ const importText = (
     const offset = caretPosition + getTextContentFromHTML(text).length
 
     return reducerFlow([
+      // Force the editable to re-render in order to trigger setSelectionToCursorOffset in useEditMode and restore the caret.
+      // Otherwise on paste, innerHTML will be modified directly and the caret will move to the beginning of the thought due to default browser behavior.
+      // See: https://github.com/cybersemics/em/issues/3277#issuecomment-3470718557
+      editableRender,
       editThought({
         oldValue: destValue,
         newValue,


### PR DESCRIPTION
Fixes #3277

The `useEditMode` hook stopped triggering on paste after 9bb9213. This caused the caret to move to the beginning of the thought due to the default browser behavior. **This PR forces a re-render with `editableRender` (which increments `state.editableNonce`) so that `useEditMode` triggers and restores the caret.**

`editableRender` only needs to be invoked in `importText`, since that is what eventually gets called by the onPaste handler when pasting single lines of text. Doing this in the reducer avoids an extra action being dispatched.

`state.editableNonce` is a bit brute force, but we need some way to differentiate pasting (re-render) from typing (no re-render) as a one-time event. There's no other difference in state that I am aware of between typing "two" or pasting "two", so this seems as good a method as any. If there are complications with `state.editableNonce` or it gets removed in the future, we can always use a separate back channel to trigger the `useEditMode` hook on paste.