### PR TITLE
BulletCursorOverlay: Render actual ContextBreadcrumb inside BulletCursorOverlay

### DIFF
--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -323,7 +323,7 @@ export default function BulletCursorOverlay({
     <PlaceholderTreeNode width={width} x={x} y={y} isTableCol1={isTableCol1}>
       {showContexts && simplePath?.length > 1 && (
         <ContextBreadcrumbs
-          cursorOverlay
+          hidden
           cssRaw={css.raw({
             /* Tighten up the space between the context-breadcrumbs and the thought (similar to the space above a note). */
             marginBottom: '-0.25em',

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -160,7 +160,6 @@ const ContextBreadcrumbs = ({
   staticText,
   thoughtsLimit,
   linkCssRaw,
-  cursorOverlay,
 }: {
   charLimit?: number
   cssRaw?: SystemStyleObject
@@ -177,8 +176,6 @@ const ContextBreadcrumbs = ({
   staticText?: boolean
   thoughtsLimit?: number
   linkCssRaw?: SystemStyleObject
-  /* Controls the visibility of this component inside BulletCursorOverlay. */
-  cursorOverlay?: boolean
 }) => {
   const [disabled, setDisabled] = React.useState(false)
   const simplePath = useSelector(state => simplifyPath(state, path), shallowEqual)
@@ -216,7 +213,7 @@ const ContextBreadcrumbs = ({
           marginLeft: 'calc(1.3em - 14.5px)',
           marginTop: '0.533em',
           minHeight: '1em',
-          visibility: hidden || cursorOverlay ? 'hidden' : undefined,
+          visibility: hidden ? 'hidden' : undefined,
         },
         cssRaw,
       )}


### PR DESCRIPTION
Fix https://github.com/cybersemics/em/issues/3162

---

Add `cursorOverlay` to indicating that the component being used inside BulletCursorOverlay. For now, the additional prop is used for controlling the visibility of the context breadcrumb inside BulletCursorOverlay. ContextBreadcrumb is needed to be import into BulletCursorOverlay to handle the case when context view is active

---
## Results

**When context view is active**

https://github.com/user-attachments/assets/71b43b02-c9ca-474c-a4e6-76dfea019464




