### PR TITLE
Fix sort animation does not run on undo

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -144,11 +144,10 @@ const TreeNode = ({
   /** Detect when this thought's on-screen position (array index) has changed. */
   const indexChanged = previousIndex !== undefined && previousIndex !== index
 
-  /** True if the last action is setSortPreference. */
+  /** True if the last undoable action is a sort change. */
   const isLastActionSort = useSelector(state => {
     const sortActions: ActionType[] = ['setSortPreference', 'toggleSort']
-    const lastPatches = state.undoPatches[state.undoPatches.length - 1]
-    return lastPatches?.some(patch => sortActions.includes(patch.actions[0]))
+    return sortActions.includes(state.lastUndoableActionType as ActionType)
   })
 
   /**


### PR DESCRIPTION
Fixes #3307

Root cause: we were checking `undoPatches` to detect sort, so after Undo the last action didn’t look like a sort.
Fix: switch detection to `state.lastUndoableActionType` so Sort, Undo, and Redo all trigger the rotate-into-place animation.

