### PR TITLE
Multiselect mobile test fix

### DIFF
--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -43,7 +43,8 @@ describe('mobile only', () => {
     await longPressThought(a, { edge: 'right', x: 100 })
     await longPressThought(b, { edge: 'right', x: 100 })
 
-    // Wait for the command menu panel to show "2 thoughts selected before we query for highlighted bullets, preventing race conditions in CI
+    // In CI, sometimes the count of highlighted bullets are incorrect. The selector query runs immediately after both long presses, but react might not have finished re-rendering all bullet components.
+    // Wait for the command menu panel to show "2 thoughts selected" before we query for highlighted bullets.
     await page.waitForFunction(
       () => {
         const panel = document.querySelector('[data-testid=command-menu-panel]')


### PR DESCRIPTION
Close #3344

The issue was very tricky to debug. So, firstly I added some debugging logs to ensure `longPressThought.ts` is working as expected so that I can narrow down the issue. In previous attempts to make the fix, I added a waiting condition in `longPressThought.ts` that waits for specific bullet element to be highlighted before `touchEnd()`. This was a reasonable addition and after some rigorous testing the issue didn't appear until recently. The current fix adds a similar waiting condition before the assertion. This now waits until the command pannel shows up with `2 thoughts selected` content. The multiple CI checks after this change has been positive but we should keep an eye on the results as the issue itself is very rare.

[Here](https://github.com/karunkop/em/actions?query=branch%3Amultiselect-mobile-test-fix) is the result of CI checks.