### PR TITLE
Replace ResizeObserver with event listener

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -51,7 +51,6 @@ const useContentWidth = () => {
       if (!(contentRef.current?.firstChild instanceof HTMLElement)) return
       const rect = contentRef.current.firstChild.getBoundingClientRect()
       if (!rect) return
-      console.log(rect.width)
       viewportStore.update({ contentWidth: rect.width })
     }
 


### PR DESCRIPTION
Fixes #3356 

Here is a straightforward replacement of the `ResizeObserver` with a `resize` event listener. It seems to work fine, but it doesn't necessarily "solve" anything except that it no longer shows an error across the top of the viewport.

I'm definitely interested in pursuing a CSS-based solution for the entire `useDropHoverWidth` use case, so I'll look a little deeper into that.