### PR TITLE
Fix: Websocket connnection warnings in puppeteer

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
           // protocol `wss` is required to resolve websocket connection failure
           hmr: {
             host: 'host.docker.internal',
+            // wss uses a secure websocket(wss://) connection. This was necessary to resolve mixed content security error which was observed when using ws protocol only.
             protocol: 'wss',
           },
         },


### PR DESCRIPTION
Close #3341 

The error was a problem with the HMR (Hot Module Replacement) websocket connection between the browser and the Vite dev server. The simple change in HMR config, enabling it to use the `wss` protocol, removes the warnings and errors from the console when running Puppeteer tests. However, I am concerned about the previous comment, which explicitly says that HMR was disabled in Puppeteer tests to not interrupt running tests, but I am not sure what that means. So the main question is, is my current change/fix acceptable knowing that HMR was explicitly disabled previously? I just know that disabling HMR will trigger a full page reload on every change. Also, I came across this solution from https://stackoverflow.com/questions/71956576/vitejs-websocket-connection-to-wss-hostport-failed-due-to-hmr.