### PR TITLE
fix: cropped Cursor Overlay at certain font sizes

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -16,6 +16,7 @@ import getThoughtFill from '../selectors/getThoughtFill'
 import isContextViewActive from '../selectors/isContextViewActive'
 import isMulticursorPath from '../selectors/isMulticursorPath'
 import rootedParentOf from '../selectors/rootedParentOf'
+import calculateCursorOverlayRadius from '../util/calculateCursorOverlayRadius'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
 import parentOf from '../util/parentOf'
@@ -210,7 +211,7 @@ const BulletHighlightOverlay = ({
   publish?: boolean
   simplePath: SimplePath
 }) => {
-  const bulletOverlayRadius = isIOSSafari ? 300 : 245
+  const bulletOverlayRadius = calculateCursorOverlayRadius()
   return (
     <ellipse
       ry={bulletOverlayRadius}

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -4,7 +4,6 @@ import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import Thought from '../@types/Thought'
 import ThoughtId from '../@types/ThoughtId'
-import { isSafari, isTouch, isiPhone } from '../browser'
 import useHideBullet from '../hooks/useHideBullet'
 import useScrollCursorIntoView from '../hooks/useScrollCursorIntoView'
 import attributeEquals from '../selectors/attributeEquals'
@@ -13,6 +12,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isContextViewActive from '../selectors/isContextViewActive'
 import rootedParentOf from '../selectors/rootedParentOf'
+import calculateCursorOverlayRadius from '../util/calculateCursorOverlayRadius'
 import equalThoughtRanked from '../util/equalThoughtRanked'
 import head from '../util/head'
 import isRoot from '../util/isRoot'
@@ -37,8 +37,6 @@ type BulletCursorOverlayProps = {
   index: number
 }
 
-const isIOSSafari = isTouch && isiPhone && isSafari()
-
 /** Returns true if two lists of children are equal. Deeply compares id, value, and rank. */
 const equalChildren = (a: Thought[], b: Thought[]) =>
   a === b ||
@@ -60,7 +58,7 @@ function CursorOverlay({
   isInContextView?: boolean
   isTableCol1?: boolean
 }) {
-  const bulletOverlayRadius = isIOSSafari ? 300 : 245
+  const bulletOverlayRadius = calculateCursorOverlayRadius()
 
   return (
     <BulletPositioner

--- a/src/util/calculateCursorOverlayRadius.ts
+++ b/src/util/calculateCursorOverlayRadius.ts
@@ -1,0 +1,9 @@
+import { isSafari, isTouch, isiPhone } from '../browser'
+
+/**
+ * Calculate the radius of the cursor overlay based on the device and browser.
+ */
+export default function calculateCursorOverlayRadius(): number {
+  const isIOSSafari = isTouch && isiPhone && isSafari()
+  return isIOSSafari ? 290 : 245
+}


### PR DESCRIPTION
Fix #3233 

Fix an issue where the cursor overlay gets cropped on iOS at certain font sizes. The fix reduces the overlay radius by ~1% so it isn’t exactly the full viewBox width, which prevents cropping.


### Results

| Before       | After      |
|--------------|------------|
| <img width="1166" height="566" alt="image" src="https://github.com/user-attachments/assets/9d9e1005-3618-48da-9f5d-f30b9d7526ea" />  | <img width="1026" height="572" alt="image" src="https://github.com/user-attachments/assets/f12ef37b-ea23-4db0-acf4-820df6ca634c" /> |
