### PR TITLE
fix: CommandCenter blurry during first render

### DIFF
--- a/src/components/CommandCenter/CommandCenter.tsx
+++ b/src/components/CommandCenter/CommandCenter.tsx
@@ -96,7 +96,7 @@ const HiddenOverlay = () => {
     <div
       className={css({
         backgroundImage: 'url(/img/command-center/overlay.webp)',
-        display: 'none',
+        visibility: 'hidden',
       })}
     />
   )


### PR DESCRIPTION
Close #3492 

---
## Description
Fixes a case where the Command Center flickering on first render by adding a hidden overlay to preload the overlay assets early, without sacrificing initial page load performance.

**Notes:** This preloading workaround will be applied to all browsers, as I noticed the issue also occurs when opening the app in Chrome on both iOS and Android.
However, on Chrome iOS and Android the flicker shows up as a brief black background during the first render.

## Results

https://github.com/user-attachments/assets/7a858142-1c7f-43f2-93b4-64d522ccee2c

