### PR TITLE
Convert `em` to `rem` unit css pt 2

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -87,7 +87,7 @@ const Alert: FC = () => {
 
       {multicursor && (
         <a
-          className={cx(anchorButtonRecipe(), css({ margin: '0 1em 1em' }))}
+          className={cx(anchorButtonRecipe(), css({ margin: '0 1rem 1rem' }))}
           {...fastClick(() => {
             dispatch(clearMulticursors())
             onClose?.()

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -88,7 +88,7 @@ const glyphFg = cva({
       isBulletExpanded: true,
       css: {
         _mobile: {
-          left: '-0.02em',
+          left: '-0.016rem',
         },
       },
     },

--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -171,10 +171,10 @@ export default function BulletCursorOverlay({
           hidden
           cssRaw={css.raw({
             /* Tighten up the space between the context-breadcrumbs and the thought (similar to the space above a note). */
-            marginBottom: '-0.25em',
+            marginBottom: '-0.21675rem',
             /* Use padding-top instead of margin-top to ensure this gets included in the dynamic height of each thought.
             Otherwise the accumulated y value will not be correct. */
-            paddingTop: '0.5em',
+            paddingTop: '0.4335rem',
           })}
           path={parentOf(simplePath)}
           homeContext={homeContext}

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -68,7 +68,7 @@ const Checkbox: FC<
         opacity: disabled ? 0.5 : undefined,
         marginBottom: children ? (parent ? '0.5rem' : '1rem') : 0,
         // child marginLeft should match .checkbox-container padding-left
-        marginLeft: child ? '2.2em' : undefined,
+        marginLeft: child ? '2.2rem' : undefined,
         pointerEvents: disabled ? 'none' : undefined,
         cursor: disabled ? 'default' : 'pointer',
       })}

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -32,7 +32,7 @@ const BaseCloseButton = ({
         transform: 'translate(50%, -50%)',
         background: 'inherit',
         border: 'inherit',
-        padding: '0.5em',
+        padding: '0.5rem',
       }
     : {}
   const letterStyles = lettered
@@ -67,7 +67,7 @@ const BaseCloseButton = ({
 const CircledCloseButton = (props: CloseButtonProps) => {
   return (
     <BaseCloseButton {...props} circled>
-      <svg fill='currentColor' width='0.5em' height='0.5em' xmlns='http://www.w3.org/2000/svg' viewBox='1 0.5 7 7'>
+      <svg fill='currentColor' width='0.5rem' height='0.5rem' xmlns='http://www.w3.org/2000/svg' viewBox='1 0.5 7 7'>
         <path d='M1.64877 0.515015C1.48064 0.515015 1.31939 0.58189 1.20064 0.700647C0.953139 0.948151 0.953139 1.3494 1.20064 1.5969L3.60384 4.00058L1.20064 6.40378C0.953139 6.65129 0.953139 7.05253 1.20064 7.30004C1.44815 7.54692 1.84939 7.54692 2.0969 7.30004L4.50058 4.89636L6.90378 7.30004C7.15128 7.54692 7.55191 7.54692 7.79941 7.30004C8.04692 7.05253 8.04692 6.65129 7.79941 6.40378L5.39621 4.00058L7.79941 1.5969C8.04692 1.3494 8.04692 0.948151 7.79941 0.700647C7.68066 0.581896 7.51941 0.515015 7.35191 0.515015C7.18378 0.515015 7.02253 0.58189 6.90378 0.700647L4.50058 3.10433L2.0969 0.700647C1.97752 0.581896 1.8169 0.515015 1.64877 0.515015Z'></path>
       </svg>
     </BaseCloseButton>

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -208,11 +208,11 @@ const ContextBreadcrumbs = ({
       aria-label={hidden ? undefined : 'context-breadcrumbs'}
       className={css(
         {
-          fontSize: '0.867em',
+          fontSize: '0.867rem',
           color: 'gray66',
-          marginLeft: 'calc(1.3em - 14.5px)',
+          marginLeft: 'calc(1.1271rem - 14.5px)',
           marginTop: '0.533em',
-          minHeight: '1em',
+          minHeight: '0.867rem',
           visibility: hidden ? 'hidden' : undefined,
         },
         cssRaw,

--- a/src/components/LayoutTree.tsx
+++ b/src/components/LayoutTree.tsx
@@ -264,7 +264,7 @@ const LayoutTree = () => {
     <div
       className={cx(
         css({
-          marginTop: '0.501em',
+          marginTop: '0.501rem',
         }),
         fauxCaretTreeProvider(indent),
       )}

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -101,7 +101,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           textAlign,
           zIndex: 'popup',
           // leave space so the circledCloseButton doesn't get cut off from the screen
-          maxWidth: circledCloseButton ? 'calc(100% - 2em)' : '100%',
+          maxWidth: circledCloseButton ? 'calc(100% - 2rem)' : '100%',
           maxHeight: '100%',
           marginInline: 'auto',
           left: 0,

--- a/src/components/SortPicker.tsx
+++ b/src/components/SortPicker.tsx
@@ -46,7 +46,7 @@ const SortOption: FC<SortOptionProps> = ({ type, supportsDirection, label, sortP
         justifyContent: 'center',
         border: isSelected ? `solid 1px {colors.fg}` : `solid 1px {colors.transparent}`,
         cursor: 'pointer',
-        fontSize: '0.9em',
+        fontSize: '0.8rem',
         borderRadius: '2px',
       })}
       aria-label={type}

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -567,10 +567,10 @@ const ThoughtContainer = ({
         <ContextBreadcrumbs
           cssRaw={css.raw({
             /* Tighten up the space between the context-breadcrumbs and the thought (similar to the space above a note). */
-            marginBottom: '-0.25em',
+            marginBottom: '-0.21675rem',
             /* Use padding-top instead of margin-top to ensure this gets included in the dynamic height of each thought.
               Otherwise the accumulated y value will not be correct. */
-            paddingTop: '0.5em',
+            paddingTop: '0.4335rem',
           })}
           path={parentOf(simplePath)}
           homeContext={homeContext}


### PR DESCRIPTION
part of #3018  

## Description
Convert em to rem unit css, affected components:
- Bullet
- Alert
- BulletCursorOverlay
- ContextBreadcrumb
- SortPicker
- PopupBase
- Checkbox
- LayoutTree