### PR TITLE
StaticThought: only apply long press attributes if isTouch

### DIFF
--- a/src/components/StaticThought.tsx
+++ b/src/components/StaticThought.tsx
@@ -35,7 +35,7 @@ export interface ThoughtProps {
   allowSingleContext?: boolean
   debugIndex?: number
   dragSource: ConnectDragSource
-  longPressProps: LongPressProps
+  longPressProps?: LongPressProps
   editing?: boolean | null
   env?: LazyEnv
   // When context view is activated, some contexts may be pending

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -604,7 +604,7 @@ const ThoughtContainer = ({
           <StaticThought
             allowSingleContext={allowSingleContext}
             dragSource={dragSourceEditable}
-            longPressProps={dragHoldResult.props}
+            longPressProps={isTouch ? dragHoldResult.props : undefined}
             env={env}
             isContextPending={isContextPending}
             isEditing={isEditing}


### PR DESCRIPTION
Fixes #3287 and #3571 

When drag-and-drop functionality was divided into 2 parts in #3355, I blocked drag-and-drop functionality from being applied to the `StaticThought` on desktop. I did not block long-press functionality from `useLongPress`, which contains some drag-and-drop overlap due to the challenges of controlling `react-dnd` behavior. Now the long-press event handlers will only be applied to `StaticThought` on touch devices.