### PR TITLE
Track mounted status in sizes cache

### DIFF
--- a/src/hooks/usePositionedThoughts.ts
+++ b/src/hooks/usePositionedThoughts.ts
@@ -21,7 +21,7 @@ const usePositionedThoughts = (
   }: {
     maxVisibleY: number
     singleLineHeight: number
-    sizes: Index<{ height: number; width?: number; isVisible: boolean; cliff?: number }>
+    sizes: Index<{ height: number; width?: number; isVisible: boolean; mounted: boolean; cliff?: number }>
   },
 ): {
   indentCursorAncestorTables: number
@@ -179,7 +179,12 @@ const usePositionedThoughts = (
           - [empty]
       */
       const isNewCliff =
-        !sizes[node.key] && cliff < 0 && prev && node.depth >= prev.depth && (prevCliff === undefined || prevCliff < 0)
+        // the node does not exist in the sizes cache, or it has been removed but is still cached (#3310)
+        !sizes[node.key]?.mounted &&
+        cliff < 0 &&
+        prev &&
+        node.depth >= prev.depth &&
+        (prevCliff === undefined || prevCliff < 0)
 
       // Capture the y position of the current thought before it is incremented by its own height for the next thought.
       const y = yaccum - (isNewCliff ? cliffPadding : 0)

--- a/src/hooks/useSizeTracking.ts
+++ b/src/hooks/useSizeTracking.ts
@@ -9,7 +9,9 @@ const SIZE_REMOVAL_DEBOUNCE = 1000
 /** Dynamically update and remove sizes for different keys. */
 const useSizeTracking = () => {
   // Track dynamic thought sizes from inner refs via VirtualThought. These are used to set the absolute y position which enables animation between any two states. isVisible is used to crop hidden thoughts.
-  const [sizes, setSizes] = useState<Index<{ height: number; width?: number; isVisible: boolean }>>({})
+  const [sizes, setSizes] = useState<Index<{ height: number; width?: number; isVisible: boolean; mounted: boolean }>>(
+    {},
+  )
   const fontSize = useSelector(state => state.fontSize)
   const unmounted = useRef(false)
 
@@ -22,6 +24,7 @@ const useSizeTracking = () => {
   // Use throttleConcat to accumulate all keys to be removed during the interval.
   // TODO: Is a root cause of the mount-unmount loop.
   const removeSize = useCallback((key: string) => {
+    setSizes(sizesOld => ({ ...sizesOld, [key]: { ...sizesOld[key], mounted: false } }))
     clearTimeout(sizeRemovalTimeouts.current.get(key))
     const timeout = setTimeout(() => {
       if (unmounted.current) return
@@ -71,6 +74,7 @@ const useSizeTracking = () => {
                   width: width || undefined,
                   cliff,
                   isVisible,
+                  mounted: true,
                 },
               },
         )


### PR DESCRIPTION
Fixes #3310 

In `usePositionedThought`, the presence of a new cliff is detected by checking that a node does not exist in the `sizes` cache. Since there's a 1-second debounce when removing a node from `sizes`, it will erroneously set `isNewCliff = false` when that debounce is still in progress. I added a `mounted` property to the `sizes` objects that can be immediately set to false in order to calculate `isNewCliff` correctly.

It would be nice to revisit this debounce and figure out if it's still necessary. I see that it was merged as part of #1713, but that doesn't have much information about the individual commits. Do you happen to remember a test case for reproducing the original issue? I tried setting `SIZE_REMOVAL_DEBOUNCE` to 0 and didn't notice anything immediately breaking.