### PR TITLE
Don't override multiline padding on iOS Safari

### DIFF
--- a/src/components/ThoughtAnnotationWrapper.tsx
+++ b/src/components/ThoughtAnnotationWrapper.tsx
@@ -75,7 +75,7 @@ const ThoughtAnnotationWrapper: FC<
                 }),
               display: 'inline-block',
               maxWidth: '100%',
-              padding: '0 0.333em',
+              paddingLeft: '0.333em',
               boxSizing: 'border-box',
               whiteSpace: ellipsizedUrl ? 'nowrap' : undefined,
               /*


### PR DESCRIPTION
Fixes #3280

It looks like [the padding](https://github.com/ethan-james/em/blob/692c63114989d40b5b73371544c330b16765aa59/src/components/ThoughtAnnotationWrapper.tsx#L78) on `ThoughtAnnotationWrapper` was overriding [paddingTop](https://github.com/ethan-james/em/blob/692c63114989d40b5b73371544c330b16765aa59/src/recipes/multiline.ts#L24) set in the multiline recipe. This doesn't seem like it should be the case because multiline has `!important` on it, but I inspected the element and I see no top padding:

<img width="1174" height="251" alt="Screenshot 2026-01-15 at 4 59 16 PM" src="https://github.com/user-attachments/assets/eed4e6e6-3d3f-483b-93b4-79c6d3f0356e" />

and then after changing `padding` to `paddingLeft`, I see top padding:

<img width="1162" height="292" alt="Screenshot 2026-01-15 at 4 58 20 PM" src="https://github.com/user-attachments/assets/62e06a7a-f31d-4208-b654-8eb8355c7db7" />
