### PR TITLE
Enable Browserstack iOS tests in GitHub Actions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,13 +15,7 @@ on:
 
 env:
   CI: true
-  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS:
-    googlechromelabs.github.io,storage.googleapis.com
-    # BrowserStack credentials - WDIO's browserstack-service handles the tunnel
-  BROWSERSTACK_USERNAME: ${{secrets.BROWSERSTACK_USERNAME}}
-  BROWSERSTACK_ACCESS_KEY: ${{secrets.BROWSERSTACK_ACCESS_KEY}}
-  BROWSERSTACK_BUILD_NAME: 'CI - ${{github.run_id}}'
-  BROWSERSTACK_PROJECT_NAME: 'em'
+  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
 
 jobs:
   run:
@@ -53,19 +47,10 @@ jobs:
         run: yarn servebuild &
 
       - name: Test iOS on BrowserStack
-        run: |
-          # Verify secrets are available before running tests
-          if [ -z "$BROWSERSTACK_USERNAME" ]; then
-            echo "ERROR: BROWSERSTACK_USERNAME environment variable is not set"
-            echo "This usually means the secret is not configured in repository settings"
-            echo "or this is a PR from a fork (secrets are not available for security reasons)"
-            exit 1
-          fi
-          if [ -z "$BROWSERSTACK_ACCESS_KEY" ]; then
-            echo "ERROR: BROWSERSTACK_ACCESS_KEY environment variable is not set"
-            echo "This usually means the secret is not configured in repository settings"
-            echo "or this is a PR from a fork (secrets are not available for security reasons)"
-            exit 1
-          fi
-          echo "BrowserStack credentials verified (username: ${BROWSERSTACK_USERNAME:0:2}...)"
-          yarn test:ios
+        run: yarn test:ios
+        env:
+          # BrowserStack credentials - WDIO's browserstack-service handles the tunnel
+          BROWSERSTACK_USERNAME: ${{secrets.BROWSERSTACK_USERNAME}}
+          BROWSERSTACK_ACCESS_KEY: ${{secrets.BROWSERSTACK_ACCESS_KEY}}
+          BROWSERSTACK_BUILD_NAME: 'CI - ${{github.run_id}}'
+          BROWSERSTACK_PROJECT_NAME: 'em'

--- a/src/e2e/iOS/config/wdio.browserstack.conf.ts
+++ b/src/e2e/iOS/config/wdio.browserstack.conf.ts
@@ -21,6 +21,9 @@ if (!process.env.CI) {
   }
 }
 
+const user = process.env.BROWSERSTACK_USERNAME
+const date = new Date().toISOString().slice(0, 10)
+
 /**
  * WDIO configuration for BrowserStack iOS testing.
  * Uses @wdio/browserstack-service for automatic tunnel management.
@@ -31,36 +34,12 @@ if (!process.env.CI) {
  *
  * Run: yarn test:ios:browserstack.
  */
-
-// Log BrowserStack credentials for debugging (mask key for security)
-const username = process.env.BROWSERSTACK_USERNAME
-const accessKey = process.env.BROWSERSTACK_ACCESS_KEY
-
-// Debug: Log all relevant environment variables
-console.info('[BrowserStack Config] CI:', process.env.CI)
-console.info('[BrowserStack Config] All BROWSERSTACK_* env vars:', {
-  BROWSERSTACK_USERNAME: username ? `${username.substring(0, 2)}...` : 'undefined',
-  BROWSERSTACK_ACCESS_KEY: accessKey ? 'defined' : 'undefined',
-  BROWSERSTACK_PROJECT_NAME: process.env.BROWSERSTACK_PROJECT_NAME || 'undefined',
-  BROWSERSTACK_BUILD_NAME: process.env.BROWSERSTACK_BUILD_NAME || 'undefined',
-})
-
-const maskedKey = accessKey
-  ? `${accessKey.substring(0, 4)}...${accessKey.substring(accessKey.length - 4)}`
-  : 'undefined'
-
-console.info('[BrowserStack Config] Username:', username || 'undefined')
-console.info('[BrowserStack Config] Access Key:', maskedKey)
-console.info('[BrowserStack Config] Project:', process.env.BROWSERSTACK_PROJECT_NAME || 'em')
-console.info('[BrowserStack Config] Build Name:', process.env.BROWSERSTACK_BUILD_NAME || 'not set')
-
 export const config: WebdriverIO.Config = {
   ...baseConfig,
 
   // BrowserStack Configuration
-  // Use env vars directly to ensure they're read at runtime, not module load time
-  user: username,
-  key: accessKey,
+  user,
+  key: process.env.BROWSERSTACK_ACCESS_KEY,
 
   // Capabilities
   capabilities: [
@@ -74,9 +53,7 @@ export const config: WebdriverIO.Config = {
         deviceName: 'iPhone 15 Plus',
         osVersion: '17',
         projectName: process.env.BROWSERSTACK_PROJECT_NAME || 'em',
-        buildName:
-          process.env.BROWSERSTACK_BUILD_NAME ||
-          `Local - ${process.env.BROWSERSTACK_USERNAME || 'unknown'} - ${new Date().toISOString().slice(0, 10)}`,
+        buildName: process.env.BROWSERSTACK_BUILD_NAME || `Local - ${user} - ${date}`,
         sessionName: 'iOS Safari Tests',
         local: true,
         debug: true,


### PR DESCRIPTION
Close #3603 

- enabled browserstacks ios automated tests while opening PRs

For the ios test to work in CI, we need to add in `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` as secrets in this repository. @raineorshine 