### PR TITLE
Remove debounce from removeSize

### DIFF
--- a/src/hooks/useSizeTracking.ts
+++ b/src/hooks/useSizeTracking.ts
@@ -10,10 +10,6 @@ const useSizeTracking = () => {
   const fontSize = useSelector(state => state.fontSize)
   const unmounted = useRef(false)
 
-  // Removing a size immediately on unmount can cause an infinite mount-unmount loop as the VirtualThought re-render triggers a new height calculation (iOS Safari only).
-  // Debouncing size removal mitigates the issue.
-  // Use throttleConcat to accumulate all keys to be removed during the interval.
-  // TODO: Is a root cause of the mount-unmount loop.
   const removeSize = useCallback((key: string) => {
     if (unmounted.current) return
     setSizes(sizesOld => {


### PR DESCRIPTION
Fixes #3310, hopefully supersedes #3640

I ripped out [setTimeout](https://github.com/ethan-james/em/blob/f954fce7c614f5cfa2bc5ed273930368ac6901b6/src/hooks/useSizeTracking.ts#L26) entirely, rather than calling `setTimeout` with a zero delay, which is another option in case this approach fails.

I tested it with the repro steps from #3310, and will continue to test it in other ways.