### PR TITLE
Enable Browsterstack iOS tests in CI with pull_request_target

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,15 +1,16 @@
 name: BrowserStack
 
-# Temporarily disable the workflow except when manually triggered
-# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
-on: workflow_dispatch
-
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request_target:
-#     types: [opened, synchronize, reopened]
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      rerun_id:
+        description: 'Optional ID for tracking repeated runs'
+        required: false
 
 env:
   CI: true


### PR DESCRIPTION
This won't trigger the CI in this PR, but once it's merged it should trigger against new PR's that are opened against `main`.