### PR TITLE
Replace setTimeout with requestAnimationFrame in useFauxCaretCssVars

### DIFF
--- a/src/hooks/useFauxCaretCssVars.ts
+++ b/src/hooks/useFauxCaretCssVars.ts
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import FauxCaretType from '../@types/FauxCaretType'
 import Path from '../@types/Path'
 import { isSafari, isTouch } from '../browser'
 import { isEndOfElementNode, isStartOfElementNode } from '../device/selection'
 import editingValueStore from '../stores/editingValue'
+import useLayoutAnimationFrameEffect from './useLayoutAnimationFrameEffect'
 
 /** Returns CSS variables that will suppress faux carets at the start or end of thoughts or notes.
  * */
@@ -34,24 +35,19 @@ const useFauxCaretNodeProvider = ({
 
   // If the thought isCursor and keyboard is open, position the faux cursor at the point where the
   // selection is created.
-  useEffect(
+  // The selection ranges aren't updated until the end of the frame when the thought is focused.
+  useLayoutAnimationFrameEffect(
     () => {
-      let timeout = undefined
       if (!isTouch || !isSafari()) return
       if (editing && isCursor) {
-        // The selection ranges aren't updated until the end of the frame when the thought is focused.
-        timeout = requestAnimationFrame(() => {
-          if (noteFocus) {
-            setFauxCaretType(isStartOfElementNode() ? 'noteStart' : isEndOfElementNode() ? 'noteEnd' : 'none')
-          } else {
-            setFauxCaretType(isStartOfElementNode() ? 'thoughtStart' : isEndOfElementNode() ? 'thoughtEnd' : 'none')
-          }
-        })
+        if (noteFocus) {
+          setFauxCaretType(isStartOfElementNode() ? 'noteStart' : isEndOfElementNode() ? 'noteEnd' : 'none')
+        } else {
+          setFauxCaretType(isStartOfElementNode() ? 'thoughtStart' : isEndOfElementNode() ? 'thoughtEnd' : 'none')
+        }
       } else {
         setFauxCaretType('none')
       }
-
-      return () => clearTimeout(timeout)
     },
     /* Changes to fadeThoughtElement and isTableCol1 can trigger the hideCaret animation to update, even though they are not directly used in calculating the caret type. */ [
       editing,


### PR DESCRIPTION
Fixes #3574

Flipping the cursor between different indent levels causes [isStartOfElementNode](https://github.com/ethan-james/em/blob/f5874eda23a1228ed88dce41c475f6c836e903ce/src/device/selection.ts#L158) to intermittently return the previous selection rather than the new selection. Replacing `setTimeout` with [requestAnimationFrame](https://github.com/ethan-james/em/blob/f5874eda23a1228ed88dce41c475f6c836e903ce/src/hooks/useFauxCaretCssVars.ts#L43) seems to reliably fix this. It's counter-intuitive because usually `requestAnimationFrame` seems to run with less of a delay than `setTimeout`, but I did mess around and get it to show me `setTimeout` coming in first (following the repro steps for #3574).

<img width="391" height="135" alt="Screenshot 2026-01-19 at 1 46 45 PM" src="https://github.com/user-attachments/assets/a85c139a-2777-4152-be8d-800700e6bc71" />

The `3` and `4` are logging `path.length`, showing that it is running for `C` and `D` respectively.

I went back through the old faux caret PRs and tested this against as many test cases as I could find, and it seems solid. #3666 still affects this solution, and looks a bit worse because both the previous cursor and the new cursor show a faux caret simultaneously.