### PR TITLE
Fix Sidebar regressions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -98,7 +98,7 @@ const Sidebar = () => {
     /** Whether the touch started on the backdrop (outside drawer). */
     startedOnBackdrop: false,
     /** Whether the finger has entered the drawer area (for backdrop-initiated swipes). */
-    paperHit: false,
+    drawerHit: false,
     /** Starting X position. */
     startX: 0,
     /** Starting Y position. */
@@ -222,7 +222,7 @@ const Sidebar = () => {
         active: true,
         isSwiping: null, // Direction not yet determined
         startedOnBackdrop,
-        paperHit: !startedOnBackdrop, // If started inside drawer, we've already "hit" it
+        drawerHit: !startedOnBackdrop, // If started inside drawer, we've already "hit" it
         startX: touchX,
         startY: touchY,
         lastTime: performance.now(),
@@ -250,10 +250,10 @@ const Sidebar = () => {
       swipe.lastX = touchX
 
       // For backdrop-initiated swipes, check if finger has entered the drawer
-      if (swipe.startedOnBackdrop && !swipe.paperHit) {
+      if (swipe.startedOnBackdrop && !swipe.drawerHit) {
         if (touchX < widthPx) {
           // Finger just entered drawer - "pick it up"
-          swipe.paperHit = true
+          swipe.drawerHit = true
           swipe.startX = touchX
           swipe.startY = touchY
         } else {
@@ -310,7 +310,7 @@ const Sidebar = () => {
       if (!swipe.active) return
 
       // Only process if we were actually swiping
-      if (swipe.isSwiping && swipe.paperHit) {
+      if (swipe.isSwiping && swipe.drawerHit) {
         const offset = Math.abs(x.get())
         const velocity = Math.max(swipe.velocity, 0)
         handleSwipeEnd(offset, velocity)
@@ -319,7 +319,7 @@ const Sidebar = () => {
       // Reset state
       swipe.active = false
       swipe.isSwiping = null
-      swipe.paperHit = false
+      swipe.drawerHit = false
       setIsSwiping(false)
     }
 


### PR DESCRIPTION
**Fixes #3713, #3714, #3715 and #3718.**

MUI's drawer had a number of manual optimizations to touch behavior. Replacing the drawer with Radix UI lost these optimizations, causing a number of behavioral regressions.

This PR directly ports logic from MUI's SwipeableDrawer to resolve these issues, and maintain behavior as close to MUI as possible:

- Rather than using an event listener bound to the drawer, use a document-level event listener – allowing swipes to start from outside the drawer.
- Allow short + fast swipes to close the drawer by using a simple scoring system that weighs both velocity & distance.
- Prevent the drawer from closing while scrolling vertically with a 3px "uncertainty threshold" – after 3px of vertical scrolling, lock horizontal swipes, and vice versa

Additionally, the drawer can now be closed as expected on Android Chrome by setting `touch-action: pan-y` on the sidebar.

## Tests

Tests were all passing, but since rebasing to `main` tests failed due to changes made in 681981c969b809cc68a72010ca4eaaaab87f27e0 (need to update tests from `SortPicker` ->  `Sort Picker).

Happy to retest/rebase on `main` again once that is fixed.

