### PR TITLE
Hide start/end faux caret on tap

### DIFF
--- a/src/components/TreeNode.tsx
+++ b/src/components/TreeNode.tsx
@@ -70,7 +70,7 @@ const TreeNode = ({
   const fadeThoughtRef = useRef<HTMLDivElement>(null)
   const [isMounted, setIsMounted] = useState(true)
 
-  const { fauxCaretNodeProviderStyles, fauxCaretTapHandler } = useFauxCaretNodeProvider({
+  const { styles: fauxCaretNodeProviderStyles, hide: hideFauxCaret } = useFauxCaretNodeProvider({
     editing,
     fadeThoughtElement: fadeThoughtRef.current,
     isCursor,
@@ -156,7 +156,12 @@ const TreeNode = ({
           ...fauxCaretNodeProviderStyles,
         }}
       >
-        <div ref={fadeThoughtRef} onClick={fauxCaretTapHandler}>
+        <div
+          ref={fadeThoughtRef}
+          // It's possible for both the positioned faux caret and the start/end faux caret to be active at once, so hide the start/end
+          // caret after a tap activates the positioned faux caret. https://github.com/cybersemics/em/pull/3757
+          onClick={hideFauxCaret}
+        >
           <VirtualThought
             debugIndex={testFlags.simulateDrop ? indexChild : undefined}
             depth={depth}

--- a/src/hooks/useFauxCaretCssVars.ts
+++ b/src/hooks/useFauxCaretCssVars.ts
@@ -61,13 +61,13 @@ const useFauxCaretNodeProvider = ({
   )
 
   return {
-    fauxCaretNodeProviderStyles: {
+    styles: {
       '--faux-caret-line-start-opacity': fauxCaretType === 'thoughtStart' ? undefined : 0,
       '--faux-caret-line-end-opacity': fauxCaretType === 'thoughtEnd' ? undefined : 0,
       '--faux-caret-note-line-start-opacity': fauxCaretType === 'noteStart' ? undefined : 0,
       '--faux-caret-note-line-end-opacity': fauxCaretType === 'noteEnd' ? undefined : 0,
     },
-    fauxCaretTapHandler: isTouch && isSafari() ? () => setFauxCaretType('none') : undefined,
+    hide: isTouch && isSafari() ? () => setFauxCaretType('none') : undefined,
   }
 }
 


### PR DESCRIPTION
Fixes #3666 

The original issue was fixed in #3746, but there were still some double-faux-caret issues. Since [fauxCaretType](https://github.com/ethan-james/em/blob/d1995e6d404412272fc381ff6bdd07ab992f8617/src/hooks/useFauxCaretCssVars.ts#L26) for start/end faux carets is controlled independently from [the positioned faux caret](https://github.com/ethan-james/em/blob/d1995e6d404412272fc381ff6bdd07ab992f8617/src/components/FauxCaret.tsx#L61), it's possible for both of them to be active at the same time.

The straightforward solution that I tried here is to add a `fauxCaretTapHandler` that will hide the start/end faux carets when a thought is tapped. The only time that I can foresee where a faux caret would change from start/end to positioned is after a tap. It would also be possible to try and create a centralized enum that permits only one discrete type of faux caret to exist at a time.