### PR TITLE
fix(WebviewBackgroundPlugin): dispatch `changeBackgroundColor` on main thread

### DIFF
--- a/packages/webview/ios/Sources/WebviewBackgroundPlugin/WebviewBackgroundPlugin.swift
+++ b/packages/webview/ios/Sources/WebviewBackgroundPlugin/WebviewBackgroundPlugin.swift
@@ -16,7 +16,9 @@ public class WebviewBackgroundPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func changeBackgroundColor(_ call: CAPPluginCall) {
         let color = call.getString("color") ?? ""
 
-        self.webView?.backgroundColor = UIColor(named: color)
-        self.webView?.scrollView.backgroundColor = UIColor(named: color)
+        DispatchQueue.main.async {
+            self.webView?.backgroundColor = UIColor(named: color)
+            self.webView?.scrollView.backgroundColor = UIColor(named: color)
+        }
     }
 }


### PR DESCRIPTION
_No corresponding issue on GitHub._

---

## Summary

@BayuAri noticed an issue where opening the Capacitor build of **em** on iOS 26.x resulted in a crash:

<img width="1762" height="952" alt="image" src="https://github.com/user-attachments/assets/6c93f290-2f41-4e37-b658-3d25bd79a6d7" />

In the screenshot, the debugger shows an exception being thrown because UI changes were being called off the main thread. The wording of the message seems to suggest this is a recent OS change, although I wasn't able to find much information about it online.

Although I wasn't able to reproduce the _crash_, I did see a console warning in Xcode's debugger that called out the same issue:

<img width="224.5" height="260" alt="Screenshot 2026-02-04 at 02 32 11" src="https://github.com/user-attachments/assets/55a5b985-2f7b-4926-83ce-3d6700fe6de2" />

The culprit is a section of code in the `WebviewBackgroundPlugin` (`packages/webview`), which changes the webview's background colour.

## Fix

In this PR, we make a small modification to the plugin to make sure UI changes to the webview are _always_ done on the main thread.

## Results

This resolved the crash for @BayuAri, and removed the console warning for me.