### PR TITLE
Disable text selection on alert notifications

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -59,6 +59,7 @@ const Notification: FC<
                 alignItems: 'center',
                 padding: '0.85em 1.1em',
                 maxWidth: '30em',
+                userSelect: 'none',
               })}
             >
               {icon}


### PR DESCRIPTION
## Summary
- Adds `userSelect: 'none'` to the alert content div in `Notification.tsx` to prevent long-press text selection on mobile
- Fixes the issue where alert text (e.g., "Permanently Deleted" confirmation) was selectable via long-press, showing an unwanted text selector and tools bubble

## Test plan
- [ ] Delete a thought and long-press on the "Permanently Deleted" alert text — text should not be selectable
- [ ] Verify alert content is still visible and readable
- [ ] Verify alert dismiss (swipe/close) still works normally

Closes #3789

🤖 Generated with [Claude Code](https://claude.com/claude-code)