### PR TITLE
Disable formatting in notes

### DIFF
--- a/src/commands/bold.ts
+++ b/src/commands/bold.ts
@@ -14,7 +14,7 @@ const bold: Command = {
   svg: Icon,
   keyboard: { key: 'b', meta: true },
   canExecute: state => {
-    return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
+    return isDocumentEditable() && !state.noteFocus && (!!state.cursor || hasMulticursor(state))
   },
   exec: dispatch => {
     dispatch(formatSelection('bold'))

--- a/src/commands/italic.ts
+++ b/src/commands/italic.ts
@@ -14,7 +14,7 @@ const italic: Command = {
   keyboard: { key: 'i', meta: true },
   multicursor: true,
   canExecute: state => {
-    return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
+    return isDocumentEditable() && !state.noteFocus && (!!state.cursor || hasMulticursor(state))
   },
   exec: dispatch => {
     dispatch(formatSelection('italic'))

--- a/src/commands/strikethrough.ts
+++ b/src/commands/strikethrough.ts
@@ -14,7 +14,7 @@ const strikethrough: Command = {
   keyboard: { key: 's', meta: true },
   multicursor: true,
   canExecute: state => {
-    return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
+    return isDocumentEditable() && !state.noteFocus && (!!state.cursor || hasMulticursor(state))
   },
   exec: (dispatch, getState, e) => {
     e.preventDefault()

--- a/src/commands/textColor.ts
+++ b/src/commands/textColor.ts
@@ -9,7 +9,7 @@ const textColor: Command = {
   label: 'Text Color',
   description: 'Change the text color or highlight color to your liking.',
   svg: TextColorWithColorPicker,
-  canExecute: state => isDocumentEditable() && !!state.cursor,
+  canExecute: state => isDocumentEditable() && !state.noteFocus && !!state.cursor,
   multicursor: {
     disallow: true,
     error: 'Cannot change text color with multiple thoughts.',

--- a/src/commands/underline.ts
+++ b/src/commands/underline.ts
@@ -16,7 +16,7 @@ const underline: Command = {
     preventSetCursor: true,
   },
   canExecute: state => {
-    return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
+    return isDocumentEditable() && !state.noteFocus && (!!state.cursor || hasMulticursor(state))
   },
   exec: dispatch => {
     dispatch(formatSelection('underline'))


### PR DESCRIPTION
Fixes #3717 

I added `!state.noteFocus` to the commands to disable the editing buttons when the caret is in a note. It is still possible to format notes using keyboard commands (i.e. Ctrl-B) and in order to disable those, I would like to add `contenteditable="plaintext-only"` to the note div. Unfortunately, `react-contenteditable` doesn't seem to offer that as a prop. Do you think it makes sense to vendor `react-contenteditable` so that I can make that change, given that the last commit to that library was 3 years ago?