### PR TITLE
fix: Preload Webp image for PWA

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       filename: 'service-worker.ts',
       injectManifest: {
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024, // Increase limit to 4 MiB
+        globPatterns: ['**/*.{js,css,html,webp}'],
       },
       manifest: {
         name: 'em',


### PR DESCRIPTION
Fix #3623 

Added `webp` to vite pwa config `globPatterns` so all webp images are included in the precache manifest.
This ensures the overlay background image is downloaded during service worker installation, eliminating first-use network fetch and guaranteeing offline availability.

**Note:** We’re still keeping the solution in #3550 so the preload image still runs in the development server. Since the service worker does not always run or behave consistently in dev mode, this ensures the background image is fetched early and prevents flicker during local development

https://github.com/user-attachments/assets/8e6f3e68-c04f-4cb8-981c-7490738be45f

