### PR TITLE
Add test to apply formatting to a selected portion of a thought

### DIFF
--- a/src/e2e/puppeteer/__tests__/format.ts
+++ b/src/e2e/puppeteer/__tests__/format.ts
@@ -4,7 +4,7 @@ import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
 import { page } from '../setup'
 
-vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
+vi.setConfig({ testTimeout: 20000, hookTimeout: 60000 })
 
 it('Apply formatting to a selected portion of a thought', async () => {
   const importText = `


### PR DESCRIPTION
Fixes #2971 

I added a test that applies formatting to a selected portion of a thought. It's a Puppeteer test because that seems like the most realistic way to test selection behavior.