### PR TITLE
Fix toolbar not sticking on Android devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing"
             android:exported="true">
 
             <intent-filter>

--- a/android/app/src/main/java/com/emtheapp/em/MainActivity.java
+++ b/android/app/src/main/java/com/emtheapp/em/MainActivity.java
@@ -1,5 +1,30 @@
 package com.emtheapp.em;
 
+import android.os.Bundle;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // When the keyboard (IME) opens, Android sends window insets to the FrameLayout that contains the WebView.
+        // This causes the WebView to resize, which causes the viewport to resize and breaks position: fixed elements.
+        // To fix this, we can strip the insets so the FrameLayout (and therefore the WebView) don't resize when the keyboard
+        // opens.
+        //
+        // This is the Android equivalent of Capacitor's iOS Keyboard { resize: 'none' }, but because that option doesn't
+        // exist on Android, we have to do it manually instead.
+        
+        ViewCompat.setOnApplyWindowInsetsListener(
+            findViewById(android.R.id.content),
+            (view, insets) -> new WindowInsetsCompat.Builder(insets)
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+                .build()
+        );
+    }
+}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=overlays-content"
     />
     <meta name="mobile-web-app-capable" content="yes" />
 


### PR DESCRIPTION
**Closes #3815**

On Android Capacitor and Chrome, `position: fixed` elements scroll when the virtual keyboard is open. Some debugging showed that this is due to the virtual viewport resizing when the keyboard is open (see debug info in the top-left)

https://github.com/user-attachments/assets/c857f8f5-5629-4755-a3ba-f0f0c79dff45

Contrast this to the behavior on iOS, where thanks to Capacitor's `{ resize: 'none' }`, the visual viewport stays the same regardless of if the keyboard is open or not:

https://github.com/user-attachments/assets/960b8346-8b3b-49c3-b1dd-be26df81736f

---

Capacitor doesn't support `{ resize: 'none' }` on Android, so we have to implement a native solution to this problem ourselves:

1. **Strip window insets:**
    - When the keyboard (IME) opens, Android sends updated window insets to the FrameLayout that contains the WebView.
    - This causes the WebView to resize, which causes the viewport to resize and breaks position: fixed elements.
    - To fix this, we can strip the insets so the FrameLayout (and therefore the WebView) don't resize when the keyboard opens.

2. **Set `android:windowSoftInputMode="adjustNothing"` in AndroidManifest.xml**
    - This disables Android's native autoscroll, matching the behavior in iOS.

3. **Set meta tag `interactive-widget=overlays-content`**
    - This disables virtual viewport resizing in _Android Chrome_.

The result: Android behaviour now matches iOS behaviour, and `position: fixed` elements stay fixed as expected.

https://github.com/user-attachments/assets/0eb98811-695a-4da5-b75f-190e6afa1894
