### PR TITLE
Decouple Tip from Notification component

### DIFF
--- a/src/components/Tips/Tip.tsx
+++ b/src/components/Tips/Tip.tsx
@@ -1,10 +1,14 @@
-import { FC, PropsWithChildren, useCallback } from 'react'
+import React, { FC, PropsWithChildren, useCallback, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useSelector } from 'react-redux'
+import { TransitionGroup } from 'react-transition-group'
 import { css } from '../../../styled-system/css'
+import { token } from '../../../styled-system/tokens'
 import TipId from '../../@types/TipId'
 import { dismissTipActionCreator as dismissTip } from '../../actions/dismissTip'
-import Notification from '../Notification'
+import { isTouch } from '../../browser'
+import FadeTransition from '../FadeTransition'
+import PopupBase from '../PopupBase'
 import LightBulbIcon from '../icons/LightBulbIcon'
 
 const icon = (
@@ -33,12 +37,58 @@ const Tip: FC<
 > = ({ tipId, children }) => {
   const dispatch = useDispatch()
   const tip = useSelector(state => state.tip)
+  const [isDismissed, setIsDismissed] = useState(false)
 
   const onClose = useCallback(() => {
     dispatch(dismissTip())
   }, [dispatch])
 
-  return <Notification icon={icon} transitionKey={tipId} value={tip === tipId ? children : null} onClose={onClose} />
+  const handleClose = useCallback(() => {
+    setIsDismissed(true)
+    onClose()
+  }, [onClose])
+
+  const value = tip === tipId ? children : null
+
+  // if dismissed, set timeout to 0 to remove tip component immediately. Otherwise it will block toolbar interactions until the timeout completes.
+  return (
+    <TransitionGroup
+      childFactory={(child: React.ReactElement<{ timeout: number }>) =>
+        !isDismissed ? child : React.cloneElement(child, { timeout: 0 })
+      }
+    >
+      {value ? (
+        <FadeTransition type='slow' onEntering={() => setIsDismissed(false)}>
+          <PopupBase
+            anchorFromBottom
+            anchorOffset={36}
+            key={tipId}
+            circledCloseButton
+            border
+            background={token('colors.panelBg')}
+            // uses swipe to dismiss from PopupBase on mobile
+            onClose={isTouch ? undefined : handleClose}
+            showXOnHover
+          >
+            <div
+              className={css({
+                gap: '12px',
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+                padding: '0.85em 1.1em',
+                maxWidth: '30em',
+              })}
+            >
+              {icon}
+              {value}
+            </div>
+          </PopupBase>
+        </FadeTransition>
+      ) : null}
+    </TransitionGroup>
+  )
 }
 
 Tip.displayName = 'Tip'


### PR DESCRIPTION
**Closes #3599** 

This small refactor separates `Tip` from the `Notification` component, which previously handled shared logic for both `Alert` and `Tip`.

As both components will be undergoing their Liminal UI redesign (Tip now, and Alert later), this PR decouples `Tip` from `Notification`. This does result in a minor amount of duplication in the short term, but this will quickly change as both the `Tip` and `Alert` get updated.

The tip's behavior is identical, and all tests continue to pass.