### PR TITLE
fix: Gesturemenu background should be overlay with device's status bar in Capacitor app

### DIFF
--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -148,11 +148,11 @@ const AppComponent: FC = () => {
 
     if (Capacitor.isNativePlatform()) {
       StatusBar.setStyle({ style: dark ? Style.Dark : Style.Light })
-      // Android only, set statusbar color to black.
       if (Capacitor.getPlatform() === 'android') {
-        StatusBar.setBackgroundColor({
-          color: colors.bg,
-        })
+        // Make the WebView extend behind the status bar (edge-to-edge), matching iOS behavior.
+        // safeAreaTop (env(safe-area-inset-top)) will equal the status bar height, and the
+        // AppComponent wrapper's paddingTop: safeAreaTop keeps normal content below the status bar.
+        StatusBar.setOverlaysWebView({ overlay: true })
       }
     }
   }, [colors, dark])

--- a/src/components/GestureMenu.tsx
+++ b/src/components/GestureMenu.tsx
@@ -36,10 +36,9 @@ const GestureMenu: FC<{
         display: 'flex',
         flexDirection: 'column',
         maxWidth: '100%',
-        maxHeight: '100dvh',
         overflow: 'hidden',
-        // maxHeight: `calc(100vh - ${token('spacing.safeAreaBottom')} - ${token('spacing.safeAreaTop')})`,
-        // paddingTop: 'safeAreaTop',
+        maxHeight: `calc(100dvh - ${token('spacing.safeAreaBottom')} - ${token('spacing.safeAreaTop')})`,
+        paddingTop: 'safeAreaTop',
       })}
     >
       <div

--- a/src/components/GestureMenu.tsx
+++ b/src/components/GestureMenu.tsx
@@ -38,6 +38,8 @@ const GestureMenu: FC<{
         maxWidth: '100%',
         maxHeight: '100dvh',
         overflow: 'hidden',
+        // maxHeight: `calc(100vh - ${token('spacing.safeAreaBottom')} - ${token('spacing.safeAreaTop')})`,
+        // paddingTop: 'safeAreaTop',
       })}
     >
       <div

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -1,4 +1,3 @@
-import { Capacitor } from '@capacitor/core'
 import React, { PropsWithChildren, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
@@ -109,7 +108,6 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           right: 0,
           width: 'max-content',
           ...borderStyles,
-          ...fullScreenStyles,
           '&:hover': {
             '& [data-close-button]': {
               opacity: showXOnHover ? 1 : undefined,
@@ -124,13 +122,7 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
         // merge style with useSwipeToDismissProps.style (transform, transition, and touchAction for sticking to user's touch)
         style={{
           ...positionFixedStyles,
-          // if fullScreen prop is true & was opened via Capacitor, so we need to set the top and bottom to 0 to make the popup take up the full height of the screen
-          ...(fullScreen && Capacitor.isNativePlatform()
-            ? {
-                top: 0,
-                bottom: 0,
-              }
-            : {}),
+          ...fullScreenStyles,
           background,
           fontSize,
           padding,

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -1,3 +1,4 @@
+import { Capacitor } from '@capacitor/core'
 import React, { PropsWithChildren, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
@@ -123,6 +124,13 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
         // merge style with useSwipeToDismissProps.style (transform, transition, and touchAction for sticking to user's touch)
         style={{
           ...positionFixedStyles,
+          // if fullScreen prop is true & was opened via Capacitor, so we need to set the top and bottom to 0 to make the popup take up the full height of the screen
+          ...(fullScreen && Capacitor.isNativePlatform()
+            ? {
+                top: 0,
+                bottom: 0,
+              }
+            : {}),
           background,
           fontSize,
           padding,

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -87,10 +87,11 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           display: 'block',
           width: '100%',
           height: '100%',
-          // when absolutely-positioned, the top position is calculated in usePositionFixed (#3222)
           marginBlock: positionFixedStyles.position === 'fixed' ? 'auto' : undefined,
-          top: 0,
-          bottom: 0,
+          // when keyboard is open, position is 'absolute' and top is scroll-adjusted — preserve it
+          // when keyboard is closed, position is 'fixed' so top/bottom 0 covers the full viewport
+          top: positionFixedStyles.position === 'absolute' ? positionFixedStyles.top : 0,
+          bottom: positionFixedStyles.position === 'absolute' ? positionFixedStyles.bottom : 0,
         }
       : {}
 

--- a/src/components/PopupBase.tsx
+++ b/src/components/PopupBase.tsx
@@ -86,7 +86,8 @@ const PopupBase = React.forwardRef<HTMLDivElement, PopupBaseProps>(
           border: 'none',
           display: 'block',
           width: '100%',
-          height: '100%',
+          // use 100dvh for fixed positioning so Android WebView reliably fills the visual viewport
+          height: positionFixedStyles.position === 'fixed' ? '100dvh' : '100%',
           marginBlock: positionFixedStyles.position === 'fixed' ? 'auto' : undefined,
           // when keyboard is open, position is 'absolute' and top is scroll-adjusted — preserve it
           // when keyboard is closed, position is 'fixed' so top/bottom 0 covers the full viewport


### PR DESCRIPTION
Close #3727

Add a fix where GestureMenu background should be underneath of device's status bar when being opened from Capacitor

### Notes
please start the code review changes from [63795b3](https://github.com/cybersemics/em/pull/3885/commits/63795b3f22b053e34e12101da262c2c1280264b7) , since the earlier commit are more related to #3646 

---
## Results

**Android**

https://github.com/user-attachments/assets/dc039ac6-096e-40f8-8ce7-cae92a21a4b3


**iOS**

https://github.com/user-attachments/assets/437764c2-9984-443e-8ca0-767f25e5ff03

