### PR TITLE
After the cursor is cleared, store a style wrapper that can be re-applied after typing

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -381,7 +381,6 @@ const Editable = ({
         // That style should be re-applied once they type something. (#3673)
 
         const wrappedValue = state.cursorCleared ? applyOuterTag(e.target.value, oldValue) : e.target.value
-        console.log(wrappedValue)
         const newValue = stripEmptyFormattingTags(addEmojiSpace(trimHtml(wrappedValue)))
 
         /* The realtime editingValue must always be updated (and not short-circuited) since oldValueRef is throttled. Otherwise, editingValueStore becomes stale and heights are not recalculated in VirtualThought.


### PR DESCRIPTION
Fixes #3673 

If a thought had a style tag that wrapped the entire thought, store that wrapper when the cursor is cleared
After the cursor is cleared, store any style wrapper that the old thought had if it wrapped the entire thought. If the user types in the cleared thought, re-apply the wrapper and immediately propagate the new value to the editable using `editThought`'s `force` property to update the editable nonce.

The only thing that I've uncovered that might still be an issue is the following:

## Steps to Reproduce

1. Create a thought.
2. Set the color of the thought.
3. Activate Clear Thought (→←).
4. Set the color of the thought back to white or another color.
5. Edit the thought.

## Current Behavior

The new text receives the color from step 2.

## Expected Behavior

Maybe it should be set to the color from step 4? Let me know what you think.