### PR TITLE
Fixed timeout issue with color swatches in puppeteer

### DIFF
--- a/src/e2e/puppeteer/__tests__/drag-and-drop-favorites.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop-favorites.ts
@@ -5,7 +5,7 @@ import paste from '../helpers/paste'
 import press from '../helpers/press'
 import { page } from '../setup'
 
-vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
 /** Get the order of favorites as displayed in the sidebar. */
 const selectFavoritesText = async () => {


### PR DESCRIPTION
Close #3827 

### Cause:

When a `ToolbarButton` is pressed, the `mousedown` event triggers `tapDown`, which updates `pressingToolbarId` in the parent `Toolbar` using `setPressingToolbarId`. Then, when the click event fires, `tapUp` checks whether the button is still considered active through the `isPressing` prop. For `isPressing` to be true, React needs to re-render the `Toolbar` and `ToolbarButton` after the `mousedown` state update and before the click event occurs. But React flushes state updates asynchronously, so when click fires, React may not have re-rendered yet, leaving `isPressing = false` and the `toolbar` command to not execute at all causing `ColorPicker` component with`text color swatches` selector to not show up in the DOM. This makes `waitForSelector` in puppeteer to timeout and fail.

### Fix:

Added `isMouseDownRef`  in `tapDown` (`mousedown`) and checked in `tapUp` (`click`), bypassing the React re-render cycle entirely. The condition now uses (isPressing || wasMouseDown), so even if the React prop hasn't updated, the ref ensures the command executes correctly. 

[Here](https://github.com/karunkop/em/actions?query=branch%3Acolor-swatch-selector) is the result for CI checks. Note that: the failed tests here are mostly for #3868 and #3914

