### PR TITLE
isThought: Use activeElement instead of focusNode

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -62,7 +62,7 @@ const ColorSwatch: FC<{
       (commandStateColor === '#ccccccff' && commandStateBackgroundColor === '#333333ff') ||
       (commandStateColor === addAlphaToHex(rgbToHex(themeColor.fg)) &&
         commandStateBackgroundColor === addAlphaToHex(rgbToHex(themeColor.bg)) &&
-        !selection.isOnThought())
+        !selection.isThought())
     ) {
       const colorMatches = currentThoughtValue.match(colorRegex) || []
 

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -81,26 +81,10 @@ export const isNote = () => {
   return !!element && element.nodeType === Node.ELEMENT_NODE && element.ariaLabel === 'note-editable'
 }
 
-/** Returns true if the selection is on a thought. */
-// We should see if it is possible to just use state.isKeyboardOpen and selection.isActive()
-export const isThought = (): boolean => {
-  // type classList as optional
-  const focusNode = window.getSelection()?.focusNode
-  if (!focusNode) return false
-  // check focusNode and focusNode.parentNode, since it could be on the TEXT_NODE or the ELEMENT_NODE
-  return isEditable(focusNode) || isEditable(focusNode.parentNode)
-}
-
-/** Returns true if the selection is on a thought. */
-export const isOnThought = (): boolean => {
-  let focusNode = window.getSelection()?.focusNode
-  while (focusNode && (focusNode as HTMLElement)?.tagName !== 'DIV') {
-    if (isEditable(focusNode)) return true
-    focusNode = focusNode?.parentNode
-  }
-  // check focusNode if it is on the TEXT_NODE or the ELEMENT_NODE
-  return isEditable(focusNode)
-}
+/** Returns true if the active element is an editable thought or note. */
+export const isThought = (): boolean =>
+  !!document.activeElement?.hasAttribute('data-editable') ||
+  (document.activeElement as HTMLElement)?.ariaLabel === 'note-editable'
 
 /** Returns true if the selection is  on the first line of a multi-line text node. Returns true if there is no selection or if the text node is only a single line. */
 export const isOnFirstLine = (): boolean => {

--- a/src/stores/commandStateStore.ts
+++ b/src/stores/commandStateStore.ts
@@ -34,7 +34,7 @@ export const updateCommandState = () => {
   const state = store.getState()
   if (!state.cursor) return
   const action =
-    selection.isActive() && selection.isOnThought()
+    selection.isActive() && selection.isThought()
       ? getCommandState(selection.html() ?? '')
       : getCommandState(pathToThought(state, state.cursor)?.value ?? '')
   commandStateStore.update(action)


### PR DESCRIPTION
Makes #3938 irrelevant
Fixes #3934

### Problem

`selection.isThought()` and `selection.isOnThought()` used `window.getSelection().focusNode` to determine whether an editable thought was focused. However, browsers do not clear `focusNode` when an element is blurred — it persists pointing to the last focused node until a new selection is made elsewhere. This caused `isThought()` to return `true` even after an editable had lost focus (e.g. after closing the Command Center), leading to bugs where `keyboardOpen(false)` was incorrectly suppressed.

`document.activeElement`, by contrast, is authoritative: it is cleared immediately when an element is blurred and reflects the true current focus state.

### Changes

**selection.ts**
- Rewrote `isThought()` to use `document.activeElement` instead of `focusNode`:
  ```ts
  export const isThought = (): boolean =>
    !!document.activeElement?.hasAttribute('data-editable') ||
    (document.activeElement as HTMLElement)?.ariaLabel === 'note-editable'
  ```
- Removed `isOnThought()` — it was a more complex traversal that ultimately checked the same thing; `isThought()` now covers both thoughts and notes.

**commandStateStore.ts**, **ColorPicker.tsx**
- Updated the two call sites of `isOnThought()` to use `isThought()`.