### PR TITLE
Puppeteer: Undo.ts test timing out issue in CI

### DIFF
--- a/src/e2e/puppeteer/__tests__/undo.ts
+++ b/src/e2e/puppeteer/__tests__/undo.ts
@@ -8,6 +8,8 @@ import keyboard from '../helpers/keyboard'
 import press from '../helpers/press'
 import { page } from '../setup'
 
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 it('Re-render cursor thought on undo', async () => {
   // create a thought "hello"
   await press('Enter')


### PR DESCRIPTION
Close #3914 

- Added default test timeout consistent with other Puppeteer tests; 5s was too low for iPhone emulation and CI runs.

[Here](https://github.com/karunkop/em/actions?query=branch%3Aundo-timing) is the result of the CI checks.