### PR TITLE
Cleared the retained value by middleware between tests

### DIFF
--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -208,6 +208,13 @@ const undoRedoReducerEnhancer: StoreEnhancer<any> =
       const { redoPatches, undoPatches } = state as State
       const actionType = action.type
 
+      // Clear the last edit thought direction when the clear action is executed.
+      if (actionType === 'clear') {
+        lastAction = undefined
+        lastEditThoughtDirection = EditThoughtDirection.None
+        return reducer(state, action)
+      }
+
       // Handle undo and redo.
       // They are defined in the redux enhancer rather than in /actions.
       if (actionType === 'undo' || actionType === 'redo') {


### PR DESCRIPTION
Close #3897 

Using the same approach as used by `pullQueue` middleware  by detecting the clear action and clearing its internal state

- Added handling for the clear action. When it runs (like in beforeEach(initStore)), the enhancer resets its internal variables (`lastAction` and `lastEditThoughtDirection`) before continuing with the normal reducer.