### PR TITLE
Always call preventDefault on undo commands

### DIFF
--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -25,7 +25,9 @@ const undoCommand: Command = {
     if (!isUndoEnabled(getState())) return
     dispatch(undo())
   },
-  canExecute: state => isUndoEnabled(state),
+  // Native browser undo creates problems when document.execCommand has been used for formatting. (#3879)
+  // canExecute should always be true so that it always calls e.preventDefault() and blocks native undo.
+  isActive: state => isUndoEnabled(state),
   longPress: dispatch => {
     dispatch(toggleDropdown({ dropDownType: 'undoSlider' }))
   },


### PR DESCRIPTION
Fixes #3879 

Commands only call `e.preventDefault()` while they [canExecute](https://github.com/ethan-james/em/blob/695a28d97dbee7fbed4bce3dc5d287f0e8697d31/src/commands.ts#L621). In the case of undo, this allows native browser undo to start functioning again once the stack of `undoPatches` is empty. I'm not 100% sure what it is about `document.execCommand` that causes the text to duplicate the way it does, as I can't replicate the issue without using formatting. The solution is to always call `e.preventDefault` on undo commands.

I can't create a component test because `document.execCommand is not implemented in JSDOM`, and I wasn't able to create a Puppeteer test that would fail on main. I assumed that the problem that I would encounter would be that `paste` is also an undoable action, and maybe it even merges with the bold command, but that didn't appear to be a problem. I tried a couple of variations of the following:

```
// We have to test this in puppeteer because it involves using document.execCommand, which is not implemented in JSDOM
it('Undo formatting twice should stop when undo stack is empty', async () => {
  await paste(`
  - a
`)

  await press('b', { meta: true })
  await press('z', { meta: true })
  await press('z', { meta: true, shift: true }) // shouldn't be necessary, seems reproducible by simply undoing twice in a row
  await press('z', { meta: true })
  await press('z', { meta: true })

  const exported = await exportThoughts()
  expect(exported).toBe(`
- a
`)
```

but they all pass on main. I'm not sure of the exact cause and can continue to look into it tomorrow if you think it's worthwhile.