### PR TITLE
ColorPicker: Check noteFocus to determine selected

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -7,6 +7,7 @@ import { isTouch } from '../browser'
 import { ColorToken } from '../colors.config'
 import * as selection from '../device/selection'
 import getThoughtById from '../selectors/getThoughtById'
+import noteValue from '../selectors/noteValue'
 import themeColors from '../selectors/themeColors'
 import commandStateStore from '../stores/commandStateStore'
 import head from '../util/head'
@@ -47,9 +48,12 @@ const ColorSwatch: FC<{
   size = size || fontSize * 1.2
 
   const selected = useSelector(state => {
-    const currentThoughtValue = (!!state.cursor && getThoughtById(state, head(state.cursor))?.value) || ''
+    const currentEditableValue =
+      (!!state.cursor &&
+        (state.noteFocus ? noteValue(state, state.cursor) : getThoughtById(state, head(state.cursor))?.value)) ||
+      ''
     const themeColor = themeColors(state)
-    /* Define the color and background color regex to get the current color of current thought
+    /* Define the color and background color regex to get the current color of current thought or note
        document.execCommand('foreColor') adds the color attribute with hex and document.execCommand('backColor') adds the background-color attribute with the rgb
        document.execCommand('foreColor') always sets the color as hex whether the value is rgb or hex. And document.execCommand('backColor') always sets the background with the rgb
     */
@@ -64,7 +68,7 @@ const ColorSwatch: FC<{
         commandStateBackgroundColor === addAlphaToHex(rgbToHex(themeColor.bg)) &&
         !selection.isThought())
     ) {
-      const colorMatches = currentThoughtValue.match(colorRegex) || []
+      const colorMatches = currentEditableValue.match(colorRegex) || []
 
       let matchColor, match
       // Get the colors and background colors used in current thought's value
@@ -77,7 +81,7 @@ const ColorSwatch: FC<{
       }
 
       const bgColors: Set<string> = new Set()
-      while ((match = bgColorRegex.exec(currentThoughtValue)) !== null) if (match[1]) bgColors.add(match[1])
+      while ((match = bgColorRegex.exec(currentEditableValue)) !== null) if (match[1]) bgColors.add(match[1])
       const matchBgColor = bgColors.size > 1 ? null : bgColors.values().next().value
 
       return !!(

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -12,6 +12,9 @@ import press from '../helpers/press'
 import setSelection from '../helpers/setSelection'
 import { page } from '../setup'
 
+/** Click the first note. Assumes that there will be only a single note. */
+const clickFirstNote = () => click('[aria-label="note-editable"]')
+
 /** Retrieve the innerHTML of the first note on the page. Assumes that there will be only a single note. */
 const getFirstNoteText = () => page.evaluate(() => document.querySelector('[aria-label="note-editable"]')?.innerHTML)
 
@@ -259,7 +262,7 @@ it('Set the background color of the note', async () => {
         - Note
   `)
 
-  await click('[aria-label="note-editable"]')
+  await clickFirstNote()
   await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
   await click('[aria-label="background color swatches"] [aria-label="green"]')
 
@@ -276,7 +279,7 @@ it('Toggling note background color on and off should remove formatting tag', asy
         - Note
   `)
 
-  await click('[aria-label="note-editable"]')
+  await clickFirstNote()
   await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
   await click('[aria-label="background color swatches"] [aria-label="green"]')
   await click('[aria-label="background color swatches"] [aria-label="green"]')
@@ -292,10 +295,49 @@ it('Setting note foreground color should remove background color', async () => {
         - <font style="background-color: #FFFFFF" color="#000000">Note</font>
   `)
 
-  await click('[aria-label="note-editable"]')
+  await clickFirstNote()
   await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
   await click('[aria-label="text color swatches"] [aria-label="yellow"]')
 
   const result = await page.evaluate(() => document.querySelector('[aria-label="note-editable"]')?.innerHTML)
   expect(result).toBe('<font color="#ffd014">Note</font>')
+})
+
+it('A thought and a note can have the same background color', async () => {
+  await paste(`
+    - a
+      - =note
+        - Note
+  `)
+
+  // set the background color on the thought
+  await clickThought('a')
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="background color swatches"] [aria-label="green"]')
+
+  // set the background color on the note
+  await clickFirstNote()
+  await click('[aria-label="background color swatches"] [aria-label="green"]')
+
+  const thought = await getEditingText()
+  expect(thought).toBe('<font color="#000000" style="background-color: rgb(0, 214, 136);">a</font>')
+
+  const note = await getFirstNoteText()
+  expect(note).toBe('<font color="#000000" style="background-color: rgb(0, 214, 136);">Note</font>')
+})
+
+it('Can change the background color of a note to match its thought', async () => {
+  await paste(`
+    - <font color="#000000" style="background-color: rgb(255, 87, 61);">a</font>  
+      - =note      
+        - <font color="#000000" style="background-color: rgb(0, 214, 136);">Note</font>
+  `)
+
+  // change the background color on the note
+  await clickFirstNote()
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="background color swatches"] [aria-label="red"]')
+
+  const note = await getFirstNoteText()
+  expect(note).toBe('<font color="#000000" style="background-color: rgb(255, 87, 61);">Note</font>')
 })


### PR DESCRIPTION
Fixes #4009

In `ColorPicker`, [selected](https://github.com/ethan-james/em/blob/9ec4d02d402b91b98ea4296b82dd543bb5b5951c/src/components/ColorPicker.tsx#L50) was looking at thought text without considering notes. I added a `state.noteFocus` condition to check the note value instead of the thought value if the caret is on the note.

I added test cases for A and B, although I wasn't able to reproduce B starting from main. I suspect that exact set of steps may have been fixed by #4001, and can check tomorrow if you think it's worthwhile. I believe the second test that I added captures where the bug would have been if I could see it.