### PR TITLE
Merge setDescendant actions in undoRedoEnhancer

### DIFF
--- a/src/commands/__tests__/undo-redo.ts
+++ b/src/commands/__tests__/undo-redo.ts
@@ -6,12 +6,14 @@ import { importTextActionCreator as importText } from '../../actions/importText'
 import { indentActionCreator as indent } from '../../actions/indent'
 import { moveThoughtDownActionCreator as moveThoughtDown } from '../../actions/moveThoughtDown'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { setDescendantActionCreator as setDescendant } from '../../actions/setDescendant'
 import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommandWithMulticursor } from '../../commands'
 import moveThoughtDownCommand from '../../commands/moveThoughtDown'
 import { HOME_TOKEN } from '../../constants'
 import { initialize } from '../../initialize'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
+import contextToPath from '../../selectors/contextToPath'
 import exportContext from '../../selectors/exportContext'
 import { getLexeme } from '../../selectors/getLexeme'
 import store from '../../stores/app'
@@ -492,6 +494,61 @@ describe('grouping', () => {
   - B`
 
     expect(exported).toEqual(expectedOutput)
+  })
+
+  it('contiguous edits to notes should be grouped', () => {
+    store.dispatch(
+      importText({
+        text: `
+        - A
+          - =note
+            - note`,
+      }),
+    )
+
+    const notePath = contextToPath(store.getState(), ['A', '=note'])!
+
+    store.dispatch([
+      setDescendant({ path: notePath, values: ['note text'] }),
+      setDescendant({ path: notePath, values: ['note text here'] }),
+      undo(),
+    ])
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - A
+    - =note
+      - note`)
+  })
+
+  it('adding foreColor and backColor to note should be grouped', () => {
+    store.dispatch(
+      importText({
+        text: `
+        - A
+          - =note
+            - note`,
+      }),
+    )
+
+    const notePath = contextToPath(store.getState(), ['A', '=note'])!
+
+    store.dispatch([
+      setDescendant({ path: notePath, values: ['<font color="#000000">note</font>'] }),
+      setDescendant({
+        path: notePath,
+        values: ['<font color="#000000" style="background-color: rgb(0, 214, 136);">note</font>'],
+      }),
+      undo(),
+    ])
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - A
+    - =note
+      - note`)
   })
 
   it('contiguous edit additions should should not be grouped with deletions', () => {


### PR DESCRIPTION
Fixes #3903

As noted, this is the same as #3551 but for notes. We can track `setDescendant` actions instead of `editThought` actions in `undoRedoEnhancer` and merge actions that have the same [EditThoughtDirection](https://github.com/ethan-james/em/blob/9e75f26b413cafc8162b76727420929b4d4fe891/src/redux-enhancers/undoRedoEnhancer.ts#L25). I had Copilot write the solution so I'm going to take some time tomorrow to clean it up and try to combine it into the existing `lastEditThoughtDirection` logic before I commit it.

I noticed a couple of things not directly related to this issue while I was figuring this out:

1. `setDescendant` actions seem to fire twice for each edit, so I needed to modify the logic to accommodate the duplicates:

```
        return newValue.length === oldValue.length
          ? lastSetDescendantNoteDirection
          : newValue.length > oldValue.length
            ? EditThoughtDirection.Longer
            : EditThoughtDirection.Shorter
```

Ideally I would be able to fix that at the source, as part of this issue or a new issue, so that it's not dispatching duplicate actions.

2. When editing a note in desktop Chrome, trailing(?) whitespace gets converted to an HTML entity, so the progressive values in `setDescendant` actions look like:

```
  - note
  - note&nbsp;
  - note t
```

which messes up the direction sense and breaks merging. That doesn't impact formatting tags, but ideally I can hunt that down and normalize those values as well.