### PR TITLE
Flaky test: Sidebar - Node is either not clickable or not an Element

### DIFF
--- a/src/e2e/puppeteer/__tests__/sidebar.ts
+++ b/src/e2e/puppeteer/__tests__/sidebar.ts
@@ -17,7 +17,15 @@ vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 /** Open sidebar and wait for it to slide all the way open. */
 const openSidebar = async () => {
   await click('[aria-label=menu]')
-  await page.locator('[data-testid="sidebar"]').wait()
+  // Wait for aria-hidden="false" and the first link to be on-screen (rect.left >= 0), since the outer sidebar is always mounted and doesn’t reflect the drawer’s slide-in animation.
+  await page.waitForFunction(() => {
+    const sidebar = document.querySelector('[data-testid="sidebar"]')
+    if (!sidebar || sidebar.getAttribute('aria-hidden') !== 'false') return false
+    const link = document.querySelector('[data-testid="sidebar-favorites"]')
+    if (!link) return false
+    const rect = link.getBoundingClientRect()
+    return rect.left >= 0 && rect.width > 0
+  })
 }
 
 /** Screenshot without the toolbar. */


### PR DESCRIPTION
Close #4148 

### Cause

The test was waiting for the outer sidebar wrapper, which is always mounted and visible, instead of the actual sliding drawer inside it. So the test tried to click a link before the drawer had fully appeared on screen. Because the element was technically “visible” but still off-screen due to animation, puppeteer couldn’t find a clickable area and threw an error.

### Fix

Updated `openSidebar()` to wait until the sidebar is actually visible and on-screen by checking aria-hidden="false" and ensuring a sidebar link has a valid position (rect.left >= 0 and width > 0), so clicks only happen after the drawer finishes sliding in.