### PR TITLE
iOS Safari console capture and cross-platform browser-control

### DIFF
--- a/.github/skills/browser-control/SKILL.md
+++ b/.github/skills/browser-control/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: browser-control
+description: >-
+  ALWAYS USE THIS SKILL to bring up a browser environment for a given target
+  platform (web, android, or ios) before driving the app. The caller (e.g.
+  issue-repro) decides the platform and passes it in; this skill selects the
+  right MCP, launches Chrome on demand, applies device emulation, and
+  navigates to the dev server.
+allowed-tools:
+  - bash
+  - chrome-devtools
+  - wdio
+---
+
+The em app runs on the web, on Android (mobile Chrome), and on iOS Safari. The right way to drive a browser depends on which of those you are targeting:
+
+| Target              | MCP             | How Chrome / Safari is launched                       |
+|---------------------|-----------------|-------------------------------------------------------|
+| `web` (desktop)     | `chrome-devtools` | First MCP call launches headless Chrome under Xvfb. |
+| `android` (mobile)  | `chrome-devtools` | Same Chrome instance, with mobile device emulation. |
+| `ios` (Safari)      | `wdio`           | `start_session` opens a remote iOS Safari session.   |
+
+Use this skill **before any browser interaction** (navigation, evaluate, click, swipe, etc.). Calling browser tools without first running through this skill leads to the wrong MCP being used, or the page being loaded under the wrong device profile and gestures not registering.
+
+## Inputs
+
+The caller must supply the target platform — one of `web`, `android`, or `ios`. This skill does **not** infer the platform from issues, tags, or body text; that is the caller's responsibility (see `issue-repro` for an example of how an issue-driven caller does the detection).
+
+If the caller has not stated a platform, stop and ask before doing anything. Picking a default would silently load the page under the wrong profile.
+
+## Stages
+
+1. **Bring up** the browser environment for the requested platform.
+2. **Navigate** to the running dev server.
+
+Once these stages complete, the caller can drive the browser. For touch gestures specifically, the caller should use the `interaction-gestures` skill — it tells you the right way to dispatch a gesture on each platform.
+
+---
+
+## Step 1: Bring Up the Environment
+
+The runner's setup phase has already started Xvfb and the Vite dev server. Chrome is **not** pre-launched — it boots when the `chrome-devtools` MCP makes its first call. Do not start Chrome yourself; just call the MCP.
+
+### Target = `web`
+
+No emulation. The first `chrome-devtools` call (e.g. `navigate`) launches Chrome with a desktop default viewport (1280×1024 from Xvfb). Skip directly to Step 2.
+
+### Target = `android`
+
+Apply mobile emulation **before any `navigate` call** — the MCP keeps a persistent Chrome, so the first navigation must happen under the mobile profile or the initial render is wrong.
+
+Call `chrome-devtools` `emulate` with a Pixel-class mobile profile:
+
+- `viewport`: `412x915x2.625,mobile,touch` — Pixel 7 dimensions in CSS px, DPR 2.625. The `mobile` flag triggers mobile media queries; `touch` delivers touch events instead of mouse events.
+- `userAgent`: a current mobile Chrome UA, e.g. `Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36`.
+
+If you have already navigated by mistake, re-apply emulation and re-navigate so the page loads cleanly under the mobile profile.
+
+### Target = `ios`
+
+Open a remote iOS Safari session via the `wdio` MCP. The MCP's `platform: 'ios'` mode is wired for native apps and requires `appPath` / `app` / `noReset`. For a real iOS **Safari** session, use `platform: 'browser'` + `browser: 'safari'` and pass the iOS specifics through the `capabilities` escape hatch.
+
+Call `start_session` with this shape (bump `deviceName` / `platformVersion` to whatever's current):
+
+```ts
+start_session({
+  provider: 'browserstack',
+  platform: 'browser',
+  browser: 'safari',
+  browserstackLocal: true,
+  capabilities: {
+    platformName: 'iOS',
+    browserName: 'Safari',
+    'appium:automationName': 'XCUITest',
+    'appium:deviceName': 'iPhone 15',
+    'appium:platformVersion': '17',
+    'bstack:options': {
+      deviceName: 'iPhone 15',
+      osVersion: '17',
+      realMobile: 'true',
+      appiumVersion: '2.0.0',
+      local: true,
+    },
+  },
+})
+```
+
+- `browserstackLocal: true` is the default for this skill. The wdio MCP launches the BrowserStack Local tunnel binary itself, so the remote device reaches the runner's `localhost:3000` via `bs-local.com:3000`. Without it the device cannot see the dev server.
+- Do **not** call `launch_chrome` — that's for Chrome only.
+- Do **not** call `emulate_device` on a real iOS Safari session; the device already serves the real iOS UA, viewport, and touch events.
+- Use **`tap_element`, not `click_element`**, for element interactions. On iOS the WebDriver `element.click()` is silently ignored — `click_element` will appear to succeed but produce no effect. Default to `tap_element`.
+- After `start_session`, subsequent `navigate`, `tap_element`, `swipe`, `execute_script` operate on the open session. Do not start a new session per step — each `start_session` call closes the previous one.
+
+If the wdio MCP is not available in this environment, stop and report back to the caller: iOS reproduction requires the wdio MCP. Do not attempt to fall back to Chrome with an iOS UA string — that does not exercise WebKit and will produce false reproductions.
+
+---
+
+## Step 2: Navigate to the Dev Server
+
+The dev server starts during the runner's setup phase, but verify it is responsive before navigating. Vite may serve HTTP or HTTPS depending on local config (the `-k` flag accepts the self-signed dev cert):
+
+```bash
+curl -fsS -o /dev/null http://localhost:3000 \
+  || curl -fsSk -o /dev/null https://localhost:3000
+```
+
+If neither responds, check `/tmp/dev-server.log` and report — do not start a second instance.
+
+Note which scheme (HTTP vs HTTPS) responded. Then navigate using the MCP for your target:
+
+- `web` / `android`: `chrome-devtools` `navigate` to `http://localhost:3000` (or `https://` if that is what responded).
+- `ios`: `wdio` `navigate` to `http://bs-local.com:3000?__ios_console_proxy`. The `bs-local.com:3000` host is BrowserStack Local's well-known hostname — the tunnel started by `browserstackLocal: true` routes it back to the runner's `localhost:3000`. The `?__ios_console_proxy` query param activates the in-app console proxy (`src/util/iOSConsoleProxy.ts`) so console output is captured into `window.__iOSConsoleProxy__`. To read captured logs at any point: `execute_script(() => window.__drainiOSConsoleLogs__())` — atomically returns and clears the buffer.
+
+If you encounter HTTPS self-signed certificate errors on Chrome, use the `thisisunsafe` bypass to proceed. On iOS Safari, accept the certificate via the wdio MCP's dialog handler if prompted.
+
+After navigation, the environment is ready. Hand back to the calling skill.
+
+---
+
+## Cleanup
+
+There is no required cleanup step. The Chrome instance and the wdio session both terminate with the agent session. If you need to start over with a clean profile mid-session:
+
+- `web` / `android`: `localStorage.clear(); location.reload();` in the page console is normally enough. Re-apply `emulate` if you reset the Chrome profile.
+- `ios`: call `wdio` `close_session` and then re-run Step 2 for `ios`.

--- a/.github/skills/interaction-gestures/SKILL.md
+++ b/.github/skills/interaction-gestures/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: interaction-gestures
+description: >-
+  Use this skill when a step requires a swipe gesture in the em app's
+  gesture zone. Tells you how to dispatch a multi-direction touch gesture on
+  web/android (Chrome DevTools MCP) and on iOS (WebdriverIO MCP) so the gesture
+  detector commits the expected command.
+allowed-tools:
+  - chrome-devtools
+  - wdio
+---
+
+The em app interprets multi-direction swipes in the **gesture zone** as commands. A correctly-formed gesture is a single continuous touch with deliberate direction changes; the detector listens for `touchstart` → series of `touchmove` with direction transitions → `touchend`.
+
+This skill assumes `browser-control` has already brought up the right MCP and applied any required device emulation. Do not call this skill on a desktop (mouse-only) profile — the detector requires touch events.
+
+## Notation
+
+Issues describe gestures in two interchangeable notations — both refer to the same thing:
+
+| Notation | Example | Meaning |
+|---|---|---|
+| Letters | `rdr` | `r`=right, `l`=left, `u`=up, `d`=down |
+| Arrows  | `→↓→` | `→`=r, `←`=l, `↑`=u, `↓`=d |
+
+## Gesture Zone
+
+The gesture zone is the **left side** of the screen in right-handed mode (the default), **below the 50px toolbar**. Starting outside the zone or during the toolbar will not register. A starting point of `(150, 350)` in CSS px is comfortably inside the zone for a typical mobile viewport (Pixel 7 ~412×915, iPhone 14 ~390×844). Adjust if the issue calls for a different viewport.
+
+## Gesture Cadence
+
+The detector is unforgiving about timing. Use these parameters — they have been validated against `src/e2e/puppeteer/helpers/gesture.ts` and register reliably:
+
+- **80px per direction**, broken into ~10px substeps.
+- **~16ms between each `touchmove`** so the detector receives a steady stream rather than two endpoints.
+- **40ms pause at each direction change** so the detector commits each leg before turning.
+- **Hold ~80ms before `touchend`** so `onPanResponderRelease` fires with the full sequence intact.
+
+Smaller distances or faster pacing will flash the gesture trace UI but fail to commit a command.
+
+---
+
+## Web / Android (Chrome DevTools MCP)
+
+Dispatch synthetic touch events via `evaluate_script`. Do not try to use the mouse-emulation `click` tool — even with `touch` emulation on, an MCP-level `click` does not produce the continuous touch sequence the detector requires.
+
+Working snippet — change `directions` to your gesture:
+
+```js
+async () => {
+  const directions = ['r', 'd']; // e.g. ['l','d','r','l','d','l'] for ldrldl
+  const startX = 150, startY = 350, stepSize = 80, substep = 10;
+  const target = document.elementFromPoint(startX, startY) || document.body;
+  const mkTouch = (x, y) => new Touch({
+    identifier: 1, target,
+    clientX: x, clientY: y, pageX: x, pageY: y,
+    screenX: x, screenY: y,
+    radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1,
+  });
+  const fire = (type, x, y) => {
+    const t = mkTouch(x, y);
+    target.dispatchEvent(new TouchEvent(type, {
+      cancelable: true, bubbles: true, composed: true,
+      touches: type === 'touchend' ? [] : [t],
+      targetTouches: type === 'touchend' ? [] : [t],
+      changedTouches: [t],
+    }));
+  };
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  let x = startX, y = startY;
+  fire('touchstart', x, y);
+  await sleep(50);
+  for (const dir of directions) {
+    let dx = 0, dy = 0;
+    if (dir === 'r') dx = stepSize;
+    else if (dir === 'l') dx = -stepSize;
+    else if (dir === 'd') dy = stepSize;
+    else if (dir === 'u') dy = -stepSize;
+    const steps = Math.max(1, Math.ceil(Math.hypot(dx, dy) / substep));
+    for (let i = 1; i <= steps; i++) {
+      x += dx / steps; y += dy / steps;
+      fire('touchmove', Math.round(x), Math.round(y));
+      await sleep(16);
+    }
+    await sleep(40);
+  }
+  await sleep(80);
+  fire('touchend', Math.round(x), Math.round(y));
+}
+```
+
+---
+
+## iOS (WebdriverIO MCP)
+
+The wdio MCP exposes a `swipe` tool, but it performs a single straight-line swipe per call. **Do not** call `swipe` once per direction for a multi-direction gesture — each call begins and ends its own touch, so the detector sees three separate one-direction swipes instead of one compound gesture, and no command will commit.
+
+Instead, run the **same JS touch-dispatch snippet** above through the wdio MCP's `execute_script` tool. Mobile Safari supports `Touch` and `TouchEvent`, and the em gesture detector works the same way regardless of whether the touch comes from the OS or from `dispatchEvent`.
+
+Call `execute_script` with the snippet above as the body. If the wdio MCP requires the script to return a value, append `return true;` after the final `fire('touchend', ...)` (the snippet is wrapped in an `async` IIFE — return its promise).
+
+If a step truly is a single straight-line swipe (not an em command — e.g. scrolling a list, dismissing a sheet), the simpler `swipe` tool is fine.
+
+### Adjusting starting coordinates on iOS
+
+The 50px toolbar offset is the same on iOS Safari, but the safe-area insets at the top of the viewport mean a starting Y of 350 is safe across all current iPhones. If you change the viewport (rotate to landscape, etc.), recompute a start point that is inside the gesture zone for that viewport.
+
+---
+
+## Validating That a Gesture Registered
+
+After dispatching, confirm the command actually committed before moving to the next step:
+
+- Watch the UI for the expected state change (the command's effect — e.g. a thought was deleted, indented, exported).
+- If nothing happens, check the console for warnings from the gesture detector. The most common causes are: starting outside the gesture zone, missing mobile emulation (web/android), or pacing too fast.
+- A gesture trace that flashes briefly and then disappears with no command means the detector saw the touch but did not match a known sequence — usually a pacing issue.
+
+Do not assume a gesture committed just because the tool call succeeded.

--- a/.github/skills/issue-repro/SKILL.md
+++ b/.github/skills/issue-repro/SKILL.md
@@ -5,6 +5,7 @@ description: >-
 allowed-tools:
   - bash
   - chrome-devtools
+  - wdio
 ---
 
 If you are working on a GitHub issue that includes "Steps to Reproduce", "Current Behavior", and "Expected Behavior" sections, you must follow this step-by-step guide to confirming the bug exists and validate your fix.
@@ -15,22 +16,21 @@ By following the documented steps in the issue, you can reliably reproduce the p
 
 ## Stages
 
-1. **Parse** — extract Steps to Reproduce, Current Behavior, Expected Behavior from the issue.
-2. **Emulate** — decide whether mobile emulation is required and apply it **before any navigation**.
-3. **Start** — ensure the dev server is running.
-4. **Reproduce** — drive the Chrome DevTools MCP through the steps; confirm the failure mode fires.
-5. **Fix** — root-cause and fix the code.
-6. **Validate** — re-run the steps; confirm the failure is gone and the expected behavior is observed.
+1. **Parse** — extract Steps to Reproduce, Current Behavior, Expected Behavior, and the **target platform** (web / android / ios) from the issue.
+2. **Set up the browser** — pass the target platform to `browser-control`, which attaches the right MCP, applies emulation, and navigates to the dev server.
+3. **Reproduce** — drive the browser MCP through the steps; confirm the failure mode fires.
+4. **Fix** — root-cause and fix the code.
+5. **Validate** — re-run the steps; confirm the failure is gone and the expected behavior is observed.
 
 **You MUST** be able to reproduce the issue directly – if you cannot, **DO NOT** assume the cause without first confirming with the user.
 **DO NOT explore a fix** until you have successfully reproduced the issue. **This is your priority.** If you **CANNOT FULLY REPRODUCE** the steps, **FAIL AND ESCALATE TO THE USER.**
-Similarly, a fix is **not complete** until both Step 4 and Step 5 pass.
+Similarly, a fix is **not complete** until both Step 5a and Step 5b pass.
 
 ---
 
 ## Step 1: Parse the Issue
 
-Use the GitHub MCP `get_issue` tool to read the full issue body.  Extract these three sections — headings vary slightly across issues so match loosely:
+Use the GitHub MCP `get_issue` tool to read the full issue body. Extract these three sections — headings vary slightly across issues so match loosely:
 
 | Section | Common headings |
 |---|---|
@@ -43,81 +43,64 @@ user for clarification. If a section is genuinely absent, stop and ask.
 
 Sometimes, there may be multiple steps to reproduce within a single issue. If so, you must reproduce and fix each one separately, following the same process for each. Do not attempt to fix multiple reproduction paths at once.
 
----
+### Determine the target platform
 
-## Step 2: Configure Device Emulation
+Pick exactly one of `web`, `android`, or `ios` — `browser-control` is going to need it in Step 2. Use issue tags first, fall back to keyword scan, default to `web`.
 
-Decide whether the issue requires mobile emulation **before doing anything else in the browser**. The Chrome DevTools MCP keeps a persistent Chrome instance, so emulation must be applied before the first navigation — otherwise the initial page load happens under the wrong profile and reproductions become unreliable.
+**Tags (primary):**
 
-### When to enable mobile emulation
+| Tag                                | Target  |
+|------------------------------------|---------|
+| `[iOS]`, `[Safari]`                | `ios`   |
+| `[Android]`, `[Mobile]`            | `android` |
+| no platform tag                    | `web`   |
 
-Enable mobile emulation if **any** of the following are true about the issue:
+`[Mobile]` without `[iOS]` is treated as `android` — that is the cheaper environment and reproduces almost all mobile-only behavior. Only switch to `ios` when the issue is explicitly about iOS Safari.
 
-- It is tagged `[Mobile]`, `[Android]`, or `[iOS]`, or its title/body explicitly mentions mobile, iPhone, Android, or "on my phone".
-- The Steps to Reproduce reference touch interactions: **tap**, **swipe**, **long-press**, **pinch**, **drag with finger**, **two-finger**, or any gesture that does not exist on a mouse. Mouse-only language ("click", "hover", "right-click") does not count.
-- The Current Behavior is described in terms of mobile-only UI (bottom sheet, mobile keyboard, on-screen keyboard, viewport zoom, virtual keyboard overlay, etc.).
+**Body keywords (fallback):**
 
-If none of those signals are present, skip this step — the desktop default is correct.
+If no tag is present, scan the title and body. If any of the iOS-specific terms below appear (and no Android-specific terms), pick `ios`:
 
-### How to enable it
+- iOS-specific: "iPhone", "iPad", "iOS", "Safari", "WebKit", "Mobile Safari".
+- Android-specific: "Android", "Chrome on mobile".
+- Generic mobile (no platform commitment): "tap", "swipe", "long-press", "pinch", "on my phone", "bottom sheet", "on-screen keyboard", "virtual keyboard". These imply `android` unless paired with an iOS-specific term above.
 
-Call the Chrome DevTools MCP `emulate` tool with an iPhone-class profile, **before any `navigate` call**:
+If desktop-only language is used ("click", "hover", "right-click", no mobile hints), pick `web`.
 
-- `viewport`: `390x844x3,mobile,touch` — iPhone 14 dimensions (390×844 CSS px), DPR 3. The `mobile` flag triggers mobile media queries; the `touch` flag delivers touch events instead of mouse events so swipe/tap/long-press behave correctly.
-- `userAgent`: a current iOS Safari UA, e.g. `Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1`.
+If you cannot determine the target after this — for example, an issue mentioning both iOS and Android — stop and ask the user which platform to reproduce on. Do not guess: an iOS-only bug will not reproduce under Android emulation and vice-versa.
 
-If you have already navigated by mistake, re-apply emulation and re-navigate so the page loads cleanly under the mobile profile.
-
----
-
-## Step 3: Start the App
-
-Check whether the dev server is already running on port 3000. Vite may serve HTTP or HTTPS depending on local config, so probe both (the `-k` flag accepts the self-signed dev cert):
-
-```bash
-curl -fsS -o /dev/null http://localhost:3000 \
-  || curl -fsSk -o /dev/null https://localhost:3000
-```
-
-If neither responds successfully, start it:
-
-```bash
-yarn start
-```
-
-Poll until port 3000 responds before continuing. The server takes ~5–15 seconds to start. Note which scheme (HTTP vs HTTPS) responded — you'll use that when navigating in the next steps.
-
-If you encounter HTTPS self-signed certificate errors, use the `thisisunsafe` bypass in Chrome to proceed.
+State the chosen target out loud before continuing, e.g. `issue-repro: target = android (issue tagged [Mobile], body mentions "swipe").`
 
 ---
 
-## Step 4: Use Chrome DevTools MCP
+## Step 2: Set Up the Browser
 
-Use the **Chrome DevTools MCP** (`chrome-devtools`) for all browser automation. Do **not** use the Playwright MCP — it is unstable and unreliable.
+Hand the target platform you picked in Step 1 to the **`browser-control`** skill. It will:
 
-The Chrome DevTools MCP provides tools such as `navigate`, `screenshot`, `evaluate`, `click`, `type`, and `get_console_logs`. Use these throughout the reproduction and validation steps.
+1. Attach the correct MCP — `chrome-devtools` for `web`/`android`, `wdio` for `ios` — and apply mobile emulation if needed, **before any navigation**.
+2. Navigate to the dev server.
+
+Do not pick the MCP, apply emulation, or start a dev server yourself — `browser-control` owns all of that. Wait for it to confirm the environment is up before continuing.
 
 ---
 
-## Step 5: Reproduce the Failure
+## Step 3: Reproduce the Failure
 
-If Step 2 determined that mobile emulation is required, confirm `emulate` has already been applied before proceeding — the first navigation below must happen under the mobile profile, not after.
+The browser environment is now ready (Step 2). Use the MCP that `browser-control` selected — `chrome-devtools` for web/android targets, `wdio` for iOS.
 
-1. Open a fresh browser tab at `http://localhost:3000`.
-
-2. **Clear app state** so you start from a clean slate. In the browser console run:
+1. **Clear app state** so you start from a clean slate. In the page console (`chrome-devtools` `evaluate_script` or `wdio` `execute_script`), run:
    ```js
    localStorage.clear(); location.reload();
    ```
 
-3. Follow the **Steps to Reproduce** from the issue **exactly as written** —
+2. Follow the **Steps to Reproduce** from the issue **exactly as written** —
    same order, same actions, no shortcuts. After each step, verify the UI
    reflects the expected intermediate state before continuing.
 
-4. After the final step, check whether the **Current Behavior** described in the
+3. After the final step, check whether the **Current Behavior** described in the
    issue occurs. Observe UI state, console log messages, or any other indication as stated in the issue.
 
-5. **Document what you observed** — quote the error message or describe the UI
+4. **Document what you observed** — quote the error message or describe the UI
    state. If the failure does not occur, **note this explicitly and do not proceed**
    **to fixing**. Instead, report to the user and ask for clarification (different
    browser, platform, version, or data state required?).
@@ -126,74 +109,13 @@ If Step 2 determined that mobile emulation is required, confirm `emulate` has al
 
 ### em App Interaction Reference
 
-- You can use the keyboard and mouse tools in the Chrome DevTools MCP to interact with the app as needed.
+- For keyboard / mouse / tap / type interactions, use the tools provided by whichever MCP `browser-control` attached.
+- For **swipe gestures** in the em gesture zone (notations like `rdr` or `→↓→`), use the **`interaction-gestures`** skill — it has the per-platform gesture dispatch (continuous touch with proper pacing) that the em gesture detector requires. Do not improvise gestures with raw `swipe` / `click` calls; they will not commit.
 - Read **em**'s UI code to understand how to trigger certain behaviors if the steps are not explicit.
-
-### Executing swipe gestures
-
-Some steps to reproduce will describe **swipe gestures** in the gesture zone (the left side of the screen in right-handed mode, below the 50px toolbar). Issues describe these in two interchangeable notations — both refer to the same thing:
-
-| Notation | Example | Meaning |
-|---|---|---|
-| Letters | `rdr` | `r`=right, `l`=left, `u`=up, `d`=down |
-| Arrows  | `→↓→` | `→`=r, `←`=l, `↑`=u, `↓`=d |
-
-**Mobile emulation must be active** (Step 2) — the gesture detector listens for touch events, which require `hasTouch: true`.
-
-To execute gestures, dispatch synthetic touch events via `evaluate_script`. The canonical reference is `src/e2e/puppeteer/helpers/gesture.ts`. Use these parameters — they have been validated to register reliably with the gesture detector:
-
-- **Start at `(150, 350)`** — comfortably inside the gesture zone for an iPhone 14 viewport.
-- **80px per direction**, broken into ~10px substeps with ~16ms between each `touchmove` and a 40ms pause at each direction change. Smaller distances or faster pacing flash the gesture trace UI but fail to commit a command.
-- **Hold ~80ms before `touchend`** so `onPanResponderRelease` fires with the full sequence intact.
-
-Working snippet — change `directions` to your gesture:
-
-```js
-async () => {
-  const directions = ['r', 'd']; // e.g. ['l','d','r','l','d','l'] for ldrldl
-  const startX = 150, startY = 350, stepSize = 80, substep = 10;
-  const target = document.elementFromPoint(startX, startY) || document.body;
-  const mkTouch = (x, y) => new Touch({
-    identifier: 1, target,
-    clientX: x, clientY: y, pageX: x, pageY: y,
-    screenX: x, screenY: y,
-    radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1,
-  });
-  const fire = (type, x, y) => {
-    const t = mkTouch(x, y);
-    target.dispatchEvent(new TouchEvent(type, {
-      cancelable: true, bubbles: true, composed: true,
-      touches: type === 'touchend' ? [] : [t],
-      targetTouches: type === 'touchend' ? [] : [t],
-      changedTouches: [t],
-    }));
-  };
-  const sleep = ms => new Promise(r => setTimeout(r, ms));
-  let x = startX, y = startY;
-  fire('touchstart', x, y);
-  await sleep(50);
-  for (const dir of directions) {
-    let dx = 0, dy = 0;
-    if (dir === 'r') dx = stepSize;
-    else if (dir === 'l') dx = -stepSize;
-    else if (dir === 'd') dy = stepSize;
-    else if (dir === 'u') dy = -stepSize;
-    const steps = Math.max(1, Math.ceil(Math.hypot(dx, dy) / substep));
-    for (let i = 1; i <= steps; i++) {
-      x += dx / steps; y += dy / steps;
-      fire('touchmove', Math.round(x), Math.round(y));
-      await sleep(16);
-    }
-    await sleep(40);
-  }
-  await sleep(80);
-  fire('touchend', Math.round(x), Math.round(y));
-}
-```
 
 ---
 
-## Step 6: Fix the Issue
+## Step 4: Fix the Issue
 
 1. Use the reproduction evidence (error message, stack trace, console output) to locate the root cause. Read the relevant source code. Do not guess the cause without evidence.
 2. Implement a targeted fix. Prefer the smallest change that addresses the root cause without breaking related behavior.
@@ -202,7 +124,7 @@ async () => {
 
 ---
 
-## Step 7: Fix-Validate Loop (Mandatory)
+## Step 5: Fix-Validate Loop (Mandatory)
 
 After applying a fix, validate it immediately. If validation fails, fix and
 validate again. Repeat until the issue is resolved or the attempt limit is reached.
@@ -213,14 +135,14 @@ of what you tried and what you observed each time.
 
 ### Validation criteria (both must pass)
 
-**7a — Failure no longer triggers**
+**5a — Failure no longer triggers**
 
-1. Open a fresh browser tab at `http://localhost:3000`.
+1. Re-navigate to the dev server in the same browser environment `browser-control` set up. (If the session has been lost, re-run Step 2.)
 2. Clear app state: `localStorage.clear(); location.reload();`
 3. Follow the **Steps to Reproduce** exactly.
 4. Confirm the **Current Behavior** (the bug) does **not** occur.
 
-**7b — Expected behavior is observed**
+**5b — Expected behavior is observed**
 
 1. In the same or a fresh tab, follow the steps again.
 2. Confirm the **Expected Behavior** from the issue is observed exactly as described.
@@ -230,20 +152,20 @@ of what you tried and what you observed each time.
 ```
 attempt = 1
 loop:
-  fix the code (Step 6)
-  run validation 7a and 7b
+  fix the code (Step 4)
+  run validation 5a and 5b
   if both pass → done, summarize what you changed
   if either fails → diagnose what still went wrong
   attempt += 1
   if attempt > 5 → escalate to user
 ```
 
-Never claim success without completing both 7a and 7b. Never skip the loop.
+Never claim success without completing both 5a and 5b. Never skip the loop.
 
 ---
 
 ## Escalation Rules
 
-- If the bug cannot be reproduced in Step 5 after a thorough attempt, stop and report to the user with what you observed. Do not proceed to fixing.
+- If the bug cannot be reproduced in Step 3 after a thorough attempt, stop and report to the user with what you observed. Do not proceed to fixing.
 - If the fix-validate loop reaches 5 attempts without success, stop and summarize: what you tried, what changed, and what still fails.
 - Default to autonomous action. Escalate only when the correct path is genuinely ambiguous.

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
   "arrowParens": "avoid",
   "jsxSingleQuote": true,
-  "importOrder": ["^\\.\\./", "^\\./"],
+  "importOrder": ["^\\./util/iOSConsoleProxy$", "<THIRD_PARTY_MODULES>", "^\\.\\./", "^\\./"],
   "importOrderSortSpecifiers": true,
   "overrides": [{ "files": "*.ts", "options": { "parser": "typescript" } }],
   "plugins": ["@trivago/prettier-plugin-sort-imports"],

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -47,8 +47,6 @@ const baseConfig = {
     platformName: 'iOS' as const,
     browserName: 'Safari' as const,
     'appium:automationName': 'XCUITest' as const,
-    // Enable the XCUITest 'safariConsole' log bucket so afterTest can drain browser console output via getLogs('safariConsole').
-    'appium:showSafariConsoleLog': true as const,
   },
 
   // Test Configurations
@@ -111,7 +109,27 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once safariConsole capture is verified in CI.
+    // Install in-page console proxy. getLogs('safariConsole') returned nothing on this BrowserStack/Appium stack despite appium:showSafariConsoleLog being set, so we capture browser-side logs into window.__capturedLogs__ for the afterTest hook to drain.
+    await browser.execute(() => {
+      const w = window as Window & { __capturedLogs__?: { level: string; message: string }[] }
+      const logs: { level: string; message: string }[] = []
+      w.__capturedLogs__ = logs
+      const c = console as unknown as Record<string, (...args: unknown[]) => void>
+      for (const method of ['log', 'warn', 'error', 'info', 'debug']) {
+        const orig = c[method].bind(console)
+        c[method] = (...args: unknown[]) => {
+          try {
+            const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+            logs.push({ level: method, message })
+          } catch {
+            // Serialization failure (e.g. circular refs) — drop this entry rather than fail the test.
+          }
+          orig(...args)
+        }
+      }
+    })
+
+    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once console-proxy capture is verified in CI.
     await browser.execute(() => console.info('SAFARI_CONSOLE_CANARY: beforeTest reached'))
 
     // Wait for the tutorial skip button and click it
@@ -125,18 +143,23 @@ const baseConfig = {
     await emptyThoughtspace.waitForExist({ timeout: 90000 })
   },
 
-  // After each test: drain the safariConsole log bucket and print it under the test title so browser-side console output is grouped per-it() in CI logs.
+  // After each test: drain window.__capturedLogs__ and print it under the test title so browser-side console output is grouped per-it() in CI logs.
   afterTest: async function (test: { fullTitle: string; title: string; parent: string }) {
     const title = test.fullTitle || `${test.parent} › ${test.title}`
     try {
-      const logs = (await browser.getLogs('safariConsole')) as { level?: string; message?: string }[]
+      const logs = await browser.execute(() => {
+        const w = window as Window & { __capturedLogs__?: { level: string; message: string }[] }
+        const collected = w.__capturedLogs__ ?? []
+        w.__capturedLogs__ = []
+        return collected
+      })
       if (!logs?.length) return
       console.info(`\n[browser console] ${title} (${logs.length} entries)`)
       for (const l of logs) {
-        console.info(`  [${l.level ?? 'log'}] ${l.message ?? JSON.stringify(l)}`)
+        console.info(`  [${l.level}] ${l.message}`)
       }
     } catch {
-      // safariConsole bucket may not be available on this driver — skip silently rather than failing the test.
+      // Page may have navigated away or execute failed — skip silently rather than fail the test.
     }
   },
 }

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -110,22 +110,15 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // TEMP canary + immediate diagnostic: emit a recognisable browser-side console.info, then check whether the proxy actually intercepted it. Remove once iOS console proxy capture is verified in CI.
-    const canaryDiag = await browser.execute(() => {
-      const lengthBefore = window.__iOSConsoleProxy__?.length ?? -1
-      const infoSrc = console.info.toString()
-      console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached')
-      const lengthAfter = window.__iOSConsoleProxy__?.length ?? -1
-      return {
-        bufferExists: Array.isArray(window.__iOSConsoleProxy__),
-        drainExists: typeof window.__drainiOSConsoleLogs__ === 'function',
-        lengthBefore,
-        lengthAfter,
-        infoSrcHead: infoSrc.slice(0, 80),
-        url: location.href,
-      }
+    // Wait for the iOS console proxy to finish installing (initialize.ts runs at app bootstrap, but browser.refresh may return before that completes). Without this wait, the canary below can fire before console.* has been wrapped, in which case the entry hits native console.info and is lost.
+    await browser.waitUntil(async () => browser.execute(() => typeof window.__drainiOSConsoleLogs__ === 'function'), {
+      timeout: 30000,
+      timeoutMsg:
+        'iOS console proxy did not install within 30s — check ?__ios_console_proxy URL flag and src/util/iOSConsoleProxy.ts',
     })
-    console.info(`[canary diagnostic] ${JSON.stringify(canaryDiag)}`)
+
+    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once iOS console proxy capture is verified in CI.
+    await browser.execute(() => console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached'))
 
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -110,15 +110,12 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // Wait for the iOS console proxy to finish installing (initialize.ts runs at app bootstrap, but browser.refresh may return before that completes). Without this wait, the canary below can fire before console.* has been wrapped, in which case the entry hits native console.info and is lost.
+    // Wait for the iOS console proxy to finish installing (initialize.ts runs at app bootstrap, but browser.refresh may return before that completes). Without this wait, app code that logs early can fire before console.* has been wrapped and those entries hit native console and are lost.
     await browser.waitUntil(async () => browser.execute(() => typeof window.__drainiOSConsoleLogs__ === 'function'), {
       timeout: 30000,
       timeoutMsg:
         'iOS console proxy did not install within 30s — check ?__ios_console_proxy URL flag and src/util/iOSConsoleProxy.ts',
     })
-
-    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once iOS console proxy capture is verified in CI.
-    await browser.execute(() => console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached'))
 
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')
@@ -135,19 +132,14 @@ const baseConfig = {
   afterTest: async function (test: { fullTitle: string; title: string; parent: string }) {
     const title = test.fullTitle || `${test.parent} › ${test.title}`
     try {
-      const result = await browser.execute(() => {
-        const collected = window.__drainiOSConsoleLogs__?.() ?? []
-        const proxyInstalled = typeof window.__drainiOSConsoleLogs__ === 'function'
-        return { logs: collected, proxyInstalled, href: location.href }
-      })
-      console.info(
-        `\n[browser console] ${title} — drained ${result.logs.length} entries (proxy installed: ${result.proxyInstalled}, url: ${result.href})`,
-      )
-      for (const l of result.logs) {
+      const logs = await browser.execute(() => window.__drainiOSConsoleLogs__?.() ?? [])
+      if (!logs.length) return
+      console.info(`\n[browser console] ${title} (${logs.length} entries)`)
+      for (const l of logs) {
         console.info(`  [${l.level}] ${l.message}`)
       }
     } catch (err) {
-      // Diagnostic: surface the failure so we can see why drain failed for specific tests, without failing the test itself.
+      // Surface the failure so it isn't silently swallowed, without failing the test itself.
       console.info(`[browser console] ${title} — drain failed: ${err instanceof Error ? err.message : String(err)}`)
     }
   },

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -111,8 +111,8 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // TEMP canary: emit a recognisable browser-side console.log so the afterTest hook has something to drain even when a test produces no app logs. Remove once safariConsole capture is verified in CI.
-    await browser.execute(() => console.log('SAFARI_CONSOLE_CANARY: beforeTest reached'))
+    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once safariConsole capture is verified in CI.
+    await browser.execute(() => console.info('SAFARI_CONSOLE_CANARY: beforeTest reached'))
 
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')
@@ -131,9 +131,9 @@ const baseConfig = {
     try {
       const logs = (await browser.getLogs('safariConsole')) as { level?: string; message?: string }[]
       if (!logs?.length) return
-      console.log(`\n[browser console] ${title} (${logs.length} entries)`)
+      console.info(`\n[browser console] ${title} (${logs.length} entries)`)
       for (const l of logs) {
-        console.log(`  [${l.level ?? 'log'}] ${l.message ?? JSON.stringify(l)}`)
+        console.info(`  [${l.level ?? 'log'}] ${l.message ?? JSON.stringify(l)}`)
       }
     } catch {
       // safariConsole bucket may not be available on this driver — skip silently rather than failing the test.

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -86,9 +86,10 @@ const baseConfig = {
     }
   },
 
-  // Navigate once at the start of the session
+  // Navigate once at the start of the session.
+  // ?__ios_console_proxy activates the iOS console proxy installed by src/util/iOSConsoleProxy.ts.
   before: async function () {
-    await browser.url('http://bs-local.com:3000')
+    await browser.url('http://bs-local.com:3000?__ios_console_proxy')
     await browser.waitUntil(
       async () => {
         const body = await browser.$('body')
@@ -109,28 +110,8 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // Install in-page console proxy. getLogs('safariConsole') returned nothing on this BrowserStack/Appium stack despite appium:showSafariConsoleLog being set, so we capture browser-side logs into window.__capturedLogs__ for the afterTest hook to drain.
-    await browser.execute(() => {
-      const w = window as Window & { __capturedLogs__?: { level: string; message: string }[] }
-      const logs: { level: string; message: string }[] = []
-      w.__capturedLogs__ = logs
-      const c = console as unknown as Record<string, (...args: unknown[]) => void>
-      for (const method of ['log', 'warn', 'error', 'info', 'debug']) {
-        const orig = c[method].bind(console)
-        c[method] = (...args: unknown[]) => {
-          try {
-            const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
-            logs.push({ level: method, message })
-          } catch {
-            // Serialization failure (e.g. circular refs) — drop this entry rather than fail the test.
-          }
-          orig(...args)
-        }
-      }
-    })
-
-    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once console-proxy capture is verified in CI.
-    await browser.execute(() => console.info('SAFARI_CONSOLE_CANARY: beforeTest reached'))
+    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once iOS console proxy capture is verified in CI.
+    await browser.execute(() => console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached'))
 
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')
@@ -143,15 +124,13 @@ const baseConfig = {
     await emptyThoughtspace.waitForExist({ timeout: 90000 })
   },
 
-  // After each test: drain window.__capturedLogs__ and print it under the test title so browser-side console output is grouped per-it() in CI logs.
+  // After each test: drain the iOS console proxy buffer and print it under the test title so browser-side console output is grouped per-it() in CI logs.
   afterTest: async function (test: { fullTitle: string; title: string; parent: string }) {
     const title = test.fullTitle || `${test.parent} › ${test.title}`
     try {
       const result = await browser.execute(() => {
-        const w = window as Window & { __capturedLogs__?: { level: string; message: string }[] }
-        const collected = w.__capturedLogs__ ?? []
-        const proxyInstalled = '__capturedLogs__' in w
-        w.__capturedLogs__ = []
+        const collected = window.__drainiOSConsoleLogs__?.() ?? []
+        const proxyInstalled = typeof window.__drainiOSConsoleLogs__ === 'function'
         return { logs: collected, proxyInstalled, href: location.href }
       })
       console.info(

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -158,8 +158,9 @@ const baseConfig = {
       for (const l of logs) {
         console.info(`  [${l.level}] ${l.message}`)
       }
-    } catch {
-      // Page may have navigated away or execute failed — skip silently rather than fail the test.
+    } catch (err) {
+      // Diagnostic: surface the failure so we can see why drain failed for specific tests, without failing the test itself.
+      console.info(`[browser console] ${title} — drain failed: ${err instanceof Error ? err.message : String(err)}`)
     }
   },
 }

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -47,14 +47,23 @@ const baseConfig = {
     platformName: 'iOS' as const,
     browserName: 'Safari' as const,
     'appium:automationName': 'XCUITest' as const,
+    // Enable the XCUITest 'safariConsole' log bucket so afterTest can drain browser console output via getLogs('safariConsole').
+    'appium:showSafariConsoleLog': true as const,
   },
 
   // Test Configurations
-  logLevel: 'info' as const,
+  logLevel: 'warn' as const,
+  // Per-package override: silence @wdio/browserstack-service's observability bookkeeping (plumbing for BrowserStack's dashboard, not diagnostic).
+  logLevels: {
+    '@wdio/browserstack-service': 'error' as const,
+  },
   bail: 0,
   waitforTimeout: 20000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
+
+  // Spec reporter gives per-it() pass/fail visibility in CI logs.
+  reporters: ['spec'],
 
   // Framework Configuration
   framework: 'mocha' as const,
@@ -102,6 +111,9 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
+    // TEMP canary: emit a recognisable browser-side console.log so the afterTest hook has something to drain even when a test produces no app logs. Remove once safariConsole capture is verified in CI.
+    await browser.execute(() => console.log('SAFARI_CONSOLE_CANARY: beforeTest reached'))
+
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')
     await skipElement.waitForExist({ timeout: 90000 })
@@ -111,6 +123,21 @@ const baseConfig = {
     // Wait for the empty thoughtspace to be ready
     const emptyThoughtspace = await $('[aria-label="empty-thoughtspace"]')
     await emptyThoughtspace.waitForExist({ timeout: 90000 })
+  },
+
+  // After each test: drain the safariConsole log bucket and print it under the test title so browser-side console output is grouped per-it() in CI logs.
+  afterTest: async function (test: { fullTitle: string; title: string; parent: string }) {
+    const title = test.fullTitle || `${test.parent} › ${test.title}`
+    try {
+      const logs = (await browser.getLogs('safariConsole')) as { level?: string; message?: string }[]
+      if (!logs?.length) return
+      console.log(`\n[browser console] ${title} (${logs.length} entries)`)
+      for (const l of logs) {
+        console.log(`  [${l.level ?? 'log'}] ${l.message ?? JSON.stringify(l)}`)
+      }
+    } catch {
+      // safariConsole bucket may not be available on this driver — skip silently rather than failing the test.
+    }
   },
 }
 

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -110,8 +110,22 @@ const baseConfig = {
     // Refresh to apply the cleared storage (much faster than full navigation)
     await browser.refresh()
 
-    // TEMP canary: emit a recognisable browser-side console.info so the afterTest hook has something to drain even when a test produces no app logs. Remove once iOS console proxy capture is verified in CI.
-    await browser.execute(() => console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached'))
+    // TEMP canary + immediate diagnostic: emit a recognisable browser-side console.info, then check whether the proxy actually intercepted it. Remove once iOS console proxy capture is verified in CI.
+    const canaryDiag = await browser.execute(() => {
+      const lengthBefore = window.__iOSConsoleProxy__?.length ?? -1
+      const infoSrc = console.info.toString()
+      console.info('IOS_CONSOLE_PROXY_CANARY: beforeTest reached')
+      const lengthAfter = window.__iOSConsoleProxy__?.length ?? -1
+      return {
+        bufferExists: Array.isArray(window.__iOSConsoleProxy__),
+        drainExists: typeof window.__drainiOSConsoleLogs__ === 'function',
+        lengthBefore,
+        lengthAfter,
+        infoSrcHead: infoSrc.slice(0, 80),
+        url: location.href,
+      }
+    })
+    console.info(`[canary diagnostic] ${JSON.stringify(canaryDiag)}`)
 
     // Wait for the tutorial skip button and click it
     const skipElement = await $('#skip-tutorial')

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -147,15 +147,17 @@ const baseConfig = {
   afterTest: async function (test: { fullTitle: string; title: string; parent: string }) {
     const title = test.fullTitle || `${test.parent} › ${test.title}`
     try {
-      const logs = await browser.execute(() => {
+      const result = await browser.execute(() => {
         const w = window as Window & { __capturedLogs__?: { level: string; message: string }[] }
         const collected = w.__capturedLogs__ ?? []
+        const proxyInstalled = '__capturedLogs__' in w
         w.__capturedLogs__ = []
-        return collected
+        return { logs: collected, proxyInstalled, href: location.href }
       })
-      if (!logs?.length) return
-      console.info(`\n[browser console] ${title} (${logs.length} entries)`)
-      for (const l of logs) {
+      console.info(
+        `\n[browser console] ${title} — drained ${result.logs.length} entries (proxy installed: ${result.proxyInstalled}, url: ${result.href})`,
+      )
+      for (const l of result.logs) {
         console.info(`  [${l.level}] ${l.message}`)
       }
     } catch (err) {

--- a/src/e2e/iOS/config/wdio.browserstack.conf.ts
+++ b/src/e2e/iOS/config/wdio.browserstack.conf.ts
@@ -47,9 +47,11 @@ export const config: WebdriverIO.Config = {
         buildName: process.env.BROWSERSTACK_BUILD_NAME || `Local - ${user} - ${date}`,
         sessionName: 'iOS Safari Tests',
         local: true,
-        debug: true,
-        networkLogs: true,
-        consoleLogs: 'verbose',
+        // These flags collect diagnostic data on BrowserStack's web dashboard,
+        // which we don't need/use.
+        debug: false,
+        networkLogs: false,
+        consoleLogs: 'errors',
         idleTimeout: 60,
       },
     },
@@ -63,7 +65,8 @@ export const config: WebdriverIO.Config = {
         browserstackLocal: true,
         testObservability: true,
         opts: {
-          verbose: true,
+          // logFile still captures local-tunnel debug output; verbose stdout would only duplicate it into the runner log.
+          verbose: false,
           forceLocal: true,
           logFile: 'browserstack.log',
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+// Side-effect import: must come first so the iOS console proxy installs before any other module body runs and captures bootstrap logs.
+import './util/iOSConsoleProxy'
 import { createRoot } from 'react-dom/client'
 import App from './components/App'
 import './index.css'

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -39,16 +39,12 @@ import syncStatusStore from './stores/syncStatus'
 import importToContext from './test-helpers/importToContext'
 import prettyPath from './test-helpers/prettyPath'
 import hashThought from './util/hashThought'
-import installiOSConsoleProxy from './util/iOSConsoleProxy'
 import initEvents from './util/initEvents'
 import isRoot from './util/isRoot'
 import mergeBatch from './util/mergeBatch'
 import owner from './util/owner'
 import throttleConcat from './util/throttleConcat'
 import urlDataSource from './util/urlDataSource'
-
-// Install the iOS console proxy at module load (before initialize() runs and before most app code logs anything). No-op unless ?__ios_console_proxy is in the URL.
-installiOSConsoleProxy()
 
 /** Number of milliseconds to throttle dispatching updateThoughts on thought/lexeme change. */
 const UPDATE_THOUGHTS_THROTTLE = 100

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -39,12 +39,16 @@ import syncStatusStore from './stores/syncStatus'
 import importToContext from './test-helpers/importToContext'
 import prettyPath from './test-helpers/prettyPath'
 import hashThought from './util/hashThought'
+import installiOSConsoleProxy from './util/iOSConsoleProxy'
 import initEvents from './util/initEvents'
 import isRoot from './util/isRoot'
 import mergeBatch from './util/mergeBatch'
 import owner from './util/owner'
 import throttleConcat from './util/throttleConcat'
 import urlDataSource from './util/urlDataSource'
+
+// Install the iOS console proxy at module load (before initialize() runs and before most app code logs anything). No-op unless ?__ios_console_proxy is in the URL.
+installiOSConsoleProxy()
 
 /** Number of milliseconds to throttle dispatching updateThoughts on thought/lexeme change. */
 const UPDATE_THOUGHTS_THROTTLE = 100

--- a/src/util/iOSConsoleProxy.ts
+++ b/src/util/iOSConsoleProxy.ts
@@ -1,0 +1,46 @@
+type CapturedLog = { level: string; message: string }
+
+declare global {
+  interface Window {
+    __iOSConsoleProxy__?: CapturedLog[]
+    __drainiOSConsoleLogs__?: () => CapturedLog[]
+  }
+}
+
+const logs: CapturedLog[] = []
+
+/** Atomically reads and clears the iOS console proxy buffer. Returns [] when nothing has been captured. */
+export const drainiOSConsoleLogs = (): CapturedLog[] => logs.splice(0)
+
+/**
+ * Installs a console proxy that captures console.{log,warn,error,info,debug} into
+ * window.__iOSConsoleProxy__ when ?__ios_console_proxy is in the URL.
+ * BrowserStack does not provide access to logs natively due to Safari WebDriver
+ * limitations, so we need this workaround to access console logs.
+ * The proxy still calls the original console method, so
+ * app behaviour is unchanged when enabled.
+ */
+const installiOSConsoleProxy = (): void => {
+  if (!new URLSearchParams(window.location.search).has('__ios_console_proxy')) return
+  if (window.__iOSConsoleProxy__) return
+
+  // Expose references so the WDIO config can reach them via browser.execute. The buffer (logs) is the same array drainiOSConsoleLogs closes over.
+  window.__iOSConsoleProxy__ = logs
+  window.__drainiOSConsoleLogs__ = drainiOSConsoleLogs
+
+  const c = console as unknown as Record<string, (...args: unknown[]) => void>
+  for (const method of ['log', 'warn', 'error', 'info', 'debug']) {
+    const orig = c[method].bind(console)
+    c[method] = (...args: unknown[]) => {
+      try {
+        const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+        logs.push({ level: method, message })
+      } catch {
+        // Serialization failure (e.g. circular refs) — drop this entry.
+      }
+      orig(...args)
+    }
+  }
+}
+
+export default installiOSConsoleProxy

--- a/src/util/iOSConsoleProxy.ts
+++ b/src/util/iOSConsoleProxy.ts
@@ -2,30 +2,47 @@ type CapturedLog = { level: string; message: string }
 
 declare global {
   interface Window {
-    __iOSConsoleProxy__?: CapturedLog[]
     __drainiOSConsoleLogs__?: () => CapturedLog[]
   }
 }
 
-const logs: CapturedLog[] = []
+// sessionStorage key for the captured-log buffer. Using sessionStorage rather than an in-memory array means the buffer survives same-tab page reloads, which iOS Safari occasionally does mid-test (the new window object would otherwise wipe an in-memory buffer).
+const KEY = '__iOSConsoleLogs__'
+
+/** Reads the buffer from sessionStorage. Returns [] on parse failure or missing buffer. */
+const read = (): CapturedLog[] => {
+  try {
+    return JSON.parse(sessionStorage.getItem(KEY) ?? '[]') as CapturedLog[]
+  } catch {
+    return []
+  }
+}
 
 /** Atomically reads and clears the iOS console proxy buffer. Returns [] when nothing has been captured. */
-export const drainiOSConsoleLogs = (): CapturedLog[] => logs.splice(0)
+export const drainiOSConsoleLogs = (): CapturedLog[] => {
+  const collected = read()
+  sessionStorage.setItem(KEY, '[]')
+  return collected
+}
 
 /**
  * Installs a console proxy that captures console.{log,warn,error,info,debug} into
- * window.__iOSConsoleProxy__ when ?__ios_console_proxy is in the URL.
+ * sessionStorage when ?__ios_console_proxy is in the URL.
  * BrowserStack does not provide access to logs natively due to Safari WebDriver
  * limitations, so we need this workaround to access console logs.
  * The proxy still calls the original console method, so
  * app behaviour is unchanged when enabled.
+ *
+ * The buffer is stored in sessionStorage (key __iOSConsoleLogs__) so it survives
+ * same-tab page reloads. Drain via window.__drainiOSConsoleLogs__() (or
+ * drainiOSConsoleLogs() from this module) — that returns the entries and clears
+ * the buffer atomically. To peek without draining, run
+ * `JSON.parse(sessionStorage.getItem('__iOSConsoleLogs__'))` in DevTools.
  */
 const installiOSConsoleProxy = (): void => {
   if (!new URLSearchParams(window.location.search).has('__ios_console_proxy')) return
-  if (window.__iOSConsoleProxy__) return
+  if (window.__drainiOSConsoleLogs__) return
 
-  // Expose references so the WDIO config can reach them via browser.execute. The buffer (logs) is the same array drainiOSConsoleLogs closes over.
-  window.__iOSConsoleProxy__ = logs
   window.__drainiOSConsoleLogs__ = drainiOSConsoleLogs
 
   const c = console as unknown as Record<string, (...args: unknown[]) => void>
@@ -34,9 +51,11 @@ const installiOSConsoleProxy = (): void => {
     c[method] = (...args: unknown[]) => {
       try {
         const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
-        logs.push({ level: method, message })
+        const buf = read()
+        buf.push({ level: method, message })
+        sessionStorage.setItem(KEY, JSON.stringify(buf))
       } catch {
-        // Serialization failure (e.g. circular refs) — drop this entry.
+        // Serialization or storage failure (e.g. circular refs, quota) — drop this entry.
       }
       orig(...args)
     }

--- a/src/util/iOSConsoleProxy.ts
+++ b/src/util/iOSConsoleProxy.ts
@@ -63,3 +63,6 @@ const installiOSConsoleProxy = (): void => {
 }
 
 export default installiOSConsoleProxy
+
+// Self-install at module load. Importing this file (e.g. as the first line of src/index.tsx) installs the proxy before any other module body runs, so app-bootstrap logs are captured. No-op when ?__ios_console_proxy isn't in the URL.
+installiOSConsoleProxy()


### PR DESCRIPTION
## Summary

- **Reliable iOS Safari console capture for CI.** Replaces the non-functional `safariConsole` / `appium:showSafariConsoleLog` path (returned empty buffers on BrowserStack) with an app-installed in-page console proxy gated by `?__ios_console_proxy`. The proxy installs at module load (before bootstrap logs fire), wraps `console.{log,warn,error,info,debug}` to push into `window.__iOSConsoleProxy__`, and exposes `window.__drainiOSConsoleLogs__()` for atomic read+clear. The wdio config's `afterTest` drains per-`it()` so per-test console output is grouped in CI logs.
- **AI-agent iOS Safari debugging.** New `browser-control` skill teaches agents to drive a real iOS Safari session on BrowserStack via the webdriverio MCP. The MCP's native `platform: 'ios'` mode is wired for native apps and hard-requires `appPath`/`app`/`noReset`; the skill documents the empirically-verified escape-hatch invocation (`platform: 'browser'` + `browser: 'safari'` + iOS specifics passed through the `capabilities` block) plus `browserstackLocal: true` for the tunnel.
- **`interaction-gestures` skill.** Per-platform multi-direction touch gesture dispatch — agents using `swipe` once per direction won't commit em's compound gestures; the skill documents the continuous touch-event sequence with the pacing the gesture detector requires.
- **`issue-repro` refactor.** Now extracts a target platform (`web` / `android` / `ios`) from the issue and delegates browser bring-up to `browser-control`. Stops it from silently using desktop Chrome for `[iOS]`-tagged issues.

## Test plan

- [ ] iOS e2e suite passes against BrowserStack on this branch — per-`it()` console output appears in CI logs and is no longer empty.
- [ ] Production build is unaffected: `installiOSConsoleProxy` returns early when `?__ios_console_proxy` is not present in the URL.
- [ ] An issue tagged `[iOS]` routed through `issue-repro` → `browser-control` opens an iOS Safari session via the wdio MCP, navigates to `http://bs-local.com:3000?__ios_console_proxy`, and `execute_script(() => window.__drainiOSConsoleLogs__())` returns captured entries.
- [ ] An issue tagged `[Mobile]` (no iOS) is routed to the `android` target via chrome-devtools MCP with Pixel-class mobile emulation applied before the first `navigate`.
- [ ] An untagged issue defaults to `web` and uses the desktop chrome-devtools profile.
- [ ] Multi-direction swipe issues (e.g. `rdr`) commit correctly on both web/android (chrome-devtools) and iOS (wdio `execute_script` with the same touch-dispatch snippet).