### PR TITLE
wait to check the thought before pressing consecutive ArrowUp key

### DIFF
--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -169,6 +169,10 @@ it('move cursor from formatted thought to first unformatted thought in descendin
   expect(downThoughtValue).toBe('pear')
 
   await press('ArrowUp')
+
+  // Before doing consecutive arrow up presses, wait until the cursor is on the apple thought then proceed with the arrow up press once again. The reason for doing is cursorUp and cursorDown are throttled to run once per animation frame, so repeated keypresses within the same frame might be ignored especially when running in CI.
+  await waitUntil(() => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML === '<b>apple</b>')
+
   await press('ArrowUp')
 
   // Wait for cursor to move to 'fruits'


### PR DESCRIPTION
Close #4213

### Problem

`press('ArrowUp/down')` executes cursorUp and cursorDown which are throttled to run once per animation frame, so repeated keypresses within the same frame might be ignored especially when running in CI.

### Solution

Before doing consecutive arrow up presses, wait until the cursor is on the required thought then proceed with the arrow up press once again.

[Here](https://github.com/karunkop/em/actions?query=branch%3Aflaky-cursor-test) is the result for CI checks!