### PR TITLE
iOS: Preserve cursor-only state after cursorBack tap

### DIFF
--- a/src/e2e/iOS/__tests__/caret.ts
+++ b/src/e2e/iOS/__tests__/caret.ts
@@ -2,6 +2,7 @@
  * IOS Safari caret positioning tests.
  * Uses WDIO test runner with Mocha framework.
  */
+import type { WindowEm } from '../../../initialize'
 import gestures from '../../../test-helpers/gestures'
 import clickThought from '../helpers/clickThought'
 import editThought from '../helpers/editThought'
@@ -15,6 +16,7 @@ import isKeyboardShown from '../helpers/isKeyboardShown'
 import newThought from '../helpers/newThought'
 import paste from '../helpers/paste'
 import tap from '../helpers/tap'
+import waitForBrowserSettled from '../helpers/waitForBrowserSettled'
 import waitForEditable from '../helpers/waitForEditable'
 import waitUntil from '../helpers/waitUntil'
 
@@ -176,9 +178,13 @@ describe('Caret', () => {
     })
 
     await tap(editableNodeHandle, { y: 60, x: 20 })
+    await waitForBrowserSettled()
 
     const editingText = await getEditingText()
     expect(editingText).toBe('foo')
+
+    const keyboardOpen = await browser.execute(() => (window.em as WindowEm).testHelpers.getState().isKeyboardOpen)
+    expect(keyboardOpen).not.toBe(true)
 
     const selectionTextContent = await getSelection().focusNode?.textContent
     expect(selectionTextContent).toBe(null)

--- a/src/e2e/iOS/helpers/waitForBrowserSettled.ts
+++ b/src/e2e/iOS/helpers/waitForBrowserSettled.ts
@@ -1,0 +1,10 @@
+/** Waits for browser layout, paint, and queued macrotasks to settle after DOM-affecting iOS e2e actions. */
+const waitForBrowserSettled = async (): Promise<void> => {
+  await browser.execute(async () => {
+    await new Promise(requestAnimationFrame)
+    await new Promise(requestAnimationFrame)
+    await new Promise(resolve => setTimeout(resolve))
+  })
+}
+
+export default waitForBrowserSettled


### PR DESCRIPTION
Strengthens the existing iOS `Swipe over cursor` test without adding runtime changes.

The test now covers the real BrowserStack path observed in diagnostics:
- close the native keyboard
- perform cursorBack via swipe-right
- tap the thought through the existing iOS tap helper
- wait for browser/focus settling
- assert the thought is selected as the app cursor, but native keyboard/edit mode remains closed

Diagnostics from a separate throwaway PR showed the tap path is a trusted iOS `touchend` followed by a trusted focus event while `isKeyboardOpen === false`. This PR captures that intended contract in the existing test.