### PR TITLE
Case-insensitive background color regex

### DIFF
--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -16,6 +16,8 @@ import strip from '../util/strip'
 import { editThoughtActionCreator as editThought } from './editThought'
 import { setDescendantActionCreator as setDescendant } from './setDescendant'
 
+const BACKGROUND_COLOR_REGEX = /background-color\s*:\s*[^;]+;?/i
+
 /** Format the browser selection or cursor thought as bold, italic, strikethrough, underline. */
 export const formatSelectionActionCreator =
   (
@@ -43,7 +45,7 @@ export const formatSelectionActionCreator =
       selection.text()?.length === strip(thought.value).length
     ) {
       // Check the value of the note or thought for a custom background color (#3901)
-      const hasCustomBackgroundColor = /background-color\s*:\s*[^;]+;?/.test(
+      const hasCustomBackgroundColor = BACKGROUND_COLOR_REGEX.test(
         state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
       )
       const savedSelection = selection.save()

--- a/src/e2e/puppeteer/__tests__/format.ts
+++ b/src/e2e/puppeteer/__tests__/format.ts
@@ -1,5 +1,7 @@
 import click from '../helpers/click'
+import clickThought from '../helpers/clickThought'
 import exportThoughts from '../helpers/exportThoughts'
+import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
 import waitForEditable from '../helpers/waitForEditable'
 import { page } from '../setup'
@@ -31,4 +33,25 @@ it('Apply formatting to a selected portion of a thought', async () => {
   expect(output).toBe(`
 - **Golden** Retriever
 `)
+})
+
+it('Apply text color to an uppercase formatting tag', async () => {
+  const importText = `
+  - Hello World`
+
+  await paste(importText)
+
+  await clickThought('Hello World')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="background color swatches"] [aria-label="blue"]')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Letter Case"]')
+  await click('[aria-label="letter case swatches"] [aria-label="UpperCase"]')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="blue"]')
+
+  const result = await getEditingText()
+  expect(result).toBe('<font color="#00c7e6">HELLO WORLD</font>')
 })


### PR DESCRIPTION
Fixes https://github.com/cybersemics/em/issues/3930 and https://github.com/cybersemics/em/issues/3877

The uppercase text tool converts all of the HTML in the thought to uppercase, including formatting tags. The background-color regex was case-sensitive, so I changed that to be case-insensitive instead.