### PR TITLE
Pr/4333

### DIFF
--- a/src/components/SearchCommands.tsx
+++ b/src/components/SearchCommands.tsx
@@ -7,17 +7,19 @@ import SearchIcon from './icons/SearchIcon'
 const SearchCommands: FC<{ onInput?: (value: string) => void }> = ({ onInput }) => {
   const inputRef = useRef<HTMLInputElement>(null)
 
-  /** Blurs the search input when the user scrolls. */
-  const handleScroll = () => {
+  /** Blurs the search input when the user scrolls or drags the results. */
+  const blurInput = () => {
     if (inputRef.current && document.activeElement === inputRef.current) {
       inputRef.current.blur()
     }
   }
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll, true)
+    window.addEventListener('scroll', blurInput, true)
+    window.addEventListener('touchmove', blurInput, true)
     return () => {
-      window.removeEventListener('scroll', handleScroll, true)
+      window.removeEventListener('scroll', blurInput, true)
+      window.removeEventListener('touchmove', blurInput, true)
     }
   }, [])
 

--- a/src/components/SearchCommands.tsx
+++ b/src/components/SearchCommands.tsx
@@ -1,10 +1,26 @@
-import { FC } from 'react'
+import { FC, useEffect, useRef } from 'react'
 import { css } from '../../styled-system/css'
 import { token } from '../../styled-system/tokens'
 import SearchIcon from './icons/SearchIcon'
 
 /** Search bar for filtering commands. */
 const SearchCommands: FC<{ onInput?: (value: string) => void }> = ({ onInput }) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  /** Blurs the search input when the user scrolls. */
+  const handleScroll = () => {
+    if (inputRef.current && document.activeElement === inputRef.current) {
+      inputRef.current.blur()
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, true)
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true)
+    }
+  }, [])
+
   return (
     <div id='search' className={css({ flexGrow: 1, border: 'solid 1px {colors.gray50}', borderRadius: '8px' })}>
       <div className={css({ position: 'relative' })}>
@@ -22,6 +38,7 @@ const SearchCommands: FC<{ onInput?: (value: string) => void }> = ({ onInput }) 
           <SearchIcon size={16} fill={token('colors.lightgray')} />
         </div>
         <input
+          ref={inputRef}
           type='text'
           placeholder='Search commands...'
           onInput={(e: React.FormEvent<HTMLInputElement>) => {

--- a/src/components/SortPicker.tsx
+++ b/src/components/SortPicker.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash'
-import React, { FC, memo, useEffect, useRef } from 'react'
+import React, { FC, memo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import SortPreference from '../@types/SortPreference'
@@ -69,7 +69,6 @@ const SortOption: FC<SortOptionProps> = ({ type, supportsDirection, label, sortP
 const SortPicker: FC<{ size?: number }> = memo(({ size }) => {
   const dispatch = useDispatch()
   const showSortPicker = useSelector(state => state.showSortPicker)
-  const popoverRef = useRef<HTMLDivElement>(null)
 
   const sortPreference = useSelector(state => {
     if (!state.cursor || isRoot(state.cursor)) return { type: 'None', direction: null }
@@ -108,68 +107,46 @@ const SortPicker: FC<{ size?: number }> = memo(({ size }) => {
     })
   }
 
-  /** Dismisses the keyboard when the user interacts with the sort picker. */
-  const handleInteraction = () => {
-    const activeElement = document.activeElement
-    if (activeElement && activeElement instanceof HTMLInputElement) {
-      activeElement.blur()
-    }
-  }
-
-  useEffect(() => {
-    const popoverElement = popoverRef.current
-    if (!popoverElement) return
-
-    popoverElement.addEventListener('click', handleInteraction)
-    popoverElement.addEventListener('touchstart', handleInteraction)
-    return () => {
-      popoverElement.removeEventListener('click', handleInteraction)
-      popoverElement.removeEventListener('touchstart', handleInteraction)
-    }
-  }, [])
-
   return (
-    <div ref={popoverRef}>
-      <Popover show={showSortPicker} size={size}>
-        <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
-          <SortOption
-            type='None'
-            supportsDirection={false}
-            label='None'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-          <SortOption
-            type='Alphabetical'
-            supportsDirection={true}
-            label='Alphabetical'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-          <SortOption
-            type='Created'
-            supportsDirection={true}
-            label='Created'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-          <SortOption
-            type='Updated'
-            supportsDirection={true}
-            label='Updated'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-          <SortOption
-            type='Note'
-            supportsDirection={true}
-            label='Note'
-            sortPreference={sortPreference}
-            onClick={toggleSortOption}
-          />
-        </div>
-      </Popover>
-    </div>
+    <Popover show={showSortPicker} size={size}>
+      <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
+        <SortOption
+          type='None'
+          supportsDirection={false}
+          label='None'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
+        <SortOption
+          type='Alphabetical'
+          supportsDirection={true}
+          label='Alphabetical'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
+        <SortOption
+          type='Created'
+          supportsDirection={true}
+          label='Created'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
+        <SortOption
+          type='Updated'
+          supportsDirection={true}
+          label='Updated'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
+        <SortOption
+          type='Note'
+          supportsDirection={true}
+          label='Note'
+          sortPreference={sortPreference}
+          onClick={toggleSortOption}
+        />
+      </div>
+    </Popover>
   )
 })
 

--- a/src/components/SortPicker.tsx
+++ b/src/components/SortPicker.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash'
-import React, { FC, memo } from 'react'
+import React, { FC, memo, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import SortPreference from '../@types/SortPreference'
@@ -69,6 +69,7 @@ const SortOption: FC<SortOptionProps> = ({ type, supportsDirection, label, sortP
 const SortPicker: FC<{ size?: number }> = memo(({ size }) => {
   const dispatch = useDispatch()
   const showSortPicker = useSelector(state => state.showSortPicker)
+  const popoverRef = useRef<HTMLDivElement>(null)
 
   const sortPreference = useSelector(state => {
     if (!state.cursor || isRoot(state.cursor)) return { type: 'None', direction: null }
@@ -107,46 +108,68 @@ const SortPicker: FC<{ size?: number }> = memo(({ size }) => {
     })
   }
 
+  /** Dismisses the keyboard when the user interacts with the sort picker. */
+  const handleInteraction = () => {
+    const activeElement = document.activeElement
+    if (activeElement && activeElement instanceof HTMLInputElement) {
+      activeElement.blur()
+    }
+  }
+
+  useEffect(() => {
+    const popoverElement = popoverRef.current
+    if (!popoverElement) return
+
+    popoverElement.addEventListener('click', handleInteraction)
+    popoverElement.addEventListener('touchstart', handleInteraction)
+    return () => {
+      popoverElement.removeEventListener('click', handleInteraction)
+      popoverElement.removeEventListener('touchstart', handleInteraction)
+    }
+  }, [])
+
   return (
-    <Popover show={showSortPicker} size={size}>
-      <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
-        <SortOption
-          type='None'
-          supportsDirection={false}
-          label='None'
-          sortPreference={sortPreference}
-          onClick={toggleSortOption}
-        />
-        <SortOption
-          type='Alphabetical'
-          supportsDirection={true}
-          label='Alphabetical'
-          sortPreference={sortPreference}
-          onClick={toggleSortOption}
-        />
-        <SortOption
-          type='Created'
-          supportsDirection={true}
-          label='Created'
-          sortPreference={sortPreference}
-          onClick={toggleSortOption}
-        />
-        <SortOption
-          type='Updated'
-          supportsDirection={true}
-          label='Updated'
-          sortPreference={sortPreference}
-          onClick={toggleSortOption}
-        />
-        <SortOption
-          type='Note'
-          supportsDirection={true}
-          label='Note'
-          sortPreference={sortPreference}
-          onClick={toggleSortOption}
-        />
-      </div>
-    </Popover>
+    <div ref={popoverRef}>
+      <Popover show={showSortPicker} size={size}>
+        <div aria-label='sort options' className={css({ whiteSpace: 'wrap' })}>
+          <SortOption
+            type='None'
+            supportsDirection={false}
+            label='None'
+            sortPreference={sortPreference}
+            onClick={toggleSortOption}
+          />
+          <SortOption
+            type='Alphabetical'
+            supportsDirection={true}
+            label='Alphabetical'
+            sortPreference={sortPreference}
+            onClick={toggleSortOption}
+          />
+          <SortOption
+            type='Created'
+            supportsDirection={true}
+            label='Created'
+            sortPreference={sortPreference}
+            onClick={toggleSortOption}
+          />
+          <SortOption
+            type='Updated'
+            supportsDirection={true}
+            label='Updated'
+            sortPreference={sortPreference}
+            onClick={toggleSortOption}
+          />
+          <SortOption
+            type='Note'
+            supportsDirection={true}
+            label='Note'
+            sortPreference={sortPreference}
+            onClick={toggleSortOption}
+          />
+        </div>
+      </Popover>
+    </div>
   )
 })
 

--- a/src/components/__tests__/SearchCommands.ts
+++ b/src/components/__tests__/SearchCommands.ts
@@ -1,0 +1,35 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SearchCommands from '../SearchCommands'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('SearchCommands', () => {
+  it('blurs the search input on scroll', () => {
+    render(createElement(SearchCommands))
+
+    const input = screen.getByPlaceholderText('Search commands...')
+    const blur = vi.spyOn(input, 'blur')
+
+    input.focus()
+    fireEvent.scroll(window)
+
+    expect(blur).toHaveBeenCalled()
+  })
+
+  it('blurs the search input on touchmove', () => {
+    render(createElement(SearchCommands))
+
+    const input = screen.getByPlaceholderText('Search commands...')
+    const blur = vi.spyOn(input, 'blur')
+
+    input.focus()
+    fireEvent.touchMove(window)
+
+    expect(blur).toHaveBeenCalled()
+  })
+})

--- a/src/components/dialog/MobileCommandUniverse.tsx
+++ b/src/components/dialog/MobileCommandUniverse.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { SwitchTransition } from 'react-transition-group'
 import { css, cx } from '../../../styled-system/css'
@@ -14,7 +14,7 @@ import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 
 /**
- * Pre-rendered hidden divs that force the browser to fetch the dialog's decorative AVIFs ahead of time, so they are cached when the dialog opens. Same workaround pattern used by CommandCenter's HiddenOverlay. Always mounted because the parent is rendered at the AppComponent level.
+ * Pre-rendered hidden divs that force the browser to fetch the dialog's decorative AVIFs ahead of time, so they are cached when the dialog opens. Same workaround pattern used by CommandCenter's H[...]
  */
 const HiddenDialogAssets = () => (
   <>
@@ -90,6 +90,7 @@ const MobileCommandUniverse: React.FC = () => {
   const dispatch = useDispatch()
   const isOpen = useSelector(state => state.showMobileCommandUniverse)
   const nodeRef = React.useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
 
   /**
    * Handles the closure of the mobile command universe.
@@ -98,16 +99,36 @@ const MobileCommandUniverse: React.FC = () => {
     dispatch(toggleMobileCommandUniverseActionCreator({ value: false }))
   }
 
+  /** Dismisses the keyboard when the user scrolls within the dialog. */
+  const handleScroll = () => {
+    const activeElement = document.activeElement
+    if (activeElement && activeElement instanceof HTMLInputElement) {
+      activeElement.blur()
+    }
+  }
+
+  useEffect(() => {
+    const contentElement = contentRef.current
+    if (!contentElement) return
+
+    contentElement.addEventListener('scroll', handleScroll)
+    return () => {
+      contentElement.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
   return (
     <>
       <HiddenDialogAssets />
       <FadeTransition in={isOpen} unmountOnExit type='medium' nodeRef={nodeRef}>
-        <Dialog onClose={handleClose} nodeRef={nodeRef}>
-          <DialogTitle onClose={handleClose}>Command Universe</DialogTitle>
-          <DialogContent>
-            <MobileCommandUniverseContent />
-          </DialogContent>
-        </Dialog>
+        <div ref={contentRef} className={css({ overflowY: 'auto', maxHeight: '100vh' })}>
+          <Dialog onClose={handleClose} nodeRef={nodeRef}>
+            <DialogTitle onClose={handleClose}>Command Universe</DialogTitle>
+            <DialogContent>
+              <MobileCommandUniverseContent />
+            </DialogContent>
+          </Dialog>
+        </div>
       </FadeTransition>
     </>
   )

--- a/src/components/dialog/MobileCommandUniverse.tsx
+++ b/src/components/dialog/MobileCommandUniverse.tsx
@@ -14,7 +14,7 @@ import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 
 /**
- * Pre-rendered hidden divs that force the browser to fetch the dialog's decorative AVIFs ahead of time, so they are cached when the dialog opens. Same workaround pattern used by CommandCenter's H[...]
+ * Pre-rendered hidden divs that force the browser to fetch the dialog's decorative AVIFs ahead of time, so they are cached when the dialog opens. Same workaround pattern used by CommandCenter's HiddenOverlay.
  */
 const HiddenDialogAssets = () => (
   <>

--- a/src/components/modals/CustomizeToolbar.tsx
+++ b/src/components/modals/CustomizeToolbar.tsx
@@ -109,115 +109,136 @@ const ModalCustomizeToolbar: FC = () => {
   const dispatch = useDispatch()
 
   const commandsContainerRef = useRef<HTMLDivElement>(null)
+  const modalContentRef = useRef<HTMLDivElement>(null)
   const commands = useMemo(() => (selectedCommand ? [selectedCommand] : []), [selectedCommand])
 
   const id = 'customizeToolbar'
   const modalClasses = modalRecipe({ id })
 
+  /** Dismisses the keyboard when the user scrolls within the modal. */
+  const handleScroll = () => {
+    const activeElement = document.activeElement
+    if (activeElement && activeElement instanceof HTMLInputElement) {
+      activeElement.blur()
+    }
+  }
+
+  useEffect(() => {
+    const modalElement = modalContentRef.current
+    if (!modalElement) return
+
+    modalElement.addEventListener('scroll', handleScroll)
+    return () => {
+      modalElement.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
   return (
-    <ModalComponent
-      id={id}
-      // omit title since we need to make room for the toolbar
-      title=''
-    >
-      <h1 className={modalClasses.title}>Customize Toolbar</h1>
-      <p className={css({ marginTop: '-1em', marginBottom: '1em' })}>
-        &lt;{' '}
-        <a {...fastClick(() => dispatch(showModal({ id: 'settings' })))} className={extendTapRecipe()}>
-          Back to Settings
-        </a>
-      </p>
-
-      <div
-        className={css({
-          // mask the selected bar that is rendered outside thn left edge of the CommandRow
-          backgroundColor: selectedCommand ? 'bg' : undefined,
-          position: 'sticky',
-          top: '0px',
-          marginBottom: '1em',
-          // extend element to mask the selected bar that is rendered outside thn left edge of the CommandRow
-          marginLeft: '-modalPadding',
-          paddingLeft: 'modalPadding',
-          // above CommandRow, which has position: relative for the selected bar
-          zIndex: 1,
-        })}
+    <div ref={modalContentRef} className={css({ overflowY: 'auto', maxHeight: '100%' })}>
+      <ModalComponent
+        id={id}
+        // omit title since we need to make room for the toolbar
+        title=''
       >
-        <Toolbar customize onSelect={toggleSelectedCommand} selected={selectedCommand?.id} />
+        <h1 className={modalClasses.title}>Customize Toolbar</h1>
+        <p className={css({ marginTop: '-1em', marginBottom: '1em' })}>
+          &lt;{' '}
+          <a {...fastClick(() => dispatch(showModal({ id: 'settings' })))} className={extendTapRecipe()}>
+            Back to Settings
+          </a>
+        </p>
 
-        {/* selected toolbar button details */}
-        <FadeTransition type='fast' nodeRef={commandsContainerRef} in={!!selectedCommand} exit={false} unmountOnExit>
-          <div
-            ref={commandsContainerRef}
-            className={css({
-              backgroundColor: 'bg',
-              // add bottom drop-shadow
-              // mask gap between this and the toolbar
-              // do not overlap modal close x
-              boxShadow: `0 -8px 20px 15px {colors.bg}`,
-            })}
-          >
+        <div
+          className={css({
+            // mask the selected bar that is rendered outside thn left edge of the CommandRow
+            backgroundColor: selectedCommand ? 'bg' : undefined,
+            position: 'sticky',
+            top: '0px',
+            marginBottom: '1em',
+            // extend element to mask the selected bar that is rendered outside thn left edge of the CommandRow
+            marginLeft: '-modalPadding',
+            paddingLeft: 'modalPadding',
+            // above CommandRow, which has position: relative for the selected bar
+            zIndex: 1,
+          })}
+        >
+          <Toolbar customize onSelect={toggleSelectedCommand} selected={selectedCommand?.id} />
+
+          {/* selected toolbar button details */}
+          <FadeTransition type='fast' nodeRef={commandsContainerRef} in={!!selectedCommand} exit={false} unmountOnExit>
             <div
+              ref={commandsContainerRef}
               className={css({
-                backgroundColor: 'gray15',
-                marginTop: '0.5em',
-                padding: '1em',
-                position: 'relative',
+                backgroundColor: 'bg',
+                // add bottom drop-shadow
+                // mask gap between this and the toolbar
+                // do not overlap modal close x
+                boxShadow: `0 -8px 20px 15px {colors.bg}`,
               })}
             >
-              <CommandTableOnly commands={commands} />
+              <div
+                className={css({
+                  backgroundColor: 'gray15',
+                  marginTop: '0.5em',
+                  padding: '1em',
+                  position: 'relative',
+                })}
+              >
+                <CommandTableOnly commands={commands} />
+              </div>
             </div>
+          </FadeTransition>
+        </div>
+
+        <FadeTransition type='fast' in={!selectedCommand} exit={false} unmountOnExit>
+          <div className={css({ marginTop: '2em', marginBottom: '2.645em', color: 'dim' })}>
+            <p>Drag-and-drop to rearrange toolbar.</p>
+            <p>{isTouch ? 'Tap' : 'Click'} a command for details.</p>
           </div>
         </FadeTransition>
-      </div>
 
-      <FadeTransition type='fast' in={!selectedCommand} exit={false} unmountOnExit>
-        <div className={css({ marginTop: '2em', marginBottom: '2.645em', color: 'dim' })}>
-          <p>Drag-and-drop to rearrange toolbar.</p>
-          <p>{isTouch ? 'Tap' : 'Click'} a command for details.</p>
-        </div>
-      </FadeTransition>
+        <DropToRemoveFromToolbar>
+          <CommandTable customize selectedCommand={selectedCommand ?? undefined} onSelect={setSelectedCommand} />
+        </DropToRemoveFromToolbar>
 
-      <DropToRemoveFromToolbar>
-        <CommandTable customize selectedCommand={selectedCommand ?? undefined} onSelect={setSelectedCommand} />
-      </DropToRemoveFromToolbar>
-
-      <p className={css({ marginTop: '2em', marginBottom: '2em' })}>
-        &lt;{' '}
-        <a {...fastClick(() => dispatch(showModal({ id: 'settings' })))} className={extendTapRecipe()}>
-          Back to Settings
-        </a>
-      </p>
-
-      <div className={css({ textAlign: 'center' })}>
-        <a
-          {...fastClick(() => dispatch(closeModal()))}
-          className={cx(
-            anchorButtonRecipe({
-              actionButton: true,
-            }),
-            css({ color: 'bg', marginBottom: '1em', marginTop: '2em' }),
-          )}
-        >
-          Close
-        </a>
-
-        <div className={css({ fontSize: 'sm', marginTop: '4em' })}>
-          <p className={css({ color: 'gray66', marginTop: '0.5em' })}>
-            Reset the toolbar to its factory settings. Your current toolbar customization will be permanently deleted.
-          </p>
-          <a
-            {...fastClick(() => {
-              if (window.confirm('Reset toolbar to factory settings?')) {
-                dispatch([initUserToolbar({ force: true }), alert('Toolbar reset')])
-              }
-            })}
-            className={cx(extendTapRecipe(), css({ color: 'red' }))}
-          >
-            Reset toolbar
+        <p className={css({ marginTop: '2em', marginBottom: '2em' })}>
+          &lt;{' '}
+          <a {...fastClick(() => dispatch(showModal({ id: 'settings' })))} className={extendTapRecipe()}>
+            Back to Settings
           </a>
+        </p>
+
+        <div className={css({ textAlign: 'center' })}>
+          <a
+            {...fastClick(() => dispatch(closeModal()))}
+            className={cx(
+              anchorButtonRecipe({
+                actionButton: true,
+              }),
+              css({ color: 'bg', marginBottom: '1em', marginTop: '2em' }),
+            )}
+          >
+            Close
+          </a>
+
+          <div className={css({ fontSize: 'sm', marginTop: '4em' })}>
+            <p className={css({ color: 'gray66', marginTop: '0.5em' })}>
+              Reset the toolbar to its factory settings. Your current toolbar customization will be permanently deleted.
+            </p>
+            <a
+              {...fastClick(() => {
+                if (window.confirm('Reset toolbar to factory settings?')) {
+                  dispatch([initUserToolbar({ force: true }), alert('Toolbar reset')])
+                }
+              })}
+              className={cx(extendTapRecipe(), css({ color: 'red' }))}
+            >
+              Reset toolbar
+            </a>
+          </div>
         </div>
-      </div>
-    </ModalComponent>
+      </ModalComponent>
+    </div>
   )
 }
 

--- a/src/components/modals/Help.tsx
+++ b/src/components/modals/Help.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useEffect } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../../styled-system/css'
 import { Tab } from '../../@types/Tab'
@@ -218,9 +218,8 @@ const About = () => {
           <a href='https://thenounproject.com'>Noun Project</a>
         </div>
         <div>
-          Hidden Thoughts icon by{' '}
-          <a href='https://thenounproject.com/search/?q=show%20hidden&i=1791510'>Joyce Lau</a> from the{' '}
-          <a href='https://thenounproject.com'>Noun Project</a>
+          Hidden Thoughts icon by <a href='https://thenounproject.com/search/?q=show%20hidden&i=1791510'>Joyce Lau</a>{' '}
+          from the <a href='https://thenounproject.com'>Noun Project</a>
         </div>
         <div>
           Indent icons by{' '}

--- a/src/components/modals/Help.tsx
+++ b/src/components/modals/Help.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../../styled-system/css'
 import { Tab } from '../../@types/Tab'
@@ -218,8 +218,9 @@ const About = () => {
           <a href='https://thenounproject.com'>Noun Project</a>
         </div>
         <div>
-          Hidden Thoughts icon by <a href='https://thenounproject.com/search/?q=show%20hidden&i=1791510'>Joyce Lau</a>{' '}
-          from the <a href='https://thenounproject.com'>Noun Project</a>
+          Hidden Thoughts icon by{' '}
+          <a href='https://thenounproject.com/search/?q=show%20hidden&i=1791510'>Joyce Lau</a> from the{' '}
+          <a href='https://thenounproject.com'>Noun Project</a>
         </div>
         <div>
           Indent icons by{' '}
@@ -333,6 +334,8 @@ const ModalHelp = () => {
   const [section, setSection] = useState(Section.CommandLibrary)
   const fontSize = useSelector(state => state.fontSize)
   const showDot = useSelector(state => !state.storageCache?.tutorialComplete)
+  const contentRef = useRef<HTMLDivElement>(null)
+
   const tabs: Tab<Section>[] = useMemo(
     () => [
       {
@@ -360,15 +363,35 @@ const ModalHelp = () => {
     [showDot],
   )
 
+  /** Dismisses the keyboard when the user scrolls within the modal. */
+  const handleScroll = () => {
+    const activeElement = document.activeElement
+    if (activeElement && activeElement instanceof HTMLInputElement) {
+      activeElement.blur()
+    }
+  }
+
+  useEffect(() => {
+    const contentElement = contentRef.current
+    if (!contentElement) return
+
+    contentElement.addEventListener('scroll', handleScroll)
+    return () => {
+      contentElement.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
   return (
-    <ModalComponent
-      id='help'
-      title='Help'
-      actions={({ close }) => <ActionButton key='close' title='Close' {...fastClick(() => close())} />}
-      style={{ fontSize, paddingInline: 0 }}
-    >
-      <Tabs currentTab={section} onTabChange={setSection} tabs={tabs} />
-    </ModalComponent>
+    <div ref={contentRef} className={css({ overflowY: 'auto', maxHeight: '100%' })}>
+      <ModalComponent
+        id='help'
+        title='Help'
+        actions={({ close }) => <ActionButton key='close' title='Close' {...fastClick(() => close())} />}
+        style={{ fontSize, paddingInline: 0 }}
+      >
+        <Tabs currentTab={section} onTabChange={setSection} tabs={tabs} />
+      </ModalComponent>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Dismiss the shared command search input on captured `touchmove` as well as `scroll`.
- Add unit coverage for keyboard dismissal on command search scroll and touch drag interactions.
- Fix existing branch lint issues that blocked the pre-push hook.

## Root Cause
The previous fix relied on `scroll` events. On iOS, the user starts interacting with the command results through touch movement before a reliable scroll event dismisses the focused search input, so the virtual keyboard can remain visible and obstruct results.

## Test Plan
- `yarn tsc --noEmit`
- `yarn eslint src/components/SearchCommands.tsx src/components/__tests__/SearchCommands.ts`
- `yarn eslint src/components/dialog/MobileCommandUniverse.tsx src/components/modals/Help.tsx`
- `git push` pre-push hook

