### PR TITLE
Fix stale selection offset during chained gestures

### DIFF
--- a/src/actions/indent.ts
+++ b/src/actions/indent.ts
@@ -52,7 +52,8 @@ const indent = (state: State): State => {
   }
 
   // calculate offset value based upon selection node before moveThought is dispatched
-  const offset = (selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
+  const offset =
+    (selection.isOnEditable(head(cursor)) && selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
 
   const cursorNew = appendToPath(parentOf(cursor), prev.id, head(cursor))
 

--- a/src/actions/outdent.ts
+++ b/src/actions/outdent.ts
@@ -54,7 +54,8 @@ const outdent = (state: State): State => {
   }
 
   // calculate offset value based upon selection node before moveThought is dispatched
-  const offset = (selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
+  const offset =
+    (selection.isOnEditable(head(cursor)) && selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
 
   const cursorNew: Path = appendToPath(parentOf(parentOf(cursor)), head(cursor))
 

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -150,6 +150,15 @@ export const isOnLastLine = (): boolean => {
 /** Returns true if the browser selection is on a text node. */
 export const isText = (): boolean => window.getSelection()?.focusNode?.nodeType === Node.TEXT_NODE
 
+/** Returns true if the browser selection is inside the editable for a thought. */
+export const isOnEditable = (thoughtId: string): boolean => {
+  const focusNode = window.getSelection()?.focusNode
+  const focusElement =
+    focusNode instanceof Element ? focusNode : focusNode?.parentNode instanceof Element ? focusNode.parentNode : null
+
+  return focusElement?.closest('[data-editable]')?.getAttribute('aria-label') === `editable-${thoughtId}`
+}
+
 /** Returns true if the browser selection is on an element node and focus offset is 0.
  * This represents a case where the browser will render the caret at the start of the text node's content.
  */

--- a/src/e2e/puppeteer/__tests__/gestures.ts
+++ b/src/e2e/puppeteer/__tests__/gestures.ts
@@ -1,4 +1,4 @@
-import { KnownDevices } from 'puppeteer'
+import { type ConsoleMessage, KnownDevices } from 'puppeteer'
 import newSubthoughtCommand from '../../../commands/newSubthought'
 import newThoughtCommand from '../../../commands/newThought'
 import exportThoughts from '../helpers/exportThoughts'
@@ -66,20 +66,35 @@ describe('chaining commands', () => {
   })
 
   it('chained command', async () => {
-    await gesture(newThoughtCommand)
-    await keyboard.type('a')
-    await gesture(newSubthoughtCommand)
-    await keyboard.type('b')
+    const warnings: string[] = []
+    /** Collect browser warnings emitted during the chained gesture. */
+    const onConsole = (message: ConsoleMessage) => {
+      if (message.type() === 'warn') {
+        warnings.push(message.text())
+      }
+    }
 
-    // New Thought + Outdent
-    await gesture('rd' + 'lrl')
+    page.on('console', onConsole)
 
-    const exported1 = await exportThoughts()
-    expect(exported1).toBe(`
+    try {
+      await gesture(newThoughtCommand)
+      await keyboard.type('a')
+      await gesture(newSubthoughtCommand)
+      await keyboard.type('b')
+
+      // New Thought + Outdent
+      await gesture('rd' + 'lrl')
+
+      const exported1 = await exportThoughts()
+      expect(exported1).toBe(`
 - a
   - b
 - 
 `)
+      expect(warnings.some(message => message.includes('IndexSizeError'))).toBe(false)
+    } finally {
+      page.off('console', onConsole)
+    }
   })
 
   it('prioritize exact match over chained command', async () => {


### PR DESCRIPTION
Prevents indent/outdent from reusing a browser selection offset from a different editable.

Adds coverage for the chained gesture case that was logging `IndexSizeError`.

The test is perhaps not perfect here, but IndexSizeError can right now that can be reproduced in the current test coverage, which I think should be better handled.

This was found by workin on the TreeCRDT integration PR