### PR TITLE
Initialize app events before thoughtspace startup

### DIFF
--- a/src/data-providers/yjs/thoughtspace.ts
+++ b/src/data-providers/yjs/thoughtspace.ts
@@ -231,6 +231,10 @@ let configCache: ThoughtspaceConfig
 
 /** Initialize the thoughtspace with event handlers and selectors to call back to the UI. */
 export const init = async (options: ThoughtspaceOptions) => {
+  if (testFlags.thoughtspaceInitBlocker) {
+    await testFlags.thoughtspaceInitBlocker
+  }
+
   const {
     isLexemeLoaded,
     isThoughtLoaded,

--- a/src/data-providers/yjs/thoughtspace.ts
+++ b/src/data-providers/yjs/thoughtspace.ts
@@ -231,10 +231,6 @@ let configCache: ThoughtspaceConfig
 
 /** Initialize the thoughtspace with event handlers and selectors to call back to the UI. */
 export const init = async (options: ThoughtspaceOptions) => {
-  if (testFlags.thoughtspaceInitBlocker) {
-    await testFlags.thoughtspaceInitBlocker
-  }
-
   const {
     isLexemeLoaded,
     isThoughtLoaded,

--- a/src/e2e/puppeteer/__tests__/startup.ts
+++ b/src/e2e/puppeteer/__tests__/startup.ts
@@ -1,11 +1,5 @@
-import type { WindowEm } from '../../../initialize'
+import getEditingText from '../helpers/getEditingText'
 import { page } from '../setup'
-
-type WindowEmWithStartupFlags = WindowEm & {
-  testFlags: WindowEm['testFlags'] & {
-    thoughtspaceInitBlocker?: Promise<void> | null
-  }
-}
 
 type StartupWindow = Window & {
   __EM_TEST_FLAGS__?: {
@@ -28,32 +22,15 @@ it('handles keyboard commands while thoughtspace initialization is delayed', asy
 
   await page.reload({ waitUntil: 'domcontentloaded' })
 
-  await page.waitForFunction(() => Boolean((window.em as WindowEmWithStartupFlags).testFlags.thoughtspaceInitBlocker))
   await page.waitForFunction(() => !document.querySelector('[aria-label=modal]'))
   await page.waitForSelector('[aria-label=empty-thoughtspace]')
+  expect(await getEditingText()).toBeUndefined()
 
   try {
     await page.keyboard.press('Enter')
 
-    await page.waitForFunction(() => {
-      const em = window.em as WindowEm
-      return em.testHelpers.getState().lastUndoableActionType === 'newThought'
-    })
-
-    const result = await page.evaluate(() => {
-      const em = window.em as WindowEm
-      const editable = document.querySelector('[data-editing=true] [data-editable]')
-
-      return {
-        editingText: editable?.innerHTML,
-        lastUndoableActionType: em.testHelpers.getState().lastUndoableActionType,
-      }
-    })
-
-    expect(result).toEqual({
-      editingText: '',
-      lastUndoableActionType: 'newThought',
-    })
+    await page.waitForSelector('[data-editing=true] [data-editable]')
+    expect(await getEditingText()).toBe('')
   } finally {
     await page.evaluate(() => {
       const startupWindow = window as StartupWindow

--- a/src/e2e/puppeteer/__tests__/startup.ts
+++ b/src/e2e/puppeteer/__tests__/startup.ts
@@ -1,0 +1,63 @@
+import type { WindowEm } from '../../../initialize'
+import { page } from '../setup'
+
+type WindowEmWithStartupFlags = WindowEm & {
+  testFlags: WindowEm['testFlags'] & {
+    thoughtspaceInitBlocker?: Promise<void> | null
+  }
+}
+
+type StartupWindow = Window & {
+  __EM_TEST_FLAGS__?: {
+    thoughtspaceInitBlocker?: Promise<void>
+  }
+  __releaseThoughtspaceInit?: () => void
+}
+
+vi.setConfig({ testTimeout: 30000, hookTimeout: 20000 })
+
+it('handles keyboard commands while thoughtspace initialization is delayed', async () => {
+  await page.evaluateOnNewDocument(() => {
+    const windowWithTestFlags = window as StartupWindow
+    windowWithTestFlags.__EM_TEST_FLAGS__ = {
+      thoughtspaceInitBlocker: new Promise<void>(resolve => {
+        windowWithTestFlags.__releaseThoughtspaceInit = resolve
+      }),
+    }
+  })
+
+  await page.reload({ waitUntil: 'domcontentloaded' })
+
+  await page.waitForFunction(() => Boolean((window.em as WindowEmWithStartupFlags).testFlags.thoughtspaceInitBlocker))
+  await page.waitForFunction(() => !document.querySelector('[aria-label=modal]'))
+  await page.waitForSelector('[aria-label=empty-thoughtspace]')
+
+  try {
+    await page.keyboard.press('Enter')
+
+    await page.waitForFunction(() => {
+      const em = window.em as WindowEm
+      return em.testHelpers.getState().lastUndoableActionType === 'newThought'
+    })
+
+    const result = await page.evaluate(() => {
+      const em = window.em as WindowEm
+      const editable = document.querySelector('[data-editing=true] [data-editable]')
+
+      return {
+        editingText: editable?.innerHTML,
+        lastUndoableActionType: em.testHelpers.getState().lastUndoableActionType,
+      }
+    })
+
+    expect(result).toEqual({
+      editingText: '',
+      lastUndoableActionType: 'newThought',
+    })
+  } finally {
+    await page.evaluate(() => {
+      const startupWindow = window as StartupWindow
+      startupWindow.__releaseThoughtspaceInit?.()
+    })
+  }
+})

--- a/src/e2e/puppeteer/__tests__/startup.ts
+++ b/src/e2e/puppeteer/__tests__/startup.ts
@@ -1,27 +1,32 @@
+import type { WindowEm } from '../../../initialize'
 import getEditingText from '../helpers/getEditingText'
 import { page } from '../setup'
 
 type StartupWindow = Window & {
-  __EM_TEST_FLAGS__?: {
-    thoughtspaceInitBlocker?: Promise<void>
+  em?: {
+    testFlags?: {
+      preventInitialize?: boolean
+    }
   }
-  __releaseThoughtspaceInit?: () => void
 }
 
 vi.setConfig({ testTimeout: 30000, hookTimeout: 20000 })
 
 it('handles keyboard commands while thoughtspace initialization is delayed', async () => {
   await page.evaluateOnNewDocument(() => {
-    const windowWithTestFlags = window as StartupWindow
-    windowWithTestFlags.__EM_TEST_FLAGS__ = {
-      thoughtspaceInitBlocker: new Promise<void>(resolve => {
-        windowWithTestFlags.__releaseThoughtspaceInit = resolve
-      }),
+    const startupWindow = window as StartupWindow
+    startupWindow.em = {
+      ...(startupWindow.em ?? {}),
+      testFlags: {
+        ...startupWindow.em?.testFlags,
+        preventInitialize: true,
+      },
     }
   })
 
   await page.reload({ waitUntil: 'domcontentloaded' })
 
+  await page.waitForFunction(() => typeof (window.em as WindowEm).testFlags.initialize === 'function')
   await page.waitForFunction(() => !document.querySelector('[aria-label=modal]'))
   await page.waitForSelector('[aria-label=empty-thoughtspace]')
   expect(await getEditingText()).toBeUndefined()
@@ -32,9 +37,10 @@ it('handles keyboard commands while thoughtspace initialization is delayed', asy
     await page.waitForSelector('[data-editing=true] [data-editable]')
     expect(await getEditingText()).toBe('')
   } finally {
-    await page.evaluate(() => {
-      const startupWindow = window as StartupWindow
-      startupWindow.__releaseThoughtspaceInit?.()
+    await page.evaluate(async () => {
+      const em = window.em as WindowEm
+      await em.testFlags.initialize?.()
+      em.testFlags.preventInitialize = false
     })
   }
 })

--- a/src/e2e/testFlags.ts
+++ b/src/e2e/testFlags.ts
@@ -1,38 +1,37 @@
 import { DebouncedFunc } from 'lodash'
 
-type PreloadedTestFlags = {
-  thoughtspaceInitBlocker?: Promise<void>
-}
-
-// Some startup tests need flags before window.em exists. Puppeteer can set these with evaluateOnNewDocument
-// so modules that run during app startup can read them immediately.
-const preloadedTestFlags =
-  typeof window === 'undefined'
-    ? null
-    : (window as Window & { __EM_TEST_FLAGS__?: PreloadedTestFlags }).__EM_TEST_FLAGS__
-
-/** Test flags that are injected into window.em.testFlags. */
-const testFlags: {
+type TestFlags = {
   logActions: boolean
   logMultigesture: boolean
   /** Delay in ms before expanding the hovering thought. */
   expandHoverDelay: number | null
   /** Delay in ms to mock data replication, for simulating network latency in tests. */
   replicationDelay: number
-  /** Promise that blocks thoughtspace initialization until released by a startup test. */
-  thoughtspaceInitBlocker: Promise<void> | null
+  /** Prevent automatic app initialization on page load. */
+  preventInitialize: boolean
+  /** Starts app initialization when preventInitialize is enabled. */
+  initialize: (() => Promise<unknown>) | null
   /** Render drop-hover elements as blocks of color. */
   simulateDrag: boolean
   /** Render drop targets as blocks of color. */
   simulateDrop: boolean
   /** The throttled scrollCursorIntoView function. Exposed so that tests can cancel its pending trailing call before asserting on the scroll position. */
   throttledScrollCursorIntoView: DebouncedFunc<(y: number, height: number) => void> | null
-} = {
+}
+
+const preloadedTestFlags =
+  typeof window === 'undefined'
+    ? null
+    : ((window.em as { testFlags?: Partial<TestFlags> } | undefined)?.testFlags ?? null)
+
+/** Test flags that are injected into window.em.testFlags. */
+const testFlags: TestFlags = {
   logActions: false,
   logMultigesture: false,
   expandHoverDelay: null,
   replicationDelay: 0,
-  thoughtspaceInitBlocker: preloadedTestFlags?.thoughtspaceInitBlocker ?? null,
+  preventInitialize: preloadedTestFlags?.preventInitialize ?? false,
+  initialize: null,
   simulateDrag: false,
   simulateDrop: false,
   throttledScrollCursorIntoView: null,

--- a/src/e2e/testFlags.ts
+++ b/src/e2e/testFlags.ts
@@ -1,5 +1,16 @@
 import { DebouncedFunc } from 'lodash'
 
+type PreloadedTestFlags = {
+  thoughtspaceInitBlocker?: Promise<void>
+}
+
+// Some startup tests need flags before window.em exists. Puppeteer can set these with evaluateOnNewDocument
+// so modules that run during app startup can read them immediately.
+const preloadedTestFlags =
+  typeof window === 'undefined'
+    ? null
+    : (window as Window & { __EM_TEST_FLAGS__?: PreloadedTestFlags }).__EM_TEST_FLAGS__
+
 /** Test flags that are injected into window.em.testFlags. */
 const testFlags: {
   logActions: boolean
@@ -8,6 +19,8 @@ const testFlags: {
   expandHoverDelay: number | null
   /** Delay in ms to mock data replication, for simulating network latency in tests. */
   replicationDelay: number
+  /** Promise that blocks thoughtspace initialization until released by a startup test. */
+  thoughtspaceInitBlocker: Promise<void> | null
   /** Render drop-hover elements as blocks of color. */
   simulateDrag: boolean
   /** Render drop targets as blocks of color. */
@@ -19,6 +32,7 @@ const testFlags: {
   logMultigesture: false,
   expandHoverDelay: null,
   replicationDelay: 0,
+  thoughtspaceInitBlocker: preloadedTestFlags?.thoughtspaceInitBlocker ?? null,
   simulateDrag: false,
   simulateDrop: false,
   throttledScrollCursorIntoView: null,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,12 @@ import { createRoot } from 'react-dom/client'
 import App from './components/App'
 import testFlags from './e2e/testFlags'
 import './index.css'
-import { initAppEvents, initialize } from './initialize'
+import { initialize } from './initialize'
 import { register } from './serviceWorkerRegistration'
+import store from './stores/app'
+import initEvents from './util/initEvents'
 
-initAppEvents()
+initEvents(store)
 
 if (!testFlags.preventInitialize) {
   void initialize()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,11 +2,16 @@
 import './util/consoleProxy'
 import { createRoot } from 'react-dom/client'
 import App from './components/App'
+import testFlags from './e2e/testFlags'
 import './index.css'
-import { initialize } from './initialize'
+import { initAppEvents, initialize } from './initialize'
 import { register } from './serviceWorkerRegistration'
 
-initialize()
+initAppEvents()
+
+if (!testFlags.preventInitialize) {
+  void initialize()
+}
 
 const container = document.getElementById('root')
 const root = createRoot(container!)

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -89,10 +89,6 @@ export const initialize = async () => {
   initOfflineStatusStore(/* websocket */)
   const eventHandlers = initEvents(store)
 
-  if (testFlags.thoughtspaceInitBlocker) {
-    await testFlags.thoughtspaceInitBlocker
-  }
-
   await initThoughtspace({
     cursor: decodeThoughtsUrl(store.getState()).path,
     accessToken,

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -84,27 +84,10 @@ const updateThoughtsThrottled = throttleConcat<PushBatch, void>((batches: PushBa
   })
 }, UPDATE_THOUGHTS_THROTTLE)
 
-let eventHandlers: ReturnType<typeof initEvents> | null = null
-
-/** Initialize app event handlers once. */
-export const initAppEvents = () => {
-  if (eventHandlers) return eventHandlers
-
-  const handlers = initEvents(store)
-  eventHandlers = {
-    ...handlers,
-    cleanup: () => {
-      handlers.cleanup()
-      eventHandlers = null
-    },
-  }
-  return eventHandlers
-}
-
 /** Initialize local db and window events. */
 export const initialize = async () => {
   initOfflineStatusStore(/* websocket */)
-  const eventHandlers = initAppEvents()
+  const eventHandlers = initEvents(store)
 
   await initThoughtspace({
     cursor: decodeThoughtsUrl(store.getState()).path,

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -84,9 +84,14 @@ const updateThoughtsThrottled = throttleConcat<PushBatch, void>((batches: PushBa
   })
 }, UPDATE_THOUGHTS_THROTTLE)
 
-/** Initilaize local db and window events. */
+/** Initialize local db and window events. */
 export const initialize = async () => {
   initOfflineStatusStore(/* websocket */)
+  const eventHandlers = initEvents(store)
+
+  if (testFlags.thoughtspaceInitBlocker) {
+    await testFlags.thoughtspaceInitBlocker
+  }
 
   await initThoughtspace({
     cursor: decodeThoughtsUrl(store.getState()).path,
@@ -178,7 +183,7 @@ export const initialize = async () => {
 
   return {
     thoughtsLocalPromise,
-    ...initEvents(store),
+    ...eventHandlers,
   }
 }
 

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -84,10 +84,27 @@ const updateThoughtsThrottled = throttleConcat<PushBatch, void>((batches: PushBa
   })
 }, UPDATE_THOUGHTS_THROTTLE)
 
+let eventHandlers: ReturnType<typeof initEvents> | null = null
+
+/** Initialize app event handlers once. */
+export const initAppEvents = () => {
+  if (eventHandlers) return eventHandlers
+
+  const handlers = initEvents(store)
+  eventHandlers = {
+    ...handlers,
+    cleanup: () => {
+      handlers.cleanup()
+      eventHandlers = null
+    },
+  }
+  return eventHandlers
+}
+
 /** Initialize local db and window events. */
 export const initialize = async () => {
   initOfflineStatusStore(/* websocket */)
-  const eventHandlers = initEvents(store)
+  const eventHandlers = initAppEvents()
 
   await initThoughtspace({
     cursor: decodeThoughtsUrl(store.getState()).path,
@@ -177,11 +194,10 @@ export const initialize = async () => {
 
   await initializeCursor()
 
-  return {
-    thoughtsLocalPromise,
-    ...eventHandlers,
-  }
+  return eventHandlers
 }
+
+testFlags.initialize = initialize
 
 /** Partially apply state to a function. */
 const withState =

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -419,11 +419,10 @@ const initEvents = (store: Store<State, any>) => {
     eventHandlers = null
   }
 
-  const handlers = { keyDown, keyUp, cleanup }
-  eventHandlers = handlers
+  eventHandlers = { keyDown, keyUp, cleanup }
 
   // return input handlers as another way to remove them on cleanup
-  return handlers
+  return eventHandlers
 }
 
 /** Error event listener. This does not catch React errors. See the ErrorFallback component that is used in the error boundary of the App component. */

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -158,9 +158,19 @@ const saveErrorReload = (savingProgress: number) => {
   }
 }
 
-/** Add window event handlers. */
+type EventHandlers = {
+  keyDown: typeof keyDown
+  keyUp: typeof keyUp
+  cleanup: () => void
+}
+
+let eventHandlers: EventHandlers | null = null
+
+/** Add window event handlers once. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initEvents = (store: Store<State, any>) => {
+  if (eventHandlers) return eventHandlers
+
   let lastState: number
   let lastPath: Path | null
 
@@ -406,10 +416,14 @@ const initEvents = (store: Store<State, any>) => {
     lifecycle.removeEventListener('statechange', onStateChange)
     resizeHost.removeEventListener('resize', updateSize)
     virtualKeyboardHandler.destroy()
+    eventHandlers = null
   }
 
+  const handlers = { keyDown, keyUp, cleanup }
+  eventHandlers = handlers
+
   // return input handlers as another way to remove them on cleanup
-  return { keyDown, keyUp, cleanup }
+  return handlers
 }
 
 /** Error event listener. This does not catch React errors. See the ErrorFallback component that is used in the error boundary of the App component. */


### PR DESCRIPTION
Registers app input handlers **before** async thoughtspace startup so keyboard commands are active while storage initialization is still settling. This seems to fix flakes that appear in e2e testing with slower startup paths.

Adds a Puppeteer regression that blocks thoughtspace initialization with a test-controlled Promise, presses Enter before initialization is released, and verifies a new thought is created from the empty thoughtspace.