### PR TITLE
fix(e2e): import page from session in drag-and-drop-multiselect test

### DIFF
--- a/src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts
@@ -5,7 +5,7 @@ import getEditingText from '../helpers/getEditingText'
 import hideHUD from '../helpers/hideHUD'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
-import { page } from '../setup'
+import { page } from '../session'
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
 


### PR DESCRIPTION
Noticed that `main` CI went red after merging #4356; this should fix the issue. I just asked Claude Code to fix it and submit a PR, so this is an AI generated fix.

---

## What

One-line fix: import the puppeteer `page` from `../session` instead of `../setup` in `drag-and-drop-multiselect.ts`.

## Why

`main` is currently red on `tsc`. Two PRs collided semantically:

- **#4352** moved the shared puppeteer `page` binding out of `setup.ts` into a new `session.ts`, and updated every e2e test/helper to `import { page } from '../session'`.
- **#4356** (landed after) added `drag-and-drop-multiselect.ts`, which still did `import { page } from '../setup'` — the only file in the suite that does. `setup.ts` no longer exports `page`, so the merge of these two passing PRs left `main` broken:

```
src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts(8,10): error TS2459:
  Module '"../setup"' declares 'page' locally, but it is not exported.
src/e2e/puppeteer/__tests__/drag-and-drop-multiselect.ts(83,74): error TS7006:
  Parameter 'el' implicitly has an 'any' type.
```

The second error was just fallout from the first — with `page` untyped as `any`, `page.$eval` lost its overload typing, so the `el` callback param had no inferred type. Switching the import to the real source fixes both; no other changes needed.

## Testing

`yarn lint:tsc` passes clean on this branch.