### PR TITLE
chore: cache yarn build:styles (skip panda codegen when inputs unchanged)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserless": "docker run -p 7566:3000 -e \"CONNECTION_TIMEOUT=-1\" browserless/chrome",
     "build": "yarn build:packages && yarn build:styles && vite build",
     "build:packages": "yarn --cwd packages/webview build",
-    "build:styles": "echo \"Building styles...\" && panda codegen",
+    "build:styles": "node ./scripts/build-styles.mjs",
     "cap:android": "BUILD_MODE=server yarn cap:sync && cap open android",
     "cap:android:static": "yarn build && BUILD_MODE=static yarn cap:sync && cap open android",
     "cap:ios": "BUILD_MODE=server yarn cap:sync && cap open ios",

--- a/scripts/build-styles.mjs
+++ b/scripts/build-styles.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Runs `panda codegen`, skipping it when its inputs are unchanged since the last run.
+ *
+ * `styled-system/` is generated output that only changes when codegen runs, so a stamp file written
+ * after each run records when codegen last succeeded and the newest input mtime is compared against
+ * it. This caching is the default because `build:styles` is invoked by `postinstall` and `yarn
+ * build`, where the ~17s codegen is wasted when nothing the config depends on changed (the common
+ * case after a `yarn install` following a `git pull` that does not touch the Panda config). Pass
+ * `--force` to regenerate unconditionally.
+ *
+ * `panda codegen` derives `styled-system/` from the config alone (the recipes and design tokens it
+ * imports), not from the `include` source globs — those drive `panda cssgen`/extraction, not
+ * codegen. The inputs are therefore the config's module import graph, discovered with esbuild's
+ * metafile rather than a hand-maintained whitelist so a newly added (possibly transitive) import
+ * cannot silently go untracked. The root package.json is included so a Panda version bump declared
+ * there also forces regeneration. If input discovery fails for any reason, the build runs — a
+ * skipped-when-stale (false negative) is a correctness bug, an unnecessary rebuild is merely slow.
+ */
+import { build } from 'esbuild'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const force = process.argv.includes('--force')
+
+/**
+ * Lists the codegen inputs as absolute paths: every module reachable from panda.config.ts (its
+ * transitive import graph, per esbuild's metafile) plus the root package.json (which declares the
+ * Panda version). Throws if esbuild cannot resolve the graph, so the caller can fall back to
+ * rebuilding rather than risk skipping when inputs are actually stale.
+ */
+const listInputs = async () => {
+  const result = await build({
+    entryPoints: [path.join(repoDir, 'panda.config.ts')],
+    bundle: true,
+    packages: 'external',
+    metafile: true,
+    write: false,
+    platform: 'node',
+    format: 'esm',
+    logLevel: 'silent',
+  })
+  return [
+    ...Object.keys(result.metafile.inputs).map(rel => path.resolve(repoDir, rel)),
+    path.join(repoDir, 'package.json'),
+  ]
+}
+
+/**
+ * Newest modification time across all inputs, or Infinity if discovery fails or an input is missing,
+ * so that a discovery error, a deleted import, or a renamed source file all force a rebuild.
+ */
+const newestInput = await listInputs()
+  .then(inputs => Math.max(...inputs.map(file => (fs.existsSync(file) ? fs.statSync(file).mtimeMs : Infinity))))
+  .catch(() => Infinity)
+
+/**
+ * The newest input is compared against a stamp file that this script writes after each successful
+ * codegen, rather than against the generated files' mtimes. `panda codegen` only rewrites files whose
+ * content changed, so unchanged outputs keep stale mtimes — making the generated files an unreliable
+ * record of when codegen last ran. The stamp lives inside the outdir (which matches `outdir` in
+ * panda.config.ts) so that deleting styled-system also clears the stamp and forces a rebuild; a
+ * missing stamp counts as never-built. The stamp is written only on success, so an interrupted
+ * codegen leaves it stale and the next run rebuilds.
+ */
+const outdir = path.join(repoDir, 'styled-system')
+const stamp = path.join(outdir, '.build-styles-cache')
+const lastBuilt = fs.existsSync(stamp) ? fs.statSync(stamp).mtimeMs : 0
+
+if (force || newestInput > lastBuilt) {
+  console.info('Building styles...')
+  execSync('panda codegen', { cwd: repoDir, stdio: 'inherit' })
+  fs.mkdirSync(outdir, { recursive: true })
+  fs.writeFileSync(stamp, '')
+} else {
+  console.info('styled-system is up to date, skipping codegen. Use `yarn build:styles --force` to rebuild.')
+}


### PR DESCRIPTION
## Plan

Speeds up `yarn install` / `yarn build` by skipping `panda codegen` when nothing it depends on has changed — the analog of the cache-aware webview build merged in df92a8c2ea (#4439). After a `git pull` that doesn't touch the Panda config, the ~17s codegen is pure waste; this makes the cached path the default, overridable with `--force`.

### 1. Existing surface area
- **Template:** `packages/webview/scripts/build.mjs` (merged) — newest-input vs. output staleness check, `git ls-files` inputs, outputs read from the build config, `--force` override.
- `package.json:27` `"build:styles": panda codegen`; invoked by `postinstall` (`:46`) and `build` (`:25`).
- `panda.config.ts` imports 28 `src/` modules (recipes + `durations.config` + transitively `colors.config` via `convertColorsToPandaCSS`); `outdir: 'styled-system'` (gitignored, `.gitignore:31`).
- `docs/folder-structure.md:15,31` confirms recipes/tokens are the Panda inputs.

### 2. Build vs. extend
Extend the merged pattern with a new sibling script `scripts/build-styles.mjs` (root `scripts/` already exists). One structural change from webview: inputs are the **config's module import graph**, not "all files in a dir" — Panda's codegen inputs are `panda.config.ts` + its transitive imports, a small subset of the repo.

### 3. Adjacent behaviour
- `postinstall` / `yarn build`: still emit `styled-system/`, just skip when fresh. ✓
- CI / production: `styled-system/` is gitignored → absent on checkout → always regenerates. ✓
- Vite dev/HMR: Panda's PostCSS integration is untouched. ✓
- **codegen-is-config-only** is the load-bearing assumption — **verified empirically**: editing a tracked component left `styled-system/` byte-identical.

### 4. Approaches
- **(chosen)** esbuild metafile of `panda.config.ts` → exact transitive input set (~240ms; captures `colors.config.ts` reached only transitively). Robust, non-whitelist analog of webview's `git ls-files`.
- (rejected) hand-glob whitelist → false-negative-prone (a future new import silently missed).

### 5. Implementation
- **New `scripts/build-styles.mjs`:** inputs = esbuild metafile of `panda.config.ts` + root `package.json` (Panda version); newest input mtime, with discovery failure / missing input → rebuild. Output freshness uses a **stamp file** (`styled-system/.build-styles-cache`) written after each successful codegen — because `panda codegen` only rewrites *changed* files, generated-file mtimes are an unreliable last-build signal (a stale `toolbar-pointer-events.d.ts` from 2025-05-23 was the bug that made an oldest-output approach never skip).
- **`package.json:27`:** `build:styles` → `node ./scripts/build-styles.mjs`.

### Verification
Confirmed: force→build, no-change→skip, recipe edit→build, config edit→build, `rm -rf styled-system`→build, then skip again. Skip-path script logic ≈ 240ms vs. ~17s codegen.

plan: complete — architectural plan produced and critique passed per .github/skills/plan/SKILL.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>