### PR TITLE
iOS: dismiss keyboard before opening Share sheet to prevent overlap (#4294)

### DIFF
--- a/src/components/__tests__/ModalExportShare.ts
+++ b/src/components/__tests__/ModalExportShare.ts
@@ -1,0 +1,66 @@
+import { Keyboard } from '@capacitor/keyboard'
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { showModalActionCreator as showModal } from '../../actions/showModal'
+import click from '../../test-helpers/click'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+
+// Emulate the native iOS Capacitor app so that the iOS-specific keyboard-dismissal path in
+// onExportClick is exercised. isTouch is left at its default (false) so that mobile-only
+// components (e.g. the signature-pad TraceGesture) are not mounted in jsdom.
+vi.mock('../../browser', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../browser')>()
+  return { ...actual, isIOS: true }
+})
+
+// Spy on the Capacitor Keyboard plugin so we can assert the keyboard is dismissed before sharing.
+vi.mock('@capacitor/keyboard', () => ({
+  Keyboard: {
+    hide: vi.fn(() => Promise.resolve()),
+    addListener: vi.fn(() => Promise.resolve({ remove: vi.fn() })),
+    removeAllListeners: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+const originalShare = Object.getOwnPropertyDescriptor(navigator, 'share')
+
+beforeEach(createTestApp)
+afterEach(() => {
+  cleanupTestApp()
+  if (originalShare) {
+    Object.defineProperty(navigator, 'share', originalShare)
+  } else {
+    delete (navigator as { share?: unknown }).share
+  }
+})
+
+// Regression test for https://github.com/cybersemics/em/issues/4294
+// On the iOS Capacitor app, tapping Share opened the native share sheet while the software
+// keyboard was still visible, causing the two to overlap. The keyboard must be dismissed before
+// navigator.share is invoked.
+it('dismisses the keyboard before opening the native share sheet on iOS', async () => {
+  // record the order in which the keyboard is hidden and the share sheet is invoked
+  const calls: string[] = []
+  vi.mocked(Keyboard.hide).mockImplementation(() => {
+    calls.push('keyboard.hide')
+    return Promise.resolve()
+  })
+  const share = vi.fn(() => {
+    calls.push('share')
+    return Promise.resolve()
+  })
+  Object.defineProperty(navigator, 'share', { configurable: true, value: share })
+
+  await dispatch([importText({ text: '- a' }), setCursor(['a']), showModal({ id: 'export' })])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await click('[data-testid="export-share-button"]')
+
+  expect(Keyboard.hide).toHaveBeenCalled()
+  expect(share).toHaveBeenCalled()
+  // the keyboard must be dismissed before the share sheet opens, otherwise they overlap (#4294)
+  expect(calls).toEqual(['keyboard.hide', 'share'])
+})

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -1,3 +1,4 @@
+import { Keyboard } from '@capacitor/keyboard'
 import ClipboardJS from 'clipboard'
 import React, {
   FC,
@@ -21,7 +22,7 @@ import ThoughtId from '../../@types/ThoughtId'
 import { alertActionCreator as alert } from '../../actions/alert'
 import { closeModalActionCreator as closeModal } from '../../actions/closeModal'
 import { errorActionCreator as error } from '../../actions/error'
-import { isMac, isTouch } from '../../browser'
+import { isIOS, isMac, isTouch } from '../../browser'
 import { HOME_PATH, HOME_TOKEN } from '../../constants'
 import replicateTree from '../../data-providers/data-helpers/replicateTree'
 import download from '../../device/download'
@@ -470,6 +471,15 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
 
   /** Shares or downloads when the export button is clicked. */
   const onExportClick = () => {
+    // On the iOS Capacitor app, the native share sheet can open while the software keyboard is
+    // still visible, causing the two to overlap (#4294). Blur the focused editable and dismiss
+    // the keyboard before presenting the share sheet. This is done synchronously (no await) so
+    // that the user-activation context required by navigator.share() is preserved.
+    if (isIOS) {
+      selection.clear()
+      Keyboard.hide()
+    }
+
     // use mobile share if it is available
     if (navigator.share) {
       navigator.share({
@@ -661,6 +671,7 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
             color: 'bg',
             backgroundColor: 'fg',
           })}
+          data-testid='export-share-button'
           disabled={exportContent === null}
           {...fastClick(onExportClick)}
         >


### PR DESCRIPTION
#4294

## Problem

On the iOS Capacitor app, exporting from a focused thought could open the native Share sheet while the software keyboard was still visible, causing the share surface to overlap and hide controls (#4294).

## Root cause

`onExportClick` in `src/components/modals/Export.tsx` calls `navigator.share()` while the editable from the cursor is still focused, so iOS keeps the software keyboard up and presents the share sheet over it.

## Fix

In `onExportClick`, on the iOS Capacitor app (`isIOS`), blur the focused editable (`selection.clear()`) and dismiss the keyboard (`Keyboard.hide()`) **before** invoking `navigator.share()`. This is done synchronously (no `await`) so the user-activation context required by `navigator.share()` is preserved.

## Reproduction note

This bug is specific to the native iOS Capacitor app (native software keyboard overlapping the native Share sheet) and cannot be reproduced in desktop/Chrome emulation. Automated iOS reproduction via BrowserStack App Automate was unavailable in this environment (BrowserStack credentials empty, `wdio` MCP not configured), so the fix is grounded in the documented reproduction evidence and the existing keyboard/share code paths.

## Tests

Added `src/components/__tests__/ModalExportShare.ts`, a unit regression test that mocks the iOS platform and the Capacitor `Keyboard` plugin and asserts that `Keyboard.hide()` is called **before** `navigator.share()` when the Share button is tapped. Verified the test fails on the unfixed code (for the right reason — `Keyboard.hide` not called) and passes with the fix.

## Architectural plan

See the issue-repro + plan gate summary in the PR thread. Key decisions: extend the sole `onExportClick` handler rather than introduce a new path; dismiss the keyboard synchronously to preserve `navigator.share()` user activation; gate the new branch on `isIOS` so download/web/desktop paths are untouched.
