### PR TITLE
🤖 ci(lint): raise eslint heap ceiling from 2GB to 4GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "deploy:patch": "yarn lint && npm version patch && yarn build && vercel deploy --prod",
     "lint:lockfile": "npx lockfile-lint",
     "lint:no-npm": "node ./scripts/no-files.js package-lock.json",
-    "lint:src": "FORCE_COLOR=1 eslint . --cache --rule 'no-console: [2, { allow: [error, info, warn] }]'",
+    "lint:src": "FORCE_COLOR=1 NODE_OPTIONS=--max-old-space-size=4096 eslint . --cache --rule 'no-console: [2, { allow: [error, info, warn] }]'",
     "lint:tsc": "tsc",
     "lint": "FORCE_COLOR=1 npm-run-all --serial \"lint:*\"",
     "postinstall": "yarn build:packages && git config core.hooksPath .hooks && yarn build:styles",


### PR DESCRIPTION
🤖 **This PR is AI-generated.**

Human note: I ran into out-of-memory issues when trying to run the linter on my HTTPS dev server branch – both in CI and locally. Turns out this is happening on `main` too, at leas when I ran the linter on my local machine.

The default heap size is 2 GB, which seems like plenty to me, but I guess not. Maybe the lint script needs further optimization in the future, but seeing as the CI runner has 16 GB of RAM, right now raising the heap limit to 4GB should put out the immediate fire.

---

## Summary

`lint:src` runs eslint with type-aware rules (`parserOptions.project`), which keeps the **entire TypeScript program** resident in memory — including panda's generated `styled-system` types. Cold, this peaks at **~4 GB RSS** and **OOMs under a 2 GB V8 heap** (the default), reproducibly, even on a clean `main`.

This pins an explicit **4 GB old-space ceiling** on `lint:src`. Putting it in the npm script (rather than the workflow) means it covers **CI `yarn lint`, the `.hooks/pre-push` hook, and local `yarn lint`** in a single line. `ubuntu-latest` has 16 GB, so there's ample headroom.

## Change

```diff
- "lint:src": "FORCE_COLOR=1 eslint . --cache ...",
+ "lint:src": "FORCE_COLOR=1 NODE_OPTIONS=--max-old-space-size=4096 eslint . --cache ...",
```

One line, one file.

## Empirical evidence

Measured on `main` (`ffe8be9912`), cold cache, Node 24 locally / Node 22 in CI:

| Scenario | Result |
|---|---|
| Cold eslint under **2 GB** heap (`--max-old-space-size=2048`) | **OOM** — `FATAL ERROR: Ineffective mark-compacts near heap limit – Allocation failed - JavaScript heap out of memory` (exit 134) |
| Cold eslint under **4 GB** heap (this PR) | ✅ passes |

Full CI sweep with the 4 GB ceiling applied — **all green, no regressions**:

| Job | Result |
|---|---|
| Lint | ✅ success |
| Test | ✅ success |
| Puppeteer | ✅ success |
| BrowserStack | ✅ success |
