### PR TITLE
Fix sidebar helper after distraction-free typing

### DIFF
--- a/src/e2e/puppeteer/__tests__/sidebar.ts
+++ b/src/e2e/puppeteer/__tests__/sidebar.ts
@@ -7,6 +7,7 @@ import openSidebar from '../helpers/openSidebar'
 import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import setTheme from '../helpers/setTheme'
+import waitForSelector from '../helpers/waitForSelector'
 
 expect.extend({
   toMatchImageSnapshot: configureSnapshots({ fileName: path.basename(__filename).replace('.ts', '') }),
@@ -36,6 +37,7 @@ describe('sidebar', () => {
   it('recently edited thoughts', async () => {
     await press('Enter')
     await keyboard.type('a')
+    await waitForSelector('[aria-label=menu]', { hidden: true })
 
     await openSidebar()
     await click('[data-testid=sidebar-recentlyEdited]')

--- a/src/e2e/puppeteer/helpers/openSidebar.ts
+++ b/src/e2e/puppeteer/helpers/openSidebar.ts
@@ -3,6 +3,8 @@ import click from './click'
 
 /** Helper function to open sidebar and wait for it to slide all the way open. */
 const openSidebar = async () => {
+  // Typing can hide the menu in distraction-free mode. Moving the pointer reveals it before clicking.
+  await page.mouse.move(1, 1)
   await click('[aria-label=menu]')
 
   // Wait for aria-hidden="false" and the first link to be on-screen (rect.left >= 0), since the outer sidebar is always mounted and doesn’t reflect the drawer’s slide-in animation.


### PR DESCRIPTION
Fixes a Puppeteer helper edge case where typing can hide the menu through distraction-free mode before `openSidebar()` runs.

`openSidebar()` now moves the pointer before clicking the menu, matching the normal user path that reveals the HUD. The sidebar test waits for the hidden-menu state after typing so this case is covered deterministically.

This is timing dependent because distraction-free typing hides the menu through a throttled update after text input. In the TreeCRDT integration PR this surfaced into testing flakes