### PR TITLE
Retarget focus to editable after autocomplete

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -339,35 +339,37 @@ const Editable = ({
   }, [])
 
   useEffect(() => {
-    if (!isTouch || !isSafari()) return
+    if (!isTouch || !isSafari() || !contentRef.current) return
+
+    const editable = contentRef.current
 
     /** After iOS autocomplete (insertReplacementText) accepts a word, no touch events reach the DOM
      * in a "dead zone" beneath the word until focus is retargeted. Moving focus to the asyncFocus dummy input
      * and back to the previous active element allows touch events to reach the DOM again.
      */
     const onAutocompleteInput = (e: Event) => {
-      if (!contentRef.current || !(e instanceof InputEvent) || e.inputType !== 'insertReplacementText') return
+      if (!editable || !(e instanceof InputEvent) || e.inputType !== 'insertReplacementText') return
 
       const savedCharOffset = selection.offsetThought() ?? selection.offset() ?? 0
 
       // Under normal circumstances, iOS autocomplete triggers an insertReplacementText event followed by an insertText event with a space.
       // It is possible to track both events and apply the fix only when the space is inserted, but it is simpler to add the space directly.
-      oldValueRef.current = contentRef.current.textContent + ' '
+      oldValueRef.current = editable.textContent + ' '
 
       // Queue and flush the change with the space-inclusive value to ensure it's captured before the editable blurs.
       throttledChangeRef.current(oldValueRef.current, { rank, simplePath })
       throttledChangeRef.current.flush()
 
       asyncFocus({ force: true })
-      contentRef.current.focus({ preventScroll: true })
+      editable.focus({ preventScroll: true })
 
       // Restore the selection offset to the character after the inserted word, and accounting for the space added above
-      queueMicrotask(() => selection.set(contentRef.current, { offset: savedCharOffset + 1 }))
+      queueMicrotask(() => selection.set(editable, { offset: savedCharOffset + 1 }))
     }
 
-    contentRef.current?.addEventListener('input', onAutocompleteInput)
-    return () => contentRef.current?.removeEventListener('input', onAutocompleteInput)
-  }, [contentRef])
+    editable?.addEventListener('input', onAutocompleteInput)
+    return () => editable?.removeEventListener('input', onAutocompleteInput)
+  }, [contentRef, rank, simplePath])
 
   useEffect(() => {
     // if there is a multicursor, blur the contentRef

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -342,29 +342,48 @@ const Editable = ({
     if (!isTouch || !isSafari() || !contentRef.current) return
 
     const editable = contentRef.current
+    const AUTOCOMPLETE_SPACE_WINDOW_MS = 250
+    let pendingAutocompleteAt: number | null = null
 
     /** After iOS autocomplete (insertReplacementText) accepts a word, no touch events reach the DOM
      * in a "dead zone" beneath the word until focus is retargeted. Moving focus to the asyncFocus dummy input
      * and back to the previous active element allows touch events to reach the DOM again.
+     *
+     * It is possible to intercept insertReplacementText and perform the focus retargeting there
+     * instead of waiting for the next insertText event, but that breaks native undo via shake or three-finger swipe.
      */
     const onAutocompleteInput = (e: Event) => {
-      if (!editable || !(e instanceof InputEvent) || e.inputType !== 'insertReplacementText') return
+      if (!editable || !(e instanceof InputEvent)) return
+
+      if (e.inputType === 'insertReplacementText') {
+        pendingAutocompleteAt = performance.now()
+        return
+      }
+
+      if (e.inputType !== 'insertText' || e.data !== ' ' || pendingAutocompleteAt == null) {
+        pendingAutocompleteAt = null
+        return
+      }
+
+      if (performance.now() - pendingAutocompleteAt > AUTOCOMPLETE_SPACE_WINDOW_MS) {
+        pendingAutocompleteAt = null
+        return
+      }
 
       const savedCharOffset = selection.offsetThought() ?? selection.offset() ?? 0
 
-      // Under normal circumstances, iOS autocomplete triggers an insertReplacementText event followed by an insertText event with a space.
-      // It is possible to track both events and apply the fix only when the space is inserted, but it is simpler to add the space directly.
-      oldValueRef.current = editable.textContent + ' '
-
-      // Queue and flush the change with the space-inclusive value to ensure it's captured before the editable blurs.
+      // Queue and flush the change with the browser-applied value to ensure it's captured before the editable blurs.
+      oldValueRef.current = editable.textContent || ''
       throttledChangeRef.current(oldValueRef.current, { rank, simplePath })
       throttledChangeRef.current.flush()
 
       asyncFocus({ force: true })
       editable.focus({ preventScroll: true })
 
-      // Restore the selection offset to the character after the inserted word, and accounting for the space added above
-      queueMicrotask(() => selection.set(editable, { offset: savedCharOffset + 1 }))
+      // Restore the selection offset captured when insertText(' ') arrived.
+      queueMicrotask(() => selection.set(editable, { offset: savedCharOffset }))
+
+      pendingAutocompleteAt = null
     }
 
     editable?.addEventListener('input', onAutocompleteInput)

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -32,6 +32,7 @@ import {
   TUTORIAL_CONTEXT2_PARENT,
 } from '../constants'
 import asyncFocus from '../device/asyncFocus'
+import preventAutoscroll, { preventAutoscrollEnd } from '../device/preventAutoscroll'
 import * as selection from '../device/selection'
 import globals from '../globals'
 import findDescendant from '../selectors/findDescendant'
@@ -378,10 +379,11 @@ const Editable = ({
       throttledChangeRef.current.flush()
 
       asyncFocus({ force: true })
-      editable.focus({ preventScroll: true })
 
+      preventAutoscroll(editable)
       // Restore the selection offset captured when insertText(' ') arrived.
-      queueMicrotask(() => selection.set(editable, { offset: savedCharOffset }))
+      selection.set(editable, { offset: savedCharOffset })
+      preventAutoscrollEnd(editable)
 
       pendingAutocompleteAt = null
     }

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -31,6 +31,7 @@ import {
   TUTORIAL_CONTEXT1_PARENT,
   TUTORIAL_CONTEXT2_PARENT,
 } from '../constants'
+import asyncFocus from '../device/asyncFocus'
 import * as selection from '../device/selection'
 import globals from '../globals'
 import findDescendant from '../selectors/findDescendant'
@@ -336,6 +337,37 @@ const Editable = ({
       commandEmitter.off('command', flush)
     }
   }, [])
+
+  useEffect(() => {
+    if (!isTouch || !isSafari()) return
+
+    /** After iOS autocomplete (insertReplacementText) accepts a word, no touch events reach the DOM
+     * in a "dead zone" beneath the word until focus is retargeted. Moving focus to the asyncFocus dummy input
+     * and back to the previous active element allows touch events to reach the DOM again.
+     */
+    const onAutocompleteInput = (e: Event) => {
+      if (!contentRef.current || !(e instanceof InputEvent) || e.inputType !== 'insertReplacementText') return
+
+      const savedCharOffset = selection.offsetThought() ?? selection.offset() ?? 0
+
+      // Under normal circumstances, iOS autocomplete triggers an insertReplacementText event followed by an insertText event with a space.
+      // It is possible to track both events and apply the fix only when the space is inserted, but it is simpler to add the space directly.
+      oldValueRef.current = contentRef.current.textContent + ' '
+
+      // Queue and flush the change with the space-inclusive value to ensure it's captured before the editable blurs.
+      throttledChangeRef.current(oldValueRef.current, { rank, simplePath })
+      throttledChangeRef.current.flush()
+
+      asyncFocus({ force: true })
+      contentRef.current.focus({ preventScroll: true })
+
+      // Restore the selection offset to the character after the inserted word, and accounting for the space added above
+      queueMicrotask(() => selection.set(contentRef.current, { offset: savedCharOffset + 1 }))
+    }
+
+    contentRef.current?.addEventListener('input', onAutocompleteInput)
+    return () => contentRef.current?.removeEventListener('input', onAutocompleteInput)
+  }, [contentRef])
 
   useEffect(() => {
     // if there is a multicursor, blur the contentRef

--- a/src/device/asyncFocus.ts
+++ b/src/device/asyncFocus.ts
@@ -33,6 +33,7 @@ export const AsyncFocus: () => (options?: { force?: boolean }) => void = () => {
   document.body.prepend(hiddenInput)
   return (options: { force?: boolean } = {}) => {
     // do not set the selection if it is already on a thought or a note
+    // provide the option to force the focus in order to retarget focus and prevent an iOS Safari bug (#4222)
     if (options.force || !selection.isThought()) {
       hiddenInput.disabled = false
       hiddenInput.focus()

--- a/src/device/asyncFocus.ts
+++ b/src/device/asyncFocus.ts
@@ -9,7 +9,7 @@ import * as selection from './selection'
  *
  * See: https://stackoverflow.com/a/45703019/480608.
  */
-export const AsyncFocus: () => () => void = () => {
+export const AsyncFocus: () => (options?: { force?: boolean }) => void = () => {
   if (!isTouch) return noop
 
   // create invisible dummy input to receive the focus
@@ -31,9 +31,9 @@ export const AsyncFocus: () => () => void = () => {
   hiddenInput.style.fontSize = '16px'
 
   document.body.prepend(hiddenInput)
-  return () => {
+  return (options: { force?: boolean } = {}) => {
     // do not set the selection if it is already on a thought or a note
-    if (!selection.isThought()) {
+    if (options.force || !selection.isThought()) {
       hiddenInput.disabled = false
       hiddenInput.focus()
       // the hidden input should not be a valid focus target unless this function was invoked


### PR DESCRIPTION
Fixes #4222 

After using the native autocomplete spacebar-to-complete functionality in iOS Safari, a dead zone appears around and underneath the text as shown in the description of #4222. No touch events reach the app within this area. In order to dismiss this dead zone, it is necessary to synchronously shift focus away from the editable and then return it to the editable.

## Root Cause
**Confidence:** low

Copilot claims that:

> UIKit registers an "undo autocorrect" gesture recognizer at the native layer (above WebKit JS dispatch). Taps near the replaced word are consumed by UIKit — they never enter the DOM at all — explaining why even capture-phase document listeners received nothing.

There is definitely a dead zone created at the native layer, but I don't think that it necessarily follows that it is created by an "undo autocorrect" gesture recognizer. See point 2 in complications below.

## Complications

1. Moving focus away from the thought causes `onBlur` to flush `throttledChangeRef` with an outdated value
**Solution:** Manually update `oldValueRef.current` and call `throttledChangeRef.current.flush()` within the `onAutocompleteInput` handler

2. Native undo (three-finger swipe or shake) is overridden when manually updating value
**Solution:** The autocomplete arrives as two separate events: `insertReplacementText` followed by `insertText` consisting of a trailing space. The focus retargeting must be delayed until `insertText` is received in order to preserve native undo.
  a. I wouldn't have noticed this if Copilot hadn't mentioned the "undo autocorrect" gesture recognizer, but three-finger swipe can be performed anywhere, not just in the area surrounding the text.
  b. Copilot swears that `insertReplacementText` will not always be followed immediately by `insertText`, and so it is necessary to reset the handler after `AUTOCOMPLETE_SPACE_WINDOW_MS = 250`. I have not seen any case where only `insertReplacementText` arrives.