### PR TITLE
Compare text content of thought when determining letter case

### DIFF
--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -27,10 +27,15 @@ const LetterCasePicker: FC<{ size?: number }> = memo(({ size }) => {
   }
   const selected = useSelector(state => {
     const value = (!!state.cursor && getThoughtById(state, head(state.cursor))?.value) || ''
-    if (value === applyLetterCase('LowerCase', value)) return 'LowerCase'
-    if (value === applyLetterCase('UpperCase', value)) return 'UpperCase'
-    if (value === applyLetterCase('SentenceCase', value)) return 'SentenceCase'
-    if (value === applyLetterCase('TitleCase', value)) return 'TitleCase'
+
+    // The letter case of the thought should be independent of its formatting.
+    const doc = new DOMParser().parseFromString(value, 'text/html')
+    const { textContent } = doc.body
+
+    if (textContent === applyLetterCase('LowerCase', textContent)) return 'LowerCase'
+    if (textContent === applyLetterCase('UpperCase', textContent)) return 'UpperCase'
+    if (textContent === applyLetterCase('SentenceCase', textContent)) return 'SentenceCase'
+    if (textContent === applyLetterCase('TitleCase', textContent)) return 'TitleCase'
     return ''
   })
   const casingTypes: LetterCaseType[] = ['LowerCase', 'UpperCase', 'SentenceCase', 'TitleCase']
@@ -48,6 +53,7 @@ const LetterCasePicker: FC<{ size?: number }> = memo(({ size }) => {
               border: selected === type ? `solid 1px {colors.fg}` : `solid 1px {colors.transparent}`,
             })}
             aria-label={type}
+            data-selected={selected === type ? 'true' : 'false'}
             {...fastClick(e => e.stopPropagation())}
             onTouchStart={e => toggleLetterCase(type, e)}
             onMouseDown={e => !isTouch && toggleLetterCase(type, e)}

--- a/src/components/__tests__/LetterCasePicker.ts
+++ b/src/components/__tests__/LetterCasePicker.ts
@@ -86,3 +86,11 @@ it('Set Upper Case with multicursor selection', async () => {
   - HELLO EVERYONE, THIS IS ROSE. THANKS FOR YOUR HELP.
   - GOODBYE EVERYONE, THIS IS MAX. THANKS FOR YOUR HELP.`)
 })
+
+it('Recognizes a styled thought with uppercase text as UpperCase', async () => {
+  await dispatch([newThought({ value: '<b>HELLO <font style="background-color: rgb(0, 128, 255);">WORLD</font></b>' })])
+  await click('[data-testid="toolbar-icon"][aria-label="Letter Case"]')
+
+  const upperCase = document.querySelector('[aria-label="UpperCase"][data-selected="true"]')
+  expect(upperCase).toBeInTheDocument()
+})


### PR DESCRIPTION
Fixes #3929

`LetterCasePicker` was determining its [selected](https://github.com/ethan-james/em/blob/5ce6a163d15457003f33ce918a203bf42e518ac6/src/components/LetterCasePicker.tsx#L28) value based on the entire content of the cursor thought. Formatting should not be compared to determine letter case, so I ran it through `DOMParser` and used the `textContent` for the comparison. That should allow it to work regardless of whether the formatting applies to the entire thought or only a portion.