### PR TITLE
chore: restrict Vercel Git deployments to main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  },
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Restrict Vercel's Git-integration deployments to the `main` branch only. Preview deployments are already handled by the custom `vercel-preview.yml` GitHub Action (using `VERCEL_TOKEN`), so the Git integration no longer needs to build any branch other than `main`.

### Why

Vercel's Git integration created deployments for **all** branches and PRs, including fork PRs. For fork PRs, Vercel's fork-authorization gate runs *before* the "Ignored Build Step" is evaluated — so the Ignored Build Step can't suppress those checks, and every fork PR fails CI on the `Vercel – em` / `Vercel – em-ai` checks.

### The fix

```json
"git": {
  "deploymentEnabled": {
    "**": false,
    "main": true
  }
}
```

Per [Vercel's docs](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled), `deploymentEnabled` lists branches that should **not** deploy — *"any unspecified branch is set to `true`"*. So `{ "main": true }` alone is a **no-op**. Instead we disable everything with `"**": false` and re-enable `main`. Per Vercel's "branches matching multiple rules" behavior, a branch deploys if at least one matching rule is `true`, so `main` still deploys while every other branch is disabled.

`**` (not `*`) is used so slashed branch names (e.g. `copilot/fix/...`) are matched — `*` does not cross `/` in minimatch.

### Manual follow-up (dashboard / not in this PR)

1. Merge this to `main`.
2. In Vercel, set Ignored Build Step back to **Automatic**.
3. Open a fork PR test.
4. Confirm `Vercel – em` / `Vercel – em-ai` checks no longer appear.

Fallback if checks persist: set `"deploymentEnabled": false` (disable all Git deploys) and move the production deploy into GitHub Actions as well.