### PR TITLE
Fix sorted rank when editing thoughts

### DIFF
--- a/src/actions/__tests__/editThought.ts
+++ b/src/actions/__tests__/editThought.ts
@@ -1,6 +1,7 @@
 import importText from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
+import toggleSort from '../../actions/toggleSort'
 import { HOME_PATH, HOME_TOKEN } from '../../constants'
 import contextToThoughtId from '../../selectors/contextToThoughtId'
 import exportContext from '../../selectors/exportContext'
@@ -374,6 +375,39 @@ describe('sort', () => {
   - b
   - C
   - D`)
+  })
+
+  it('empty thought in descending sorted context should sort above an earlier sibling on edit', () => {
+    const steps = [
+      newThought({ value: 'A' }),
+      toggleSort({ simplePath: HOME_PATH }),
+      toggleSort({ simplePath: HOME_PATH }),
+      newThought({ value: '' }),
+      editThought([''], 'B'),
+    ]
+
+    const state = reducerFlow(steps)(initialState())
+    const thoughtA = contextToThought(state, ['A'])!
+    const thoughtB = contextToThought(state, ['B'])!
+
+    expect(thoughtB.rank).toBeLessThan(thoughtA.rank)
+  })
+
+  it('empty thought in descending sorted context should sort above all lower siblings on edit', () => {
+    const steps = [
+      newThought({ value: 'A' }),
+      newThought({ value: 'B' }),
+      toggleSort({ simplePath: HOME_PATH }),
+      toggleSort({ simplePath: HOME_PATH }),
+      newThought({ value: '' }),
+      editThought([''], 'C'),
+    ]
+
+    const state = reducerFlow(steps)(initialState())
+    const thoughtB = contextToThought(state, ['B'])!
+    const thoughtC = contextToThought(state, ['C'])!
+
+    expect(thoughtC.rank).toBeLessThan(thoughtB.rank)
   })
 
   it('rank should not change when editing a thought to empty', () => {

--- a/src/actions/editThought.ts
+++ b/src/actions/editThought.ts
@@ -144,7 +144,10 @@ const editThought = (state: State, { cursorOffset, force, oldValue, newValue, pa
     ...(editedThought.generating ? { generating: false } : null),
     rank:
       newValue !== '' && (sortType === 'Alphabetical' || sortType === 'Created' || sortType === 'Updated')
-        ? getSortedRank(state, editedThought.parentId, newValue, editedThought.created)
+        ? getSortedRank(state, editedThought.parentId, newValue, {
+            created: editedThought.created,
+            excludeThoughtId: editedThought.id,
+          })
         : editedThought.rank,
     value: newValue,
     lastUpdated: timestamp(),
@@ -177,7 +180,9 @@ const editThought = (state: State, { cursorOffset, force, oldValue, newValue, pa
       const sortPreference = getSortPreference(state, parentThought.parentId)
       const sortType = sortPreference.type
       if (sortType === 'Note') {
-        const newParentRank = getSortedRank(state, parentThought.parentId, newValue)
+        const newParentRank = getSortedRank(state, parentThought.parentId, newValue, {
+          excludeThoughtId: parentThought.id,
+        })
         thoughtIndexUpdates[parentThought.id] = {
           ...parentThought,
           rank: newParentRank,

--- a/src/selectors/getSortedRank.ts
+++ b/src/selectors/getSortedRank.ts
@@ -6,6 +6,13 @@ import getSortPreference from './getSortPreference'
 import noteValue from './noteValue'
 import thoughtToPath from './thoughtToPath'
 
+interface GetSortedRankOptions {
+  /** The created timestamp to use for Created sort. */
+  created?: number
+  /** Existing thought to ignore when recalculating its rank after an edit. */
+  excludeThoughtId?: ThoughtId | null
+}
+
 /** Calculates the rank for a given index in a sorted array of thoughts. */
 const calculateRank = (thoughts: { rank: number }[], index: number): number => {
   // if there is no such child, return the rank of the last child + 1
@@ -25,18 +32,23 @@ const calculateRank = (thoughts: { rank: number }[], index: number): number => {
  * This is currently optional to reflect the fact that most call sites do not need to call this function for newly-created thoughts.
  * Instead, they can assume that a newly-created thought goes at the end of the list if sort preference is Created (#3782).
  */
-const getSortedRank = (state: State, id: ThoughtId, value: string, created?: number) => {
-  const children = id ? getAllChildrenSorted(state, id) : []
+const getSortedRank = (state: State, id: ThoughtId, value: string, options?: number | GetSortedRankOptions) => {
+  const childrenAll = id ? getAllChildrenSorted(state, id) : []
+
+  if (childrenAll.length === 0) return 0
+
+  const sortPreference = getSortPreference(state, id)
+  const { created, excludeThoughtId } = typeof options === 'number' ? { created: options } : options || {}
+  const isDescending = sortPreference.direction === 'Desc'
+  const excludedThoughtId =
+    excludeThoughtId || (sortPreference.type === 'Updated' ? state.cursor?.[state.cursor.length - 1] : null)
+  const children = excludedThoughtId ? childrenAll.filter(thought => thought.id !== excludedThoughtId) : childrenAll
 
   if (children.length === 0) return 0
 
-  const sortPreference = getSortPreference(state, id)
-  const isDescending = sortPreference.direction === 'Desc'
-  const thoughts = children.filter(thought => !state.cursor || thought.id !== state.cursor[state.cursor.length - 1])
-
   // Handle Updated sorting
   if (sortPreference.type === 'Updated') {
-    return isDescending ? thoughts[0].rank - 1 : (thoughts[thoughts.length - 1]?.rank || 0) + 1
+    return isDescending ? children[0].rank - 1 : (children[children.length - 1]?.rank || 0) + 1
   }
 
   // Handle Created sorting (#3782)


### PR DESCRIPTION
## Summary

Fixes #4500.

This updates sorted rank recalculation when editing a thought so the thought being edited is excluded from the sibling rank comparison.
Without that exclusion, the old value can interfere with the new rank calculation, especially in descending sorted contexts.

Changes:
- Add `excludeThoughtId` support to `getSortedRank`.
- Pass the edited thought id when recalculating rank in `editThought`.
- Preserve existing `created` rank behavior.
- Add regression coverage for editing thoughts in descending sorted contexts.

## Testing

- `yarn lint` passed
- `yarn build` passed
- `yarn test --run` passed