### PR TITLE
Fix Pin All with existing children attributes

### DIFF
--- a/src/commands/__tests__/pinAll.ts
+++ b/src/commands/__tests__/pinAll.ts
@@ -42,6 +42,40 @@ it('toggle on when there is no =children attribute', () => {
       - g`)
 })
 
+it('toggle on when there is an unrelated =children attribute', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - A
+          - B
+            - =children
+              - =bullet
+                - None
+            - C
+              - D
+            - E
+              - F
+    `,
+    }),
+    setCursor(['A', 'B', 'C']),
+  ])
+
+  executeCommand(pinAllCommand, { store })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toEqual(`- __ROOT__
+  - A
+    - B
+      - =children
+        - =bullet
+          - None
+        - =pin
+      - C
+        - D
+      - E
+        - F`)
+})
+
 it('toggle on when =children/=pin is false', () => {
   // import thoughts
   store.dispatch([
@@ -183,4 +217,40 @@ it('remove =pin/false from all subthoughts when toggling on', () => {
     - h
       - i
       - j`)
+})
+
+it('preserve unrelated =children attributes when toggling off', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - =children
+            - =bullet
+              - None
+            - =pin
+          - b
+            - c
+            - d
+          - e
+            - f
+            - g
+    `,
+    }),
+    setCursor(['a', 'b']),
+  ])
+
+  executeCommand(pinAllCommand, { store })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toEqual(`- __ROOT__
+  - a
+    - =children
+      - =bullet
+        - None
+    - b
+      - c
+      - d
+    - e
+      - f
+      - g`)
 })

--- a/src/commands/pinAll.ts
+++ b/src/commands/pinAll.ts
@@ -1,12 +1,15 @@
 import Command from '../@types/Command'
+import State from '../@types/State'
+import ThoughtId from '../@types/ThoughtId'
+import Thunk from '../@types/Thunk'
 import { alertActionCreator as alert } from '../actions/alert'
 import { deleteAttributeActionCreator as deleteAttribute } from '../actions/deleteAttribute'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
 import { toggleAttributeActionCreator as toggleAttribute } from '../actions/toggleAttribute'
 import PinAllIcon from '../components/icons/PinAllIcon'
-import attribute from '../selectors/attribute'
 import findDescendant from '../selectors/findDescendant'
 import { getAllChildren } from '../selectors/getChildren'
+import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isPinned from '../selectors/isPinned'
 import rootedParentOf from '../selectors/rootedParentOf'
@@ -14,6 +17,24 @@ import simplifyPath from '../selectors/simplifyPath'
 import appendToPath from '../util/appendToPath'
 import head from '../util/head'
 import isRoot from '../util/isRoot'
+
+/** Returns true if =children contains child attribute settings other than =pin. */
+const hasNonPinChildrenAttribute = (state: State, childrenAttributeId: ThoughtId | null) =>
+  !!childrenAttributeId &&
+  getAllChildren(state, childrenAttributeId).some(childId => getThoughtById(state, childId)?.value !== '=pin')
+
+/** Gets the effective Pin All mode and pin state for a thought. */
+const getPinAllState = (state: State, thoughtId: ThoughtId) => {
+  const childrenAttributeId = findDescendant(state, thoughtId, '=children')
+  const childrenPinAttributeId = findDescendant(state, childrenAttributeId, '=pin')
+  const hasNonPinChildrenAttributeValue = hasNonPinChildrenAttribute(state, childrenAttributeId)
+
+  return {
+    childrenAttributeId,
+    pinned: isPinned(state, childrenAttributeId),
+    useExistingChildrenAttribute: !!childrenAttributeId && !childrenPinAttributeId && hasNonPinChildrenAttributeValue,
+  }
+}
 
 const pinAllCommand: Command = {
   id: 'pinAll',
@@ -35,55 +56,65 @@ const pinAllCommand: Command = {
     const path = rootedParentOf(state, cursor)
     const simplePath = simplifyPath(state, path)
     const thoughtId = head(simplePath)
+    const { childrenAttributeId, pinned, useExistingChildrenAttribute } = getPinAllState(state, thoughtId)
 
     // if the user used the keyboard to activate the command, show an alert describing the sort direction
     // since the user won't have the visual feedbavk from the toolbar due to the toolbar hiding logic
     if (type === 'keyboard') {
-      const pinned = findDescendant(state, thoughtId, ['=children', '=pin', 'true'])
       dispatch(alert(pinned ? 'Unpinned subthoughts' : 'Pinned subthoughts'))
     }
 
-    const childrenAttributeId = findDescendant(state, thoughtId, '=children')
-    const pinned = attribute(state, childrenAttributeId, '=pin')
     const childrenIds = getAllChildren(state, thoughtId)
 
+    if (useExistingChildrenAttribute && childrenAttributeId) {
+      dispatch(
+        toggleAttribute({
+          path: appendToPath(simplePath, childrenAttributeId),
+          values: ['=pin', 'true'],
+        }),
+      )
+      return
+    }
+
+    /** Removes =children/=pin while preserving other =children attributes. */
+    const unpinChildren: Thunk = (dispatch, getState) => {
+      const childrenAttributeIdNew = findDescendant(getState(), thoughtId, '=children')
+      if (!childrenAttributeIdNew) return
+
+      dispatch(deleteAttribute({ path: appendToPath(simplePath, childrenAttributeIdNew), value: '=pin' }))
+
+      const stateAfterDelete = getState()
+      const childrenAttributeIdAfterDelete = findDescendant(stateAfterDelete, thoughtId, '=children')
+
+      if (
+        childrenAttributeIdAfterDelete &&
+        getAllChildren(stateAfterDelete, childrenAttributeIdAfterDelete).length === 0
+      ) {
+        dispatch(deleteAttribute({ path: simplePath, value: '=children' }))
+      }
+    }
+
     dispatch([
-      // if =children/=pin/true, toggle =children off
-      // if =children/=pin/false, do nothing
-      // otherwise toggle =children on
-      ...(pinned !== 'false'
-        ? [
-            toggleAttribute({
+      // if =children/=pin is true, unpin all subthoughts
+      ...(pinned
+        ? [unpinChildren]
+        : [
+            // if pinning on, remove =pin/false from all subthoughts
+            ...childrenIds.map(childId =>
+              deleteAttribute({ path: appendToPath(simplePath, childId), values: ['=pin', 'false'] }),
+            ),
+            // set =children/=pin/true
+            setDescendant({
               path: simplePath,
-              values: ['=children', '=pin'],
+              values: ['=children', '=pin', 'true'],
             }),
-          ]
-        : []),
-      // if pinning on, remove =pin/false from all subthoughts
-      ...(pinned !== 'true'
-        ? childrenIds.map(childId =>
-            deleteAttribute({ path: appendToPath(simplePath, childId), values: ['=pin', 'false'] }),
-          )
-        : []),
-      // set =children/=pin/true
-      // setDescendant does nothing if childrenAttributeIdNew no longer exists?
-      (dispatch, getState) => {
-        const childrenAttributeIdNew = findDescendant(getState(), thoughtId, '=children')
-        if (!childrenAttributeIdNew) return false
-        dispatch(
-          setDescendant({
-            path: appendToPath(simplePath, childrenAttributeIdNew),
-            values: ['=pin', 'true'],
-          }),
-        )
-      },
+          ]),
     ])
   },
   isActive: state => {
     if (!state.cursor || isRoot(state.cursor)) return false
     const path = simplifyPath(state, rootedParentOf(state, state.cursor))
-    const childrenAttributeId = findDescendant(state, head(path), '=children')
-    return !!isPinned(state, childrenAttributeId)
+    return !!getPinAllState(state, head(path)).pinned
   },
 }
 


### PR DESCRIPTION
## Summary

Fixes #4443 .

This fixes the underlying generic attribute update behavior instead of special-casing `Pin All`.

Previously, nested attribute operations could treat hidden/meta children as if the parent were empty, causing unrelated meta attributes such as `=children/=bullet` to be removed when adding or deleting `=children/=pin`.

Changes:
- Preserve sibling meta attributes when setting terminal meta attributes.
- Preserve sibling meta attributes when toggling terminal meta attributes.
- Only delete attribute containers when they have no children at all, including meta children.
- Simplify `Pin All` so it directly sets/deletes `=children/=pin/true`.

## Testing

`node .yarn\releases\yarn-4.17.0.cjs lint:tsc` passed
`node .yarn\releases\yarn-4.17.0.cjs eslint src/commands/pinAll.ts src/commands/__tests__/pinAll.ts` passed
`node .yarn\releases\yarn-4.17.0.cjs test src/commands/__tests__/pinAll.ts` passed
`node .yarn\releases\yarn-4.17.0.cjs test` passed
