### PR TITLE
Stabilize context view ordering

### DIFF
--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -230,8 +230,10 @@ it('Verify superscript colors in different views', async () => {
   await clickThought('m')
   await click('[data-testid="toolbar-icon"][aria-label="Context View"]')
 
-  // ArrowDown to first context 'b'
+  // ArrowDown to the green 'b' context. Keyboard traversal visits the first context and its child before reaching it.
   // TODO: Why does clickThought('b') not work here?
+  await press('ArrowDown')
+  await press('ArrowDown')
   await press('ArrowDown')
   const supColor3 = await getSuperscriptColor()
   expect(supColor3).toBeTruthy()

--- a/src/selectors/__tests__/getContextsSortedAndRanked.ts
+++ b/src/selectors/__tests__/getContextsSortedAndRanked.ts
@@ -1,0 +1,67 @@
+import State from '../../@types/State'
+import importText from '../../actions/importText'
+import { HOME_TOKEN } from '../../constants'
+import contextToThoughtId from '../../selectors/contextToThoughtId'
+import getContextsSortedAndRanked from '../../selectors/getContextsSortedAndRanked'
+import getThoughtById from '../../selectors/getThoughtById'
+import initialState from '../../util/initialState'
+
+const FIXED_HOME_ROOT_VALUE = '00000000000000000000000000000001'
+
+/** Updates a thought value in the reducer state used by selector tests. */
+const setThoughtValue = (state: State, id: string, value: string): State => ({
+  ...state,
+  thoughts: {
+    ...state.thoughts,
+    thoughtIndex: {
+      ...state.thoughts.thoughtIndex,
+      [id]: {
+        ...state.thoughts.thoughtIndex[id],
+        value,
+      },
+    },
+  },
+})
+
+describe('getContextsSortedAndRanked', () => {
+  it.each([HOME_TOKEN, FIXED_HOME_ROOT_VALUE])(
+    'does not let root token value affect top-level context order: %s',
+    rootValue => {
+      const text = `
+        - a
+          - m
+            - x
+        - v
+          - b
+            - m
+              - y
+      `
+
+      const state = importText(initialState(), { text })
+      const vId = contextToThoughtId(state, ['v'])
+      const bId = contextToThoughtId(state, ['v', 'b'])
+
+      if (!vId || !bId) throw new Error('Failed to set up context sort fixture.')
+
+      const stateWithFormattedContext = [HOME_TOKEN, vId, bId].reduce(
+        (stateAcc, id) =>
+          setThoughtValue(
+            stateAcc,
+            id,
+            id === HOME_TOKEN
+              ? rootValue
+              : id === vId
+                ? '<font color="#ff573d">v</font>'
+                : '<font color="#00d688">b</font>',
+          ),
+        state,
+      )
+
+      const contextParentValues = getContextsSortedAndRanked(stateWithFormattedContext, 'm').map(
+        thought => getThoughtById(stateWithFormattedContext, thought.parentId)?.value,
+      )
+
+      expect(contextParentValues).toEqual(['a', '<font color="#00d688">b</font>'])
+    },
+  )
+})

--- a/src/selectors/getContextsSortedAndRanked.ts
+++ b/src/selectors/getContextsSortedAndRanked.ts
@@ -49,7 +49,9 @@ const getContextsSortedAndRanked = (state: State, value: string): Thought[] => {
     const path = unroot(simplePath)
     const breadcrumbs = rootedParentOf(state, parentOf(path))
     const parent = getThoughtById(state, thought.parentId)
-    const breadcrumbThoughts = childIdsToThoughts(state, breadcrumbs)
+    // Root token values are provider implementation details. Treat the root as an empty breadcrumb so
+    // context order does not change between providers that use different root ids.
+    const breadcrumbThoughts = isRoot(breadcrumbs) ? [] : childIdsToThoughts(state, breadcrumbs)
     if (!breadcrumbThoughts.every(nonNull)) return MISSING_TOKEN
     const encodedBreadcrumbs = breadcrumbThoughts
       .map(thought => (thought ? thought.value : MISSING_TOKEN))


### PR DESCRIPTION
Stabilizes Context View ordering by keeping provider-specific root token values out of the context sort key.

For top-level contexts, the root thought was being used as a breadcrumb, so internal root values like `__ROOT__` or a fixed backend id could affect visible order. Root breadcrumbs now sort as empty.

The color test now follows the corrected stable traversal order: `m -> a -> x -> green b`.