### PR TITLE
Compare formatting tags independent of applied order

### DIFF
--- a/src/e2e/puppeteer/__tests__/sort.ts
+++ b/src/e2e/puppeteer/__tests__/sort.ts
@@ -1,0 +1,47 @@
+import click from '../helpers/click'
+import clickThought from '../helpers/clickThought'
+import command from '../helpers/command'
+import exportThoughts from '../helpers/exportThoughts'
+import paste from '../helpers/paste'
+
+vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
+
+/** Returns the visible order of the single-letter thoughts A–E from the exported outline. Strips markdown formatting (e.g. **E**, ***D***) and meta thoughts (=sort, Alphabetical, Desc). */
+const getLetterOrder = (exported: string): string[] =>
+  exported
+    .split('\n')
+    .map(line => line.replace(/[-*\s]/g, ''))
+    .filter(value => ['A', 'B', 'C', 'D', 'E'].includes(value))
+
+// https://github.com/cybersemics/em/issues/3977
+it('a thought formatted with multiple styles is sorted by its highest-priority format (bold) in reverse alphabetical order', async () => {
+  await paste(`
+    - A
+    - B
+    - C
+    - D
+    - E
+  `)
+
+  // set the cursor on a home child so that Sort targets the home context
+  await clickThought('A')
+
+  // Sort - Alphabetically - Descending (None → Alphabetical/Asc → Alphabetical/Desc)
+  await command('toggleSort')
+  await command('toggleSort')
+
+  // Add Bold to E and C
+  await clickThought('E')
+  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
+  await clickThought('C')
+  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
+
+  // Add Italic to D, then Bold to D (cursor remains on D after each format)
+  await clickThought('D')
+  await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
+
+  // Bold D should be sorted among the bold thoughts by its text, landing between E and C
+  const exported = await exportThoughts()
+  expect(getLetterOrder(exported)).toEqual(['E', 'D', 'C', 'B', 'A'])
+})

--- a/src/e2e/puppeteer/__tests__/sort.ts
+++ b/src/e2e/puppeteer/__tests__/sort.ts
@@ -48,36 +48,3 @@ it('a thought formatted with multiple styles is given greater priority than thou
   const exported = await exportThoughts()
   expect(getLetterOrder(exported)).toEqual(['D', 'E', 'C', 'B', 'A'])
 })
-
-// https://github.com/cybersemics/em/issues/3977
-it('a thought with more formatting types outranks one with fewer, even if the latter has a higher-priority format', async () => {
-  await paste(`
-    - A
-    - B
-    - C
-  `)
-
-  // set the cursor on a home child so that Sort targets the home context
-  await clickThought('A')
-
-  // Sort - Alphabetically - Descending (None → Alphabetical/Asc → Alphabetical/Desc)
-  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
-  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
-  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
-  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
-
-  // Add Bold + Italic to A (two formats, highest priority is bold)
-  await clickThought('A')
-  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
-  await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
-
-  // Add Italic + Underline + Strikethrough to A (three formats, no bold)
-  await clickThought('B')
-  await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
-  await click('[data-testid="toolbar-icon"][aria-label="Underline"]')
-  await click('[data-testid="toolbar-icon"][aria-label="Strikethrough"]')
-
-  // A's three formats outrank B's two, even though B has bold (the highest-priority format)
-  const exported = await exportThoughts()
-  expect(getLetterOrder(exported)).toEqual(['B', 'A', 'C'])
-})

--- a/src/e2e/puppeteer/__tests__/sort.ts
+++ b/src/e2e/puppeteer/__tests__/sort.ts
@@ -1,6 +1,5 @@
 import click from '../helpers/click'
 import clickThought from '../helpers/clickThought'
-import command from '../helpers/command'
 import exportThoughts from '../helpers/exportThoughts'
 import paste from '../helpers/paste'
 
@@ -14,7 +13,7 @@ const getLetterOrder = (exported: string): string[] =>
     .filter(value => ['A', 'B', 'C', 'D', 'E'].includes(value))
 
 // https://github.com/cybersemics/em/issues/3977
-it('a thought formatted with multiple styles is sorted by its highest-priority format (bold) in reverse alphabetical order', async () => {
+it('a thought formatted with multiple styles is given greater priority than thoughts with a single format', async () => {
   await paste(`
     - A
     - B
@@ -27,8 +26,10 @@ it('a thought formatted with multiple styles is sorted by its highest-priority f
   await clickThought('A')
 
   // Sort - Alphabetically - Descending (None → Alphabetical/Asc → Alphabetical/Desc)
-  await command('toggleSort')
-  await command('toggleSort')
+  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
+  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
+  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
 
   // Add Bold to E and C
   await clickThought('E')
@@ -41,7 +42,42 @@ it('a thought formatted with multiple styles is sorted by its highest-priority f
   await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
   await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
 
-  // Bold D should be sorted among the bold thoughts by its text, landing between E and C
+  await clickThought('B')
+
+  // D and B both have two formats, so they outrank the singly-bold E and C; D's bold outranks B's italic within the pair
   const exported = await exportThoughts()
-  expect(getLetterOrder(exported)).toEqual(['E', 'D', 'C', 'B', 'A'])
+  expect(getLetterOrder(exported)).toEqual(['D', 'E', 'C', 'B', 'A'])
+})
+
+// https://github.com/cybersemics/em/issues/3977
+it('a thought with more formatting types outranks one with fewer, even if the latter has a higher-priority format', async () => {
+  await paste(`
+    - A
+    - B
+    - C
+  `)
+
+  // set the cursor on a home child so that Sort targets the home context
+  await clickThought('A')
+
+  // Sort - Alphabetically - Descending (None → Alphabetical/Asc → Alphabetical/Desc)
+  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
+  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Sort Picker"]')
+  await click('[aria-label="sort options"] [aria-label="Alphabetical"]')
+
+  // Add Bold + Italic to A (two formats, highest priority is bold)
+  await clickThought('A')
+  await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
+
+  // Add Italic + Underline + Strikethrough to A (three formats, no bold)
+  await clickThought('B')
+  await click('[data-testid="toolbar-icon"][aria-label="Italic"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Underline"]')
+  await click('[data-testid="toolbar-icon"][aria-label="Strikethrough"]')
+
+  // A's three formats outrank B's two, even though B has bold (the highest-priority format)
+  const exported = await exportThoughts()
+  expect(getLetterOrder(exported)).toEqual(['B', 'A', 'C'])
 })

--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -140,10 +140,10 @@ it('compareFormattingTagPriority', () => {
   expect(compareFormattingTagPriority('<u>A</u>', '<u>A</u>')).toBe(0)
   expect(compareFormattingTagPriority('<strike>A</strike>', '<strike>A</strike>')).toBe(0)
 
-  // non-formatted = 0
+  // a formatted first character sorts above an unformatted one; both unformatted = 0
   expect(compareFormattingTagPriority('a', 'b')).toBe(0)
-  expect(compareFormattingTagPriority('<b>A</b>', 'b')).toBe(0)
-  expect(compareFormattingTagPriority('a', '<b>B</b>')).toBe(0)
+  expect(compareFormattingTagPriority('<b>A</b>', 'b')).toBe(-1)
+  expect(compareFormattingTagPriority('a', '<b>B</b>')).toBe(1)
 
   // strong/b aliases = 0
   expect(compareFormattingTagPriority('<strong>A</strong>', '<b>A</b>')).toBe(0)
@@ -179,6 +179,23 @@ it('compareFormattingTagPriority', () => {
   // italic+underline+strikethrough (three types, no bold) outranks bold+italic (two types, includes bold)
   expect(compareFormattingTagPriority('<i><u><s>A</s></u></i>', '<b><i>A</i></b>')).toBe(-1)
   expect(compareFormattingTagPriority('<b><i>A</i></b>', '<i><u><s>A</s></u></i>')).toBe(1)
+
+  // only the formatting of the first character counts; formatting of later characters is ignored (#3977)
+  // first character is bold only, so it sorts equal to a plain bold thought despite the trailing italic
+  expect(compareFormattingTagPriority('<b>A</b><i>bc</i>', '<b>A</b>')).toBe(0)
+  // a thought whose first character has two formats outranks one whose second format is on a later character
+  expect(compareFormattingTagPriority('<b><i>A</i></b>', '<b>A</b><i>bc</i>')).toBe(-1)
+  expect(compareFormattingTagPriority('<b>A</b><i>bc</i>', '<b><i>A</i></b>')).toBe(1)
+  // a thought whose first character is unformatted sorts below one whose first character is formatted, ignoring later formatting
+  expect(compareFormattingTagPriority('A<i>bc</i>', '<u>A</u>')).toBe(1)
+
+  // formatting on later characters is ignored; only the first character's formatting is considered (#3977)
+  // both first characters are unformatted, so they sort equally
+  expect(compareFormattingTagPriority('A<b>bc</b>', 'A<i>bc</i>')).toBe(0)
+  // a's first character is unformatted while b's is formatted, so b sorts above a
+  expect(compareFormattingTagPriority('A<b>bc</b>', '<b>A</b>')).toBe(1)
+  // multiple formats on later characters are still ignored when the first character is plain, so b (formatted first character) sorts above a
+  expect(compareFormattingTagPriority('A<b><i>bc</i></b>', '<u>A</u>')).toBe(1)
 })
 
 it('compareDateStrings', () => {

--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -161,15 +161,24 @@ it('compareFormattingTagPriority', () => {
   expect(compareFormattingTagPriority('<strong>A</strong>', '<i>A</i>')).toBe(-1)
   expect(compareFormattingTagPriority('<em>A</em>', '<b>A</b>')).toBe(1)
 
-  // multiple formatting tags are sorted by their highest-priority tag regardless of nesting order (#3977)
+  // more distinct formatting types are given greater priority, regardless of nesting order (#3977)
   expect(compareFormattingTagPriority('<i><b>A</b></i>', '<i>A</i>')).toBe(-1)
   expect(compareFormattingTagPriority('<b><i>A</i></b>', '<i>A</i>')).toBe(-1)
   expect(compareFormattingTagPriority('<i>A</i>', '<i><b>A</b></i>')).toBe(1)
-  // a bold+italic thought sorts equal to a bold thought (both resolve to bold priority)
-  expect(compareFormattingTagPriority('<i><b>A</b></i>', '<b>A</b>')).toBe(0)
-  // underline+italic resolves to italic (the highest priority present), so it sorts above a plain underline
+  // a bold+italic thought (two types) outranks a plain bold thought (one type)
+  expect(compareFormattingTagPriority('<i><b>A</b></i>', '<b>A</b>')).toBe(-1)
+  expect(compareFormattingTagPriority('<b>A</b>', '<i><b>A</b></i>')).toBe(1)
+  // thoughts with the same number of types are tie-broken by their highest-priority tag
+  expect(compareFormattingTagPriority('<i><b>A</b></i>', '<b><i>A</i></b>')).toBe(0)
+
+  // underline+italic (two types) outranks a plain underline or a plain italic (one type)
   expect(compareFormattingTagPriority('<u><i>A</i></u>', '<u>A</u>')).toBe(-1)
-  expect(compareFormattingTagPriority('<u><i>A</i></u>', '<i>A</i>')).toBe(0)
+  expect(compareFormattingTagPriority('<u><i>A</i></u>', '<i>A</i>')).toBe(-1)
+
+  // more formatting types outranks fewer, even if the thought with fewer has a higher-priority tag (#3977)
+  // italic+underline+strikethrough (three types, no bold) outranks bold+italic (two types, includes bold)
+  expect(compareFormattingTagPriority('<i><u><s>A</s></u></i>', '<b><i>A</i></b>')).toBe(-1)
+  expect(compareFormattingTagPriority('<b><i>A</i></b>', '<i><u><s>A</s></u></i>')).toBe(1)
 })
 
 it('compareDateStrings', () => {
@@ -288,12 +297,8 @@ describe('compareThought', () => {
     })
 
     it('sort equally-formatted thoughts by their visible text, ignoring formatting markup (#3977)', () => {
-      // a bold+italic thought should sort among the bold thoughts by its text, not by the leading tag (<i vs <b)
-      // descending: <b>E</b> > <i><b>D</b></i> > <b>C</b>
-      expect(compareThoughtDescending(thought('<i><b>D</b></i>'), thought('<b>E</b>'))).toBe(1)
-      expect(compareThoughtDescending(thought('<i><b>D</b></i>'), thought('<b>C</b>'))).toBe(-1)
-      expect(compareThoughtDescending(thought('<b>E</b>'), thought('<i><b>D</b></i>'))).toBe(-1)
-      expect(compareThoughtDescending(thought('<b>C</b>'), thought('<i><b>D</b></i>'))).toBe(1)
+      expect(compareThoughtDescending(thought('<b><i>E</b>'), thought('<i><b>D</b></i>'))).toBe(-1)
+      expect(compareThoughtDescending(thought('<b><i>C</b>'), thought('<i><b>D</b></i>'))).toBe(1)
     })
 
     it('sort empty thought above formatted thoughts in descending order', () => {

--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -160,6 +160,16 @@ it('compareFormattingTagPriority', () => {
   // strong/em ordering (strong = bold priority, em = italic priority)
   expect(compareFormattingTagPriority('<strong>A</strong>', '<i>A</i>')).toBe(-1)
   expect(compareFormattingTagPriority('<em>A</em>', '<b>A</b>')).toBe(1)
+
+  // multiple formatting tags are sorted by their highest-priority tag regardless of nesting order (#3977)
+  expect(compareFormattingTagPriority('<i><b>A</b></i>', '<i>A</i>')).toBe(-1)
+  expect(compareFormattingTagPriority('<b><i>A</i></b>', '<i>A</i>')).toBe(-1)
+  expect(compareFormattingTagPriority('<i>A</i>', '<i><b>A</b></i>')).toBe(1)
+  // a bold+italic thought sorts equal to a bold thought (both resolve to bold priority)
+  expect(compareFormattingTagPriority('<i><b>A</b></i>', '<b>A</b>')).toBe(0)
+  // underline+italic resolves to italic (the highest priority present), so it sorts above a plain underline
+  expect(compareFormattingTagPriority('<u><i>A</i></u>', '<u>A</u>')).toBe(-1)
+  expect(compareFormattingTagPriority('<u><i>A</i></u>', '<i>A</i>')).toBe(0)
 })
 
 it('compareDateStrings', () => {
@@ -275,6 +285,15 @@ describe('compareThought', () => {
       expect(compareThoughtDescending(thought('<i>A</i>'), thought('<u>A</u>'))).toBe(-1)
       expect(compareThoughtDescending(thought('<u>A</u>'), thought('<strike>A</strike>'))).toBe(-1)
       expect(compareThoughtDescending(thought('<strike>A</strike>'), thought('<u>A</u>'))).toBe(1)
+    })
+
+    it('sort equally-formatted thoughts by their visible text, ignoring formatting markup (#3977)', () => {
+      // a bold+italic thought should sort among the bold thoughts by its text, not by the leading tag (<i vs <b)
+      // descending: <b>E</b> > <i><b>D</b></i> > <b>C</b>
+      expect(compareThoughtDescending(thought('<i><b>D</b></i>'), thought('<b>E</b>'))).toBe(1)
+      expect(compareThoughtDescending(thought('<i><b>D</b></i>'), thought('<b>C</b>'))).toBe(-1)
+      expect(compareThoughtDescending(thought('<b>E</b>'), thought('<i><b>D</b></i>'))).toBe(-1)
+      expect(compareThoughtDescending(thought('<b>C</b>'), thought('<i><b>D</b></i>'))).toBe(1)
     })
 
     it('sort empty thought above formatted thoughts in descending order', () => {

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -34,10 +34,8 @@ const FORMATTING_TAG_PRIORITY: Record<string, number> = {
   span: 7,
 }
 
-const FORMATTING_PRIORITY_TAG_NAMES = Object.keys(FORMATTING_TAG_PRIORITY)
-
-/** Matches any formatting opening tag in a string for priority ordering. Includes all tags in FORMATTING_TAG_PRIORITY (e.g. s as an alias for strike). Global so all applied tags can be scanned, not just the outermost one (#3977). */
-const REGEX_FORMATTING_PRIORITY = new RegExp(`<(${FORMATTING_PRIORITY_TAG_NAMES.join('|')})[^>]*>`, 'g')
+/** Matches a single opening HTML tag anchored at the start of a string, capturing its tag name. Used to collect the formatting tags that enclose a thought's first character (#3977). */
+const REGEX_LEADING_TAG = /^<([a-zA-Z0-9]+)[^>]*>/
 
 // Date pattern regex constants for performance optimization
 // Month names for reuse across date patterns (pipe-separated for regex)
@@ -181,46 +179,38 @@ export const compareFormatting = <T, U>(a: T, b: U): ComparatorValue => {
   return aStartsWithHtml && !bStartsWithHtml ? -1 : bStartsWithHtml && !aStartsWithHtml ? 1 : 0
 }
 
-/** Extracts the highest priority (lowest number) among all formatting tags present in an HTML string,
- * or undefined if the string contains no recognized formatting tags. Scanning all tags (rather than just the outermost)
- * ensures sorting is not affected by the order in which multiple formats were applied (#3977). */
-const getFormattingTagPriority = (html: string): number | undefined => {
-  let highestPriority: number | undefined
-  // reset lastIndex since REGEX_FORMATTING_PRIORITY is global and stateful across exec calls
-  REGEX_FORMATTING_PRIORITY.lastIndex = 0
-  let match: RegExpExecArray | null
-  while ((match = REGEX_FORMATTING_PRIORITY.exec(html)) !== null) {
-    const priority = FORMATTING_TAG_PRIORITY[match[1]]
-    if (highestPriority === undefined || priority < highestPriority) {
-      highestPriority = priority
-    }
-  }
-  return highestPriority
-}
-
-/** Counts the number of distinct formatting types present in an HTML string. Aliased tags (e.g. b/strong, i/em, strike/s)
- * are counted as a single type since they share a priority. Returns 0 if the string contains no recognized formatting tags. */
-const getFormattingTypeCount = (html: string): number => {
+/** Returns the set of formatting tag priorities that enclose the first character of an HTML string (#3977).
+ * Empty formatting tags are filtered out before sorting, no formatting tag closes before the first character.
+ * Returns an empty set if the first character is unformatted.
+ * Aliased tags (e.g. b/strong, i/em, strike/s) share a priority, so applying more than one of them counts as a single type. */
+const getFirstCharacterFormattingPriorities = (html: string): Set<number> => {
   const priorities = new Set<number>()
-  // reset lastIndex since REGEX_FORMATTING_PRIORITY is global and stateful across exec calls
-  REGEX_FORMATTING_PRIORITY.lastIndex = 0
+  let rest = html
   let match: RegExpExecArray | null
-  while ((match = REGEX_FORMATTING_PRIORITY.exec(html)) !== null) {
-    priorities.add(FORMATTING_TAG_PRIORITY[match[1]])
+  // collect the leading run of opening tags; a non-tag character marks the thought's first character
+  while ((match = REGEX_LEADING_TAG.exec(rest)) !== null) {
+    const tagName = match[1].toLowerCase()
+    if (tagName in FORMATTING_TAG_PRIORITY) priorities.add(FORMATTING_TAG_PRIORITY[tagName])
+    rest = rest.slice(match[0].length)
   }
-  return priorities.size
+  return priorities
 }
 
-/** A comparator that sorts formatted strings by their formatting tag priority. Thoughts with more distinct types of
- * formatting are given greater priority (sorted first); ties are broken by the highest-priority tag
- * (bold < italic < underline < strikethrough). Returns 0 if either string is not a recognized formatting tag. */
+/** A comparator that sorts formatted strings by the formatting tag priority of their first character. A thought whose
+ * first character is formatted sorts above one whose first character is not. Among thoughts whose first character is
+ * formatted, those with more distinct types of formatting are given greater priority (sorted first); ties are broken by
+ * the highest-priority tag (bold < italic < underline < strikethrough). Formatting of characters other than the first is
+ * ignored (#3977). Returns 0 only when neither string's first character is formatted. */
 export const compareFormattingTagPriority: ComparatorFunction<string> = (a: string, b: string): ComparatorValue => {
-  const aPriority = getFormattingTagPriority(a)
-  const bPriority = getFormattingTagPriority(b)
-  if (aPriority === undefined || bPriority === undefined) return 0
-  // more distinct formatting types = greater priority = sorted first
-  const typeCountComparison = compare(getFormattingTypeCount(b), getFormattingTypeCount(a))
-  return typeCountComparison || compare(aPriority, bPriority)
+  const aPriorities = getFirstCharacterFormattingPriorities(a)
+  const bPriorities = getFirstCharacterFormattingPriorities(b)
+  // a formatted first character sorts above an unformatted one; two unformatted first characters sort equally
+  if (aPriorities.size === 0 || bPriorities.size === 0) {
+    return aPriorities.size === bPriorities.size ? 0 : aPriorities.size === 0 ? 1 : -1
+  }
+  // more distinct formatting types on the first character = greater priority = sorted first
+  const typeCountComparison = compare(bPriorities.size, aPriorities.size)
+  return typeCountComparison || compare(Math.min(...aPriorities), Math.min(...bPriorities))
 }
 
 /** A comparison function that sorts date strings. Only handles date vs date comparisons. */

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -198,11 +198,29 @@ const getFormattingTagPriority = (html: string): number | undefined => {
   return highestPriority
 }
 
-/** A comparator that sorts formatted strings by their formatting tag priority (bold < italic < underline < strikethrough). Returns 0 if either string is not a recognized formatting tag. */
+/** Counts the number of distinct formatting types present in an HTML string. Aliased tags (e.g. b/strong, i/em, strike/s)
+ * are counted as a single type since they share a priority. Returns 0 if the string contains no recognized formatting tags. */
+const getFormattingTypeCount = (html: string): number => {
+  const priorities = new Set<number>()
+  // reset lastIndex since REGEX_FORMATTING_PRIORITY is global and stateful across exec calls
+  REGEX_FORMATTING_PRIORITY.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = REGEX_FORMATTING_PRIORITY.exec(html)) !== null) {
+    priorities.add(FORMATTING_TAG_PRIORITY[match[1]])
+  }
+  return priorities.size
+}
+
+/** A comparator that sorts formatted strings by their formatting tag priority. Thoughts with more distinct types of
+ * formatting are given greater priority (sorted first); ties are broken by the highest-priority tag
+ * (bold < italic < underline < strikethrough). Returns 0 if either string is not a recognized formatting tag. */
 export const compareFormattingTagPriority: ComparatorFunction<string> = (a: string, b: string): ComparatorValue => {
   const aPriority = getFormattingTagPriority(a)
   const bPriority = getFormattingTagPriority(b)
-  return aPriority !== undefined && bPriority !== undefined ? compare(aPriority, bPriority) : 0
+  if (aPriority === undefined || bPriority === undefined) return 0
+  // more distinct formatting types = greater priority = sorted first
+  const typeCountComparison = compare(getFormattingTypeCount(b), getFormattingTypeCount(a))
+  return typeCountComparison || compare(aPriority, bPriority)
 }
 
 /** A comparison function that sorts date strings. Only handles date vs date comparisons. */

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -10,6 +10,7 @@ import thoughtToPath from '../selectors/thoughtToPath'
 import compareByRank from './compareByRank'
 import isAttribute from './isAttribute'
 import lower from './lower'
+import stripTags from './stripTags'
 
 const STARTS_WITH_EMOJI_REGEX = new RegExp(`^${EMOJI_REGEX.source}`)
 const IGNORED_PREFIXES = ['the ']
@@ -35,10 +36,8 @@ const FORMATTING_TAG_PRIORITY: Record<string, number> = {
 
 const FORMATTING_PRIORITY_TAG_NAMES = Object.keys(FORMATTING_TAG_PRIORITY)
 
-/** Matches the outermost formatting tag of a string for priority ordering. Includes all tags in FORMATTING_TAG_PRIORITY (e.g. s as an alias for strike). */
-const REGEX_FORMATTING_PRIORITY = new RegExp(
-  `^<(${FORMATTING_PRIORITY_TAG_NAMES.join('|')})[^>]*>(.*?)<\\s*/\\s*(${FORMATTING_PRIORITY_TAG_NAMES.join('|')})>`,
-)
+/** Matches any formatting opening tag in a string for priority ordering. Includes all tags in FORMATTING_TAG_PRIORITY (e.g. s as an alias for strike). Global so all applied tags can be scanned, not just the outermost one (#3977). */
+const REGEX_FORMATTING_PRIORITY = new RegExp(`<(${FORMATTING_PRIORITY_TAG_NAMES.join('|')})[^>]*>`, 'g')
 
 // Date pattern regex constants for performance optimization
 // Month names for reuse across date patterns (pipe-separated for regex)
@@ -89,8 +88,10 @@ const removeEmojisAndSpaces = (s: string) => s.replace(REGEX_EMOJI_GLOBAL, '').t
 /** Remove ignored prefixes from comparator inputs. */
 const removeIgnoredPrefixes = (s: string) => s.replace(REGEX_IGNORED_PREFIXES, '$2')
 
-/** Removes emojis, spaces, and prefix 'the' to make a string comparable.  */
-const normalizeCharacters = _.flow(removeEmojisAndSpaces, removeIgnoredPrefixes, removeDiacritics)
+/** Strips HTML formatting tags, emojis, spaces, and prefix 'the' to make a string comparable.
+ * Tags are stripped so that the lexicographic comparison sorts by the visible text rather than the markup (e.g. so that <i><b>D</b></i> compares as "D", not "<i><b>D...").
+ * Formatting priority is handled separately by compareFormattingTagPriority, so removing tags here does not affect formatting-based ordering (#3977). */
+const normalizeCharacters = _.flow(stripTags, removeEmojisAndSpaces, removeIgnoredPrefixes, removeDiacritics)
 
 /** Parse a date string and handle M/d (e.g. "2/1") and written formats (e.g. "March 3") for Safari. */
 const parseDate = (s: string): number => {
@@ -180,10 +181,21 @@ export const compareFormatting = <T, U>(a: T, b: U): ComparatorValue => {
   return aStartsWithHtml && !bStartsWithHtml ? -1 : bStartsWithHtml && !aStartsWithHtml ? 1 : 0
 }
 
-/** Extracts the priority of the outermost formatting tag from an HTML string, or undefined if the string is not a recognized formatting tag. */
+/** Extracts the highest priority (lowest number) among all formatting tags present in an HTML string,
+ * or undefined if the string contains no recognized formatting tags. Scanning all tags (rather than just the outermost)
+ * ensures sorting is not affected by the order in which multiple formats were applied (#3977). */
 const getFormattingTagPriority = (html: string): number | undefined => {
-  const match = REGEX_FORMATTING_PRIORITY.exec(html)
-  return match ? FORMATTING_TAG_PRIORITY[match[1]] : undefined
+  let highestPriority: number | undefined
+  // reset lastIndex since REGEX_FORMATTING_PRIORITY is global and stateful across exec calls
+  REGEX_FORMATTING_PRIORITY.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = REGEX_FORMATTING_PRIORITY.exec(html)) !== null) {
+    const priority = FORMATTING_TAG_PRIORITY[match[1]]
+    if (highestPriority === undefined || priority < highestPriority) {
+      highestPriority = priority
+    }
+  }
+  return highestPriority
 }
 
 /** A comparator that sorts formatted strings by their formatting tag priority (bold < italic < underline < strikethrough). Returns 0 if either string is not a recognized formatting tag. */


### PR DESCRIPTION
Fixes #3977 

Tag matching was only performed on the outermost tag, so its priority was used to determine the sort ranking of the thought. Now, all tags that apply to the first readable character are parsed and the highest-priority tag is used for comparison. Additionally, the number of tags is counted and thoughts are sorted by highest combo formatting down to lowest combo formatting.

## Complications

[normalizeCharacters](https://github.com/ethan-james/em/blob/1b2eae4219895c0caa386160b939c9a745c817f5/src/util/compareThought.ts#L91) was comparing strings with tags included in them, which led to sorting based on invisible characters rather than the visible text of the thought. Now, `stripTags` is called during the `compareReadableText` step.

## Follow Up

1. It seems like [compareFormatting](https://github.com/ethan-james/em/blob/1b2eae4219895c0caa386160b939c9a745c817f5/src/util/compareThought.ts#L176) may have been subsumed by `compareFormattingTagPriority` and it is a potential candidate for removal.
2. As mentioned in https://github.com/cybersemics/em/issues/3977#issuecomment-4870458833, it may be preferable to treat 2+ tags as a single combo stack rather than sorting 4 tags above 3 tags above 2 tags above 1 tag above 0 tags.