### PR TITLE
fix: Shift+Down/Up selects table col2 cousin, not the parent

### DIFF
--- a/src/commands/__tests__/cursorDown.ts
+++ b/src/commands/__tests__/cursorDown.ts
@@ -1,0 +1,123 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { executeCommand } from '../../commands'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import headValue from '../../util/headValue'
+import cursorDownCommand from '../cursorDown'
+
+// Disable animation frame throttling so each command executes synchronously and deterministically across tests.
+vi.mock('../../util/throttleByAnimationFrame', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (f: (...args: any[]) => void) => f,
+}))
+
+beforeEach(initStore)
+
+/** Synthetic Shift+Down keyboard event. */
+const shiftDownEvent = { shiftKey: true, preventDefault: () => {} } as unknown as KeyboardEvent
+
+/** Returns the sorted values of the current multicursor set. */
+const multicursorValues = (): (string | undefined)[] => {
+  const state = store.getState()
+  return Object.values(state.multicursors)
+    .map(path => headValue(state, path))
+    .sort()
+}
+
+describe('cursorDown Shift+Down multiselect in table view second column', () => {
+  it('extends the multiselect to the next col2 cell within the same cell', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r2', 'd']),
+    ])
+
+    executeCommand(cursorDownCommand, { store, event: shiftDownEvent })
+
+    expect(multicursorValues()).toEqual(['d', 'e'])
+  })
+
+  it('extends the multiselect to the first col2 cell of the next row (cousin) when at the last cell', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r2', 'e']),
+    ])
+
+    executeCommand(cursorDownCommand, { store, event: shiftDownEvent })
+
+    expect(multicursorValues()).toEqual(['e', 'f'])
+  })
+
+  it('does nothing at the last col2 cell of the last row', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r3', 'g']),
+    ])
+
+    executeCommand(cursorDownCommand, { store, event: shiftDownEvent })
+
+    expect(multicursorValues()).toEqual([])
+  })
+
+  it('extends the multiselect to the next sibling in normal list view (no regression)', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+          - c
+        `,
+      }),
+      setCursor(['a']),
+    ])
+
+    executeCommand(cursorDownCommand, { store, event: shiftDownEvent })
+
+    expect(multicursorValues()).toEqual(['a', 'b'])
+  })
+})

--- a/src/commands/__tests__/cursorUp.ts
+++ b/src/commands/__tests__/cursorUp.ts
@@ -1,0 +1,123 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { executeCommand } from '../../commands'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import headValue from '../../util/headValue'
+import cursorUpCommand from '../cursorUp'
+
+// Disable animation frame throttling so each command executes synchronously and deterministically across tests.
+vi.mock('../../util/throttleByAnimationFrame', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (f: (...args: any[]) => void) => f,
+}))
+
+beforeEach(initStore)
+
+/** Synthetic Shift+Up keyboard event. */
+const shiftUpEvent = { shiftKey: true, preventDefault: () => {} } as unknown as KeyboardEvent
+
+/** Returns the sorted values of the current multicursor set. */
+const multicursorValues = (): (string | undefined)[] => {
+  const state = store.getState()
+  return Object.values(state.multicursors)
+    .map(path => headValue(state, path))
+    .sort()
+}
+
+describe('cursorUp Shift+Up multiselect in table view second column', () => {
+  it('extends the multiselect to the previous col2 cell within the same cell', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r2', 'e']),
+    ])
+
+    executeCommand(cursorUpCommand, { store, event: shiftUpEvent })
+
+    expect(multicursorValues()).toEqual(['d', 'e'])
+  })
+
+  it('extends the multiselect to the last col2 cell of the previous row (cousin) when at the first cell', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r2', 'd']),
+    ])
+
+    executeCommand(cursorUpCommand, { store, event: shiftUpEvent })
+
+    expect(multicursorValues()).toEqual(['c', 'd'])
+  })
+
+  it('does nothing at the first col2 cell of the first row', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - =view
+              - Table
+            - r1
+              - b
+              - c
+            - r2
+              - d
+              - e
+            - r3
+              - f
+              - g
+        `,
+      }),
+      setCursor(['a', 'r1', 'b']),
+    ])
+
+    executeCommand(cursorUpCommand, { store, event: shiftUpEvent })
+
+    expect(multicursorValues()).toEqual([])
+  })
+
+  it('extends the multiselect to the previous sibling in normal list view (no regression)', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+          - c
+        `,
+      }),
+      setCursor(['b']),
+    ])
+
+    executeCommand(cursorUpCommand, { store, event: shiftUpEvent })
+
+    expect(multicursorValues()).toEqual(['a', 'b'])
+  })
+})

--- a/src/commands/cursorDown.ts
+++ b/src/commands/cursorDown.ts
@@ -13,7 +13,9 @@ import attributeEquals from '../selectors/attributeEquals'
 import { getChildrenSorted } from '../selectors/getChildren'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isMulticursorPath from '../selectors/isMulticursorPath'
+import isTableCol2 from '../selectors/isTableCol2'
 import nextSibling from '../selectors/nextSibling'
+import nextTableCousin from '../selectors/nextTableCousin'
 import nextThought from '../selectors/nextThought'
 import rootedParentOf from '../selectors/rootedParentOf'
 import appendToPath from '../util/appendToPath'
@@ -59,10 +61,14 @@ const cursorDownCommand: Command = {
         : // otherwise, get the first thought in the home context
           getChildrenSorted(state, HOME_TOKEN)[0]
 
-      const nextPath = nextSiblingThought
-        ? // non-first child path
-          appendToPath(parentOf(path), nextSiblingThought.id)
-        : nextThought(state)
+      const nextPath =
+        // in the second column of a table view, extend to the next thought at the same depth (the next cousin), crossing col1 row boundaries instead of falling through to the next col1 row (uncle)
+        cursor && isTableCol2(state, cursor)
+          ? nextTableCousin(state, cursor)
+          : nextSiblingThought
+            ? // non-first child path
+              appendToPath(parentOf(path), nextSiblingThought.id)
+            : nextThought(state)
 
       // if there is no next path, do nothing
       if (!nextPath) return

--- a/src/commands/cursorUp.ts
+++ b/src/commands/cursorUp.ts
@@ -13,7 +13,9 @@ import attributeEquals from '../selectors/attributeEquals'
 import { getChildrenSorted } from '../selectors/getChildren'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isMulticursorPath from '../selectors/isMulticursorPath'
+import isTableCol2 from '../selectors/isTableCol2'
 import prevSibling from '../selectors/prevSibling'
+import prevTableCousin from '../selectors/prevTableCousin'
 import rootedParentOf from '../selectors/rootedParentOf'
 import appendToPath from '../util/appendToPath'
 import head from '../util/head'
@@ -58,13 +60,17 @@ const cursorUpCommand: Command = {
         : // otherwise, get the last thought in the home context
           getChildrenSorted(state, HOME_TOKEN).slice(-1)[0]
 
-      const prevPath = prevThought
-        ? // non-first child path
-          appendToPath(parentOf(path), prevThought.id)
-        : // when the cursor is on the first child in a context, move up a level
-          !isRoot(pathParent)
-          ? pathParent
-          : null
+      const prevPath =
+        // in the second column of a table view, extend to the previous thought at the same depth (the previous cousin), crossing col1 row boundaries instead of falling through to the col1 parent
+        cursor && isTableCol2(state, cursor)
+          ? prevTableCousin(state, cursor)
+          : prevThought
+            ? // non-first child path
+              appendToPath(parentOf(path), prevThought.id)
+            : // when the cursor is on the first child in a context, move up a level
+              !isRoot(pathParent)
+              ? pathParent
+              : null
 
       // if there is no previous path, do nothing
       if (!prevPath) return

--- a/src/selectors/isTableCol2.ts
+++ b/src/selectors/isTableCol2.ts
@@ -1,0 +1,16 @@
+import Path from '../@types/Path'
+import State from '../@types/State'
+import head from '../util/head'
+import isRoot from '../util/isRoot'
+import attributeEquals from './attributeEquals'
+import rootedParentOf from './rootedParentOf'
+
+/** Returns true if the thought at the given path is in the second column of a table view, i.e. its grandparent has =view/Table. */
+const isTableCol2 = (state: State, path: Path): boolean => {
+  const parentPath = rootedParentOf(state, path)
+  if (isRoot(parentPath)) return false
+  const grandparentPath = rootedParentOf(state, parentPath)
+  return attributeEquals(state, head(grandparentPath), '=view', 'Table')
+}
+
+export default isTableCol2

--- a/src/selectors/nextTableCousin.ts
+++ b/src/selectors/nextTableCousin.ts
@@ -1,0 +1,31 @@
+import Path from '../@types/Path'
+import State from '../@types/State'
+import appendToPath from '../util/appendToPath'
+import head from '../util/head'
+import { getChildrenSorted } from './getChildren'
+import isTableCol2 from './isTableCol2'
+import nextSibling from './nextSibling'
+import rootedParentOf from './rootedParentOf'
+
+/** Gets the next thought at the same depth as a table view second-column (col2) thought, crossing col1 row boundaries (i.e. the next "cousin"). Returns the next cell within the same col1 row if it exists, otherwise the first col2 cell of the nearest following non-empty col1 row. Returns null if the path is not a col2 thought or there is no next cousin. */
+const nextTableCousin = (state: State, path: Path): Path | null => {
+  if (!isTableCol2(state, path)) return null
+
+  const parentPath = rootedParentOf(state, path)
+
+  // the next cell within the same col1 row
+  const sibling = nextSibling(state, path)
+  if (sibling) return appendToPath(parentPath, sibling.id)
+
+  // otherwise, the first col2 cell of the nearest following non-empty col1 row
+  const grandparentPath = rootedParentOf(state, parentPath)
+  const rows = getChildrenSorted(state, head(grandparentPath))
+  const rowIndex = rows.findIndex(row => row.id === head(parentPath))
+  const nextRow = rows.slice(rowIndex + 1).find(row => getChildrenSorted(state, row.id).length > 0)
+  if (!nextRow) return null
+
+  const firstCell = getChildrenSorted(state, nextRow.id)[0]
+  return appendToPath(grandparentPath, nextRow.id, firstCell.id)
+}
+
+export default nextTableCousin

--- a/src/selectors/prevTableCousin.ts
+++ b/src/selectors/prevTableCousin.ts
@@ -1,0 +1,35 @@
+import Path from '../@types/Path'
+import State from '../@types/State'
+import appendToPath from '../util/appendToPath'
+import head from '../util/head'
+import { getChildrenSorted } from './getChildren'
+import isTableCol2 from './isTableCol2'
+import prevSibling from './prevSibling'
+import rootedParentOf from './rootedParentOf'
+
+/** Gets the previous thought at the same depth as a table view second-column (col2) thought, crossing col1 row boundaries (i.e. the previous "cousin"). Returns the previous cell within the same col1 row if it exists, otherwise the last col2 cell of the nearest preceding non-empty col1 row. Returns null if the path is not a col2 thought or there is no previous cousin. */
+const prevTableCousin = (state: State, path: Path): Path | null => {
+  if (!isTableCol2(state, path)) return null
+
+  const parentPath = rootedParentOf(state, path)
+
+  // the previous cell within the same col1 row
+  const sibling = prevSibling(state, path)
+  if (sibling) return appendToPath(parentPath, sibling.id)
+
+  // otherwise, the last col2 cell of the nearest preceding non-empty col1 row
+  const grandparentPath = rootedParentOf(state, parentPath)
+  const rows = getChildrenSorted(state, head(grandparentPath))
+  const rowIndex = rows.findIndex(row => row.id === head(parentPath))
+  const prevRow = rows
+    .slice(0, rowIndex)
+    .reverse()
+    .find(row => getChildrenSorted(state, row.id).length > 0)
+  if (!prevRow) return null
+
+  const cells = getChildrenSorted(state, prevRow.id)
+  const lastCell = cells[cells.length - 1]
+  return appendToPath(grandparentPath, prevRow.id, lastCell.id)
+}
+
+export default prevTableCousin


### PR DESCRIPTION
## Problem

When the cursor is in the **second column** of a table view (or the multiselect consists only of col2 thoughts), `Shift+Down` / `Shift+Up` should extend the multiselect to the **next / previous thought at the same depth** (the "cousin"), crossing col1 row boundaries. Previously, when a col2 cell had no in-cell sibling, the fallback landed on the **col1 row (uncle / parent)** instead of the adjacent row's col2 cell.

### Steps to Reproduce (reference tree)

```
- a
  - =view
    - Table
  - r1
    - b
    - c
  - r2
    - d
    - e
  - r3
    - f
    - g
```

The flattened col2 sequence is `b, c, d, e, f, g`. Expected `Shift+Down/Up` extension from a col2 cell:

- `d` Shift+Down → `{d, e}` (next cell in same row)
- `e` Shift+Down → `{e, f}` (`e` is last in `r2` → first col2 cell of `r3`)
- `e` Shift+Up → `{e, d}` (previous cell in same row)
- `d` Shift+Up → `{d, c}` (`d` is first in `r2` → last col2 cell of `r1`; previously wrongly selected the col1 parent `r2`)
- ends of the sequence (`g` down, `b` up) → no change

## Changes

- Add selectors `isTableCol2`, `nextTableCousin`, `prevTableCousin`.
- Use them in the `Shift` branch of the `cursorDown` / `cursorUp` **commands** to compute the target path when the cursor is in table col2. All other views (normal list, col1, plain arrow navigation) are unchanged. The downstream multicursor add/remove/extend logic is untouched.
- Add command-level unit tests (`src/commands/__tests__/cursorDown.ts`, `cursorUp.ts`) covering in-cell extension, cross-row cousin extension, sequence ends (no-op), and a normal list-view no-regression case.

## Testing

- New unit tests pass; verified they fail for the right reason on the unfixed code (cursor landed on the col1 parent/uncle).
- `yarn lint` clean.
- Full unit suite: `1364 passed | 75 skipped`, 0 failures.

## Notes / scope

- Cousin is defined by same-depth linear order (e.g. `e` down → `f`, the first cell of the next row), not by matching child-index.
- Nested tables / deeper col2 children and context-view interplay are out of scope.