### PR TITLE
fix(estimate): paginate Everhour project tasks in backfill

### DIFF
--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -1,4 +1,5 @@
-# LIMIT=10 DRY_RUN=true yarn backfill
+# LIMIT=10 PAGE=1 DRY_RUN=true yarn backfill
+# PAGE sets the 1-based Everhour task page to start from (default 1).
 # API Token can be refreshed at https://app.everhour.com/#/account/profile
 EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -159,71 +159,81 @@ const main = async () => {
   }
   console.info(`Found Everhour project: "${project.name}" (${project.id})`)
 
-  // 2. Fetch tasks from the Everhour project
-  const tasks = await everhour.getProjectTasks(everhourProjectId)
-  console.info(`Found ${tasks.length} tasks in Everhour project`)
-
-  // 3. Filter to tasks without estimates
-  const tasksWithoutEstimates = tasks.filter(task => !task.estimate || !task.estimate.total)
-  console.info(`Found ${tasksWithoutEstimates.length} tasks without estimates`)
-
-  // 4. Extract issue numbers and fetch GitHub issues
+  // 2. Extract issue numbers and fetch GitHub issues
   const instructions = loadInstructions(repoRoot)
   const samples = loadSamples(repoRoot)
   const promptVersion = getPromptVersion(repoRoot)
 
+  // 3. Page through the project's tasks, processing one page at a time rather than loading
+  //    every task up front. Everhour caps a page at PAGE_SIZE tasks; a shorter page is the
+  //    last one. We stop early once `limit` tasks have been processed.
+  const PAGE_SIZE = 250
   let processed = 0
+  let page = 1
 
-  for (const task of tasksWithoutEstimates) {
-    if (processed >= limit) break
+  while (processed < limit) {
+    const tasks = await everhour.getProjectTasks(everhourProjectId, page, PAGE_SIZE)
+    console.info(`Fetched ${tasks.length} tasks from Everhour project (page ${page})`)
 
-    // Try to extract the issue number from the task ID or name; fall back to GitHub title search
-    let issueNumber = extractIssueNumber(task)
-    if (issueNumber === null) {
-      issueNumber = await findIssueByTitle(task.name, owner, repoName, githubToken)
+    // Filter to tasks without estimates within this page.
+    const tasksWithoutEstimates = tasks.filter(task => !task.estimate || !task.estimate.total)
+    console.info(`  ${tasksWithoutEstimates.length} tasks without estimates on page ${page}`)
+
+    for (const task of tasksWithoutEstimates) {
+      if (processed >= limit) break
+
+      // Try to extract the issue number from the task ID or name; fall back to GitHub title search
+      let issueNumber = extractIssueNumber(task)
+      if (issueNumber === null) {
+        issueNumber = await findIssueByTitle(task.name, owner, repoName, githubToken)
+      }
+      if (issueNumber === null) {
+        console.info(`  Skipping task "${task.name}" (${task.id}) - no GitHub issue number found`)
+        continue
+      }
+
+      // Fetch the GitHub issue
+      const issueResp = await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issueNumber}`, {
+        headers: { Authorization: `Bearer ${githubToken}` },
+      })
+
+      if (!issueResp.ok) {
+        console.info(`  Skipping issue #${issueNumber} - GitHub API error ${issueResp.status}`)
+        continue
+      }
+
+      const issue: GitHubIssue = (await issueResp.json()) as GitHubIssue
+
+      // Do not estimate closed issues.
+      if (issue.state === 'closed') {
+        console.info(`  Skipping issue #${issueNumber} - closed`)
+        continue
+      }
+
+      if (!issue.body) {
+        console.info(`  Skipping issue #${issueNumber} - empty body`)
+        continue
+      }
+
+      await processTask({
+        issue,
+        taskId: task.id,
+        everhour,
+        githubToken,
+        owner,
+        repoName,
+        instructions,
+        samples,
+        promptVersion,
+        dryRunAI,
+        dryRunEverhour,
+      })
+      processed++
     }
-    if (issueNumber === null) {
-      console.info(`  Skipping task "${task.name}" (${task.id}) - no GitHub issue number found`)
-      continue
-    }
 
-    // Fetch the GitHub issue
-    const issueResp = await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issueNumber}`, {
-      headers: { Authorization: `Bearer ${githubToken}` },
-    })
-
-    if (!issueResp.ok) {
-      console.info(`  Skipping issue #${issueNumber} - GitHub API error ${issueResp.status}`)
-      continue
-    }
-
-    const issue: GitHubIssue = (await issueResp.json()) as GitHubIssue
-
-    // Do not estimate closed issues.
-    if (issue.state === 'closed') {
-      console.info(`  Skipping issue #${issueNumber} - closed`)
-      continue
-    }
-
-    if (!issue.body) {
-      console.info(`  Skipping issue #${issueNumber} - empty body`)
-      continue
-    }
-
-    await processTask({
-      issue,
-      taskId: task.id,
-      everhour,
-      githubToken,
-      owner,
-      repoName,
-      instructions,
-      samples,
-      promptVersion,
-      dryRunAI,
-      dryRunEverhour,
-    })
-    processed++
+    // A page shorter than PAGE_SIZE means there are no further pages to fetch.
+    if (tasks.length < PAGE_SIZE) break
+    page++
   }
 
   console.info(`\nBackfill complete. Processed ${processed} tasks.`)

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -131,6 +131,11 @@ const main = async () => {
   if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
 
   const limit = parseInt(process.env.LIMIT ?? '10', 10)
+  // 1-based page to begin Everhour task pagination from. Floor invalid or <1 values to 1 so a
+  // bad PAGE never sends NaN/0 to the API. Combined with LIMIT this processes up to LIMIT tasks
+  // starting from page PAGE.
+  const startPageRaw = parseInt(process.env.PAGE ?? '1', 10)
+  const startPage = Number.isFinite(startPageRaw) && startPageRaw >= 1 ? startPageRaw : 1
   // Dry-run is the safe default: the backfill only calls the model / writes to Everhour when
   // explicitly disabled with DRY_RUN[_AI|_EVERHOUR]=false. DRY_RUN sets the default for both
   // stages; the per-stage vars override it.
@@ -147,7 +152,7 @@ const main = async () => {
     process.env.GITHUB_WORKSPACE ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 
   console.info(
-    `Backfill config: limit=${limit}, dryRunAI=${dryRunAI}, dryRunEverhour=${dryRunEverhour}, project=${everhourProjectId}`,
+    `Backfill config: limit=${limit}, startPage=${startPage}, dryRunAI=${dryRunAI}, dryRunEverhour=${dryRunEverhour}, project=${everhourProjectId}`,
   )
 
   // 1. Confirm the project exists on Everhour before doing any work, so a bad
@@ -169,7 +174,7 @@ const main = async () => {
   //    last one. We stop early once `limit` tasks have been processed.
   const PAGE_SIZE = 250
   let processed = 0
-  let page = 1
+  let page = startPage
 
   while (processed < limit) {
     const tasks = await everhour.getProjectTasks(everhourProjectId, page, PAGE_SIZE)

--- a/scripts/estimate/src/everhour/client.ts
+++ b/scripts/estimate/src/everhour/client.ts
@@ -47,9 +47,14 @@ class EverhourClient {
     return this.request<EverhourProject>(`/projects/${projectId}`)
   }
 
-  /** Fetches all tasks for a project. */
-  async getProjectTasks(projectId: string): Promise<EverhourTask[]> {
-    return this.request<EverhourTask[]>(`/projects/${projectId}/tasks`)
+  /**
+   * Fetches a single page of tasks for a project. The Everhour tasks endpoint is paginated
+   * via `limit` (page size, max 250) and `page` (1-based); a page shorter than `limit`
+   * indicates the last page. Callers should page through results rather than assuming the
+   * first response contains every task.
+   */
+  async getProjectTasks(projectId: string, page = 1, limit = 250): Promise<EverhourTask[]> {
+    return this.request<EverhourTask[]>(`/projects/${projectId}/tasks?limit=${limit}&page=${page}`)
   }
 
   /** Sets the estimate for a task in seconds. */


### PR DESCRIPTION
## Problem

The backfill script logged `Found 250 tasks in Everhour project` even though the project (gh:143808059) has far more than 250 tasks. `EverhourClient.getProjectTasks` fetched `/projects/:id/tasks` with no pagination params, and Everhour's tasks endpoint returns at most one page (default/max page size 250). Every task beyond the first page was silently never processed.

## Fix

- **`everhour/client.ts`**: `getProjectTasks` now accepts `page` (1-based) and `limit` (page size, default 250) and appends them as `?limit=…&page=…` query params.
- **`backfill.ts`**: Replaced the fetch-all-then-loop with a page-at-a-time `while` loop. It fetches one page, filters to tasks missing estimates, processes them (respecting the existing `LIMIT` processing cap), then advances to the next page only when needed. Paging stops once the processing limit is reached or a page shorter than `PAGE_SIZE` signals the last page — so we never load every page at once.

Per the request, tasks are fetched and processed one page at a time rather than all up front.

## Verification

- `tsc --noEmit` passes for `scripts/estimate`.
- Existing estimate unit tests pass (14/14 via vitest).
- Prettier applied.

## Notes

Confirmed against the Everhour API docs: the tasks endpoint is an array response paginated via `limit` (max 250) + `page`; a page shorter than the requested `limit` indicates the final page.