### PR TITLE
fix(estimate): skip PR-linked Everhour tasks with a clear reason

### DIFF
--- a/scripts/estimate/src/__tests__/backfill.ts
+++ b/scripts/estimate/src/__tests__/backfill.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { isPullRequest } from '../backfill.ts'
+
+describe('isPullRequest', () => {
+  it('returns false for an issue with no pull_request field', () => {
+    expect(isPullRequest({})).toBe(false)
+  })
+
+  it('returns false when pull_request is null', () => {
+    expect(isPullRequest({ pull_request: null })).toBe(false)
+  })
+
+  it('returns true when pull_request is present', () => {
+    expect(isPullRequest({ pull_request: { url: 'https://api.github.com/repos/o/r/pulls/215' } })).toBe(true)
+  })
+})

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -37,11 +37,24 @@ interface GitHubIssue {
   body: string | null
   state: string
   labels: Array<{ name: string }>
+  /** Present (non-null) only when the number actually refers to a pull request. */
+  pull_request?: unknown
 }
+
+/**
+ * Determines whether a GitHub issues-API object (or search result) actually refers to a pull request.
+ * PRs and issues share GitHub's number space; the `pull_request` field is the only reliable signal
+ * that a given number is a PR rather than an issue.
+ */
+export const isPullRequest = (item: { pull_request?: unknown }): boolean => item.pull_request != null
 
 /**
  * Searches GitHub for an issue matching the given title exactly.
  * Used as a fallback when the Everhour task ID does not encode the issue number.
+ *
+ * The `search/issues` endpoint matches pull requests as well as issues, so an exact issue match is
+ * preferred over a PR. A PR-only match is still returned so the caller can skip it with an accurate
+ * "it is a pull request" reason rather than a misleading "no issue number found".
  */
 const findIssueByTitle = async (
   title: string,
@@ -54,9 +67,12 @@ const findIssueByTitle = async (
     headers: { Authorization: `Bearer ${githubToken}` },
   })
   if (!resp.ok) return null
-  const data = (await resp.json()) as { items: Array<{ number: number; title: string }> }
-  const exact = data.items.find(item => item.title === title)
-  return exact?.number ?? null
+  const data = (await resp.json()) as {
+    items: Array<{ number: number; title: string; pull_request?: unknown }>
+  }
+  const exactMatches = data.items.filter(item => item.title === title)
+  const issueMatch = exactMatches.find(item => !isPullRequest(item))
+  return (issueMatch ?? exactMatches[0])?.number ?? null
 }
 
 /**
@@ -198,6 +214,14 @@ const main = async () => {
     }
 
     const issue: GitHubIssue = (await issueResp.json()) as GitHubIssue
+
+    // Some Everhour tasks are linked to pull requests, not issues. GitHub's issues API returns PRs
+    // too (they share the number space), so detect and skip them before the closed-state check —
+    // otherwise a merged PR would be reported with the misleading "closed" reason.
+    if (isPullRequest(issue)) {
+      console.info(`  Skipping #${issueNumber} "${issue.title}" - it is a pull request, not an issue`)
+      continue
+    }
 
     // Do not estimate closed issues.
     if (issue.state === 'closed') {


### PR DESCRIPTION
Builds on #4302.

## Problem

Some Everhour tasks are linked to GitHub **pull requests**, not issues (e.g. the task "Split up util.js into separate files." → PR #215). The backfill reported these with a misleading message:

```
Skipping task "Split up util.js into separate files." (gh:353138591) - no GitHub issue number found
```

GitHub's REST `/issues/{number}` endpoint and the `search/issues` endpoint both return PRs (PRs and issues share the number space), so a PR-linked task was either mislabeled as "no issue number found" or skipped only as "closed" (for a merged PR).

## Fix

Detect PRs via the `pull_request` field — the only reliable REST signal that a number is a PR:

- Add an exported `isPullRequest` predicate and a `pull_request?` field on `GitHubIssue`.
- In the backfill loop, skip PRs with an accurate reason **before** the closed-state check, so a merged PR reports "it is a pull request" instead of "closed":
  ```
  Skipping #215 "Split up util.js into separate files." - it is a pull request, not an issue
  ```
- Harden `findIssueByTitle` to prefer a non-PR exact title match, falling back to a PR-only match so the accurate PR skip message still fires.

## Testing

- New unit test `scripts/estimate/src/__tests__/backfill.ts` covering `isPullRequest`.
- `yarn lint`, estimate `typecheck`, and the estimate unit tests all pass.

Script-only change — no app source touched, so no snapshot/e2e impact.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>