### PR TITLE
feat(estimate): add PAGE env var to backfill start page

### DIFF
--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -1,4 +1,5 @@
-# LIMIT=10 DRY_RUN=true yarn backfill
+# LIMIT=10 PAGE=1 DRY_RUN=true yarn backfill
+# PAGE sets the 1-based Everhour task page to start from (default 1).
 # API Token can be refreshed at https://app.everhour.com/#/account/profile
 EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -131,6 +131,11 @@ const main = async () => {
   if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
 
   const limit = parseInt(process.env.LIMIT ?? '10', 10)
+  // 1-based page to begin Everhour task pagination from. Floor invalid or <1 values to 1 so a
+  // bad PAGE never sends NaN/0 to the API. Combined with LIMIT this processes up to LIMIT tasks
+  // starting from page PAGE.
+  const startPageRaw = parseInt(process.env.PAGE ?? '1', 10)
+  const startPage = Number.isFinite(startPageRaw) && startPageRaw >= 1 ? startPageRaw : 1
   // Dry-run is the safe default: the backfill only calls the model / writes to Everhour when
   // explicitly disabled with DRY_RUN[_AI|_EVERHOUR]=false. DRY_RUN sets the default for both
   // stages; the per-stage vars override it.
@@ -147,7 +152,7 @@ const main = async () => {
     process.env.GITHUB_WORKSPACE ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 
   console.info(
-    `Backfill config: limit=${limit}, dryRunAI=${dryRunAI}, dryRunEverhour=${dryRunEverhour}, project=${everhourProjectId}`,
+    `Backfill config: limit=${limit}, startPage=${startPage}, dryRunAI=${dryRunAI}, dryRunEverhour=${dryRunEverhour}, project=${everhourProjectId}`,
   )
 
   // 1. Confirm the project exists on Everhour before doing any work, so a bad
@@ -169,7 +174,7 @@ const main = async () => {
   //    last one. We stop early once `limit` tasks have been processed.
   const PAGE_SIZE = 250
   let processed = 0
-  let page = 1
+  let page = startPage
 
   while (processed < limit) {
     const tasks = await everhour.getProjectTasks(everhourProjectId, page, PAGE_SIZE)


### PR DESCRIPTION
## Summary

Adds support for a `PAGE` environment variable to `scripts/estimate/src/backfill.ts`, letting the Everhour backfill begin task pagination on any page instead of always starting at page 1.

## Changes

- Parse `PAGE` from env in `main()` (default `1`), floored to `1` on invalid/`<1` values so a bad value never sends `NaN`/`0` to Everhour (which uses 1-based pages).
- Seed the pagination loop with the parsed start page instead of hardcoded `let page = 1`.
- Include `startPage` in the `Backfill config:` log line.
- Document `PAGE` in `scripts/estimate/.env.example`.

## Behavior

`PAGE` + `LIMIT` = "process up to `LIMIT` tasks starting from page `PAGE`". Per-page filtering, the `LIMIT` cutoff (counts tasks processed), and the last-page short-circuit (`tasks.length < PAGE_SIZE`) are unchanged.

## Testing

- `tsc --noEmit` (typecheck) passes for `scripts/estimate`.
- No existing test for `backfill.ts`; change follows the current env-var parsing pattern, so none added.