### PR TITLE
feat(estimate): link issue numbers in logs via OSC 8 hyperlinks

### DIFF
--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import extractIssueNumber from './everhour/extractIssueNumber.ts'
 import estimateIssue from './lib/estimateIssue.ts'
+import issueLink from './lib/issueLink.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
 
@@ -111,6 +112,7 @@ const processTask = async ({
       body: issue.body!,
       labels: issue.labels.map(l => l.name),
     },
+    issueRef: issueLink(owner, repoName, issue.number),
     instructions,
     samples,
     token: githubToken,
@@ -133,7 +135,7 @@ const processTask = async ({
     body: JSON.stringify({ body: commentBody }),
   })
 
-  console.info(`  Estimated issue #${issue.number}: ${category} / ${hours}h`)
+  console.info(`  Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
 }
 
 const main = async () => {
@@ -219,7 +221,9 @@ const main = async () => {
       })
 
       if (!issueResp.ok) {
-        console.info(`  Skipping issue #${issueNumber} - GitHub API error ${issueResp.status}`)
+        console.info(
+          `  Skipping issue ${issueLink(owner, repoName, issueNumber)} - GitHub API error ${issueResp.status}`,
+        )
         continue
       }
 
@@ -229,18 +233,20 @@ const main = async () => {
       // too (they share the number space), so detect and skip them before the closed-state check —
       // otherwise a merged PR would be reported with the misleading "closed" reason.
       if (isPullRequest(issue)) {
-        console.info(`  Skipping #${issueNumber} "${issue.title}" - it is a pull request, not an issue`)
+        console.info(
+          `  Skipping ${issueLink(owner, repoName, issueNumber)} "${issue.title}" - it is a pull request, not an issue`,
+        )
         continue
       }
 
       // Do not estimate closed issues.
       if (issue.state === 'closed') {
-        console.info(`  Skipping issue #${issueNumber} - closed`)
+        console.info(`  Skipping issue ${issueLink(owner, repoName, issueNumber)} - closed`)
         continue
       }
 
       if (!issue.body) {
-        console.info(`  Skipping issue #${issueNumber} - empty body`)
+        console.info(`  Skipping issue ${issueLink(owner, repoName, issueNumber)} - empty body`)
         continue
       }
 

--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs'
 import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import { type EstimateCategory, HOURS_TO_CATEGORY, VALID_HOURS, categoryToSeconds } from './everhour/estimates.ts'
+import issueLink from './lib/issueLink.ts'
 
 const TRUSTED_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR']
 
@@ -172,7 +173,9 @@ const main = async () => {
     `Everhour estimate updated: ${category} / ${roundedHours}h\nA PR has been opened to add the corrected sample.`,
   )
 
-  console.info(`Manual correction applied for issue #${issue.number}: ${category} / ${roundedHours}h`)
+  console.info(
+    `Manual correction applied for issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${roundedHours}h`,
+  )
 }
 
 /** Posts a comment on a GitHub issue. */

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs'
 import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import estimateIssue from './lib/estimateIssue.ts'
+import issueLink from './lib/issueLink.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
 
@@ -67,6 +68,7 @@ const main = async () => {
   const taskId = `gh:${issue.number}`
   const estimate = await estimateIssue({
     issue: issueInput,
+    issueRef: issueLink(owner, repoName, issue.number),
     instructions,
     samples,
     token: githubToken,
@@ -91,7 +93,7 @@ const main = async () => {
     body: JSON.stringify({ body: commentBody }),
   })
 
-  console.info(`Estimated issue #${issue.number}: ${category} / ${hours}h`)
+  console.info(`Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/estimate/src/lib/__tests__/issueLink.ts
+++ b/scripts/estimate/src/lib/__tests__/issueLink.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import issueLink from '../issueLink.ts'
+
+describe('issueLink', () => {
+  it('wraps the visible #N in an OSC 8 hyperlink to the issue URL', () => {
+    const result = issueLink('cybersemics', 'em', 123)
+    const url = 'https://github.com/cybersemics/em/issues/123'
+    expect(result).toBe(`\u001b]8;;${url}\u001b\\#123\u001b]8;;\u001b\\`)
+  })
+
+  it('embeds the target URL and the plain #N fallback text', () => {
+    const result = issueLink('cybersemics', 'em', 4302)
+    expect(result).toContain('https://github.com/cybersemics/em/issues/4302')
+    expect(result).toContain('#4302')
+  })
+})

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -22,6 +22,7 @@ export interface Estimate {
  */
 const estimateIssue = async ({
   issue,
+  issueRef,
   instructions,
   samples,
   token,
@@ -31,6 +32,8 @@ const estimateIssue = async ({
   dryRunEverhour = false,
 }: {
   issue: IssueInput
+  /** Clickable issue reference (`#N` as an OSC 8 terminal hyperlink) for log output; see issueLink. */
+  issueRef: string
   instructions: string
   samples: EstimateSample[]
   token: string
@@ -41,7 +44,7 @@ const estimateIssue = async ({
 }): Promise<Estimate | null> => {
   // Skip AI inference entirely in AI dry-run mode.
   if (dryRunAI) {
-    console.info(`[DRY_RUN_AI] Would estimate ${taskId}`)
+    console.info(`[DRY_RUN_AI] Would estimate ${issueRef} "${issue.title}"`)
     return null
   }
 
@@ -57,7 +60,7 @@ const estimateIssue = async ({
   // Write the estimate to Everhour unless the Everhour write is being dry-run.
   if (dryRunEverhour) {
     console.info(
-      `[DRY_RUN_EVERHOUR] Would set Everhour estimate for ${taskId}: ${estimate.category} / ${estimate.hours}h`,
+      `[DRY_RUN_EVERHOUR] Would set Everhour estimate for ${issueRef} "${issue.title}": ${estimate.category} / ${estimate.hours}h`,
     )
   } else {
     await everhour.setEstimate(taskId, estimate.seconds)

--- a/scripts/estimate/src/lib/issueLink.ts
+++ b/scripts/estimate/src/lib/issueLink.ts
@@ -1,0 +1,13 @@
+/**
+ * Formats a GitHub issue reference as an OSC 8 terminal hyperlink to the issue on GitHub.com.
+ *
+ * The visible text is `#N`; terminals that support OSC 8 render it as a clickable link, while
+ * terminals that don't simply show the plain `#N` (the escape sequence is inert). The full URL
+ * is never printed, keeping log lines compact.
+ */
+const issueLink = (owner: string, repo: string, issueNumber: number): string => {
+  const url = `https://github.com/${owner}/${repo}/issues/${issueNumber}`
+  return `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
+}
+
+export default issueLink


### PR DESCRIPTION
## Summary

Makes the estimate scripts' log output link the issue number so you can jump straight to the issue on GitHub.com.

Previously the dry-run line printed only the opaque Everhour task ID:

```
[DRY_RUN_AI] Would estimate gh:4102534773
```

Now, across **all runs** (not just dry runs), every `#N` reference is a clickable **OSC 8 terminal hyperlink** to `github.com/{owner}/{repo}/issues/{N}`. Terminals that support OSC 8 render a clickable `#N`; others fall back to plain `#N`. The full URL is never printed. The dry-run line also shows the issue title:

```
[DRY_RUN_AI] Would estimate #4302 "Some issue title"
```

## Changes

- **New `scripts/estimate/src/lib/issueLink.ts`** — shared helper wrapping a visible `#N` in an OSC 8 hyperlink (+ unit test).
- **`estimateIssue.ts`** — takes a prebuilt `issueRef`; rewrites both dry-run lines (and shows the title).
- **`backfill.ts`** — linked `#N` on the success line and every issue-number skip line; passes `issueRef` through.
- **`issue.ts`** / **`command.ts`** — linked `#N` on their success lines.

## Testing

- `yarn lint` — clean
- `yarn vitest run --project unit scripts/estimate` — 41 passed (incl. new `issueLink` test)
- `yarn typecheck` (scripts/estimate) — clean

## Notes

Stacked on `copilot/automate-estimation-for-issues` (the estimate feature branch), so this PR targets that branch rather than `main`.