### PR TITLE
fix(estimate): use valid GitHub Models id as default model

### DIFF
--- a/scripts/estimate/src/lib/inference.ts
+++ b/scripts/estimate/src/lib/inference.ts
@@ -1,5 +1,5 @@
 // Inference tuning constants, overridable via ESTIMATE_* env vars for experimentation.
-const MODEL = process.env.ESTIMATE_MODEL ?? 'claude-opus-4-8'
+const MODEL = process.env.ESTIMATE_MODEL ?? 'openai/gpt-4.1'
 const TEMPERATURE = process.env.ESTIMATE_TEMPERATURE != null ? Number(process.env.ESTIMATE_TEMPERATURE) : 0
 const MAX_VALIDATION_ATTEMPTS =
   process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS != null ? Number(process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS) : 3


### PR DESCRIPTION
## Problem

Running the estimate scripts (`backfill`, `issue`, `command`) failed on every inference call with:

```
Error: GitHub Models API error 404: {"error":{"code":"unknown_model","message":"Unknown model: /claude-opus-4-8"...}}
```

The default model in `scripts/estimate/src/lib/inference.ts` was `claude-opus-4-8`, which is **not** a valid [GitHub Models](https://models.github.ai) identifier. The catalog uses `publisher/model` ids and does not host any Claude models — only OpenAI, Meta, DeepSeek, Mistral, Cohere, and Microsoft.

## Fix

Default `MODEL` to `openai/gpt-4.1`, which:
- Is present in the GitHub Models catalog (verified via `GET /catalog/models`).
- Returns `200` with the existing request shape (`temperature: 0` + `response_format: { type: 'json_object' }`).
- Remains overridable via the `ESTIMATE_MODEL` env var.

Note: reasoning models like `gpt-5` are unavailable to the workflow token and/or reject `temperature`, so `gpt-4.1` is the safe capable default.

## Verification

- Queried the catalog to confirm no Claude models exist and `openai/gpt-4.1` is available.
- Exercised the `inference` module directly with a real token — it now returns e.g. `{"estimate":"XXS"}` for a typo-fix prompt.
- `yarn workspace em-estimate typecheck` passes.
- `yarn lint` passes (pre-push hook).