### PR TITLE
fix(tauri): serve dev server over HTTP to fix blank desktop window

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "../package.json",
   "identifier": "com.thinkwithem.em",
   "build": {
-    "beforeDevCommand": "yarn start",
+    "beforeDevCommand": "yarn start:http",
     "devUrl": "http://localhost:3000",
     "beforeBuildCommand": "yarn build",
     "frontendDist": "../build"


### PR DESCRIPTION
## Problem

Running `yarn tauri:dev` opened a blank white desktop window.

`src-tauri/tauri.conf.json` set `devUrl` to `http://localhost:3000`, but `beforeDevCommand` ran `yarn start`, which serves the Vite dev server over **HTTPS with a self-signed cert** (`basicSsl()` in `vite.config.ts`, enabled whenever `HTTP` is unset). macOS **WKWebView refuses self-signed certificates and provides no way to programmatically ignore them**, so the webview failed to load and rendered blank.

## Fix

Switch `beforeDevCommand` to the existing `yarn start:http` script (`HTTP=1 vite --host --port 3000`), which serves plain HTTP and matches the `http://localhost:3000` `devUrl`.

```diff
-    "beforeDevCommand": "yarn start",
+    "beforeDevCommand": "yarn start:http",
```

## Notes

- Web/browser dev (`yarn start`) is unchanged and still uses HTTPS; only the Tauri desktop flow is affected.
- `localhost` is a secure context even over HTTP, so PWA/service-worker registration still works inside the Tauri webview.
- If a separate HTTPS dev server is already occupying port 3000, `yarn tauri:dev` will still show a blank window — for desktop dev, let `tauri:dev` manage the HTTP server (or run `yarn start:http` yourself) rather than the default HTTPS `yarn start`.
- HTTPS-in-webview was considered and rejected: WKWebView cannot be configured to accept self-signed certs (only manual Keychain trust), so it is not a shippable fix.