### PR TITLE
fix(estimate): send overall type discriminator to Everhour estimate API

### DIFF
--- a/scripts/estimate/src/everhour/__tests__/client.ts
+++ b/scripts/estimate/src/everhour/__tests__/client.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import EverhourClient from '../client.ts'
+
+describe('EverhourClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('setEstimate sends the overall type discriminator required by the Everhour API', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = new EverhourClient({ apiKey: 'test-key' })
+    await client.setEstimate('123', 7200)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.everhour.com/tasks/123/estimate')
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body as string)).toEqual({ type: 'overall', total: 7200 })
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/scripts/estimate/src/everhour/client.ts
+++ b/scripts/estimate/src/everhour/client.ts
@@ -61,7 +61,7 @@ class EverhourClient {
   async setEstimate(taskId: string, seconds: number): Promise<void> {
     await this.request(`/tasks/${taskId}/estimate`, {
       method: 'PUT',
-      body: JSON.stringify({ total: seconds }),
+      body: JSON.stringify({ type: 'overall', total: seconds }),
     })
   }
 


### PR DESCRIPTION
## Problem

Running the estimate backfill fails when writing an estimate to Everhour:

```
Error: Everhour API error 400: {"code":400,"message":"The discriminator field name \"type\" for base-class \"Everhour\\Domain\\Task\\DTO\\TaskEstimate\" was not found in input data."}
```

The `PUT /tasks/{id}/estimate` endpoint accepts a discriminated union (`overall` vs per-`users` estimates) and requires a `type` discriminator field, which `setEstimate` was not sending.

## Fix

Include `type: 'overall'` alongside `total` in the request body of `EverhourClient.setEstimate`, matching the Everhour API's expected shape for a single overall estimate in seconds.

## Testing

- Added a regression test that mocks `fetch` and asserts the request body sent to `/tasks/{id}/estimate` is `{ type: 'overall', total }`.
- `yarn vitest run scripts/estimate/src/everhour/__tests__/client.ts` passes.
- `yarn typecheck` in `scripts/estimate` passes.