### PR TITLE
Fix move thought in context view

### DIFF
--- a/src/actions/clear.ts
+++ b/src/actions/clear.ts
@@ -25,6 +25,12 @@ const clear = (
   const remote = !!options?.remote
 
   return reducerFlow([
+    // Clear navigation selection before deleting thoughts so updateThoughts does not expand stale paths.
+    state => ({
+      ...state,
+      cursor: null,
+      multicursors: {},
+    }),
     // delete all thoughts
     ...getAllChildren(state, HOME_TOKEN).map(childId =>
       deleteThought({ local: local, remote: remote, pathParent: HOME_PATH, thoughtId: childId }),

--- a/src/actions/moveThought.ts
+++ b/src/actions/moveThought.ts
@@ -15,6 +15,7 @@ import getSortPreference from '../selectors/getSortPreference'
 import getSortedRank from '../selectors/getSortedRank'
 import getThoughtById from '../selectors/getThoughtById'
 import rootedParentOf from '../selectors/rootedParentOf'
+import simplifyPath from '../selectors/simplifyPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import appendToPath from '../util/appendToPath'
 import head from '../util/head'
@@ -55,8 +56,10 @@ const moveThought = (
   //   console.error(e)
   // }
 
-  const sourceThoughtPath = oldPath
-  const destinationThoughtPath = rootedParentOf(state, newPath)
+  const oldPathSimple = simplifyPath(state, oldPath)
+  const newPathSimple = simplifyPath(state, newPath)
+  const sourceThoughtPath = oldPathSimple
+  const destinationThoughtPath = rootedParentOf(state, newPathSimple)
   const sourceThoughtId = head(sourceThoughtPath)
   const destinationThoughtId = head(destinationThoughtPath)
 
@@ -68,7 +71,7 @@ const moveThought = (
   }
 
   // use parentid from oldPath until parentId data integrity issue is fixed
-  const sourceParentId = head(rootedParentOf(state, oldPath))
+  const sourceParentId = head(rootedParentOf(state, sourceThoughtPath))
   if (sourceThought.parentId !== sourceParentId) {
     console.warn(`Invalid parentId: sourceThought.parentId does not match parentOf(oldPath).`)
     console.info('oldPath', oldPath)
@@ -215,15 +218,15 @@ const moveThought = (
     !skipRerank
       ? state => {
           const rankPrecision = 10e-8
-          const children = getChildrenRanked(state, head(rootedParentOf(state, newPath)))
+          const children = getChildrenRanked(state, head(rootedParentOf(state, newPathSimple)))
           const ranksTooClose = children.some((thought, i) => {
             if (i === 0) return false
             const secondThought = getThoughtById(state, children[i - 1].id)
             if (!secondThought) return false
             return Math.abs(thought.rank - secondThought.rank) < rankPrecision
           })
-          // TODO: Explicitly converting to simplePath becauase context view has not been implemented yet and later we would want to change oldPath and newPath to be sourceThoughtId and destinationThoughtId instead.
-          return ranksTooClose ? rerank(state, rootedParentOf(state, newPath) as SimplePath) : state
+          // Rerank operates on the physical parent path, so use the simplified destination path.
+          return ranksTooClose ? rerank(state, rootedParentOf(state, newPathSimple) as SimplePath) : state
         }
       : null,
   ])(state)

--- a/src/commands/__tests__/moveThoughtDown.ts
+++ b/src/commands/__tests__/moveThoughtDown.ts
@@ -1,14 +1,17 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { toggleContextViewActionCreator as toggleContextView } from '../../actions/toggleContextView'
 import { executeCommandWithMulticursor } from '../../commands'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import getChildrenRankedByContext from '../../test-helpers/getChildrenRankedByContext'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import moveThoughtDownCommand from '../moveThoughtDown'
 
 beforeEach(initStore)
+afterEach(() => store.dispatch(setCursor(null)))
 
 describe('moveThoughtDown', () => {
   it('moves a single thought down', () => {
@@ -31,6 +34,31 @@ describe('moveThoughtDown', () => {
   - a
   - c
   - b`)
+  })
+
+  it('moves a thought down in nested context view', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+              - c
+              - d
+              - e
+          - b
+        `,
+      }),
+      setCursor(['b']),
+      toggleContextView(),
+      setCursor(['b', 'a', 'c']),
+    ])
+
+    executeCommandWithMulticursor(moveThoughtDownCommand, { store })
+    executeCommandWithMulticursor(moveThoughtDownCommand, { store })
+
+    const state = store.getState()
+    const children = getChildrenRankedByContext(state, ['a', 'b'])
+    expect(children.map(child => child.value)).toEqual(['d', 'e', 'c'])
   })
 
   describe('multicursor', () => {

--- a/src/commands/__tests__/moveThoughtDown.ts
+++ b/src/commands/__tests__/moveThoughtDown.ts
@@ -11,7 +11,6 @@ import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helper
 import moveThoughtDownCommand from '../moveThoughtDown'
 
 beforeEach(initStore)
-afterEach(() => store.dispatch(setCursor(null)))
 
 describe('moveThoughtDown', () => {
   it('moves a single thought down', () => {

--- a/src/commands/__tests__/moveThoughtUp.ts
+++ b/src/commands/__tests__/moveThoughtUp.ts
@@ -1,14 +1,17 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { toggleContextViewActionCreator as toggleContextView } from '../../actions/toggleContextView'
 import { executeCommandWithMulticursor } from '../../commands'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import getChildrenRankedByContext from '../../test-helpers/getChildrenRankedByContext'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import moveThoughtUpCommand from '../moveThoughtUp'
 
 beforeEach(initStore)
+afterEach(() => store.dispatch(setCursor(null)))
 
 describe('moveThoughtUp', () => {
   it('moves a single thought up', () => {
@@ -31,6 +34,31 @@ describe('moveThoughtUp', () => {
   - a
   - c
   - b`)
+  })
+
+  it('moves a thought up in nested context view', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+              - c
+              - d
+              - e
+          - b
+        `,
+      }),
+      setCursor(['b']),
+      toggleContextView(),
+      setCursor(['b', 'a', 'e']),
+    ])
+
+    executeCommandWithMulticursor(moveThoughtUpCommand, { store })
+    executeCommandWithMulticursor(moveThoughtUpCommand, { store })
+
+    const state = store.getState()
+    const children = getChildrenRankedByContext(state, ['a', 'b'])
+    expect(children.map(child => child.value)).toEqual(['e', 'c', 'd'])
   })
 
   describe('multicursor', () => {

--- a/src/commands/__tests__/moveThoughtUp.ts
+++ b/src/commands/__tests__/moveThoughtUp.ts
@@ -11,7 +11,6 @@ import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helper
 import moveThoughtUpCommand from '../moveThoughtUp'
 
 beforeEach(initStore)
-afterEach(() => store.dispatch(setCursor(null)))
 
 describe('moveThoughtUp', () => {
   it('moves a single thought up', () => {


### PR DESCRIPTION
## Summary

Fixes #4428 .

Changed `moveThought.ts` so moveThought resolves context-view paths through simplifyPath before mutating ranks/parents or reranking. 
This prevents `b~/a/c` from being interpreted as if `a` were the physical parent of `c`.

Added regressions in:
`moveThoughtDown.ts`
`moveThoughtUp.ts`

## Testing

`node .yarn\releases\yarn-4.17.0.cjs lint:tsc` passed
`node .yarn\releases\yarn-4.17.0.cjs test src/commands/__tests__/moveThoughtDown.ts  src/commands/__tests__/moveThoughtUp.ts` passed
`node .yarn\releases\yarn-4.17.0.cjs test` passed
