### PR TITLE
Estimate script: README, CLI flags, and issue-number resolution fix

### DIFF
--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -36,3 +36,27 @@ Three GitHub Action workflows in `.github/workflows/` drive the estimation scrip
 | [Estimate - Issue Opened](../../.github/workflows/estimate-issue-opened.yml) | `src/issue.ts`    | Issue opened                             | Estimates the issue and posts an audit comment with the estimated hours.                                                                        |
 | [Estimate - /estimate command](../../.github/workflows/estimate-command.yml) | `src/command.ts`  | Issue comment starting with `/estimate ` | Applies the manual correction and opens a pull request adding the correction as a new estimation sample under `.github/instructions/estimate/`. |
 | [Estimate - Backfill](../../.github/workflows/estimate-backfill.yml)         | `src/backfill.ts` | Manual (`workflow_dispatch`)             | Backfills estimates for existing issues in the configured Everhour project, up to the optional `limit` input (defaults to 10).                  |
+
+## Everhour task fields
+
+Fields returned per task by the Everhour API (`GET /projects/{id}/tasks`). GitHub-linked tasks embed the issue's internal database ID in `id`; the issue number is resolved from `number` (or `url` as a fallback).
+
+| Field         | Type             | Example                                                                       |
+| ------------- | ---------------- | ----------------------------------------------------------------------------- |
+| `id`          | string           | `"gh:498948741"` (`gh:<issue_database_id>` for GitHub-linked tasks)           |
+| `name`        | string           | `"Cmd + Shift + H → Home"`                                                    |
+| `type`        | string           | `"task"`                                                                      |
+| `status`      | string           | `"open"` / `"closed"`                                                         |
+| `url`         | string           | `"https://github.com/cybersemics/em/issues/76"`                               |
+| `number`      | string           | `"76"` (GitHub issue number)                                                  |
+| `projects`    | string[]         | `["gh:143808059"]` (repo ID)                                                  |
+| `labels`      | string[]         | `["dependency-bug"]`                                                          |
+| `assignees`   | object[] \| null | `[{ accountId: "gh:750276", accountName: "raineorshine", userId: 872373 }]`   |
+| `completed`   | boolean          | `true`                                                                        |
+| `completedAt` | string           | `"2019-10-07 02:16:55"`                                                       |
+| `createdAt`   | string           | `"2019-09-26 15:09:11"`                                                       |
+| `iteration`   | string           | Sprint/iteration ID                                                           |
+| `estimate`    | object           | `{ type: "overall", total: 57600 }` (seconds; may include `users`)            |
+| `time`        | object           | `{ total: 240900, users: { "872552": 240900 }, timerTime: 222900 }` (seconds) |
+
+`estimate` and `time` only appear when set (most tasks omit them). `assignees` is `null` when unassigned.

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -21,3 +21,11 @@ LIMIT=10 DRY_RUN=true yarn backfill
 ```
 
 Valid estimate values: `1h` (XXS), `2h` (XS), `4h` (S), `8h` (M), `16h` (L), `24h` (XL), `48h` (XXL).
+
+## Workflows
+
+Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings.
+
+- **[Estimate - Issue Opened](../../.github/workflows/estimate-issue-opened.yml)** — Runs when a new issue is opened. Estimates the issue and posts an audit comment with the estimated hours (`src/issue.ts`).
+- **[Estimate - /estimate command](../../.github/workflows/estimate-command.yml)** — Runs when an issue comment starting with `/estimate ` is created. Applies the manual correction and opens a pull request adding the correction as a new estimation sample under `.github/instructions/estimate/` (`src/command.ts`).
+- **[Estimate - Backfill](../../.github/workflows/estimate-backfill.yml)** — Manually triggered via `workflow_dispatch`. Backfills estimates for existing issues in the configured Everhour project, up to the optional `limit` input (defaults to 10) (`src/backfill.ts`).

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -19,7 +19,7 @@ cd scripts/estimate
 yarn backfill --dry 10
 ```
 
-Dry-run flags: `--dry` skips both the model call and the Everhour write; `--dry-ai` skips only the model call; `--dry-everhour` skips only the Everhour write.
+Dry-run flags: `--dry` skips both the model call and the Everhour write; `--dry-ai` skips only the model call; `--dry-everhour` skips only the Everhour write (and the issue audit comment).
 
 Manual correction (via issue comment)
 

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -1,5 +1,7 @@
 # Estimate
 
+AI-powered issue estimation for the `em` project. Analyzes GitHub issues, assigns a t-shirt-size effort estimate, and syncs the estimated hours to Everhour.
+
 ## Setup
 
 Define env variables in `scripts/estimate/.env`:

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -16,7 +16,7 @@ EVERHOUR_PROJECT_ID=
 ```bash
 # Backfill (dry run)
 cd scripts/estimate
-DRY_RUN=true yarn backfill 10
+yarn backfill --dry 10
 
 # Manual correction (via issue comment)
 /estimate 4h

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -16,7 +16,7 @@ EVERHOUR_PROJECT_ID=
 ```bash
 # Backfill (dry run)
 cd scripts/estimate
-LIMIT=10 DRY_RUN=true yarn backfill
+DRY_RUN=true yarn backfill 10
 
 # Manual correction (via issue comment)
 /estimate 4h

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -19,6 +19,8 @@ cd scripts/estimate
 yarn backfill --dry 10
 ```
 
+Dry-run flags: `--dry` skips both the model call and the Everhour write; `--dry-ai` skips only the model call; `--dry-everhour` skips only the Everhour write.
+
 Manual correction (via issue comment)
 
 ```md

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -1,0 +1,23 @@
+# Estimate
+
+## Setup
+
+Define env variables in `scripts/estimate/.env`:
+
+```
+EVERHOUR_API_KEY=
+EVERHOUR_PROJECT_ID=
+```
+
+## Usage
+
+```bash
+# Backfill (dry run)
+cd scripts/estimate
+LIMIT=10 DRY_RUN=true yarn backfill
+
+# Manual correction (via issue comment)
+/estimate 4h
+```
+
+Valid estimate values: `1h` (XXS), `2h` (XS), `4h` (S), `8h` (M), `16h` (L), `24h` (XL), `48h` (XXL).

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -17,8 +17,11 @@ EVERHOUR_PROJECT_ID=
 # Backfill (dry run)
 cd scripts/estimate
 yarn backfill --dry 10
+```
 
-# Manual correction (via issue comment)
+Manual correction (via issue comment)
+
+```md
 /estimate 4h
 ```
 
@@ -28,6 +31,8 @@ Valid estimate values: `1h` (XXS), `2h` (XS), `4h` (S), `8h` (M), `16h` (L), `24
 
 Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings.
 
-- **[Estimate - Issue Opened](../../.github/workflows/estimate-issue-opened.yml)** — Runs when a new issue is opened. Estimates the issue and posts an audit comment with the estimated hours (`src/issue.ts`).
-- **[Estimate - /estimate command](../../.github/workflows/estimate-command.yml)** — Runs when an issue comment starting with `/estimate ` is created. Applies the manual correction and opens a pull request adding the correction as a new estimation sample under `.github/instructions/estimate/` (`src/command.ts`).
-- **[Estimate - Backfill](../../.github/workflows/estimate-backfill.yml)** — Manually triggered via `workflow_dispatch`. Backfills estimates for existing issues in the configured Everhour project, up to the optional `limit` input (defaults to 10) (`src/backfill.ts`).
+| Workflow                                                                     | Script            | Trigger                                  | Description                                                                                                                                     |
+| ---------------------------------------------------------------------------- | ----------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Estimate - Issue Opened](../../.github/workflows/estimate-issue-opened.yml) | `src/issue.ts`    | Issue opened                             | Estimates the issue and posts an audit comment with the estimated hours.                                                                        |
+| [Estimate - /estimate command](../../.github/workflows/estimate-command.yml) | `src/command.ts`  | Issue comment starting with `/estimate ` | Applies the manual correction and opens a pull request adding the correction as a new estimation sample under `.github/instructions/estimate/`. |
+| [Estimate - Backfill](../../.github/workflows/estimate-backfill.yml)         | `src/backfill.ts` | Manual (`workflow_dispatch`)             | Backfills estimates for existing issues in the configured Everhour project, up to the optional `limit` input (defaults to 10).                  |

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -240,9 +240,7 @@ const main = async () => {
       // too (they share the number space), so detect and skip them before the closed-state check —
       // otherwise a merged PR would be reported with the misleading "closed" reason.
       if (isPullRequest(issue)) {
-        console.info(
-          `  Skipping ${issueLink(owner, repoName, issueNumber)} "${issue.title}" - it is a pull request, not an issue`,
-        )
+        console.info(`  Skipping ${issueLink(owner, repoName, issueNumber)} "${issue.title}" - PR`)
         continue
       }
 

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -148,18 +148,23 @@ const main = async () => {
   const everhourProjectId = process.env.EVERHOUR_PROJECT_ID
   if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
 
-  // Limit resolves from the first CLI argument (`yarn backfill 10`), falling back to the LIMIT
-  // env var, then a default of 10.
-  const limit = parseInt(process.argv[2] ?? process.env.LIMIT ?? '10', 10)
+  // Parse CLI args into flags and positionals. `--dry` enables dry-run; the first positional is
+  // the limit (`yarn backfill 10`, `yarn backfill --dry 10`, etc.).
+  const args = process.argv.slice(2)
+  const dryFlag = args.includes('--dry')
+  const positionals = args.filter(arg => !arg.startsWith('-'))
+  // Limit resolves from the first positional CLI argument, falling back to the LIMIT env var, then
+  // a default of 10.
+  const limit = parseInt(positionals[0] ?? process.env.LIMIT ?? '10', 10)
   // 1-based page to begin Everhour task pagination from. Floor invalid or <1 values to 1 so a
   // bad PAGE never sends NaN/0 to the API. Combined with LIMIT this processes up to LIMIT tasks
   // starting from page PAGE.
   const startPageRaw = parseInt(process.env.PAGE ?? '1', 10)
   const startPage = Number.isFinite(startPageRaw) && startPageRaw >= 1 ? startPageRaw : 1
-  // Dry-run is off by default: the backfill calls the model / writes to Everhour unless
-  // explicitly enabled with DRY_RUN[_AI|_EVERHOUR]=true. DRY_RUN sets the default for both
+  // Dry-run is off by default: the backfill calls the model / writes to Everhour unless explicitly
+  // enabled with the `--dry` flag or DRY_RUN[_AI|_EVERHOUR]=true. DRY_RUN sets the default for both
   // stages; the per-stage vars override it.
-  const dryRunDefault = process.env.DRY_RUN === 'true'
+  const dryRunDefault = dryFlag || process.env.DRY_RUN === 'true'
   const dryRunAI = process.env.DRY_RUN_AI !== undefined ? process.env.DRY_RUN_AI === 'true' : dryRunDefault
   const dryRunEverhour =
     process.env.DRY_RUN_EVERHOUR !== undefined ? process.env.DRY_RUN_EVERHOUR === 'true' : dryRunDefault

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -205,11 +205,14 @@ const main = async () => {
     const tasks = await everhour.getProjectTasks(everhourProjectId, page, PAGE_SIZE)
     console.info(`Fetched ${tasks.length} tasks from Everhour project (page ${page})`)
 
-    // Filter to tasks without estimates within this page.
-    const tasksWithoutEstimates = tasks.filter(task => !task.estimate || !task.estimate.total)
-    console.info(`  ${tasksWithoutEstimates.length} tasks without estimates on page ${page}`)
+    // Filter to open, incomplete tasks without estimates. Closed or completed tasks are skipped
+    // here so we never query GitHub for issues that would be rejected as closed anyway.
+    const tasksToEstimate = tasks.filter(
+      task => (!task.estimate || !task.estimate.total) && task.status !== 'closed' && !task.completed,
+    )
+    console.info(`  ${tasksToEstimate.length} open tasks without estimates on page ${page}`)
 
-    for (const task of tasksWithoutEstimates) {
+    for (const task of tasksToEstimate) {
       if (processed >= limit) break
 
       // Try to extract the issue number from the task ID or name; fall back to GitHub title search

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -152,6 +152,8 @@ const main = async () => {
   // the limit (`yarn backfill 10`, `yarn backfill --dry 10`, etc.).
   const args = process.argv.slice(2)
   const dryFlag = args.includes('--dry')
+  const dryAiFlag = args.includes('--dry-ai')
+  const dryEverhourFlag = args.includes('--dry-everhour')
   const positionals = args.filter(arg => !arg.startsWith('-'))
   // Limit resolves from the first positional CLI argument, falling back to the LIMIT env var, then
   // a default of 10.
@@ -162,12 +164,14 @@ const main = async () => {
   const startPageRaw = parseInt(process.env.PAGE ?? '1', 10)
   const startPage = Number.isFinite(startPageRaw) && startPageRaw >= 1 ? startPageRaw : 1
   // Dry-run is off by default: the backfill calls the model / writes to Everhour unless explicitly
-  // enabled with the `--dry` flag or DRY_RUN[_AI|_EVERHOUR]=true. DRY_RUN sets the default for both
-  // stages; the per-stage vars override it.
+  // enabled. `--dry` (or DRY_RUN=true) sets the default for both stages; the per-stage `--dry-ai` /
+  // `--dry-everhour` flags and DRY_RUN_AI / DRY_RUN_EVERHOUR vars enable dry-run for a single stage.
   const dryRunDefault = dryFlag || process.env.DRY_RUN === 'true'
-  const dryRunAI = process.env.DRY_RUN_AI !== undefined ? process.env.DRY_RUN_AI === 'true' : dryRunDefault
+  const dryRunAI =
+    dryAiFlag || (process.env.DRY_RUN_AI !== undefined ? process.env.DRY_RUN_AI === 'true' : dryRunDefault)
   const dryRunEverhour =
-    process.env.DRY_RUN_EVERHOUR !== undefined ? process.env.DRY_RUN_EVERHOUR === 'true' : dryRunDefault
+    dryEverhourFlag ||
+    (process.env.DRY_RUN_EVERHOUR !== undefined ? process.env.DRY_RUN_EVERHOUR === 'true' : dryRunDefault)
 
   const repo = process.env.GITHUB_REPOSITORY ?? 'cybersemics/em'
   const [owner, repoName] = repo.split('/')

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -122,8 +122,9 @@ const processTask = async ({
     dryRunEverhour,
   })
 
-  // Skip the audit comment when inference was dry-run (no estimate produced).
-  if (!estimate) return
+  // Skip the audit comment when inference was dry-run (no estimate produced) or when the Everhour
+  // write was dry-run — a dry Everhour run must not post a comment claiming an estimate was recorded.
+  if (!estimate || dryRunEverhour) return
 
   const { category, hours } = estimate
 

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -148,7 +148,9 @@ const main = async () => {
   const everhourProjectId = process.env.EVERHOUR_PROJECT_ID
   if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
 
-  const limit = parseInt(process.env.LIMIT ?? '10', 10)
+  // Limit resolves from the first CLI argument (`yarn backfill 10`), falling back to the LIMIT
+  // env var, then a default of 10.
+  const limit = parseInt(process.argv[2] ?? process.env.LIMIT ?? '10', 10)
   // 1-based page to begin Everhour task pagination from. Floor invalid or <1 values to 1 so a
   // bad PAGE never sends NaN/0 to the API. Combined with LIMIT this processes up to LIMIT tasks
   // starting from page PAGE.

--- a/scripts/estimate/src/everhour/__tests__/extractIssueNumber.ts
+++ b/scripts/estimate/src/everhour/__tests__/extractIssueNumber.ts
@@ -30,6 +30,21 @@ describe('extractIssueNumber', () => {
     expect(extractIssueNumber({ id: 'manual', name: 'Doubly-linked Items' })).toBeNull()
   })
 
+  it('extracts from the GitHub URL when the task ID is gh:ISSUE_ID (2 segments)', () => {
+    expect(
+      extractIssueNumber({
+        id: 'gh:498948741',
+        name: 'Cmd + Shift + H → Home',
+        url: 'https://github.com/cybersemics/em/issues/76',
+        number: '76',
+      }),
+    ).toBe(76)
+  })
+
+  it('extracts from the number field when the task ID and URL are absent', () => {
+    expect(extractIssueNumber({ id: 'gh:498948741', name: 'Some issue', number: '76' })).toBe(76)
+  })
+
   it('prefers task ID extraction over foreignId', () => {
     expect(extractIssueNumber({ id: 'gh:143808059:100', name: 'Issue', foreignId: '999' })).toBe(100)
   })

--- a/scripts/estimate/src/everhour/__tests__/extractIssueNumber.ts
+++ b/scripts/estimate/src/everhour/__tests__/extractIssueNumber.ts
@@ -45,6 +45,17 @@ describe('extractIssueNumber', () => {
     expect(extractIssueNumber({ id: 'gh:498948741', name: 'Some issue', number: '76' })).toBe(76)
   })
 
+  it('prefers the number field over URL scraping', () => {
+    expect(
+      extractIssueNumber({
+        id: 'gh:498948741',
+        name: 'Some issue',
+        number: '76',
+        url: 'https://github.com/cybersemics/em/issues/999',
+      }),
+    ).toBe(76)
+  })
+
   it('prefers task ID extraction over foreignId', () => {
     expect(extractIssueNumber({ id: 'gh:143808059:100', name: 'Issue', foreignId: '999' })).toBe(100)
   })

--- a/scripts/estimate/src/everhour/extractIssueNumber.ts
+++ b/scripts/estimate/src/everhour/extractIssueNumber.ts
@@ -5,10 +5,10 @@ import type { EverhourTask } from './types.ts'
  *
  * Tries several strategies in order:
  * 1. **Task ID** — standard Everhour GitHub format `gh:REPO_ID:ISSUE_NUMBER`
- * 2. **URL** — GitHub issue/PR URL, e.g. `https://github.com/owner/repo/issues/76`. Covers the
- *    `gh:ISSUE_ID` task-ID form (2 segments) where the ID is GitHub's internal issue database ID
+ * 2. **number** — explicit issue-number field returned by Everhour for GitHub-linked tasks. Covers
+ *    the `gh:ISSUE_ID` task-ID form (2 segments) where the ID is GitHub's internal issue database ID
  *    rather than the issue number, so strategy 1 cannot apply.
- * 3. **number** — explicit issue-number field returned by Everhour for GitHub-linked tasks
+ * 3. **URL** — GitHub issue/PR URL, e.g. `https://github.com/owner/repo/issues/76`
  * 4. **foreignId** — numeric string returned by some Everhour API versions for GitHub-linked tasks
  * 5. **Task name** — `#NUMBER` appearing anywhere in the name (e.g. `"Fix bug (#123)"` or `"#123 Title"`).
  *
@@ -23,18 +23,19 @@ const extractIssueNumber = (task: EverhourTask): number | null => {
     if (!isNaN(num)) return num
   }
 
-  // Strategy 2: GitHub issue/PR URL, e.g. "https://github.com/owner/repo/issues/76". Matches pull
+  // Strategy 2: explicit "number" field returned by Everhour for GitHub-linked tasks. Preferred over
+  // URL scraping since it is a structured field rather than a value parsed out of a string.
+  if (task.number) {
+    const num = parseInt(task.number, 10)
+    if (!isNaN(num)) return num
+  }
+
+  // Strategy 3: GitHub issue/PR URL, e.g. "https://github.com/owner/repo/issues/76". Matches pull
   // request URLs too — issues and PRs share GitHub's number space, and the caller detects and skips
   // PRs with an accurate reason.
   if (task.url) {
     const match = task.url.match(/\/(?:issues|pull)\/(\d+)/)
     if (match) return parseInt(match[1], 10)
-  }
-
-  // Strategy 3: explicit "number" field returned by Everhour for GitHub-linked tasks.
-  if (task.number) {
-    const num = parseInt(task.number, 10)
-    if (!isNaN(num)) return num
   }
 
   // Strategy 4: foreignId field returned by some Everhour API versions

--- a/scripts/estimate/src/everhour/extractIssueNumber.ts
+++ b/scripts/estimate/src/everhour/extractIssueNumber.ts
@@ -3,10 +3,14 @@ import type { EverhourTask } from './types.ts'
 /**
  * Extracts a GitHub issue number from an Everhour task.
  *
- * Tries three strategies in order:
+ * Tries several strategies in order:
  * 1. **Task ID** — standard Everhour GitHub format `gh:REPO_ID:ISSUE_NUMBER`
- * 2. **foreignId** — numeric string returned by some Everhour API versions for GitHub-linked tasks
- * 3. **Task name** — `#NUMBER` appearing anywhere in the name (e.g. `"Fix bug (#123)"` or `"#123 Title"`).
+ * 2. **URL** — GitHub issue/PR URL, e.g. `https://github.com/owner/repo/issues/76`. Covers the
+ *    `gh:ISSUE_ID` task-ID form (2 segments) where the ID is GitHub's internal issue database ID
+ *    rather than the issue number, so strategy 1 cannot apply.
+ * 3. **number** — explicit issue-number field returned by Everhour for GitHub-linked tasks
+ * 4. **foreignId** — numeric string returned by some Everhour API versions for GitHub-linked tasks
+ * 5. **Task name** — `#NUMBER` appearing anywhere in the name (e.g. `"Fix bug (#123)"` or `"#123 Title"`).
  *
  * Returns `null` when no issue number can be extracted (e.g. manually-created Everhour tasks that have
  * no GitHub counterpart).
@@ -19,13 +23,27 @@ const extractIssueNumber = (task: EverhourTask): number | null => {
     if (!isNaN(num)) return num
   }
 
-  // Strategy 2: foreignId field returned by some Everhour API versions
+  // Strategy 2: GitHub issue/PR URL, e.g. "https://github.com/owner/repo/issues/76". Matches pull
+  // request URLs too — issues and PRs share GitHub's number space, and the caller detects and skips
+  // PRs with an accurate reason.
+  if (task.url) {
+    const match = task.url.match(/\/(?:issues|pull)\/(\d+)/)
+    if (match) return parseInt(match[1], 10)
+  }
+
+  // Strategy 3: explicit "number" field returned by Everhour for GitHub-linked tasks.
+  if (task.number) {
+    const num = parseInt(task.number, 10)
+    if (!isNaN(num)) return num
+  }
+
+  // Strategy 4: foreignId field returned by some Everhour API versions
   if (task.foreignId) {
     const num = parseInt(task.foreignId, 10)
     if (!isNaN(num)) return num
   }
 
-  // Strategy 3: "#NUMBER" anywhere in the task name (e.g. "Fix bug (#123)" or "#123 Title")
+  // Strategy 5: "#NUMBER" anywhere in the task name (e.g. "Fix bug (#123)" or "#123 Title")
   const match = task.name.match(/#(\d+)/)
   return match ? parseInt(match[1], 10) : null
 }

--- a/scripts/estimate/src/everhour/types.ts
+++ b/scripts/estimate/src/everhour/types.ts
@@ -8,6 +8,10 @@ export interface EverhourEstimate {
 export interface EverhourTask {
   id: string
   name: string
+  /** GitHub issue number string returned by Everhour for GitHub-linked tasks. */
+  number?: string
+  /** GitHub issue/PR URL returned by Everhour for GitHub-linked tasks, e.g. ".../issues/76". */
+  url?: string
   /** GitHub issue number string returned by some Everhour API versions for GitHub-linked tasks. */
   foreignId?: string
   time?: { total?: number }

--- a/scripts/estimate/src/everhour/types.ts
+++ b/scripts/estimate/src/everhour/types.ts
@@ -8,6 +8,10 @@ export interface EverhourEstimate {
 export interface EverhourTask {
   id: string
   name: string
+  /** Task status returned by Everhour, e.g. "open" or "closed". */
+  status?: string
+  /** Whether the task is completed (e.g. the linked GitHub issue is closed). */
+  completed?: boolean
   /** GitHub issue number string returned by Everhour for GitHub-linked tasks. */
   number?: string
   /** GitHub issue/PR URL returned by Everhour for GitHub-linked tasks, e.g. ".../issues/76". */


### PR DESCRIPTION
## Summary

Improvements to the `scripts/estimate` Everhour estimation tooling: a new README, backfill CLI flags, and a fix for tasks that were incorrectly skipped during backfill.

## Documentation

- Add `scripts/estimate/README.md` with a purpose statement, setup/usage, the GitHub Action workflows (as a table), dry-run flag reference, and the full set of fields the Everhour task API returns.

## Backfill CLI

- Accept the limit as a positional argument: `yarn backfill 10` (env `LIMIT` still works as a fallback).
- Add `--dry` (skip both the model call and the Everhour write), `--dry-ai` (skip only the model call), and `--dry-everhour` (skip only the Everhour write). Flag parsing is order-independent and layers on top of the existing `DRY_RUN[_AI|_EVERHOUR]` env vars.
- `--dry-everhour` no longer posts the issue audit comment, since no estimate is actually recorded.

## Fixes

- **Resolve issue numbers from Everhour `number`/`url` fields.** Tasks synced with the `gh:<issue_database_id>` id form (2 segments) embed GitHub's internal issue database ID rather than the issue number, so `extractIssueNumber` returned `null` and backfill skipped them with "no GitHub issue number found". It now reads the structured `number` field (preferred), falling back to scraping the issue number from `url`. Added regression tests.
- **Skip closed/completed Everhour tasks early**, before querying GitHub, avoiding unnecessary API calls for issues that would be rejected as closed anyway.
- Shorten the pull-request skip log message to `- PR`.

## Testing

- `extractIssueNumber` unit tests (11 passing), typecheck, and prettier all pass.