### PR TITLE
fix(tauri): ad-hoc sign macOS builds to stop "damaged" error

### DIFF
--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -23,6 +23,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
+  # Exposed at workflow level so the macOS keychain-import step can gate on its
+  # presence. Empty when the signing secret is unset, in which case macOS builds
+  # fall back to ad-hoc signing (see the tauri-action step below).
+  APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
 
 jobs:
   build:
@@ -77,10 +81,35 @@ jobs:
       - name: Set desktop version (MSI-compatible)
         run: yarn tauri:version
 
+      # Import the Developer ID certificate into a temporary keychain so codesign
+      # can find the identity. Runs only on macOS when the certificate secret is
+      # configured; otherwise the build proceeds with ad-hoc signing.
+      - name: Import Apple signing certificate
+        if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import "$RUNNER_TEMP/certificate.p12" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
       - name: Build and publish desktop app
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Falls back to ad-hoc signing ("-") when no Developer ID identity is
+          # configured. Ad-hoc signing is required on Apple Silicon so downloaded
+          # builds are not rejected as "damaged". When the signing secrets are
+          # present the real identity is used and notarization is performed.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: pre
           releaseName: em desktop (main)
@@ -91,6 +120,7 @@ jobs:
             Run: ${{ github.run_number }}
 
             > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
+            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
           prerelease: true
           releaseDraft: false
           args: ${{ matrix.args }}

--- a/.github/workflows/tauri-release-prod.yml
+++ b/.github/workflows/tauri-release-prod.yml
@@ -19,6 +19,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
+  # Exposed at workflow level so the macOS keychain-import step can gate on its
+  # presence. Empty when the signing secret is unset, in which case macOS builds
+  # fall back to ad-hoc signing (see the tauri-action step below).
+  APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
 
 jobs:
   build:
@@ -73,10 +77,35 @@ jobs:
       - name: Set desktop version (MSI-compatible)
         run: yarn tauri:version
 
+      # Import the Developer ID certificate into a temporary keychain so codesign
+      # can find the identity. Runs only on macOS when the certificate secret is
+      # configured; otherwise the build proceeds with ad-hoc signing.
+      - name: Import Apple signing certificate
+        if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import "$RUNNER_TEMP/certificate.p12" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
       - name: Build and publish desktop app
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Falls back to ad-hoc signing ("-") when no Developer ID identity is
+          # configured. Ad-hoc signing is required on Apple Silicon so downloaded
+          # builds are not rejected as "damaged". When the signing secrets are
+          # present the real identity is used and notarization is performed.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: em desktop ${{ github.ref_name }}
@@ -84,6 +113,7 @@ jobs:
             em desktop release ${{ github.ref_name }}.
 
             > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
+            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
           prerelease: false
           releaseDraft: false
           args: ${{ matrix.args }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,9 @@
     "longDescription": "em is a beautiful, minimalistic note-taking app for personal sensemaking.",
     "copyright": "Copyright © Cybersemics",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "linux": {
       "deb": {
         "depends": []


### PR DESCRIPTION
## Summary

Fixes the macOS `"em.app" is damaged and can't be opened` error when opening the downloaded `em_1.0.0_aarch64.dmg`.

### Root cause

The desktop build feature (#4474) produces **unsigned** bundles. Tauri, with no `signingIdentity` configured, never runs `codesign` on the `.app`, so the bundle has no valid `_CodeSignature` seal. On Apple Silicon, macOS requires a valid code signature for any app downloaded from the internet — a quarantined, unsigned arm64 bundle is hard-blocked as "damaged" with no right-click-to-open bypass.

This is **not** a regression from v351: the Tauri desktop CI was added *after* the v351 tag, so CI never built a desktop app for v351. A locally-built copy isn't quarantined, so it opened fine — that's the "worked on v351" experience. This is the first time a *downloaded* build has been run.

### Fix

- **`src-tauri/tauri.conf.json`** — set `bundle.macOS.signingIdentity` to `"-"` (ad-hoc). This gives the bundle a valid ad-hoc seal, converting the hard "damaged" block into the normal, bypassable "unverified developer" Gatekeeper prompt. Also fixes locally-built copies.
- **`tauri-release-prod.yml` / `tauri-release-main.yml`** — wire up real Developer ID signing + notarization for when secrets are added, degrading cleanly to ad-hoc when they aren't:
  - A guarded "Import Apple signing certificate" step (macOS only, runs only when `APPLE_CERTIFICATE` is set) imports the `.p12` into a temporary keychain — the recipe from Tauri's own docs.
  - The tauri-action step sets `APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}` plus `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID`. Per Tauri docs, the env var **overrides** the config default, so the real identity wins once secrets exist and notarization runs; with no secrets it stays ad-hoc.
  - Release notes now mention the right-click → Open / `xattr -cr` bypass.

### To fully sign + notarize later

Add these repo secrets (no code change needed): `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`.

### Testing

Signing only runs on tag/main release builds (not on PR CI), so it can't be exercised here. Validated that `tauri.conf.json` is valid JSON, both workflows parse as YAML with the import step correctly positioned and gated, and prettier reports all three files already formatted.