### PR TITLE
Fix ellipsis bullet visibility

### DIFF
--- a/src/components/__tests__/Bullet.ts
+++ b/src/components/__tests__/Bullet.ts
@@ -54,6 +54,52 @@ describe('render', () => {
     expect(bullets.length).toBe(0)
   })
 
+  it('do not render a bullet on a thought with value "..."', async () => {
+    await dispatch([
+      importText({
+        text: `
+        - ...
+      `,
+      }),
+    ])
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const bullets = document.querySelectorAll('[aria-label="bullet"]')
+    expect(bullets.length).toBe(0)
+  })
+
+  it('do not render a bullet on a formatted thought with value "..."', async () => {
+    await dispatch([
+      importText({
+        text: `
+        - **...**
+      `,
+      }),
+    ])
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const bullets = document.querySelectorAll('[aria-label="bullet"]')
+    expect(bullets.length).toBe(0)
+  })
+
+  it('render a bullet on an ellipsis thought with =bullet', async () => {
+    await dispatch([
+      importText({
+        text: `
+        - ...
+          - =bullet
+      `,
+      }),
+    ])
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const bullets = document.querySelectorAll('[aria-label="bullet"]')
+    expect(bullets.length).toBe(1)
+  })
+
   it('do not render bullets on a child of a thought with =children/=bullet/None', async () => {
     await dispatch([
       importText({

--- a/src/hooks/useHideBullet.ts
+++ b/src/hooks/useHideBullet.ts
@@ -12,6 +12,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import rootedParentOf from '../selectors/rootedParentOf'
 import equalPath from '../util/equalPath'
 import head from '../util/head'
+import stripTags from '../util/stripTags'
 
 /** Gets a globally defined bullet. */
 const getGlobalBullet = (key: string) => GLOBAL_STYLE_ENV[key as keyof typeof GLOBAL_STYLE_ENV]?.bullet
@@ -43,6 +44,10 @@ const useHideBullet = ({
     /** Returns true if the bullet should be hidden. */
     const hideBullet = () =>
       thought.value !== '=grandchildren' && attributeEquals(state, head(simplePath), '=bullet', 'None')
+
+    /** Returns true if the bullet should be hidden because the thought value is an ellipsis. */
+    const hideBulletEllipsis = () =>
+      stripTags(thought.value) === '...' && !findDescendant(state, head(simplePath), '=bullet')
 
     /** Returns true if the bullet should be hidden because it is in table column 1 and is not the cursor. */
     const hideBulletTable = () => {
@@ -80,7 +85,7 @@ const useHideBullet = ({
       return bulletEnv.some(envChildBullet => envChildBullet === 'None')
     }
 
-    return hideBullet() || hideBulletTable() || hideBulletZoom() || hideBulletEnv()
+    return hideBullet() || hideBulletEllipsis() || hideBulletTable() || hideBulletZoom() || hideBulletEnv()
   })
 
   return hideBullet


### PR DESCRIPTION
## Summary

Fixes #4542.

- Hide the bullet by default for thoughts whose visible value is exactly `...`.
- Strip formatting tags before checking the value, so formatted ellipses like `**...**` behave the same.
- Allow an explicit `=bullet` attribute to override the default and show the bullet.

## Testing

- `prettier --check src/hooks/useHideBullet.ts src/components/__tests__/Bullet.ts`
- `eslint src/hooks/useHideBullet.ts src/components/__tests__/Bullet.ts`
- `tsc --noEmit --pretty false`
- `vitest --project unit --run src/components/__tests__/Bullet.ts`
- `vitest --project unit --run src/components/__tests__/Bullet.ts src/components/__tests__/ContextView.ts`