### PR TITLE
Fix cursor forward after splitting subthought

### DIFF
--- a/src/actions/__tests__/splitSentences.ts
+++ b/src/actions/__tests__/splitSentences.ts
@@ -2,9 +2,12 @@ import newThought from '../../actions/newThought'
 import splitSentences from '../../actions/splitSentences'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
+import cursorForward from '../cursorForward'
+import importText from '../importText'
 
 /**
  * Function: splitThought.
@@ -673,6 +676,20 @@ describe('parenthetical content', () => {
 
     expect(exported).toBe(`- ${HOME_TOKEN}
   - This (has parentheses) in the middle`)
+  })
+
+  it('cursorForward moves to the extracted subthought after splitting a thought with existing children', () => {
+    const text = `
+      - One two (three four)
+        - A
+        - B
+        - C
+    `
+    const steps = [importText({ text }), setCursor(['One two (three four)']), splitSentences(), cursorForward]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expectPathToEqual(stateNew, stateNew.cursor, ['One two', 'three four'])
   })
 })
 

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -57,7 +57,6 @@ export interface NewThoughtPayload {
   at?: Path
   /** Callback for when the updates have been synced with IDB. */
   idbSynced?: () => void
-  id?: ThoughtId
   insertNewSubthought?: boolean
   insertBefore?: boolean
   value?: string
@@ -80,7 +79,6 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
   const {
     at,
     idbSynced,
-    id,
     insertNewSubthought,
     insertBefore,
     value = '',
@@ -160,7 +158,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
           : getRankAfter(state, simplePath)
 
   // when creating a new context in a context view, newThoughtId is the new empty thought (a/~m/_), and newContextId is the newly added Lexeme context (/ABS/_/m)
-  const newThoughtId = id || createId()
+  const newThoughtId = createId()
   const newContextId = insertContext ? createId() : null
 
   const reducers = [

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -57,6 +57,7 @@ export interface NewThoughtPayload {
   at?: Path
   /** Callback for when the updates have been synced with IDB. */
   idbSynced?: () => void
+  id?: ThoughtId
   insertNewSubthought?: boolean
   insertBefore?: boolean
   value?: string
@@ -79,6 +80,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
   const {
     at,
     idbSynced,
+    id,
     insertNewSubthought,
     insertBefore,
     value = '',
@@ -158,7 +160,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
           : getRankAfter(state, simplePath)
 
   // when creating a new context in a context view, newThoughtId is the new empty thought (a/~m/_), and newContextId is the newly added Lexeme context (/ABS/_/m)
-  const newThoughtId = createId()
+  const newThoughtId = id || createId()
   const newContextId = insertContext ? createId() : null
 
   const reducers = [

--- a/src/actions/splitSentences.ts
+++ b/src/actions/splitSentences.ts
@@ -10,6 +10,8 @@ import getTextContentFromHTML from '../device/getTextContentFromHTML'
 import getThoughtById from '../selectors/getThoughtById'
 import simplifyPath from '../selectors/simplifyPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
+import appendToPath from '../util/appendToPath'
+import createId from '../util/createId'
 import head from '../util/head'
 import reducerFlow from '../util/reducerFlow'
 import splitSentence from '../util/splitSentence'
@@ -37,15 +39,16 @@ const splitSentences = (state: State): State => {
       newValue: firstSentence.value,
       path: simplifyPath(state, cursor),
     }),
-    ...otherSentences.map(sentence => (state: State) => {
-      const stateNew = newThought({ value: sentence.value, insertNewSubthought: sentence.insertNewSubThought })(state)
+    ...otherSentences.map(sentence => {
       if (sentence.insertNewSubThought) {
-        cursorForwardPath = stateNew.cursor
+        const id = createId()
+        cursorForwardPath = appendToPath(cursor, id)
+        return newThought({ value: sentence.value, insertNewSubthought: true, id })
       }
-      return stateNew
+      return newThought({ value: sentence.value })
     }),
     setCursor({ path: cursor, offset: getTextContentFromHTML(firstSentence.value).length }),
-    (state: State) => (cursorForwardPath ? cursorHistory({ cursor: cursorForwardPath })(state) : state),
+    cursorForwardPath ? cursorHistory({ cursor: cursorForwardPath }) : null,
     editableRender,
   ]
 

--- a/src/actions/splitSentences.ts
+++ b/src/actions/splitSentences.ts
@@ -10,8 +10,6 @@ import getTextContentFromHTML from '../device/getTextContentFromHTML'
 import getThoughtById from '../selectors/getThoughtById'
 import simplifyPath from '../selectors/simplifyPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
-import appendToPath from '../util/appendToPath'
-import createId from '../util/createId'
 import head from '../util/head'
 import reducerFlow from '../util/reducerFlow'
 import splitSentence from '../util/splitSentence'
@@ -31,28 +29,29 @@ const splitSentences = (state: State): State => {
   }
 
   const [firstSentence, ...otherSentences] = sentences
-  let cursorForwardPath: State['cursor'] = null
 
-  const reducers = [
+  const stateAfterSplit = reducerFlow([
     editThought({
       oldValue: value,
       newValue: firstSentence.value,
       path: simplifyPath(state, cursor),
     }),
-    ...otherSentences.map(sentence => {
-      if (sentence.insertNewSubThought) {
-        const id = createId()
-        cursorForwardPath = appendToPath(cursor, id)
-        return newThought({ value: sentence.value, insertNewSubthought: true, id })
-      }
-      return newThought({ value: sentence.value })
-    }),
+    ...otherSentences.map(sentence =>
+      newThought({ value: sentence.value, insertNewSubthought: sentence.insertNewSubThought }),
+    ),
+  ])(state)
+
+  const cursorForwardPath = otherSentences.some(sentence => sentence.insertNewSubThought)
+    ? stateAfterSplit.cursor
+    : null
+
+  const reducers = [
     setCursor({ path: cursor, offset: getTextContentFromHTML(firstSentence.value).length }),
     cursorForwardPath ? cursorHistory({ cursor: cursorForwardPath }) : null,
     editableRender,
   ]
 
-  return reducerFlow(reducers)(state)
+  return reducerFlow(reducers)(stateAfterSplit)
 }
 
 /** Action-creator for splitSentences. */

--- a/src/actions/splitSentences.ts
+++ b/src/actions/splitSentences.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
+import cursorHistory from '../actions/cursorHistory'
 import editThought from '../actions/editThought'
 import editableRender from '../actions/editableRender'
 import newThought from '../actions/newThought'
@@ -28,6 +29,7 @@ const splitSentences = (state: State): State => {
   }
 
   const [firstSentence, ...otherSentences] = sentences
+  let cursorForwardPath: State['cursor'] = null
 
   const reducers = [
     editThought({
@@ -35,10 +37,15 @@ const splitSentences = (state: State): State => {
       newValue: firstSentence.value,
       path: simplifyPath(state, cursor),
     }),
-    ...otherSentences.map(sentence =>
-      newThought({ value: sentence.value, insertNewSubthought: sentence.insertNewSubThought }),
-    ),
+    ...otherSentences.map(sentence => (state: State) => {
+      const stateNew = newThought({ value: sentence.value, insertNewSubthought: sentence.insertNewSubThought })(state)
+      if (sentence.insertNewSubThought) {
+        cursorForwardPath = stateNew.cursor
+      }
+      return stateNew
+    }),
     setCursor({ path: cursor, offset: getTextContentFromHTML(firstSentence.value).length }),
+    (state: State) => (cursorForwardPath ? cursorHistory({ cursor: cursorForwardPath })(state) : state),
     editableRender,
   ]
 


### PR DESCRIPTION
## Summary

Fixes #4522.

When Split Sentences extracts parenthetical content into a new subthought, Cursor Forward now moves to that newly extracted subthought instead of falling back to the first existing child.

## Changes

- Records the newly created subthought in cursor history after Split Sentences restores the cursor to the parent.
- Adds a regression test for splitting `One two (three four)` when the thought already has children `A`, `B`, and `C`.

## Testing

- `tsc --noEmit`
- `vitest --project unit --run src/actions/__tests__/splitSentences.ts src/actions/__tests__/cursorForward.ts`