### PR TITLE
chore: bump setup-node to v6 in estimate workflows

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -25,7 +25,7 @@ jobs:
           # backfill.ts runs `git log` to compute the prompt version; a shallow
           # clone would make it resolve to "unknown", so fetch full history.
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
Bumps `actions/setup-node@v4` → `@v6` in the three estimate workflows, bringing them in line with the rest of the repo (which already uses v6).

## Changes
- `.github/workflows/estimate-backfill.yml`
- `.github/workflows/estimate-command.yml`
- `.github/workflows/estimate-issue-opened.yml`

Pure version bump — the only input used (`node-version`) is unchanged across major versions.