### PR TITLE
chore: use yarn --immutable instead of deprecated --frozen-lockfile

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build
       - name: Backfill Everhour estimates

--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build
       - name: Handle estimate command

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build
       - name: Estimate issue


### PR DESCRIPTION
## Summary

Yarn 4.17.0 emits `YN0050: The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead`.

Three CI workflows still used the deprecated flag. This replaces `yarn install --frozen-lockfile` with `yarn install --immutable` — the direct Yarn 4 replacement recommended by the warning, with identical behavior (fail if the lockfile would change).

## Changes

- `.github/workflows/estimate-command.yml`
- `.github/workflows/estimate-issue-opened.yml`
- `.github/workflows/estimate-backfill.yml`

This matches the plain-`yarn` (immutable-in-CI) convention used by every other workflow in the repo. YAML-only change, no source or test impact.