### PR TITLE
chore: cache yarn dependencies in CI workflows

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         run: yarn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         run: yarn

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         run: yarn

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -354,6 +354,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         if: steps.patch.outputs.empty != 'true'
@@ -462,6 +463,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         if: steps.patch.outputs.empty != 'true'
@@ -579,6 +581,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         if: steps.patch.outputs.empty != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'yarn'
 
       - name: Install npm dependencies
         run: yarn


### PR DESCRIPTION
## Summary

Enables yarn dependency caching in the main CI workflows so dependencies are restored from cache on subsequent runs and only re-downloaded when `yarn.lock` changes.

This is done via the built-in caching in `actions/setup-node` — adding `cache: 'yarn'` to the `Set Node.js version` step. It keys the cache on a hash of `yarn.lock`, restoring yarn's global cache on a match.

## Workflows updated

- `test.yml`
- `lint.yml`
- `puppeteer.yml`
- `ios.yml`
- `tdd.yml` (all three jobs)

Each of these enables Corepack **before** `setup-node`, so the Yarn 4 cache path resolves correctly.

## Already had caching (no change)

- `vercel-preview.yml`
- `copilot-setup-steps.yml`

## Intentionally skipped

- `docs.yml` — has no `setup-node` step and is disabled (manual trigger only).
- `estimate-*.yml` — not hot-path CI; use `setup-node@v4` without Corepack.
- `tauri-release-*.yml` / `update-browserslist.yml` — release/scheduled jobs, out of scope for this change (can follow up if desired).

## Notes

Expected effect: first run on a branch populates the cache; later runs with an unchanged `yarn.lock` skip the network fetch of packages, speeding up install.