### PR TITLE
test: mock Range.getClientRects in jsdom setup

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -34,5 +34,11 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock)
 
 HTMLImageElement.prototype.decode = vi.fn().mockResolvedValue(undefined)
 
+// jsdom does not implement Range.prototype.getClientRects, which getCaretOffset uses for glyph hit-testing.
+// Return an empty list to match jsdom's zero-size layout, preventing "range.getClientRects is not a function" errors.
+if (typeof Range.prototype.getClientRects !== 'function') {
+  Range.prototype.getClientRects = () => []
+}
+
 // stub jest globally. This is needed incase jest is being directly referenced in the code.
 vi.stubGlobal('jest', vi)


### PR DESCRIPTION
## Problem

Unit tests emitted repeated stderr noise:

```
TypeError: range.getClientRects is not a function
 at isWithinTextNode (src/device/getCaretOffset.ts:276:36)
 ...
 at HTMLDivElement.onMouseDown (src/components/Editable/useEditMode.ts:174:40)
```

`getCaretOffset` uses `Range.prototype.getClientRects` for glyph hit-testing. jsdom does not implement this method, so any `onMouseDown` handler triggered during a unit test (e.g. `cursorDown`, `Tutorial`, `deleteThought`) threw. The tests still passed, but the failures polluted the output.

## Fix

Polyfill `Range.prototype.getClientRects` in `src/setupTests.js` to return an empty list when it is missing. This matches jsdom's zero-size layout behavior (its `getBoundingClientRect` already returns zeros), so `getCaretOffset` gracefully finds no glyph matches instead of throwing. No application code is changed.

## Verification

- `cursorDown.ts` — 19 passed, no `getClientRects` errors
- `Tutorial.ts` — 30 passed, no `getClientRects` errors