### PR TITLE
chore: bump checkout to v6 in estimate workflows

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -22,7 +22,7 @@ jobs:
   backfill:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # backfill.ts runs `git log` to compute the prompt version; a shallow
           # clone would make it resolve to "unknown", so fetch full history.

--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -19,7 +19,7 @@ jobs:
     if: startsWith(github.event.comment.body, '/estimate ')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -16,7 +16,7 @@ jobs:
   estimate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v6 in the three estimate workflows that were still pinned to v4, aligning them with the rest of the repo (which already uses `@v6`).

Changed files:
- `.github/workflows/estimate-backfill.yml`
- `.github/workflows/estimate-command.yml`
- `.github/workflows/estimate-issue-opened.yml`

This is a pure, mechanical version bump — no other workflows or inputs were touched. Kept isolated from the separate `setup-node@v6` upgrade.