### PR TITLE
fix(estimate): migrate issue estimation off retired GitHub Models to OpenAI

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -8,6 +8,16 @@ on:
         description: Maximum number of tasks to process (blank = script default of 10)
         required: false
         type: number
+      dryRunEverhour:
+        description: Run inference but skip writing estimates to Everhour
+        required: false
+        default: false
+        type: boolean
+      dryRunAI:
+        description: Skip AI inference entirely (no estimates produced)
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   # To post the estimate audit comment on each backfilled issue.
@@ -15,8 +25,6 @@ permissions:
   # To read the estimation instructions/samples from .github/instructions/estimate/
   # and to run `git log` for the prompt version.
   contents: read
-  # To call the GitHub Models inference API with GITHUB_TOKEN (backfill.ts runs AI inference).
-  models: read
 
 jobs:
   backfill:
@@ -37,8 +45,13 @@ jobs:
         run: node scripts/estimate/src/backfill.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OpenAI API key used for issue estimation inference (backfill.ts).
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}
           # An EVERHOUR_PROJECT_ID secret must be configured in repo settings.
           EVERHOUR_PROJECT_ID: ${{ secrets.EVERHOUR_PROJECT_ID }}
           # Blank input falls through to the script's default (parseInt(LIMIT ?? '10')).
           LIMIT: ${{ inputs.limit }}
+          # Optional per-stage dry-run toggles for manual runs; default false in production.
+          DRY_RUN_EVERHOUR: ${{ inputs.dryRunEverhour }}
+          DRY_RUN_AI: ${{ inputs.dryRunAI }}

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -9,8 +9,6 @@ permissions:
   issues: write
   # To read the estimation instructions and samples from .github/instructions/estimate/.
   contents: read
-  # To call the GitHub Models inference API with GITHUB_TOKEN (issue.ts runs AI inference).
-  models: read
 
 jobs:
   estimate:
@@ -27,4 +25,6 @@ jobs:
         run: node scripts/estimate/src/issue.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OpenAI API key used for issue estimation inference (issue.ts).
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}

--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -5,3 +5,5 @@
 # API Token can be refreshed at https://app.everhour.com/#/account/profile
 EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=
+# OpenAI API key used for the estimation inference call.
+OPENAI_API_KEY=

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -9,6 +9,7 @@ Define env variables in `scripts/estimate/.env`:
 ```
 EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=
+OPENAI_API_KEY=
 ```
 
 ## Usage
@@ -31,7 +32,7 @@ Valid estimate values: `1h` (XXS), `2h` (XS), `4h` (S), `8h` (M), `16h` (L), `24
 
 ## Workflows
 
-Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings.
+Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings. The Issue Opened and Backfill workflows additionally require an `OPENAI_API_KEY` secret for the estimation inference call.
 
 | Workflow                                                                     | Script            | Trigger                                  | Description                                                                                                                                     |
 | ---------------------------------------------------------------------------- | ----------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -86,6 +86,7 @@ const processTask = async ({
   taskId,
   everhour,
   githubToken,
+  openaiApiKey,
   owner,
   repoName,
   instructions,
@@ -98,6 +99,7 @@ const processTask = async ({
   taskId: string
   everhour: EverhourClient
   githubToken: string
+  openaiApiKey: string
   owner: string
   repoName: string
   instructions: string
@@ -115,7 +117,7 @@ const processTask = async ({
     issueRef: issueLink(owner, repoName, issue.number),
     instructions,
     samples,
-    token: githubToken,
+    openaiApiKey,
     everhour,
     taskId,
     dryRunAI,
@@ -142,6 +144,9 @@ const processTask = async ({
 const main = async () => {
   const githubToken = process.env.GITHUB_TOKEN
   if (!githubToken) throw new Error('GITHUB_TOKEN is required')
+
+  const openaiApiKey = process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
 
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')
@@ -268,6 +273,7 @@ const main = async () => {
         taskId: task.id,
         everhour,
         githubToken,
+        openaiApiKey,
         owner,
         repoName,
         instructions,

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -36,6 +36,9 @@ const main = async () => {
   const githubToken = process.env.GITHUB_TOKEN
   if (!githubToken) throw new Error('GITHUB_TOKEN is required')
 
+  const openaiApiKey = process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')
 
@@ -71,7 +74,7 @@ const main = async () => {
     issueRef: issueLink(owner, repoName, issue.number),
     instructions,
     samples,
-    token: githubToken,
+    openaiApiKey,
     everhour,
     taskId,
   })

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -25,7 +25,7 @@ const estimateIssue = async ({
   issueRef,
   instructions,
   samples,
-  token,
+  openaiApiKey,
   everhour,
   taskId,
   dryRunAI = false,
@@ -36,7 +36,8 @@ const estimateIssue = async ({
   issueRef: string
   instructions: string
   samples: EstimateSample[]
-  token: string
+  /** OpenAI API key passed through to the inference call. */
+  openaiApiKey: string
   everhour: EverhourClient
   taskId: string
   dryRunAI?: boolean
@@ -49,7 +50,7 @@ const estimateIssue = async ({
   }
 
   const prompt = buildPrompt(samples, issue)
-  const outputs = await inference({ token, prompt, instructions })
+  const outputs = await inference({ apiKey: openaiApiKey, prompt, instructions })
   const { estimate: category } = validateEstimate(outputs)
   const estimate: Estimate = {
     category,

--- a/scripts/estimate/src/lib/inference.ts
+++ b/scripts/estimate/src/lib/inference.ts
@@ -1,26 +1,27 @@
 // Inference tuning constants, overridable via ESTIMATE_* env vars for experimentation.
-const MODEL = process.env.ESTIMATE_MODEL ?? 'openai/gpt-4.1'
+const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-4.1'
 const TEMPERATURE = process.env.ESTIMATE_TEMPERATURE != null ? Number(process.env.ESTIMATE_TEMPERATURE) : 0
 const MAX_VALIDATION_ATTEMPTS =
   process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS != null ? Number(process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS) : 3
 
 /** Options for the AI inference call. */
 interface CallOptions {
-  token: string
+  /** OpenAI API key used to authenticate the inference request. */
+  apiKey: string
   prompt: string
   /** Estimation instructions used as the system message. */
   instructions: string
 }
 
-/** Calls GitHub Models inference API. Returns raw string outputs for validation. */
-const inference = async ({ token, prompt, instructions }: CallOptions): Promise<string[]> => {
+/** Calls the OpenAI chat completions API. Returns raw string outputs for validation. */
+const inference = async ({ apiKey, prompt, instructions }: CallOptions): Promise<string[]> => {
   const outputs: string[] = []
 
   for (let attempt = 0; attempt < MAX_VALIDATION_ATTEMPTS; attempt++) {
-    const response = await fetch('https://models.github.ai/inference/chat/completions', {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -36,7 +37,7 @@ const inference = async ({ token, prompt, instructions }: CallOptions): Promise<
 
     if (!response.ok) {
       const body = await response.text().catch(() => '')
-      throw new Error(`GitHub Models API error ${response.status}: ${body}`)
+      throw new Error(`OpenAI API error ${response.status}: ${body}`)
     }
 
     const data = (await response.json()) as { choices: { message: { content: string } }[] }


### PR DESCRIPTION
## Problem

The **Estimate** workflows failed with `GitHub Models API error 403`. Root cause is **not** permissions — **GitHub Models is being retired**. A direct `curl` of the endpoint from CI (with a `models:read`-scoped `GITHUB_TOKEN`) returns:

```
HTTP/2 403
deprecation: @1777939200
link: <https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/>; rel="deprecation"
sunset: Thu, 30 Jul 2026 00:00:00 GMT
content-length: 0
```

Per GitHub's changelog, Models — playground, catalog, **inference API, and BYOK** — closed to new customers (2026-06-16) and is fully retired **2026-07-30**. This repo already 403s, so the inference call must move off GitHub Models.

> Note: the earlier `models: read` change (PR #4574) was based on a wrong hypothesis and was merged before this was understood; this PR removes it.

## Fix

Migrate estimation inference to the **OpenAI API** (smallest diff — the code already speaks OpenAI's `/chat/completions` dialect):

- `inference.ts`: call `https://api.openai.com/v1/chat/completions`, authenticated with `OPENAI_API_KEY`; default model `gpt-4.1` (was `openai/gpt-4.1`); `ESTIMATE_MODEL` override retained.
- `estimateIssue.ts` / `backfill.ts` / `issue.ts`: thread `openaiApiKey`; require `OPENAI_API_KEY`. `GITHUB_TOKEN` is still used for GitHub API + audit comments.
- Workflows: add `OPENAI_API_KEY` env to `estimate-backfill.yml` and `estimate-issue-opened.yml`; removed the now-moot `models: read`. `estimate-command.yml` untouched (no inference). Backfill dispatch gains `dryRunEverhour` / `dryRunAI` inputs for safe manual verification.
- Docs: document `OPENAI_API_KEY` in `README.md` and `.env.example`.

## Verification

An `OPENAI_API_KEY` repository secret has been added. Verified by dispatching the backfill on this branch with `dryRunEverhour=true` (real inference, no Everhour writes).