### PR TITLE
chore(estimate): default issue estimation model to gpt-5-mini

### DIFF
--- a/scripts/estimate/src/lib/inference.ts
+++ b/scripts/estimate/src/lib/inference.ts
@@ -1,6 +1,9 @@
 // Inference tuning constants, overridable via ESTIMATE_* env vars for experimentation.
-const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-4.1'
-const TEMPERATURE = process.env.ESTIMATE_TEMPERATURE != null ? Number(process.env.ESTIMATE_TEMPERATURE) : 0
+const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-5-mini'
+// Only sent when explicitly set. GPT-5 reasoning models reject a non-default temperature
+// (e.g. 0), so it is omitted by default; determinism is instead handled by the validation
+// retry loop below. Set ESTIMATE_TEMPERATURE to override for models that support it.
+const TEMPERATURE = process.env.ESTIMATE_TEMPERATURE != null ? Number(process.env.ESTIMATE_TEMPERATURE) : undefined
 const MAX_VALIDATION_ATTEMPTS =
   process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS != null ? Number(process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS) : 3
 
@@ -26,7 +29,7 @@ const inference = async ({ apiKey, prompt, instructions }: CallOptions): Promise
       },
       body: JSON.stringify({
         model: MODEL,
-        temperature: TEMPERATURE,
+        ...(TEMPERATURE != null ? { temperature: TEMPERATURE } : {}),
         messages: [
           { role: 'system', content: instructions },
           { role: 'user', content: prompt },


### PR DESCRIPTION
## Why

The estimation workflow (`scripts/estimate`) called OpenAI's `gpt-4.1` for issue effort estimates. Estimation is a calibrated-judgment task (spotting hidden work, integration complexity, testing burden, ambiguity) rather than a raw code-generation task, which is better served by a reasoning model. This also refreshes the workflow away from an older model default.

## What changed

- **Default model `gpt-4.1` -> `gpt-5-mini`.** A reasoning model tuned for good judgment at low cost, which fits this automated, high-volume workflow (per-issue estimation plus backfill). The `ESTIMATE_MODEL` override still lets you bump to `gpt-5` for accuracy-critical runs or drop to `gpt-5-nano` for the cheapest option.
- **`temperature` is now only sent when explicitly set** via `ESTIMATE_TEMPERATURE`. GPT-5 reasoning models reject a non-default `temperature` (the old code always sent `0`, which would 400 every call under the new default). Output determinism is instead handled by the existing validation-retry loop.

## Notes for reviewers

- This is a config-level change in one file; no test pinned the model or temperature, and no docs referenced them.
- The one non-obvious coupling is the temperature guard: it is required for the model swap to work, not an independent cleanup.
- Verified locally: `prettier --check` clean and `tsc --noEmit` passes in `scripts/estimate`.