### PR TITLE
Fix select all in nested context views

### DIFF
--- a/src/actions/__tests__/addAllMulticursor.ts
+++ b/src/actions/__tests__/addAllMulticursor.ts
@@ -1,6 +1,8 @@
 import addAllMulticursor from '../../actions/addAllMulticursor'
+import importText from '../../actions/importText'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
+import toggleContextView from '../../actions/toggleContextView'
 import contextToPath from '../../selectors/contextToPath'
 import addMulticursorAtFirstMatch from '../../test-helpers/addMulticursorAtFirstMatch'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
@@ -108,6 +110,113 @@ describe('addAllMulticursor', () => {
       [hashPath(a1)]: a1,
       [hashPath(a2)]: a2,
       [hashPath(a3)]: a3,
+    })
+  })
+
+  it('selects all contexts at the cursor level inside a context view', () => {
+    const text = `
+      - a
+        - m
+          - x
+          - y
+          - z
+      - b
+        - m
+          - t
+          - u
+          - v
+    `
+
+    const stateNew = reducerFlow([
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a']),
+      addAllMulticursor,
+    ])(initialState())
+
+    const a = contextToPath(stateNew, ['a', 'm', 'a'])!
+    const b = contextToPath(stateNew, ['a', 'm', 'b'])!
+
+    expect(stateNew.multicursors).toEqual({
+      [hashPath(a)]: a,
+      [hashPath(b)]: b,
+    })
+  })
+
+  it('selects all siblings of a context after crossing a context view boundary', () => {
+    const text = `
+      - a
+        - m
+          - x
+          - y
+          - z
+      - b
+        - m
+          - t
+          - u
+          - v
+    `
+
+    const stateNew = reducerFlow([
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'b', 't']),
+      addAllMulticursor,
+    ])(initialState())
+
+    const t = contextToPath(stateNew, ['a', 'm', 'b', 't'])!
+    const u = contextToPath(stateNew, ['a', 'm', 'b', 'u'])!
+    const v = contextToPath(stateNew, ['a', 'm', 'b', 'v'])!
+
+    expect(stateNew.multicursors).toEqual({
+      [hashPath(t)]: t,
+      [hashPath(u)]: u,
+      [hashPath(v)]: v,
+    })
+  })
+
+  it('selects all contexts at the cursor level inside a nested context view', () => {
+    const text = `
+      - a
+        - m
+          - p
+            - n
+              - ap
+          - q
+            - n
+              - aq
+      - b
+        - m
+          - r
+            - n
+              - br
+          - s
+            - n
+              - bs
+    `
+
+    const stateNew = reducerFlow([
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a', 'p', 'n']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a', 'p', 'n', 'p']),
+      addAllMulticursor,
+    ])(initialState())
+
+    const p = contextToPath(stateNew, ['a', 'm', 'a', 'p', 'n', 'p'])!
+    const q = contextToPath(stateNew, ['a', 'm', 'a', 'p', 'n', 'q'])!
+    const r = contextToPath(stateNew, ['a', 'm', 'a', 'p', 'n', 'r'])!
+    const s = contextToPath(stateNew, ['a', 'm', 'a', 'p', 'n', 's'])!
+
+    expect(stateNew.multicursors).toEqual({
+      [hashPath(p)]: p,
+      [hashPath(q)]: q,
+      [hashPath(r)]: r,
+      [hashPath(s)]: s,
     })
   })
 })

--- a/src/actions/__tests__/selectBetween.ts
+++ b/src/actions/__tests__/selectBetween.ts
@@ -7,6 +7,7 @@ import head from '../../util/head'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 import importText from '../importText'
+import toggleContextView from '../toggleContextView'
 
 test('select between two thoughts in the root', () => {
   const text = `
@@ -98,6 +99,100 @@ test('if no thoughts are selected, select all thoughts at the cursor level', () 
     .sort()
 
   expect(selected).toEqual(['a', 'b', 'c', 'd', 'e', 'f'])
+})
+
+test('if no thoughts are selected in a context view, select all contexts at the cursor level', () => {
+  const text = `
+    - a
+      - m
+        - x
+        - y
+        - z
+    - b
+      - m
+        - t
+        - u
+        - v
+  `
+
+  const steps = [
+    importText({ text }),
+    setCursor(['a', 'm']),
+    toggleContextView,
+    setCursor(['a', 'm', 'a']),
+    selectBetween,
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const selected = Object.values(stateNew.multicursors)
+    .map(path => prettyPath(stateNew, path))
+    .sort()
+
+  expect(selected).toEqual(['a/m/a', 'a/m/b'])
+})
+
+test('select between two contexts in a context view', () => {
+  const text = `
+    - a
+      - m
+        - x
+    - b
+      - m
+        - y
+    - c
+      - m
+        - z
+  `
+
+  const steps = [
+    importText({ text }),
+    setCursor(['a', 'm']),
+    toggleContextView,
+    setCursor(['a', 'm', 'a']),
+    addMulticursor(['a', 'm', 'a']),
+    addMulticursor(['a', 'm', 'c']),
+    selectBetween,
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const selected = Object.values(stateNew.multicursors)
+    .map(path => prettyPath(stateNew, path))
+    .sort()
+
+  expect(selected).toEqual(['a/m/a', 'a/m/b', 'a/m/c'])
+})
+
+test('if no thoughts are selected after crossing a context view boundary, select all thoughts at the cursor level', () => {
+  const text = `
+    - a
+      - m
+        - x
+        - y
+        - z
+    - b
+      - m
+        - t
+        - u
+        - v
+  `
+
+  const steps = [
+    importText({ text }),
+    setCursor(['a', 'm']),
+    toggleContextView,
+    setCursor(['a', 'm', 'b', 't']),
+    selectBetween,
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const selected = Object.values(stateNew.multicursors)
+    .map(path => prettyPath(stateNew, path))
+    .sort()
+
+  expect(selected).toEqual(['a/m/b/t', 'a/m/b/u', 'a/m/b/v'])
 })
 
 test('if no thoughts are selected and there is no cursor, select all thoughts at root', () => {

--- a/src/actions/addAllMulticursor.ts
+++ b/src/actions/addAllMulticursor.ts
@@ -1,26 +1,14 @@
 import _ from 'lodash'
-import Path from '../@types/Path'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
-import { HOME_TOKEN } from '../constants'
-import { getChildrenSorted } from '../selectors/getChildren'
-import rootedParentOf from '../selectors/rootedParentOf'
+import getSiblingPaths from '../selectors/getSiblingPaths'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
-import head from '../util/head'
-import parentOf from '../util/parentOf'
 import reducerFlow from '../util/reducerFlow'
 import addMulticursor from './addMulticursor'
 
 /** Adds all siblings of the current cursor (or all root thoughts) to the multicursor set. */
 const addAllMulticursor = (state: State): State => {
-  const { cursor } = state
-  const parentId = cursor ? head(rootedParentOf(state, cursor)) : HOME_TOKEN
-  const siblings = getChildrenSorted(state, parentId)
-
-  const addMulticursorSteps = siblings.map(sibling => (state: State) => {
-    const siblingPath: Path = cursor ? [...parentOf(cursor), sibling.id] : [sibling.id]
-    return addMulticursor(state, { path: siblingPath })
-  })
+  const addMulticursorSteps = getSiblingPaths(state).map(path => addMulticursor({ path }))
 
   return reducerFlow(addMulticursorSteps)(state)
 }

--- a/src/actions/selectBetween.ts
+++ b/src/actions/selectBetween.ts
@@ -2,14 +2,9 @@ import { curryRight, sortBy } from 'lodash'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import alert from '../actions/alert'
-import { HOME_PATH } from '../constants'
-import { getChildrenSorted } from '../selectors/getChildren'
-import getThoughtById from '../selectors/getThoughtById'
-import rootedParentOf from '../selectors/rootedParentOf'
+import getSiblingPaths from '../selectors/getSiblingPaths'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
-import appendToPath from '../util/appendToPath'
-import equalPath from '../util/equalPath'
-import head from '../util/head'
+import hashPath from '../util/hashPath'
 import reducerFlow from '../util/reducerFlow'
 import addMulticursor from './addMulticursor'
 
@@ -22,17 +17,15 @@ const selectBetween = (state: State): State => {
     return alert(state, { value: 'Select Between requires at least two selected thoughts.' })
   }
 
-  const cursorParent = cursor ? rootedParentOf(state, cursor) : HOME_PATH
+  const cursorSiblingPaths = getSiblingPaths(state, cursor)
+  const cursorSiblingIndex = new Map(cursorSiblingPaths.map((path, i) => [hashPath(path), i]))
 
   // verify that all selected paths are at the same level
-  if (!multicursorPaths.every(path => equalPath(rootedParentOf(state, path), cursorParent))) {
+  if (multicursorPaths.length > 0 && !multicursorPaths.every(path => cursorSiblingIndex.has(hashPath(path)))) {
     return alert(state, { value: 'Select Between only works when the selected thoughts are at the same level.' })
   }
 
-  const cursorSiblingPaths = getChildrenSorted(state, head(cursorParent)).map(child =>
-    appendToPath(cursorParent, child.id),
-  )
-  const multicursorPathsSorted = sortBy(multicursorPaths, path => getThoughtById(state, head(path))?.rank ?? -1)
+  const multicursorPathsSorted = sortBy(multicursorPaths, path => cursorSiblingIndex.get(hashPath(path)) ?? -1)
 
   // find the first and last selected paths, defaulting to the first and last cursor siblings
   const firstPath = multicursorPathsSorted.at(0) ?? cursorSiblingPaths.at(0)
@@ -42,14 +35,18 @@ const selectBetween = (state: State): State => {
     return alert(state, { value: 'Select Between requires two selected thoughts.' })
   }
 
-  const firstRank = getThoughtById(state, head(firstPath))?.rank ?? -1
-  const lastRank = getThoughtById(state, head(lastPath))?.rank ?? -1
+  const firstIndex = cursorSiblingIndex.get(hashPath(firstPath))
+  const lastIndex = cursorSiblingIndex.get(hashPath(lastPath))
+
+  if (firstIndex === undefined || lastIndex === undefined) {
+    return alert(state, { value: 'Select Between only works when the selected thoughts are at the same level.' })
+  }
+
+  const startIndex = Math.min(firstIndex, lastIndex)
+  const endIndex = Math.max(firstIndex, lastIndex)
 
   // add every path between the first and last selected paths to the multicursor
-  const pathsToAdd = cursorSiblingPaths.filter(path => {
-    const thought = getThoughtById(state, head(path))
-    return thought && thought.rank >= firstRank && thought.rank <= lastRank
-  })
+  const pathsToAdd = cursorSiblingPaths.slice(startIndex, endIndex + 1)
 
   return reducerFlow(pathsToAdd.map(path => addMulticursor({ path })))(state)
 }

--- a/src/selectors/__tests__/isAllSelected.ts
+++ b/src/selectors/__tests__/isAllSelected.ts
@@ -1,0 +1,49 @@
+import importText from '../../actions/importText'
+import toggleContextView from '../../actions/toggleContextView'
+import addMulticursor from '../../test-helpers/addMulticursorAtFirstMatch'
+import setCursor from '../../test-helpers/setCursorFirstMatch'
+import initialState from '../../util/initialState'
+import reducerFlow from '../../util/reducerFlow'
+import isAllSelected from '../isAllSelected'
+
+describe('isAllSelected', () => {
+  const text = `
+    - a
+      - m
+        - x
+        - y
+        - z
+    - b
+      - m
+        - t
+        - u
+        - v
+  `
+
+  it('returns true when all contexts at the cursor level are selected in a context view', () => {
+    const state = reducerFlow([
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a']),
+      addMulticursor(['a', 'm', 'a']),
+      addMulticursor(['a', 'm', 'b']),
+    ])(initialState())
+
+    expect(isAllSelected(state)).toBe(true)
+  })
+
+  it('returns false when only child thoughts are selected in a context view', () => {
+    const state = reducerFlow([
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a']),
+      addMulticursor(['a', 'm', 'a', 'x']),
+      addMulticursor(['a', 'm', 'a', 'y']),
+      addMulticursor(['a', 'm', 'a', 'z']),
+    ])(initialState())
+
+    expect(isAllSelected(state)).toBe(false)
+  })
+})

--- a/src/selectors/getSiblingPaths.ts
+++ b/src/selectors/getSiblingPaths.ts
@@ -1,0 +1,32 @@
+import Path from '../@types/Path'
+import State from '../@types/State'
+import { HOME_PATH, HOME_TOKEN } from '../constants'
+import appendToPath from '../util/appendToPath'
+import head from '../util/head'
+import { getChildrenSorted } from './getChildren'
+import getContextsSortedAndRanked from './getContextsSortedAndRanked'
+import getThoughtById from './getThoughtById'
+import isContextViewActive from './isContextViewActive'
+import rootedParentOf from './rootedParentOf'
+import simplifyPath from './simplifyPath'
+
+/** Gets all sibling paths at the given path's visual level, including context-view boundaries. */
+const getSiblingPaths = (state: State, path: Path | null = state.cursor): Path[] => {
+  const parentPath = path ? rootedParentOf(state, path) : HOME_PATH
+
+  if (path && isContextViewActive(state, parentPath)) {
+    const contextViewThought = getThoughtById(state, head(parentPath))
+
+    return contextViewThought
+      ? getContextsSortedAndRanked(state, contextViewThought.value).flatMap(context => {
+          const contextParent = getThoughtById(state, context.parentId)
+          return contextParent ? [appendToPath(parentPath, contextParent.id)] : []
+        })
+      : []
+  }
+
+  const parentId = path ? head(simplifyPath(state, parentPath)) : HOME_TOKEN
+  return getChildrenSorted(state, parentId).map(child => appendToPath(parentPath, child.id))
+}
+
+export default getSiblingPaths

--- a/src/selectors/isAllSelected.ts
+++ b/src/selectors/isAllSelected.ts
@@ -1,17 +1,15 @@
 import State from '../@types/State'
-import { HOME_TOKEN } from '../constants'
-import head from '../util/head'
-import { getChildren } from './getChildren'
-import rootedParentOf from './rootedParentOf'
+import hashPath from '../util/hashPath'
+import getSiblingPaths from './getSiblingPaths'
 
 /** Returns true if the cursor and all its siblings are selected in the multicursor. */
 const isAllSelected = (state: State): boolean => {
-  const { cursor } = state
-  const parentId = cursor ? head(rootedParentOf(state, cursor)) : HOME_TOKEN
-  const childrenIds = getChildren(state, parentId).map(child => child.id)
-  // ignore order
-  const multicursorIdSet = new Set(Object.values(state.multicursors).map(path => head(path)))
-  return childrenIds.length === multicursorIdSet.size && childrenIds.every(childId => multicursorIdSet.has(childId))
+  const siblingPathHashes = getSiblingPaths(state).map(hashPath)
+  const multicursorHashSet = new Set(Object.values(state.multicursors).map(hashPath))
+  return (
+    siblingPathHashes.length === multicursorHashSet.size &&
+    siblingPathHashes.every(siblingPathHash => multicursorHashSet.has(siblingPathHash))
+  )
 }
 
 export default isAllSelected


### PR DESCRIPTION
## Summary

Fixes #4567.

The bug was that Select All was using the raw parent path inside context view, so `a/m~/a` selected `x/y/z` instead of sibling contexts `a/b` as requested in the issue.

## Changes
- Adds shared context-aware sibling path resolution for selection at the current visual level.
- Updates Select All, Select Between, and all-selected detection to respect context-view boundaries.
- Adds regression tests for context views, nested context views, crossed context boundaries, and Select Between behavior.

## Testing

- `yarn vitest --project unit run src/actions/__tests__/addAllMulticursor.ts src/actions/__tests__/selectBetween.ts src/selectors/__tests__/isAllSelected.ts`
- `yarn lint:tsc`
- `yarn eslint src/selectors/getSiblingPaths.ts src/actions/addAllMulticursor.ts src/actions/selectBetween.ts src/selectors/isAllSelected.ts src/actions/__tests__/addAllMulticursor.ts src/actions/__tests__/selectBetween.ts src/selectors/__tests__/isAllSelected.ts`
- `yarn vitest --project unit run`