### PR TITLE
fix(ci): make the BrowserStack concurrency queue lossless with queue: max

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,9 +16,12 @@ on:
 # overlapping runs (a main push + PR syncs + reruns) can over-subscribe it and fail with session-creation
 # timeouts. Allowing one active run at a time keeps total live sessions within maxInstances.
 # cancel-in-progress: false queues runs instead of cancelling them, so no run is dropped.
+# queue: max extends the queue from the default 1 to the maximum of 100, ensuring runs don't get silently
+# dropped if lots of jobs queue up.
 concurrency:
   group: browserstack
   cancel-in-progress: false
+  queue: max
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
### Symptom

PRs intermittently get stuck with the required **BrowserStack** check showing *"Expected – Waiting for status to be reported"*. 

Currently affected: #4552, #4553, #4554, #4555, #4556 (all blocked since 2026-07-09).

### Root cause

`ios.yml` serializes all BrowserStack runs behind one repo-wide concurrency group.

The comment says `cancel-in-progress: false` "queues runs instead of cancelling them, so no run is dropped" – but that's not how GitHub's default queue works.

Per the [workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency), the default is `queue: single`:

> At most one job or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced.

So while one run executes, the group's waiting room holds exactly one run – and every newly triggered run **cancels the previous waiter**. When Dependabot opens PRs in a burst, all but the last-queued run are dropped.

Of **51 BrowserStack runs in ~25 hours, 16 (31%) were evicted**:

| Evicted run | Queued (UTC) | Event | Ref |
|---|---|---|---|
| 29023911445 | 07-09 14:04:59 | PR | dependabot…prettier |
| 29023951829 | 07-09 14:05:33 | PR | dependabot…mui-emotion (#4552) |
| 29024065765 | 07-09 14:07:12 | PR | dependabot…idb-keyval (#4553) |
| 29024088823 | 07-09 14:07:33 | PR | dependabot…immer (#4554) |
| 29024114955 | 07-09 14:07:57 | PR | dependabot…dotenv (#4555) |
| 29024162468 | 07-09 14:08:39 | PR | dependabot…react-dialog (#4556) |
| 29024258485 | 07-09 14:10:07 | **push** | **main** |
| 29044745755 | 07-09 19:33:17 | PR | fix/4522-split-sentence… |
| 29056839224 | 07-09 23:14:34 | PR | raineorshine-chore-yarn-immutable |
| 29056906002 | 07-09 23:16:01 | PR | raineorshine-silver-invention |
| 29057104187 | 07-09 23:20:31 | **push** | **main** |
| 29057147921 | 07-09 23:21:32 | PR | raineorshine…cache-yarn-deps-ci |
| 29057158522 | 07-09 23:21:46 | **push** | **main** |
| 29057193559 | 07-09 23:22:35 | PR | raineorshine-literate-happiness |
| 29057310748 | 07-09 23:25:14 | PR | raineorshine…checkout-v6 |
| 29057428544 | 07-09 23:27:57 | **push** | **main** |

The pattern is clear: whenever runs arrive faster than one finishes (~5–7 min), only the run currently executing and the last one queued survive.

### Fix

```yaml
concurrency:
  group: browserstack
  cancel-in-progress: false
  queue: max
```

One added line. [`queue: max`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency) raises the group's pending capacity from 1 to 100, processed FIFO by wait-start time.

**The original design is otherwise unchanged**: still exactly one BrowserStack run executing at a time, so the shared parallel-session pool is protected precisely as intended – the queue just stops losing runs.

### Validation

An AI automated test reproduced the issue empirically in an isolated repo ([fbmcipher/gha-concurrency-probe](https://github.com/fbmcipher/gha-concurrency-probe)):

| Arm | Concurrency config | Result per burst of 4 PRs |
|---|---|---|
| A — current design | repo-wide group, default queue | ✅ ✖ ✖ ✅ — middle PRs' runs evicted with 0 jobs; their required check stuck at **"Expected — Waiting for status to be reported"**, merge blocked ([PR 2](https://github.com/fbmcipher/gha-concurrency-probe/pull/2), [PR 3](https://github.com/fbmcipher/gha-concurrency-probe/pull/3)) |
| B — **this PR** | repo-wide group + `queue: max` | ✅ ✅ ✅ ✅ — three runs observed simultaneously pending, then executed strictly serially, finishing 2m07s apart in FIFO order |

### Note

The currently stuck PRs (#4552–#4556) still need a nudge (`@dependabot rebase` or re-running their cancelled run) – nothing re-triggers them when this merges.
