### PR TITLE
chore(estimate): render full issue URL in CI logs

### DIFF
--- a/scripts/estimate/src/lib/__tests__/issueLink.ts
+++ b/scripts/estimate/src/lib/__tests__/issueLink.ts
@@ -1,16 +1,55 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import issueLink from '../issueLink.ts'
 
 describe('issueLink', () => {
-  it('wraps the visible #N in an OSC 8 hyperlink to the issue URL', () => {
-    const result = issueLink('cybersemics', 'em', 123)
-    const url = 'https://github.com/cybersemics/em/issues/123'
-    expect(result).toBe(`\u001b]8;;${url}\u001b\\#123\u001b]8;;\u001b\\`)
+  const originalCI = process.env.CI
+
+  afterEach(() => {
+    // Restore the original CI value so cases don't leak into each other.
+    if (originalCI === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalCI
+    }
   })
 
-  it('embeds the target URL and the plain #N fallback text', () => {
-    const result = issueLink('cybersemics', 'em', 4302)
-    expect(result).toContain('https://github.com/cybersemics/em/issues/4302')
-    expect(result).toContain('#4302')
+  describe('in CI', () => {
+    beforeEach(() => {
+      process.env.CI = 'true'
+    })
+
+    it('renders the plain #N followed by the full issue URL', () => {
+      const result = issueLink('cybersemics', 'em', 33)
+      expect(result).toBe('#33 - https://github.com/cybersemics/em/issues/33')
+    })
+
+    it('does not emit any OSC 8 escape sequence', () => {
+      const result = issueLink('cybersemics', 'em', 33)
+      expect(result).not.toContain('\u001b]8')
+    })
+  })
+
+  describe('outside CI', () => {
+    beforeEach(() => {
+      delete process.env.CI
+    })
+
+    it('wraps the visible #N in an OSC 8 hyperlink to the issue URL', () => {
+      const result = issueLink('cybersemics', 'em', 123)
+      const url = 'https://github.com/cybersemics/em/issues/123'
+      expect(result).toBe(`\u001b]8;;${url}\u001b\\#123\u001b]8;;\u001b\\`)
+    })
+
+    it('embeds the target URL and the plain #N fallback text', () => {
+      const result = issueLink('cybersemics', 'em', 4302)
+      expect(result).toContain('https://github.com/cybersemics/em/issues/4302')
+      expect(result).toContain('#4302')
+    })
+
+    it('treats CI=false as not in CI', () => {
+      process.env.CI = 'false'
+      const result = issueLink('cybersemics', 'em', 7)
+      expect(result).toContain('\u001b]8')
+    })
   })
 })

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -32,7 +32,7 @@ const estimateIssue = async ({
   dryRunEverhour = false,
 }: {
   issue: IssueInput
-  /** Clickable issue reference (`#N` as an OSC 8 terminal hyperlink) for log output; see issueLink. */
+  /** Issue reference (`#N` with the full URL in CI, or an OSC 8 terminal hyperlink locally) for log output; see issueLink. */
   issueRef: string
   instructions: string
   samples: EstimateSample[]

--- a/scripts/estimate/src/lib/issueLink.ts
+++ b/scripts/estimate/src/lib/issueLink.ts
@@ -1,13 +1,18 @@
 /**
- * Formats a GitHub issue reference as an OSC 8 terminal hyperlink to the issue on GitHub.com.
+ * Formats a GitHub issue reference for log output, adapting to the runtime environment.
  *
- * The visible text is `#N`; terminals that support OSC 8 render it as a clickable link, while
- * terminals that don't simply show the plain `#N` (the escape sequence is inert). The full URL
- * is never printed, keeping log lines compact.
+ * In CI (`process.env.CI` set to anything other than `false`), where terminals such as the
+ * GitHub Actions log viewer do not render OSC 8 hyperlinks, the full URL is printed inline as
+ * `#N - https://github.com/owner/repo/issues/N` so the link is visible and copyable.
+ *
+ * Locally, it emits an OSC 8 terminal hyperlink whose visible text is `#N`; terminals that
+ * support OSC 8 render it as a clickable link, while terminals that don't simply show the plain
+ * `#N` (the escape sequence is inert), keeping log lines compact.
  */
 const issueLink = (owner: string, repo: string, issueNumber: number): string => {
   const url = `https://github.com/${owner}/${repo}/issues/${issueNumber}`
-  return `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
+  const isCI = process.env.CI != null && process.env.CI !== '' && process.env.CI !== 'false'
+  return isCI ? `#${issueNumber} - ${url}` : `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
 }
 
 export default issueLink


### PR DESCRIPTION
## Summary

In CI, `issueLink` (used by the estimate scripts for log output) now renders the full issue URL instead of an OSC 8 terminal hyperlink.

The GitHub Actions log viewer does not render OSC 8 hyperlinks, so previously only the plain `#N` was visible in CI logs with no way to reach the issue. `issueLink` now branches on `process.env.CI`:

- **CI** → `#33 - https://github.com/cybersemics/em/issues/33`
- **Local** → unchanged compact OSC 8 hyperlink whose visible text is `#N`

`issueRef` is consumed only for `console.info` log output (`estimateIssue.ts`, `backfill.ts`, `issue.ts`, `command.ts`), so this affects log rendering only — no issue comment bodies or Everhour writes.

## Changes

- `scripts/estimate/src/lib/issueLink.ts` — CI branch + updated JSDoc
- `scripts/estimate/src/lib/estimateIssue.ts` — reworded `issueRef` doc comment
- `scripts/estimate/src/lib/__tests__/issueLink.ts` — cover both CI and local branches (toggling `process.env.CI`)

## Testing

- `yarn vitest run --project unit scripts/estimate/src/lib/__tests__/issueLink.ts` — 5 passed
- `yarn workspace em-estimate typecheck` — clean