### PR TITLE
feat(estimate): add startPage input to backfill dispatch workflow

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -8,6 +8,10 @@ on:
         description: Maximum number of tasks to process (blank = script default of 10)
         required: false
         type: number
+      startPage:
+        description: 1-based Everhour task page to begin pagination from (blank = page 1)
+        required: false
+        type: number
       dryRunEverhour:
         description: Run inference but skip writing estimates to Everhour
         required: false
@@ -52,6 +56,8 @@ jobs:
           EVERHOUR_PROJECT_ID: ${{ secrets.EVERHOUR_PROJECT_ID }}
           # Blank input falls through to the script's default (parseInt(LIMIT ?? '10')).
           LIMIT: ${{ inputs.limit }}
+          # Blank input falls through to the script's default (parseInt(PAGE ?? '1')).
+          PAGE: ${{ inputs.startPage }}
           # Optional per-stage dry-run toggles for manual runs; default false in production.
           DRY_RUN_EVERHOUR: ${{ inputs.dryRunEverhour }}
           DRY_RUN_AI: ${{ inputs.dryRunAI }}


### PR DESCRIPTION
## Summary

Adds a `startPage` input to the `Estimate - Backfill` manual dispatch workflow so runs can begin Everhour task pagination from an arbitrary page.

The backfill script (`scripts/estimate/src/backfill.ts`) already reads a `PAGE` env var (1-based, floors invalid/`<1` values to page 1). This PR simply exposes it as a `workflow_dispatch` input and wires it through:

- New `startPage` input under `workflow_dispatch.inputs` (mirrors the existing `limit` input: `type: number`, `required: false`, blank = default).
- `PAGE: ${{ inputs.startPage }}` added to the backfill step's `env` block.

No script or test changes are needed — a blank input falls through to the script's existing page-1 default.