### PR TITLE
fix(estimate): link prompt version to instructions file at commit

### DIFF
--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -6,31 +6,17 @@
  * fetches the corresponding GitHub issue → runs AI inference → writes the
  * estimate back to Everhour and leaves an audit comment on the GitHub issue.
  */
-import { execSync } from 'child_process'
 import 'dotenv/config'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import extractIssueNumber from './everhour/extractIssueNumber.ts'
 import estimateIssue from './lib/estimateIssue.ts'
+import getPromptVersion from './lib/getPromptVersion.ts'
 import issueLink from './lib/issueLink.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
-
-/**
- * Gets the short git commit hash of the most recent change to the estimate instructions file.
- * Used to tag AI-generated estimates with the prompt version for auditability.
- */
-const getPromptVersion = (repoRoot: string): string => {
-  try {
-    return execSync('git log -1 --format=%h -- .github/instructions/estimate/estimate.instructions.md', {
-      cwd: repoRoot,
-      encoding: 'utf-8',
-    }).trim()
-  } catch {
-    return 'unknown'
-  }
-}
+import promptVersionLink from './lib/promptVersionLink.ts'
 
 interface GitHubIssue {
   number: number
@@ -131,7 +117,7 @@ const processTask = async ({
   const { category, hours } = estimate
 
   // Leave audit comment on GitHub issue
-  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersion}\nSource: backfill`
+  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}\nSource: backfill`
   await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${githubToken}`, 'Content-Type': 'application/json' },

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -2,33 +2,22 @@
  * Estimates a newly opened GitHub issue and writes the result to Everhour.
  * Triggered by: .github/workflows/estimate-issue-opened.yml
  */
-import { execSync } from 'child_process'
 import 'dotenv/config'
 import * as fs from 'fs'
 import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import estimateIssue from './lib/estimateIssue.ts'
+import getPromptVersion from './lib/getPromptVersion.ts'
 import issueLink from './lib/issueLink.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
+import promptVersionLink from './lib/promptVersionLink.ts'
 
 interface IssuePayload {
   number: number
   title: string
   body: string | null
   labels: Array<{ name: string }>
-}
-
-/** Gets the prompt version (latest commit hash touching the estimate instructions file). */
-const getPromptVersion = (repoRoot: string): string => {
-  try {
-    return execSync('git log -1 --format=%h -- .github/instructions/estimate/estimate.instructions.md', {
-      cwd: repoRoot,
-      encoding: 'utf-8',
-    }).trim()
-  } catch {
-    return 'unknown'
-  }
 }
 
 /** Main entry point for the issue-opened estimation workflow. */
@@ -85,7 +74,7 @@ const main = async () => {
   const promptVersion = getPromptVersion(repoRoot)
 
   // Leave audit comment
-  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersion}`
+  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}`
 
   await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`, {
     method: 'POST',

--- a/scripts/estimate/src/lib/__tests__/promptVersionLink.ts
+++ b/scripts/estimate/src/lib/__tests__/promptVersionLink.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import promptVersionLink from '../promptVersionLink.ts'
+
+describe('promptVersionLink', () => {
+  const sha = '630ac1b41f903625bbf6a1c6aa18461bb192a0a0'
+
+  it('links the abbreviated hash to the instructions file at the full commit SHA', () => {
+    const result = promptVersionLink('cybersemics', 'em', sha)
+    const url = `https://github.com/cybersemics/em/blob/${sha}/.github/instructions/estimate/estimate.instructions.md`
+    expect(result).toBe(`[630ac1b](${url})`)
+  })
+
+  it('embeds the full SHA in the URL and shows the short hash as link text', () => {
+    const result = promptVersionLink('cybersemics', 'em', sha)
+    expect(result).toContain(`/blob/${sha}/`)
+    expect(result).toContain('[630ac1b]')
+  })
+
+  it('returns plain text without a link when the version is unknown', () => {
+    expect(promptVersionLink('cybersemics', 'em', 'unknown')).toBe('unknown')
+  })
+})

--- a/scripts/estimate/src/lib/getPromptVersion.ts
+++ b/scripts/estimate/src/lib/getPromptVersion.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process'
+
+/**
+ * Gets the full git commit hash of the most recent change to the estimate instructions file.
+ * Used to tag AI-generated estimates with the prompt version for auditability. The full SHA (rather
+ * than the abbreviated hash) is returned so it can be embedded verbatim in a GitHub blob URL that
+ * links to the prompt file as it existed at that commit. Returns 'unknown' when git is unavailable.
+ */
+const getPromptVersion = (repoRoot: string): string => {
+  try {
+    return execSync('git log -1 --format=%H -- .github/instructions/estimate/estimate.instructions.md', {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+    }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+export default getPromptVersion

--- a/scripts/estimate/src/lib/promptVersionLink.ts
+++ b/scripts/estimate/src/lib/promptVersionLink.ts
@@ -1,0 +1,16 @@
+/**
+ * Formats a prompt version (a full git commit SHA) as a markdown link to the estimate instructions
+ * file as it existed at that commit.
+ *
+ * A bare commit hash in a GitHub comment auto-links to the commit page; an explicit blob link points
+ * at the prompt file itself, which is the artifact reviewers actually want to inspect. The visible
+ * text is the abbreviated 7-character hash. When the version is 'unknown' (git lookup failed) the
+ * plain text is returned with no link.
+ */
+const promptVersionLink = (owner: string, repo: string, version: string): string => {
+  if (version === 'unknown') return version
+  const url = `https://github.com/${owner}/${repo}/blob/${version}/.github/instructions/estimate/estimate.instructions.md`
+  return `[${version.slice(0, 7)}](${url})`
+}
+
+export default promptVersionLink


### PR DESCRIPTION
## Summary

The estimate audit comments render `Prompt version:` followed by a bare commit hash. GitHub auto-links a bare hash to the **commit page** (`.../commit/<sha>`). This changes it to an explicit markdown link to the prompt **file at that commit**:

`https://github.com/cybersemics/em/blob/<full-sha>/.github/instructions/estimate/estimate.instructions.md`

Applied to **both** the backfill and issue-opened workflows, which post identical audit comments.

## Changes

- **New** `lib/getPromptVersion.ts` — shared git helper; consolidates the duplicated copy from `issue.ts`/`backfill.ts` and returns the **full** SHA (`%H` instead of `%h`) so it can be embedded verbatim in the blob URL.
- **New** `lib/promptVersionLink.ts` — pure formatter `(owner, repo, version) => string` returning `[<short7>](<blob-url>)`, or plain text when the version is `unknown`. Mirrors the existing `lib/issueLink.ts` convention.
- **New** `lib/__tests__/promptVersionLink.ts` — unit test (full SHA in URL, short hash as text, `unknown` fallback).
- `issue.ts` / `backfill.ts` — drop their local `getPromptVersion` and wrap the version in the link within the audit comment.

## Decisions

- Full SHA in the URL (matches the requested example); short 7-char hash as the visible link text.
- Instructions path inlined in each file per the single-default-export rule.

## Verification

- `yarn test` — 48 estimate unit tests pass (including the new one)
- `yarn lint` — no issues
- `scripts/estimate` `yarn typecheck` — clean