### PR TITLE
fix(estimate): prevent process.exit from truncating CI logs

### DIFF
--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -130,15 +130,31 @@ const processTask = async ({
 
   const { category, hours } = estimate
 
-  // Leave audit comment on GitHub issue
-  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersion}\nSource: backfill`
-  await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${githubToken}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ body: commentBody }),
-  })
-
+  // Log the estimate first: it has already been written to Everhour by estimateIssue, so it must be
+  // reported even if the best-effort audit comment below fails. Logging after the POST risked losing
+  // this line entirely when the comment request threw.
   console.info(`  Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
+
+  // Leave an audit comment on the GitHub issue. Best-effort: a comment failure must not abort the
+  // backfill run or discard the estimate already recorded, so failures are warned, not thrown.
+  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersion}\nSource: backfill`
+  try {
+    const commentResp = await fetch(
+      `https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${githubToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: commentBody }),
+      },
+    )
+    if (!commentResp.ok) {
+      console.warn(
+        `  Failed to post audit comment on ${issueLink(owner, repoName, issue.number)} - GitHub API error ${commentResp.status}`,
+      )
+    }
+  } catch (err) {
+    console.warn(`  Failed to post audit comment on ${issueLink(owner, repoName, issue.number)}:`, err)
+  }
 }
 
 const main = async () => {
@@ -295,6 +311,10 @@ const main = async () => {
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch(err => {
     console.error(err)
-    process.exit(1)
+    // Set exitCode instead of calling process.exit(1): process.exit() terminates before Node drains
+    // its async stdout/stderr writes, which silently truncates buffered log output (including this
+    // error) when the streams are pipes, as in CI. Setting exitCode lets the process exit naturally
+    // with a non-zero status once the event loop is empty, flushing all pending output first.
+    process.exitCode = 1
   })
 }

--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -190,7 +190,10 @@ const postComment = async (token: string, owner: string, repo: string, issueNumb
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch(err => {
     console.error(err)
-    process.exit(1)
+    // Set exitCode instead of calling process.exit(1): process.exit() terminates before Node drains
+    // its async stdout/stderr writes, which silently truncates buffered log output (including this
+    // error) when the streams are pipes, as in CI. Setting exitCode lets the process exit naturally.
+    process.exitCode = 1
   })
 }
 

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -84,24 +84,41 @@ const main = async () => {
   // Get prompt version
   const promptVersion = getPromptVersion(repoRoot)
 
-  // Leave audit comment
+  // Log the estimate first: it has already been written to Everhour by estimateIssue, so it must be
+  // reported even if the best-effort audit comment below fails.
+  console.info(`Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
+
+  // Leave an audit comment. Best-effort: a comment failure must not discard the estimate already recorded.
   const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersion}`
 
-  await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${githubToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ body: commentBody }),
-  })
-
-  console.info(`Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
+  try {
+    const commentResp = await fetch(
+      `https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ body: commentBody }),
+      },
+    )
+    if (!commentResp.ok) {
+      console.warn(
+        `Failed to post audit comment on ${issueLink(owner, repoName, issue.number)} - GitHub API error ${commentResp.status}`,
+      )
+    }
+  } catch (err) {
+    console.warn(`Failed to post audit comment on ${issueLink(owner, repoName, issue.number)}:`, err)
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch(err => {
     console.error(err)
-    process.exit(1)
+    // Set exitCode instead of calling process.exit(1): process.exit() terminates before Node drains
+    // its async stdout/stderr writes, which silently truncates buffered log output (including this
+    // error) when the streams are pipes, as in CI. Setting exitCode lets the process exit naturally.
+    process.exitCode = 1
   })
 }


### PR DESCRIPTION
## Problem

A backfill run ended abruptly in CI — its full output stopped at a PR-skip line with **no** `Estimated issue …` line, **no** `Backfill complete.` line, and **no** error/stack trace:

```
 Skipping #3939 ... - PR
<end of output>
```

`Backfill complete.` prints on every normal completion of `main()`, so its absence means `main()` **threw**. But the thrown error wasn't visible either.

## Root cause

All three script entrypoints (`backfill.ts`, `issue.ts`, `command.ts`) used this error handler:

```js
main().catch(err => {
  console.error(err)
  process.exit(1)
})
```

`process.exit()` terminates the process **before Node drains its async stdout/stderr writes**. When those streams are pipes — as they are under GitHub Actions (`.github/workflows/estimate-backfill.yml` runs `node scripts/estimate/src/backfill.ts`) — buffered output is silently discarded. So the `console.error(err)` and any pending `console.info` lines were lost, and the run looked like it stopped for no reason.

Because the Everhour write (`estimateIssue.ts` → `everhour.setEstimate(...)`) happens **before** the GitHub audit-comment POST, an error at the comment step could leave the estimate recorded in Everhour while the `Estimated issue` log never printed — exactly the "estimated but not logged" symptom.

## Changes

1. **`backfill.ts`, `issue.ts`, `command.ts`** — replace `process.exit(1)` with `process.exitCode = 1`, so the process exits non-zero **naturally**, flushing all output first. This alone would have surfaced the real error.
2. **`backfill.ts`, `issue.ts`** — harden the audit-comment POST:
   - Log the estimate **before** posting (it's already in Everhour by that point), so it's always reported.
   - Make the comment **best-effort**: check `resp.ok` and catch failures as `console.warn`, instead of letting a comment error throw and abort the run (important for batch runs where one bad comment shouldn't kill the remaining tasks).

## Verification

- `yarn workspace em-estimate typecheck` — passes
- `vitest run scripts/estimate` — 48/48 pass
- `prettier --check` on changed files — clean