### PR TITLE
chore(estimate): append issue URL at end of CI log line

### DIFF
--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -14,6 +14,7 @@ import EverhourClient from './everhour/client.ts'
 import extractIssueNumber from './everhour/extractIssueNumber.ts'
 import estimateIssue from './lib/estimateIssue.ts'
 import issueLink from './lib/issueLink.ts'
+import issueUrlSuffix from './lib/issueUrlSuffix.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
 
@@ -115,6 +116,7 @@ const processTask = async ({
       labels: issue.labels.map(l => l.name),
     },
     issueRef: issueLink(owner, repoName, issue.number),
+    issueUrl: issueUrlSuffix(owner, repoName, issue.number),
     instructions,
     samples,
     openaiApiKey,
@@ -138,7 +140,9 @@ const processTask = async ({
     body: JSON.stringify({ body: commentBody }),
   })
 
-  console.info(`  Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
+  console.info(
+    `  Estimated issue ${issueLink(owner, repoName, issue.number)} @ ${category} / ${hours}h${issueUrlSuffix(owner, repoName, issue.number)}`,
+  )
 }
 
 const main = async () => {
@@ -242,7 +246,7 @@ const main = async () => {
 
       if (!issueResp.ok) {
         console.info(
-          `  Skipping issue ${issueLink(owner, repoName, issueNumber)} - GitHub API error ${issueResp.status}`,
+          `  Skipping issue ${issueLink(owner, repoName, issueNumber)} - GitHub API error ${issueResp.status}${issueUrlSuffix(owner, repoName, issueNumber)}`,
         )
         continue
       }
@@ -253,18 +257,24 @@ const main = async () => {
       // too (they share the number space), so detect and skip them before the closed-state check —
       // otherwise a merged PR would be reported with the misleading "closed" reason.
       if (isPullRequest(issue)) {
-        console.info(`  Skipping ${issueLink(owner, repoName, issueNumber)} "${issue.title}" - PR`)
+        console.info(
+          `  Skipping ${issueLink(owner, repoName, issueNumber)} "${issue.title}" - PR${issueUrlSuffix(owner, repoName, issueNumber)}`,
+        )
         continue
       }
 
       // Do not estimate closed issues.
       if (issue.state === 'closed') {
-        console.info(`  Skipping issue ${issueLink(owner, repoName, issueNumber)} - closed`)
+        console.info(
+          `  Skipping issue ${issueLink(owner, repoName, issueNumber)} - closed${issueUrlSuffix(owner, repoName, issueNumber)}`,
+        )
         continue
       }
 
       if (!issue.body) {
-        console.info(`  Skipping issue ${issueLink(owner, repoName, issueNumber)} - empty body`)
+        console.info(
+          `  Skipping issue ${issueLink(owner, repoName, issueNumber)} - empty body${issueUrlSuffix(owner, repoName, issueNumber)}`,
+        )
         continue
       }
 

--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import { type EstimateCategory, HOURS_TO_CATEGORY, VALID_HOURS, categoryToSeconds } from './everhour/estimates.ts'
 import issueLink from './lib/issueLink.ts'
+import issueUrlSuffix from './lib/issueUrlSuffix.ts'
 
 const TRUSTED_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR']
 
@@ -174,7 +175,7 @@ const main = async () => {
   )
 
   console.info(
-    `Manual correction applied for issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${roundedHours}h`,
+    `Manual correction applied for issue ${issueLink(owner, repoName, issue.number)} @ ${category} / ${roundedHours}h${issueUrlSuffix(owner, repoName, issue.number)}`,
   )
 }
 

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url'
 import EverhourClient from './everhour/client.ts'
 import estimateIssue from './lib/estimateIssue.ts'
 import issueLink from './lib/issueLink.ts'
+import issueUrlSuffix from './lib/issueUrlSuffix.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples from './lib/loadSamples.ts'
 
@@ -72,6 +73,7 @@ const main = async () => {
   const estimate = await estimateIssue({
     issue: issueInput,
     issueRef: issueLink(owner, repoName, issue.number),
+    issueUrl: issueUrlSuffix(owner, repoName, issue.number),
     instructions,
     samples,
     openaiApiKey,
@@ -96,7 +98,9 @@ const main = async () => {
     body: JSON.stringify({ body: commentBody }),
   })
 
-  console.info(`Estimated issue ${issueLink(owner, repoName, issue.number)}: ${category} / ${hours}h`)
+  console.info(
+    `Estimated issue ${issueLink(owner, repoName, issue.number)} @ ${category} / ${hours}h${issueUrlSuffix(owner, repoName, issue.number)}`,
+  )
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/estimate/src/lib/__tests__/issueLink.ts
+++ b/scripts/estimate/src/lib/__tests__/issueLink.ts
@@ -18,9 +18,9 @@ describe('issueLink', () => {
       process.env.CI = 'true'
     })
 
-    it('renders the plain #N followed by the full issue URL', () => {
+    it('renders the plain #N label with no URL (the URL is appended separately at line end)', () => {
       const result = issueLink('cybersemics', 'em', 33)
-      expect(result).toBe('#33 - https://github.com/cybersemics/em/issues/33')
+      expect(result).toBe('#33')
     })
 
     it('does not emit any OSC 8 escape sequence', () => {

--- a/scripts/estimate/src/lib/__tests__/issueLink.ts
+++ b/scripts/estimate/src/lib/__tests__/issueLink.ts
@@ -1,16 +1,55 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import issueLink from '../issueLink.ts'
 
 describe('issueLink', () => {
-  it('wraps the visible #N in an OSC 8 hyperlink to the issue URL', () => {
-    const result = issueLink('cybersemics', 'em', 123)
-    const url = 'https://github.com/cybersemics/em/issues/123'
-    expect(result).toBe(`\u001b]8;;${url}\u001b\\#123\u001b]8;;\u001b\\`)
+  const originalCI = process.env.CI
+
+  afterEach(() => {
+    // Restore the original CI value so cases don't leak into each other.
+    if (originalCI === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalCI
+    }
   })
 
-  it('embeds the target URL and the plain #N fallback text', () => {
-    const result = issueLink('cybersemics', 'em', 4302)
-    expect(result).toContain('https://github.com/cybersemics/em/issues/4302')
-    expect(result).toContain('#4302')
+  describe('in CI', () => {
+    beforeEach(() => {
+      process.env.CI = 'true'
+    })
+
+    it('renders the plain #N followed by the full issue URL', () => {
+      const result = issueLink('cybersemics', 'em', 33)
+      expect(result).toBe('#33 - https://github.com/cybersemics/em/issues/33')
+    })
+
+    it('does not emit any OSC 8 escape sequence', () => {
+      const result = issueLink('cybersemics', 'em', 33)
+      expect(result).not.toContain('\u001b]8')
+    })
+  })
+
+  describe('outside CI', () => {
+    beforeEach(() => {
+      delete process.env.CI
+    })
+
+    it('wraps the visible #N in an OSC 8 hyperlink to the issue URL', () => {
+      const result = issueLink('cybersemics', 'em', 123)
+      const url = 'https://github.com/cybersemics/em/issues/123'
+      expect(result).toBe(`\u001b]8;;${url}\u001b\\#123\u001b]8;;\u001b\\`)
+    })
+
+    it('embeds the target URL and the plain #N fallback text', () => {
+      const result = issueLink('cybersemics', 'em', 4302)
+      expect(result).toContain('https://github.com/cybersemics/em/issues/4302')
+      expect(result).toContain('#4302')
+    })
+
+    it('treats CI=false as not in CI', () => {
+      process.env.CI = 'false'
+      const result = issueLink('cybersemics', 'em', 7)
+      expect(result).toContain('\u001b]8')
+    })
   })
 })

--- a/scripts/estimate/src/lib/__tests__/issueUrlSuffix.ts
+++ b/scripts/estimate/src/lib/__tests__/issueUrlSuffix.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import issueUrlSuffix from '../issueUrlSuffix.ts'
+
+describe('issueUrlSuffix', () => {
+  const originalCI = process.env.CI
+
+  afterEach(() => {
+    // Restore the original CI value so cases don't leak into each other.
+    if (originalCI === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalCI
+    }
+  })
+
+  describe('in CI', () => {
+    beforeEach(() => {
+      process.env.CI = 'true'
+    })
+
+    it('returns a leading " - " followed by the full issue URL', () => {
+      const result = issueUrlSuffix('cybersemics', 'em', 1607)
+      expect(result).toBe(' - https://github.com/cybersemics/em/issues/1607')
+    })
+  })
+
+  describe('outside CI', () => {
+    it('returns an empty string when CI is unset', () => {
+      delete process.env.CI
+      expect(issueUrlSuffix('cybersemics', 'em', 1607)).toBe('')
+    })
+
+    it('returns an empty string when CI=false', () => {
+      process.env.CI = 'false'
+      expect(issueUrlSuffix('cybersemics', 'em', 1607)).toBe('')
+    })
+  })
+})

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -32,7 +32,7 @@ const estimateIssue = async ({
   dryRunEverhour = false,
 }: {
   issue: IssueInput
-  /** Clickable issue reference (`#N` as an OSC 8 terminal hyperlink) for log output; see issueLink. */
+  /** Issue reference (`#N` with the full URL in CI, or an OSC 8 terminal hyperlink locally) for log output; see issueLink. */
   issueRef: string
   instructions: string
   samples: EstimateSample[]

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -23,6 +23,7 @@ export interface Estimate {
 const estimateIssue = async ({
   issue,
   issueRef,
+  issueUrl = '',
   instructions,
   samples,
   openaiApiKey,
@@ -32,8 +33,10 @@ const estimateIssue = async ({
   dryRunEverhour = false,
 }: {
   issue: IssueInput
-  /** Issue reference (`#N` with the full URL in CI, or an OSC 8 terminal hyperlink locally) for log output; see issueLink. */
+  /** Issue reference label (`#N`, as an OSC 8 terminal hyperlink locally) for log output; see issueLink. */
   issueRef: string
+  /** Trailing ` - <url>` suffix appended at the end of log lines in CI; empty locally. See issueUrlSuffix. */
+  issueUrl?: string
   instructions: string
   samples: EstimateSample[]
   /** OpenAI API key passed through to the inference call. */
@@ -45,7 +48,7 @@ const estimateIssue = async ({
 }): Promise<Estimate | null> => {
   // Skip AI inference entirely in AI dry-run mode.
   if (dryRunAI) {
-    console.info(`[DRY_RUN_AI] Would estimate ${issueRef} "${issue.title}"`)
+    console.info(`[DRY_RUN_AI] Would estimate ${issueRef} "${issue.title}"${issueUrl}`)
     return null
   }
 
@@ -61,7 +64,7 @@ const estimateIssue = async ({
   // Write the estimate to Everhour unless the Everhour write is being dry-run.
   if (dryRunEverhour) {
     console.info(
-      `[DRY_RUN_EVERHOUR] Would set Everhour estimate for ${issueRef} "${issue.title}": ${estimate.category} / ${estimate.hours}h`,
+      `[DRY_RUN_EVERHOUR] Would set Everhour estimate for ${issueRef} "${issue.title}": ${estimate.category} / ${estimate.hours}h${issueUrl}`,
     )
   } else {
     await everhour.setEstimate(taskId, estimate.seconds)

--- a/scripts/estimate/src/lib/issueLink.ts
+++ b/scripts/estimate/src/lib/issueLink.ts
@@ -1,18 +1,20 @@
 /**
- * Formats a GitHub issue reference for log output, adapting to the runtime environment.
+ * Formats the `#N` label of a GitHub issue reference for log output, adapting to the environment.
  *
- * In CI (`process.env.CI` set to anything other than `false`), where terminals such as the
- * GitHub Actions log viewer do not render OSC 8 hyperlinks, the full URL is printed inline as
- * `#N - https://github.com/owner/repo/issues/N` so the link is visible and copyable.
+ * In CI (`process.env.CI` set to anything other than `false`), where terminals such as the GitHub
+ * Actions log viewer do not render OSC 8 hyperlinks, it emits the plain `#N`. The full URL is
+ * appended separately at the end of the log line via issueUrlSuffix — keeping it clear of any
+ * trailing punctuation (e.g. a `:`) that a terminal's URL auto-detection would otherwise absorb
+ * into the link and break.
  *
- * Locally, it emits an OSC 8 terminal hyperlink whose visible text is `#N`; terminals that
- * support OSC 8 render it as a clickable link, while terminals that don't simply show the plain
- * `#N` (the escape sequence is inert), keeping log lines compact.
+ * Locally, it emits an OSC 8 terminal hyperlink whose visible text is `#N`; terminals that support
+ * OSC 8 render it as a clickable link, while terminals that don't simply show the plain `#N` (the
+ * escape sequence is inert), keeping log lines compact.
  */
 const issueLink = (owner: string, repo: string, issueNumber: number): string => {
   const url = `https://github.com/${owner}/${repo}/issues/${issueNumber}`
   const isCI = process.env.CI != null && process.env.CI !== '' && process.env.CI !== 'false'
-  return isCI ? `#${issueNumber} - ${url}` : `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
+  return isCI ? `#${issueNumber}` : `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
 }
 
 export default issueLink

--- a/scripts/estimate/src/lib/issueLink.ts
+++ b/scripts/estimate/src/lib/issueLink.ts
@@ -1,13 +1,18 @@
 /**
- * Formats a GitHub issue reference as an OSC 8 terminal hyperlink to the issue on GitHub.com.
+ * Formats a GitHub issue reference for log output, adapting to the runtime environment.
  *
- * The visible text is `#N`; terminals that support OSC 8 render it as a clickable link, while
- * terminals that don't simply show the plain `#N` (the escape sequence is inert). The full URL
- * is never printed, keeping log lines compact.
+ * In CI (`process.env.CI` set to anything other than `false`), where terminals such as the
+ * GitHub Actions log viewer do not render OSC 8 hyperlinks, the full URL is printed inline as
+ * `#N - https://github.com/owner/repo/issues/N` so the link is visible and copyable.
+ *
+ * Locally, it emits an OSC 8 terminal hyperlink whose visible text is `#N`; terminals that
+ * support OSC 8 render it as a clickable link, while terminals that don't simply show the plain
+ * `#N` (the escape sequence is inert), keeping log lines compact.
  */
 const issueLink = (owner: string, repo: string, issueNumber: number): string => {
   const url = `https://github.com/${owner}/${repo}/issues/${issueNumber}`
-  return `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
+  const isCI = process.env.CI != null && process.env.CI !== '' && process.env.CI !== 'false'
+  return isCI ? `#${issueNumber} - ${url}` : `\u001b]8;;${url}\u001b\\#${issueNumber}\u001b]8;;\u001b\\`
 }
 
 export default issueLink

--- a/scripts/estimate/src/lib/issueUrlSuffix.ts
+++ b/scripts/estimate/src/lib/issueUrlSuffix.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns the trailing ` - <url>` suffix that surfaces a GitHub issue URL at the very end of a CI
+ * log line, or an empty string when not in CI.
+ *
+ * Complements issueLink: in CI the `#N` label is plain text (no OSC 8 hyperlink), so the full URL
+ * has to be shown for it to be reachable. Appending it at the end of the line — rather than inline
+ * after `#N` — keeps it clear of any following punctuation (e.g. `: S / 4h`) that a terminal's URL
+ * auto-detection would otherwise swallow into the link and break.
+ *
+ * Locally the URL lives in the OSC 8 escape emitted by issueLink, so no suffix is needed.
+ */
+const issueUrlSuffix = (owner: string, repo: string, issueNumber: number): string => {
+  const isCI = process.env.CI != null && process.env.CI !== '' && process.env.CI !== 'false'
+  return isCI ? ` - https://github.com/${owner}/${repo}/issues/${issueNumber}` : ''
+}
+
+export default issueUrlSuffix


### PR DESCRIPTION
## Summary

Follow-up fix to the CI issue-URL rendering. The previous inline `#N - url` form placed the URL **mid-line**, so trailing text like `: S / 4h` got absorbed into the URL by terminal URL auto-detection (the `:` became part of the link), breaking it.

This separates the `#N` label from the URL and always places the URL at the **very end** of the log line in CI:

```
Estimated issue #1607 @ S / 4h - https://github.com/cybersemics/em/issues/1607
```

## Changes

- `scripts/estimate/src/lib/issueLink.ts` — now emits just the `#N` label (OSC 8 hyperlink locally, plain `#N` in CI).
- `scripts/estimate/src/lib/issueUrlSuffix.ts` (new) — returns ` - <url>` in CI (empty locally); appended at the end of each log line so no trailing punctuation can be absorbed into the link.
- `scripts/estimate/src/lib/estimateIssue.ts` — accepts an `issueUrl` suffix and appends it to the dry-run log lines.
- `backfill.ts`, `issue.ts`, `command.ts` — estimate/correction lines reformatted to `#N @ cat / Xh - url`; skip lines append the URL suffix at the end.
- Tests updated (`issueLink`) and added (`issueUrlSuffix`).

## Testing

- `yarn vitest run --project unit scripts/estimate` — 51 passed
- `yarn workspace em-estimate typecheck` — clean
- Verified rendered output with `CI=true`: URL sits at the end of the line, clear of any trailing text.

Supersedes #4586.