### PR TITLE
fix(estimate): resolve real Everhour task ID instead of gh:&lt;issueNumber&gt;

### DIFF
--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -31,3 +31,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}
+          EVERHOUR_PROJECT_ID: ${{ secrets.EVERHOUR_PROJECT_ID }}

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -28,3 +28,4 @@ jobs:
           # OpenAI API key used for issue estimation inference (issue.ts).
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}
+          EVERHOUR_PROJECT_ID: ${{ secrets.EVERHOUR_PROJECT_ID }}

--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -55,6 +55,9 @@ const main = async () => {
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')
 
+  const everhourProjectId = process.env.EVERHOUR_PROJECT_ID
+  if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
+
   const eventPath = process.env.GITHUB_EVENT_PATH
   if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required')
 
@@ -85,10 +88,22 @@ const main = async () => {
   const category = HOURS_TO_CATEGORY[roundedHours] as EstimateCategory
   const seconds = categoryToSeconds(category)
 
-  // Update Everhour immediately
+  // Update Everhour immediately. Everhour task IDs for GitHub-linked tasks embed the issue's internal
+  // database ID (gh:<issue_database_id>), not the issue number, so the task must be looked up rather
+  // than synthesized.
   const everhour = new EverhourClient({ apiKey: everhourApiKey })
-  const taskId = `gh:${issue.number}`
-  await everhour.setEstimate(taskId, seconds)
+  const task = await everhour.findTaskByIssueNumber(everhourProjectId, issue.number)
+  if (!task) {
+    await postComment(
+      githubToken,
+      owner,
+      repoName,
+      issue.number,
+      'Could not find a matching Everhour task for this issue, so the estimate was not updated.',
+    )
+    return
+  }
+  await everhour.setEstimate(task.id, seconds)
 
   // Create sample file content
   const sample = {

--- a/scripts/estimate/src/everhour/__tests__/client.ts
+++ b/scripts/estimate/src/everhour/__tests__/client.ts
@@ -21,4 +21,52 @@ describe('EverhourClient', () => {
 
     vi.unstubAllGlobals()
   })
+
+  describe('findTaskByIssueNumber', () => {
+    it('resolves the real Everhour task ID from the issue number', async () => {
+      // Everhour encodes GitHub-linked tasks as gh:<issue_database_id>; the issue number lives in the
+      // `number` field, so the task ID cannot be derived from the issue number and must be looked up.
+      const tasks = [
+        { id: 'gh:498948741', name: 'Some issue', number: '76' },
+        { id: 'gh:143808059:100', name: 'Another issue' },
+      ]
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify(tasks), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const client = new EverhourClient({ apiKey: 'test-key' })
+      const task = await client.findTaskByIssueNumber('proj-1', 76)
+
+      expect(task?.id).toBe('gh:498948741')
+      vi.unstubAllGlobals()
+    })
+
+    it('pages through tasks until a match is found', async () => {
+      const fullPage = Array.from({ length: 250 }, (_, i) => ({ id: `t${i}`, name: `Task ${i}` }))
+      const secondPage = [{ id: 'gh:143808059:42', name: 'Target' }]
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify(fullPage), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(secondPage), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const client = new EverhourClient({ apiKey: 'test-key' })
+      const task = await client.findTaskByIssueNumber('proj-1', 42)
+
+      expect(task?.id).toBe('gh:143808059:42')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      vi.unstubAllGlobals()
+    })
+
+    it('returns null when no task matches the issue number', async () => {
+      const tasks = [{ id: 'gh:498948741', name: 'Some issue', number: '76' }]
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify(tasks), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const client = new EverhourClient({ apiKey: 'test-key' })
+      const task = await client.findTaskByIssueNumber('proj-1', 999)
+
+      expect(task).toBeNull()
+      vi.unstubAllGlobals()
+    })
+  })
 })

--- a/scripts/estimate/src/everhour/client.ts
+++ b/scripts/estimate/src/everhour/client.ts
@@ -1,3 +1,4 @@
+import extractIssueNumber from './extractIssueNumber.ts'
 import type { EverhourClientOptions, EverhourProject, EverhourTask } from './types.ts'
 
 const DEFAULT_BASE_URL = 'https://api.everhour.com'
@@ -63,6 +64,27 @@ class EverhourClient {
       method: 'PUT',
       body: JSON.stringify({ type: 'overall', total: seconds }),
     })
+  }
+
+  /**
+   * Resolves the Everhour task for a GitHub issue by paging through the project's tasks and matching
+   * on the issue number (via extractIssueNumber). Returns null when no task matches.
+   *
+   * Everhour encodes GitHub-linked tasks with an ID like `gh:<issue_database_id>` — GitHub's internal
+   * database ID, NOT the issue number — so the task ID cannot be synthesized from the issue number and
+   * must be looked up. See scripts/estimate/README.md ("Everhour task fields").
+   */
+  async findTaskByIssueNumber(projectId: string, issueNumber: number): Promise<EverhourTask | null> {
+    const PAGE_SIZE = 250
+    let page = 1
+    // Page until a matching task is found or a short page signals the last page.
+    while (true) {
+      const tasks = await this.getProjectTasks(projectId, page, PAGE_SIZE)
+      const match = tasks.find(task => extractIssueNumber(task) === issueNumber)
+      if (match) return match
+      if (tasks.length < PAGE_SIZE) return null
+      page++
+    }
   }
 
   /** Gets a single task by ID. */

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -32,6 +32,9 @@ const main = async () => {
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')
 
+  const everhourProjectId = process.env.EVERHOUR_PROJECT_ID
+  if (!everhourProjectId) throw new Error('EVERHOUR_PROJECT_ID is required')
+
   const eventPath = process.env.GITHUB_EVENT_PATH
   if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required')
 
@@ -58,7 +61,16 @@ const main = async () => {
     labels: issue.labels.map(l => l.name),
   }
   const everhour = new EverhourClient({ apiKey: everhourApiKey })
-  const taskId = `gh:${issue.number}`
+  // Everhour task IDs for GitHub-linked tasks embed the issue's internal database ID
+  // (gh:<issue_database_id>), not the issue number, so the task must be looked up rather than
+  // synthesized. Skip gracefully if Everhour has not yet synced a task for this issue.
+  const task = await everhour.findTaskByIssueNumber(everhourProjectId, issue.number)
+  if (!task) {
+    console.warn(
+      `No matching Everhour task found for ${issueLink(owner, repoName, issue.number)}, skipping estimate.${issueUrlSuffix(owner, repoName, issue.number)}`,
+    )
+    return
+  }
   const estimate = await estimateIssue({
     issue: issueInput,
     issueRef: issueLink(owner, repoName, issue.number),
@@ -67,7 +79,7 @@ const main = async () => {
     samples,
     openaiApiKey,
     everhour,
-    taskId,
+    taskId: task.id,
   })
   if (!estimate) return
   const { category, hours } = estimate


### PR DESCRIPTION
## Problem

The `/estimate` command workflow fails with:

```
Error: Everhour API error 404: {"code":404,"message":"Not Found"}
  at EverhourClient.setEstimate (.../everhour/client.ts:62:5)
  at async main (.../command.ts:91:3)
```

([failing run](https://github.com/cybersemics/em/actions/runs/29114326656/job/86433896343))

## Root cause

Both `command.ts` and `issue.ts` synthesized the Everhour task ID as `gh:${issue.number}`. But Everhour encodes GitHub-linked tasks as `gh:<issue_database_id>` — GitHub's **internal database ID**, not the issue number (see `scripts/estimate/README.md` → "Everhour task fields"). So e.g. issue #76 is task `gh:498948741`, and `PUT /tasks/gh:76/estimate` targets a nonexistent task → 404.

`backfill.ts` was unaffected because it already resolves real task IDs by paging the project's tasks and matching via `extractIssueNumber`.

## Fix

- Add `EverhourClient.findTaskByIssueNumber(projectId, issueNumber)` — pages the project's tasks and matches on issue number using the existing `extractIssueNumber` resolver.
- `command.ts` and `issue.ts` now look up the real task and call `setEstimate(task.id, …)`. If no matching task exists (e.g. Everhour hasn't synced a freshly opened issue yet), they skip gracefully — `command.ts` posts an informative comment, `issue.ts` warns and returns — instead of crashing.
- Both scripts require `EVERHOUR_PROJECT_ID` (needed to page tasks), and both workflows now inject the `EVERHOUR_PROJECT_ID` secret.
- Added `EverhourClient` tests: single-page match, multi-page paging, and not-found → `null`.

## Verification

- `yarn workspace em-estimate build` (tsc) ✅
- `yarn test scripts/estimate` — 57 passed ✅
- `yarn lint` ✅