### PR TITLE
fix(estimate): pass everhourProjectId to applyCorrection

### DIFF
--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -85,7 +85,7 @@ const main = async () => {
   }
 
   try {
-    await applyCorrection(githubToken, everhourApiKey, owner, repoName, comment, issue, hours)
+    await applyCorrection(githubToken, everhourApiKey, everhourProjectId, owner, repoName, comment, issue, hours)
     await postReaction(githubToken, owner, repoName, comment.id, 'rocket')
   } catch (err) {
     await postReaction(githubToken, owner, repoName, comment.id, '-1')
@@ -97,6 +97,7 @@ const main = async () => {
 const applyCorrection = async (
   githubToken: string,
   everhourApiKey: string,
+  everhourProjectId: string,
   owner: string,
   repoName: string,
   comment: CommentEvent['comment'],


### PR DESCRIPTION
## Problem

The `Estimate - /estimate command` workflow was failing at the **Build estimate workspace** step:

```
src/command.ts(115,53): error TS2304: Cannot find name 'everhourProjectId'.
```

`applyCorrection` referenced `everhourProjectId`, but that variable is only defined in `main`. It was never threaded into the function, so the `em-estimate` workspace failed to type-check (`tsc --noEmit`).

## Fix

Add `everhourProjectId: string` as a parameter to `applyCorrection` and pass it from `main` at the call site, matching how the other env-derived values (`githubToken`, `everhourApiKey`) are already passed.

## Verification

- `yarn workspace em-estimate build` now exits 0.

Ref failing run: https://github.com/cybersemics/em/actions/runs/29115476290/job/86437672871