### PR TITLE
feat(estimate): output created PR at end of /estimate command

### DIFF
--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -190,7 +190,7 @@ const applyCorrection = async (
 
   // Open PR
   const prBody = `Adds a corrected estimate sample from \`/estimate ${roundedHours}h\`.\n\nIssue: ${owner}/${repoName}#${issue.number}\nExpected estimate: ${category} / ${roundedHours}h`
-  await fetch(`https://api.github.com/repos/${owner}/${repoName}/pulls`, {
+  const prResp = await fetch(`https://api.github.com/repos/${owner}/${repoName}/pulls`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${githubToken}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -200,6 +200,7 @@ const applyCorrection = async (
       base: defaultBranch,
     }),
   })
+  const pr = (await prResp.json()) as { html_url?: string }
 
   // Confirm via comment
   await postComment(
@@ -212,6 +213,15 @@ const applyCorrection = async (
 
   console.info(
     `Manual correction applied for issue ${issueLink(owner, repoName, issue.number)} @ ${category} / ${roundedHours}h${issueUrlSuffix(owner, repoName, issue.number)}`,
+  )
+
+  // Surface the opened PR at the end of the run. The GitHub Pulls API returns html_url only on
+  // success; if it is absent (e.g. a PR already exists for the branch, or creation failed), fall
+  // back to a clear message rather than printing "undefined".
+  console.info(
+    pr.html_url
+      ? `Opened PR to add the corrected sample: ${pr.html_url}`
+      : 'No PR URL was returned; the PR may already exist or creation failed.',
   )
 }
 


### PR DESCRIPTION
## Problem

The `/estimate Nh` command (`scripts/estimate/src/command.ts` → `applyCorrection`) opens a PR that adds the corrected training sample, but the Pulls API `fetch` response was discarded. The created PR was never surfaced — the only final output was the correction line:

```
Manual correction applied for issue #1198 @ L / 16h - https://github.com/cybersemics/em/issues/1198
```

## Change

- Capture the Pulls API `fetch` response instead of discarding it.
- Parse `html_url` from the response and `console.info` it as the final line of the run.
- Guard the missing-`html_url` case (e.g. a PR already exists for the branch, or creation failed) with a clear fallback message rather than printing `undefined`.

Output now ends with, e.g.:

```
Opened PR to add the corrected sample: https://github.com/cybersemics/em/pull/1234
```

## Notes

- Console output only (per request) — no change to the GitHub confirmation comment.
- The full `html_url` is emitted directly (auto-links in GitHub Actions logs, clickable/visible locally), so no dedicated OSC-8 link helper was added.
- No new unit test: existing `command.ts` tests cover only the pure helpers; `applyCorrection` is network-heavy and untested. Verified `tsc --noEmit`, prettier, and the existing command tests pass.