### PR TITLE
Call setCursor onTouchEnd when moving between thoughts

### DIFF
--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -24,6 +24,16 @@ let lastTouchEndTime = 0
 let lastTouchEndTarget: EventTarget | null = null
 const GHOST_MOUSE_WINDOW_MS = 700
 
+/**
+ * Returns true if the last real touchend recently (within GHOST_MOUSE_WINDOW_MS) landed on a DIFFERENT
+ * editable than `editable` — the shared signature of iOS's rapid-tap retargeting (#4173). Reads the last
+ * recorded touchend from module state.
+ */
+const isRetargetedTap = (editable: EventTarget): boolean =>
+  !!lastTouchEndTarget &&
+  lastTouchEndTarget !== editable &&
+  performance.now() - lastTouchEndTime < GHOST_MOUSE_WINDOW_MS
+
 /** Automatically sets the selection on the given contentRef element when the thought should be selected. Handles a variety of conditions that determine whether this should occur. */
 const useEditMode = ({
   contentRef,
@@ -160,6 +170,8 @@ const useEditMode = ({
     /** Ends the touch, records it for ghost-click detection, and sets the cursor on the tapped thought. */
     const onTouchEnd = (e: TouchEvent) => {
       pressingRef.current = false
+      // Evaluate against the PREVIOUS touchend before overwriting it below.
+      const willRetarget = isRetargetedTap(editable)
       lastTouchEndTime = performance.now()
       lastTouchEndTarget = editable
 
@@ -167,12 +179,13 @@ const useEditMode = ({
       // retargets the synthesized mousedown/focus to the previously-focused thought (onMouseDown suppresses
       // that ghost), so onFocus cannot be relied on to move the cursor. Set the cursor here, reading fresh
       // store state (not the render closure) to avoid staleness across rapid taps.
-      const s = store.getState()
+      const state = store.getState()
       const move =
-        s.isKeyboardOpen &&
-        !equalPath(s.cursor, path) &&
-        !hasMulticursor(s) &&
-        s.longPress === LongPressState.Inactive &&
+        willRetarget &&
+        state.isKeyboardOpen &&
+        !equalPath(state.cursor, path) &&
+        !hasMulticursor(state) &&
+        state.longPress === LongPressState.Inactive &&
         style?.visibility !== 'hidden'
       if (!move) return
 
@@ -220,12 +233,7 @@ const useEditMode = ({
       // second tap already moved focus. A genuine mousedown follows its own touchend within a few ms on the
       // same element; a ghost arrives later on a different thought. Dropping it (preventDefault also blocks
       // the focus change) keeps the cursor on the thought the user actually tapped.
-      if (
-        isTouch &&
-        isSafari() &&
-        editable !== lastTouchEndTarget &&
-        performance.now() - lastTouchEndTime < GHOST_MOUSE_WINDOW_MS
-      ) {
+      if (isTouch && isSafari() && isRetargetedTap(editable)) {
         e.preventDefault()
         return
       }

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -14,6 +14,16 @@ import usePrevious from '../../hooks/usePrevious'
 import hasMulticursor from '../../selectors/hasMulticursor'
 import equalPath from '../../util/equalPath'
 
+// #4173: Ghost-click suppression state. On a rapid tap between adjacent thoughts, iOS Safari coalesces the
+// two taps into a double-tap and emits a delayed, retargeted synthesized mousedown/click/dblclick on the
+// previously-focused thought ~50-250ms after the second tap's touchend. That delayed mousedown would drive
+// onMouseDown -> setCursor and yank the cursor back. We record the last real touchend (time + element); a
+// genuine mousedown follows its own touchend within a few ms on the same element, whereas the ghost arrives
+// later on a different thought, so it can be detected and dropped.
+let lastTouchEndTime = 0
+let lastTouchEndTarget: EventTarget | null = null
+const GHOST_MOUSE_WINDOW_MS = 700
+
 /** Automatically sets the selection on the given contentRef element when the thought should be selected. Handles a variety of conditions that determine whether this should occur. */
 const useEditMode = ({
   contentRef,
@@ -147,42 +157,38 @@ const useEditMode = ({
     /** Marks the beginning of a touch so that onMouseDown can determine whether a long press is occurring. */
     const onTouchStart = () => (pressingRef.current = true)
 
-    /** Marks the end of a touch, indicating to onMouseDown that a long press is not occurring. */
-    const onTouchEnd = (e: TouchEvent) => {
+    /** Ends the touch, records it for ghost-click detection, and sets the cursor on the tapped thought. */
+    const onTouchEnd = () => {
       pressingRef.current = false
-      console.log('onTouchEnd', Date.now(), e)
-      /**
-       * Backstops #4173: on iOS Safari a rapid tap on an adjacent thought is absorbed by WebKit's
-       * touch-adjustment, which retargets the synthesized mousedown/focus to the already-focused thought — so
-       * onMouseDown never fires on the tapped thought and the caret stays put (tapping a distant thought works
-       * because it falls outside the adjustment radius). touchend is the only event that reliably fires on the
-       * tapped thought, so mirror onMouseDown here: place the caret at the tap point on the newly tapped
-       * (non-cursor) thought while the keyboard is open. Repositioning within the cursor thought is left to
-       * onMouseDown, which fires reliably because that thought is already focused.
-       */
-      if (
-        !editing ||
-        isCursor ||
-        isMulticursor ||
-        // globals.touching ||
-        style?.visibility === 'hidden' ||
-        store.getState().longPress !== LongPressState.Inactive
+      lastTouchEndTime = performance.now()
+      lastTouchEndTarget = editable
+
+      // #4173: touchend is the only event iOS reliably delivers to the tapped thought — on a rapid tap it
+      // retargets the synthesized mousedown/focus to the previously-focused thought (onMouseDown suppresses
+      // that ghost), so onFocus cannot be relied on to move the cursor. Set the cursor here, reading fresh
+      // store state (not the render closure) to avoid staleness across rapid taps.
+      const s = store.getState()
+      const move =
+        s.isKeyboardOpen &&
+        !equalPath(s.cursor, path) &&
+        !hasMulticursor(s) &&
+        s.longPress === LongPressState.Inactive &&
+        style?.visibility !== 'hidden'
+      if (!move) return
+
+      // Dispatch only the Redux cursor; the declarative selection effect places the caret on the next render.
+      // Calling selection.set() synchronously during touchend triggers iOS's text-selection machinery, which
+      // swallows the immediately-following rapid tap. Placing the caret at the end of the thought gives the
+      // effect a non-null cursorOffset so it sets the selection.
+      dispatch(
+        setCursor({
+          path,
+          offset: editable.textContent?.length ?? 0,
+          cursorHistoryClear: true,
+          isKeyboardOpen: true,
+          preserveMulticursor: true,
+        }),
       )
-        return
-
-      // Suppress the synthesized mouse/focus events, which iOS retargets to the previously-focused thought
-      // and which would otherwise move the cursor back to it.
-      if (e.cancelable) e.preventDefault()
-
-      // Place the caret where the user tapped. getCaretOffset is coordinate-based, so it resolves the offset
-      // even though focus has not (and will not) move via the retargeted events. Fall back to the end of the
-      // thought if the tap is in a void area or the coordinates are unavailable.
-      const { offset } = getCaretOffset(editable, {
-        clientX: e.changedTouches[0].clientX,
-        clientY: e.changedTouches[0].clientY,
-      })
-
-      setCaretOffset(offset ?? editable.textContent?.length ?? 0, { cursorHistoryClear: true })
     }
 
     /**
@@ -202,6 +208,21 @@ const useEditMode = ({
       // If the press is ongoing (touchend has not been dispatched) then a long press is ongoing and setCaretOffset will interfere
       // with default iOS Safari drag-and-drop text selection.
       if (pressingRef.current) return
+
+      // #4173: Suppress WebKit's delayed retargeted ghost mouse events. On a rapid tap between adjacent
+      // thoughts, iOS emits a delayed mousedown/click/dblclick on the previously-focused thought after the
+      // second tap already moved focus. A genuine mousedown follows its own touchend within a few ms on the
+      // same element; a ghost arrives later on a different thought. Dropping it (preventDefault also blocks
+      // the focus change) keeps the cursor on the thought the user actually tapped.
+      if (
+        isTouch &&
+        isSafari() &&
+        editable !== lastTouchEndTarget &&
+        performance.now() - lastTouchEndTime < GHOST_MOUSE_WINDOW_MS
+      ) {
+        e.preventDefault()
+        return
+      }
 
       // If editing or the cursor is on the thought, allow the default browser selection or perform manual caret positioning so the offset is correct.
       // See: #981
@@ -272,6 +293,7 @@ const useEditMode = ({
     path,
     dispatch,
     store,
+    style?.visibility,
   ])
 
   // Resume focus if sidebar was just closed and isEditing is true.

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -139,16 +139,51 @@ const useEditMode = ({
     if (!editable) return
 
     /** Sets the DOM selection and updates the Redux cursor state. */
-    const setCaretOffset = (offset: number) => {
+    const setCaretOffset = (offset: number, { cursorHistoryClear }: { cursorHistoryClear?: boolean } = {}) => {
       selection.set(editable, { offset })
-      dispatch(setCursor({ path, offset }))
+      dispatch(setCursor({ path, offset, cursorHistoryClear }))
     }
 
     /** Marks the beginning of a touch so that onMouseDown can determine whether a long press is occurring. */
     const onTouchStart = () => (pressingRef.current = true)
 
     /** Marks the end of a touch, indicating to onMouseDown that a long press is not occurring. */
-    const onTouchEnd = () => (pressingRef.current = false)
+    const onTouchEnd = (e: TouchEvent) => {
+      pressingRef.current = false
+      console.log('onTouchEnd', Date.now(), e)
+      /**
+       * Backstops #4173: on iOS Safari a rapid tap on an adjacent thought is absorbed by WebKit's
+       * touch-adjustment, which retargets the synthesized mousedown/focus to the already-focused thought — so
+       * onMouseDown never fires on the tapped thought and the caret stays put (tapping a distant thought works
+       * because it falls outside the adjustment radius). touchend is the only event that reliably fires on the
+       * tapped thought, so mirror onMouseDown here: place the caret at the tap point on the newly tapped
+       * (non-cursor) thought while the keyboard is open. Repositioning within the cursor thought is left to
+       * onMouseDown, which fires reliably because that thought is already focused.
+       */
+      if (
+        !editing ||
+        isCursor ||
+        isMulticursor ||
+        // globals.touching ||
+        style?.visibility === 'hidden' ||
+        store.getState().longPress !== LongPressState.Inactive
+      )
+        return
+
+      // Suppress the synthesized mouse/focus events, which iOS retargets to the previously-focused thought
+      // and which would otherwise move the cursor back to it.
+      if (e.cancelable) e.preventDefault()
+
+      // Place the caret where the user tapped. getCaretOffset is coordinate-based, so it resolves the offset
+      // even though focus has not (and will not) move via the retargeted events. Fall back to the end of the
+      // thought if the tap is in a void area or the coordinates are unavailable.
+      const { offset } = getCaretOffset(editable, {
+        clientX: e.changedTouches[0].clientX,
+        clientY: e.changedTouches[0].clientY,
+      })
+
+      setCaretOffset(offset ?? editable.textContent?.length ?? 0, { cursorHistoryClear: true })
+    }
 
     /**
      * Handles the mousedown event for the editable element.
@@ -226,7 +261,18 @@ const useEditMode = ({
         editable.removeEventListener('focus', onFocus)
       }
     }
-  }, [contentRef, editingOrOnCursor, isCursor, isMulticursor, fontSize, allowDefaultSelection, path, dispatch])
+  }, [
+    contentRef,
+    editing,
+    editingOrOnCursor,
+    isCursor,
+    isMulticursor,
+    fontSize,
+    allowDefaultSelection,
+    path,
+    dispatch,
+    store,
+  ])
 
   // Resume focus if sidebar was just closed and isEditing is true.
   // Disable focus restoration on mobile until the hamburger menu & sidebar backdrop can be made to

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -176,8 +176,7 @@ const useEditMode = ({
         style?.visibility !== 'hidden'
       if (!move) return
 
-      // Place the caret where the user tapped (fall back to the end of the thought if the tap is in a void
-      // area or coordinates are unavailable). getCaretOffset is coordinate-based, so it resolves the offset
+      // Place the caret where the user tapped. getCaretOffset is coordinate-based, so it resolves the offset
       // even though the synthesized mousedown/focus retargeted away.
       const { offset } = getCaretOffset(editable, {
         clientX: e.changedTouches[0].clientX,

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -177,37 +177,38 @@ const useEditMode = ({
 
       // #4173: touchend is the only event iOS reliably delivers to the tapped thought — on a rapid tap it
       // retargets the synthesized mousedown/focus to the previously-focused thought (onMouseDown suppresses
-      // that ghost), so onFocus cannot be relied on to move the cursor. Set the cursor here, reading fresh
-      // store state (not the render closure) to avoid staleness across rapid taps.
-      const state = store.getState()
-      const move =
-        willRetarget &&
-        state.isKeyboardOpen &&
-        !equalPath(state.cursor, path) &&
-        !hasMulticursor(state) &&
-        state.longPress === LongPressState.Inactive &&
-        style?.visibility !== 'hidden'
-      if (!move) return
+      // that ghost), so onFocus cannot be relied on to move the cursor. Set the cursor here.
+      dispatch((dispatch, getState) => {
+        const state = getState()
+        const move =
+          willRetarget &&
+          state.isKeyboardOpen &&
+          !equalPath(state.cursor, path) &&
+          !hasMulticursor(state) &&
+          state.longPress === LongPressState.Inactive &&
+          style?.visibility !== 'hidden'
+        if (!move) return
 
-      // Place the caret where the user tapped. getCaretOffset is coordinate-based, so it resolves the offset
-      // even though the synthesized mousedown/focus retargeted away.
-      const { offset } = getCaretOffset(editable, {
-        clientX: e.changedTouches[0].clientX,
-        clientY: e.changedTouches[0].clientY,
+        // Place the caret where the user tapped. getCaretOffset is coordinate-based, so it resolves the offset
+        // even though the synthesized mousedown/focus retargeted away.
+        const { offset } = getCaretOffset(editable, {
+          clientX: e.changedTouches[0].clientX,
+          clientY: e.changedTouches[0].clientY,
+        })
+
+        // Dispatch only the Redux cursor; the declarative selection effect places the caret on the next render.
+        // Calling selection.set() synchronously during touchend triggers iOS's text-selection machinery, which
+        // swallows the immediately-following rapid tap.
+        dispatch(
+          setCursor({
+            path,
+            offset,
+            cursorHistoryClear: true,
+            isKeyboardOpen: true,
+            preserveMulticursor: true,
+          }),
+        )
       })
-
-      // Dispatch only the Redux cursor; the declarative selection effect places the caret on the next render.
-      // Calling selection.set() synchronously during touchend triggers iOS's text-selection machinery, which
-      // swallows the immediately-following rapid tap.
-      dispatch(
-        setCursor({
-          path,
-          offset,
-          cursorHistoryClear: true,
-          isKeyboardOpen: true,
-          preserveMulticursor: true,
-        }),
-      )
     }
 
     /**
@@ -306,7 +307,6 @@ const useEditMode = ({
     allowDefaultSelection,
     path,
     dispatch,
-    store,
     style?.visibility,
   ])
 

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -158,7 +158,7 @@ const useEditMode = ({
     const onTouchStart = () => (pressingRef.current = true)
 
     /** Ends the touch, records it for ghost-click detection, and sets the cursor on the tapped thought. */
-    const onTouchEnd = () => {
+    const onTouchEnd = (e: TouchEvent) => {
       pressingRef.current = false
       lastTouchEndTime = performance.now()
       lastTouchEndTarget = editable
@@ -176,14 +176,21 @@ const useEditMode = ({
         style?.visibility !== 'hidden'
       if (!move) return
 
+      // Place the caret where the user tapped (fall back to the end of the thought if the tap is in a void
+      // area or coordinates are unavailable). getCaretOffset is coordinate-based, so it resolves the offset
+      // even though the synthesized mousedown/focus retargeted away.
+      const { offset } = getCaretOffset(editable, {
+        clientX: e.changedTouches[0].clientX,
+        clientY: e.changedTouches[0].clientY,
+      })
+
       // Dispatch only the Redux cursor; the declarative selection effect places the caret on the next render.
       // Calling selection.set() synchronously during touchend triggers iOS's text-selection machinery, which
-      // swallows the immediately-following rapid tap. Placing the caret at the end of the thought gives the
-      // effect a non-null cursorOffset so it sets the selection.
+      // swallows the immediately-following rapid tap.
       dispatch(
         setCursor({
           path,
-          offset: editable.textContent?.length ?? 0,
+          offset,
           cursorHistoryClear: true,
           isKeyboardOpen: true,
           preserveMulticursor: true,


### PR DESCRIPTION
Fixes #4173

Rapid taps between thoughts trigger the same type of focus-retargeting on iOS Safari that was implicated in #4291 and #4394. The mouse events arrive on the wrong element, so all of the cursor-management logic sets focus on the wrong element. The only events that arrive on the correct editable are touch events, so it is necessary to manage the cursor from there.

It is also necessary to detect and block mouse events that land on the wrong editable. This is accomplished by storing the last element to receive a touch event, and then calling `preventDefault` in `onMouseDown` in order to stop focus on the re-targeted editable.

## Complication

It was necessary to avoid calling `selection.set` inside `onTouchEnd`, as that would swallow subsequent rapid taps entirely. This moves us a bit closer to the future imagined in #4470.

## Lack of test coverage

Copilot was unable to reproduce the bug in BrowserStack. Efforts are documented in https://github.com/cybersemics/em/pull/4538. The taps were confirmed to be landing in the correct places, but latency between taps was pretty high, above 750ms. When I instrumented the iPhone and reproduced the bug manually, taps were closer to 250ms apart.

Copilot was able to get the taps closer together by combining them in a single `performActions` call, but it didn't help to reproduce the bug.

## Further thoughts

1. I gated the `onTouchEnd` event so that it would only fire when a tap fit the profile for being re-targeted. I'm not sure that changed the behavior, but it felt safer and it eliminates duplicate calls to `setCursor` in some cases.

2. This logic is only invoked when [state.isKeyboardOpen](https://github.com/ethan-james/em/blob/f2e5957d56d4dd6e9664a3abe7e4880415607c6b/src/components/Editable/useEditMode.ts#L185) is true, plus it benefits from being able to call `getCaretOffset` to correctly set the caret offset. For those reasons, I wanted it inside of `useEditMode` even though there are some duplicate checks in `handleTapBehavior` in `Editable`.

This does mean that there are `touchend` handlers in `useEditMode` as well as in `Editable`, and both of them will run and both can call `preventDefault`. This is perhaps not ideal.

3. The module-level variables [lastTouchEndTime and lastTouchEndTarget](https://github.com/ethan-james/em/blob/f2e5957d56d4dd6e9664a3abe7e4880415607c6b/src/components/Editable/useEditMode.ts#L23) are necessary to allow `onMouseDown` to short-circuit when the re-targeted mouse event hits the wrong editable. It may be a better idea to migrate in the direction of handling all caret-setting behavior in `onTouchEnd` on iOS, although it would still be necessary to gate `mousedown` in order to prevent re-targeted focus pulling the caret back to the wrong thought.