### PR TITLE
fix(estimate): drop rocket reaction and followup comment on /estimate

### DIFF
--- a/scripts/estimate/src/command.ts
+++ b/scripts/estimate/src/command.ts
@@ -86,7 +86,9 @@ const main = async () => {
 
   try {
     await applyCorrection(githubToken, everhourApiKey, everhourProjectId, owner, repoName, comment, issue, hours)
-    await postReaction(githubToken, owner, repoName, comment.id, 'rocket')
+    // Mirror Copilot's status signal: swap the 👀 acknowledgment (added by the workflow) for 👍 on success.
+    await removeEyesReaction(githubToken, owner, repoName, comment.id)
+    await postReaction(githubToken, owner, repoName, comment.id, '+1')
   } catch (err) {
     await postReaction(githubToken, owner, repoName, comment.id, '-1')
     throw err
@@ -201,15 +203,6 @@ const applyCorrection = async (
     }),
   })
 
-  // Confirm via comment
-  await postComment(
-    githubToken,
-    owner,
-    repoName,
-    issue.number,
-    `Estimate updated: ${category} / ${roundedHours}h\nA PR has been opened to add the corrected sample.`,
-  )
-
   console.info(
     `Manual correction applied for issue ${issueLink(owner, repoName, issue.number)} @ ${category} / ${roundedHours}h${issueUrlSuffix(owner, repoName, issue.number)}`,
   )
@@ -224,14 +217,8 @@ const postComment = async (token: string, owner: string, repo: string, issueNumb
   })
 }
 
-/** Adds an emoji reaction to an issue comment to signal command status (e.g. 'rocket' on success, '-1' on failure). */
-const postReaction = async (
-  token: string,
-  owner: string,
-  repo: string,
-  commentId: number,
-  content: 'rocket' | '+1' | '-1' | 'eyes',
-) => {
+/** Adds an emoji reaction to an issue comment to signal command status (e.g. '+1' on success, '-1' on failure). */
+const postReaction = async (token: string, owner: string, repo: string, commentId: number, content: '+1' | '-1') => {
   await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}/reactions`, {
     method: 'POST',
     headers: {
@@ -240,6 +227,36 @@ const postReaction = async (
       Accept: 'application/vnd.github+json',
     },
     body: JSON.stringify({ content }),
+  })
+}
+
+/**
+ * Removes the 👀 acknowledgment reaction added by the workflow's github-actions[bot] on success, so the
+ * comment ends up with only 👍. Best-effort: the Everhour update is already applied, so a failure here
+ * must not throw. Filtered to github-actions[bot] to avoid removing a human's 👀 reaction.
+ */
+const removeEyesReaction = async (token: string, owner: string, repo: string, commentId: number) => {
+  const listResp = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}/reactions?content=eyes`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    },
+  )
+  if (!listResp.ok) return
+
+  const reactions = (await listResp.json()) as Array<{ id: number; user: { login: string } | null }>
+  const eyes = reactions.find(reaction => reaction.user?.login === 'github-actions[bot]')
+  if (!eyes) return
+
+  await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}/reactions/${eyes.id}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+    },
   })
 }
 


### PR DESCRIPTION
## Summary

Tweaks the `/estimate Nh` command's success signal to mirror how Copilot itself signals status, and removes redundant noise:

- **Reaction:** on success, remove the 👀 eyes acknowledgment (added by the workflow) and add 👍 (`+1`) instead of adding 🚀. GitHub's reaction API has no check-mark, and 👍 is exactly what Copilot uses for "done."
- **Comment:** drop the "Estimate updated: … / A PR has been opened…" followup comment. The Everhour update and sample PR are already visible in the issue feed.

Genuine error comments (untrusted commenter, Everhour task-not-found) are left untouched.

## Changes

- `scripts/estimate/src/command.ts`
  - Replace the success `postReaction('rocket')` with `removeEyesReaction` + `postReaction('+1')`.
  - Delete the success followup `postComment` in `applyCorrection`.
  - Add a best-effort `removeEyesReaction` helper (lists reactions, filters to `github-actions[bot]`'s 👀, deletes it) so a human's 👀 is never removed and a failure never throws over the already-applied Everhour update.
  - Tighten the `postReaction` content union to `'+1' | '-1'`.

No workflow change — the 👀 acknowledgment still fires immediately from the Acknowledge step before the slow build.

## Testing

- `yarn workspace em-estimate typecheck` — passes
- `yarn vitest run scripts/estimate/src/__tests__/command.ts` — 9 passing (pure-function coverage; no changes needed)