### PR TITLE
ci: skip Puppeteer & BrowserStack for instructions-only PRs

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,10 +32,44 @@ env:
   VITE_BROWSER_CONSOLE_CAPTURE: 1
 
 jobs:
+  # Cheap gate that decides whether the expensive BrowserStack job should run.
+  # It outputs run=true unless a PR touches nothing but .github/instructions/**.
+  # Keeping the trigger unchanged (rather than using paths-ignore) is required because
+  # BrowserStack is a required status check: a workflow that never runs would leave the check
+  # unreported and block the PR. A job skipped via `if` still reports its required check as
+  # passing, so instructions-only PRs stay mergeable.
+  #
+  # The plain checkout (used only so paths-filter can diff push events) resolves to the base
+  # repo commit under pull_request_target, not the PR's fork head, so no untrusted code runs in
+  # this privileged context. The token is scoped to pull-requests: read.
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          # run is true when at least one changed file is outside .github/instructions/.
+          filters: |
+            run:
+              - '!.github/instructions/**'
+
   run:
     name: BrowserStack
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.changed_files > 0
+    needs: changes
+    # Only pull requests are gated on the changed-file filter; pushes to main and manual
+    # workflow_dispatch runs always execute.
+    if: github.event_name != 'pull_request_target' || needs.changes.outputs.run == 'true'
 
     steps:
       - name: Clone repository

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -19,10 +19,40 @@ env:
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
 
 jobs:
+  # Cheap gate that decides whether the expensive Puppeteer job should run.
+  # It outputs run=true unless a PR touches nothing but .github/instructions/**.
+  # Keeping the trigger unchanged (rather than using paths-ignore) is required because
+  # Puppeteer is a required status check: a workflow that never runs would leave the check
+  # unreported and block the PR. A job skipped via `if` still reports its required check as
+  # passing, so instructions-only PRs stay mergeable.
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          # run is true when at least one changed file is outside .github/instructions/.
+          filters: |
+            run:
+              - '!.github/instructions/**'
+
   run:
     name: Puppeteer
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.changed_files > 0
+    needs: changes
+    # Only pull requests are gated on the changed-file filter; pushes to main and manual
+    # workflow_dispatch runs always execute.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.run == 'true'
     services:
       browserless:
         image: browserless/chrome:latest


### PR DESCRIPTION
## Summary

Skip the expensive **Puppeteer** and **BrowserStack** CI jobs when a PR changes nothing but `.github/instructions/**/*`.

## Why not `paths-ignore`

`Puppeteer` and `BrowserStack` are **required status checks** on `main`. A `paths-ignore` trigger filter would prevent the workflow from running, leaving the required check unreported — which **blocks the PR forever**. So the trigger is left unchanged and the heavy job is skipped via a job-level `if` instead. A job skipped through `if` still reports its required-check context as **passing**, keeping instructions-only PRs mergeable (same principle as the existing `changed_files > 0` guard this replaces).

## How

Each workflow gains a cheap `Changes` gate job using `dorny/paths-filter@v3`:

- Filter `'!.github/instructions/**'` → output `run == 'true'` when at least one changed file is **outside** `.github/instructions/`; instructions-only (or empty) change sets yield `false`.
- The heavy job gains `needs: changes` + `if: <event guard> || needs.changes.outputs.run == 'true'`.
- **Non-PR events** (push to `main`, `workflow_dispatch`) always run — only PRs are gated.

### Notes on `ios.yml` (`pull_request_target`)

- The gate job is scoped to `pull-requests: read` and does **not** check out the PR's fork head (the plain checkout resolves to the trusted base commit under `pull_request_target`), so no untrusted code runs in the privileged context.

## Testing

- YAML validated; `actionlint` clean on the added gate jobs (the two remaining `actionlint` notes — `queue: max` and an SC2086 in the serve script — are pre-existing and unrelated).
- Files verified prettier-clean.