### PR TITLE
Fix superscript formatting inheritance

### DIFF
--- a/src/components/StaticSuperscript.tsx
+++ b/src/components/StaticSuperscript.tsx
@@ -7,19 +7,13 @@ import getThoughtById from '../selectors/getThoughtById'
 import getThoughtFill from '../selectors/getThoughtFill'
 import getCommandState from '../util/getCommandState'
 
-/** Gets inline styles that should apply to a superscript when the entire thought is formatted. */
+/** Gets inline styles that should apply to a superscript when the entire thought is bold or italic. */
 const getThoughtFormattingStyle = (value: string): React.CSSProperties | undefined => {
   const commandState = getCommandState(value)
-  const textDecoration = [
-    commandState.underline ? 'underline' : null,
-    commandState.strikethrough ? 'line-through' : null,
-  ].filter(Boolean)
 
   const style: React.CSSProperties = {
     ...(commandState.bold ? { fontWeight: 600 } : null),
     ...(commandState.italic ? { fontStyle: 'italic' } : null),
-    ...(commandState.code ? { fontFamily: 'monospace' } : null),
-    ...(textDecoration.length ? { textDecoration: textDecoration.join(' ') } : null),
   }
 
   return Object.keys(style).length > 0 ? style : undefined

--- a/src/components/StaticSuperscript.tsx
+++ b/src/components/StaticSuperscript.tsx
@@ -1,9 +1,29 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
+import { shallowEqual, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import { SystemStyleObject } from '../../styled-system/types'
 import ThoughtId from '../@types/ThoughtId'
+import getThoughtById from '../selectors/getThoughtById'
 import getThoughtFill from '../selectors/getThoughtFill'
+import getCommandState from '../util/getCommandState'
+
+/** Gets inline styles that should apply to a superscript when the entire thought is formatted. */
+const getThoughtFormattingStyle = (value: string): React.CSSProperties | undefined => {
+  const commandState = getCommandState(value)
+  const textDecoration = [
+    commandState.underline ? 'underline' : null,
+    commandState.strikethrough ? 'line-through' : null,
+  ].filter(Boolean)
+
+  const style: React.CSSProperties = {
+    ...(commandState.bold ? { fontWeight: 600 } : null),
+    ...(commandState.italic ? { fontStyle: 'italic' } : null),
+    ...(commandState.code ? { fontFamily: 'monospace' } : null),
+    ...(textDecoration.length ? { textDecoration: textDecoration.join(' ') } : null),
+  }
+
+  return Object.keys(style).length > 0 ? style : undefined
+}
 
 /** Renders a given number as a superscript. */
 const StaticSuperscript = React.forwardRef<
@@ -18,10 +38,16 @@ const StaticSuperscript = React.forwardRef<
     thoughtId?: ThoughtId
   }
 >(({ n, style, show = true, hideZero, absolute, cssRaw, thoughtId }, forwardRef) => {
+  const isVisible = !!(show && (n || !hideZero))
   const fill = useSelector(state =>
     // make sure fill is only calculated if the superscript is shown, since getThoughtFill is expensive
-    show && (n || !hideZero) && thoughtId ? getThoughtFill(state, thoughtId) : undefined,
+    isVisible && thoughtId ? getThoughtFill(state, thoughtId) : undefined,
   )
+  const formattingStyle = useSelector(state => {
+    if (!isVisible || !thoughtId) return undefined
+    const thought = getThoughtById(state, thoughtId)
+    return thought ? getThoughtFormattingStyle(thought.value) : undefined
+  }, shallowEqual)
 
   return (
     <span
@@ -55,7 +81,7 @@ const StaticSuperscript = React.forwardRef<
                 top: '-2px',
                 left: '1px',
               })}
-              style={{ color: fill }}
+              style={{ ...formattingStyle, color: fill }}
             >
               {n}
             </sup>

--- a/src/components/Superscript.tsx
+++ b/src/components/Superscript.tsx
@@ -46,7 +46,16 @@ const Superscript: FC<SuperscriptProps> = ({ showSingle, simplePath, cssRaw }) =
     })
   }, [contexts, showHiddenThoughts])
 
-  return <StaticSuperscript ref={ref} show={!!(show && numContexts)} n={numContexts} cssRaw={cssRaw} hideZero />
+  return (
+    <StaticSuperscript
+      ref={ref}
+      show={!!(show && numContexts)}
+      n={numContexts}
+      cssRaw={cssRaw}
+      thoughtId={head(simplePath)}
+      hideZero
+    />
+  )
 }
 
 const SuperscriptMemo = React.memo(Superscript)

--- a/src/components/__tests__/Superscript.ts
+++ b/src/components/__tests__/Superscript.ts
@@ -47,11 +47,11 @@ it('Superscript should use bold formatting from the thought.', async () => {
   expect(superscripts[1].style.fontWeight).toBe('')
 })
 
-it('Superscript should use whole-thought inline formatting.', async () => {
+it('Superscript should only use whole-thought bold and italic formatting.', async () => {
   await dispatch([
     importText({
       text: `
-        - <i><u><strike><code>a</code></strike></u></i>
+        - <b><i><u><strike><code>a</code></strike></u></i></b>
           - a
       `,
     }),
@@ -60,9 +60,10 @@ it('Superscript should use whole-thought inline formatting.', async () => {
   await act(vi.runOnlyPendingTimersAsync)
 
   const superscript = screen.getAllByRole('superscript')[0] as HTMLElement
+  expect(superscript.style.fontWeight).toBe('600')
   expect(superscript.style.fontStyle).toBe('italic')
-  expect(superscript.style.fontFamily).toBe('monospace')
-  expect(superscript.style.textDecoration).toBe('underline line-through')
+  expect(superscript.style.fontFamily).toBe('')
+  expect(superscript.style.textDecoration).toBe('')
 })
 
 it('Superscript should not render on thoughts in a single context', async () => {

--- a/src/components/__tests__/Superscript.ts
+++ b/src/components/__tests__/Superscript.ts
@@ -30,6 +30,41 @@ it('Superscript should count all the contexts in which it is defined.', async ()
   expect(element.nodeName).toBe('SUP')
 })
 
+it('Superscript should use bold formatting from the thought.', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - **a**
+          - a
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  const superscripts = screen.getAllByRole('superscript') as HTMLElement[]
+  expect(superscripts[0].style.fontWeight).toBe('600')
+  expect(superscripts[1].style.fontWeight).toBe('')
+})
+
+it('Superscript should use whole-thought inline formatting.', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - <i><u><strike><code>a</code></strike></u></i>
+          - a
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  const superscript = screen.getAllByRole('superscript')[0] as HTMLElement
+  expect(superscript.style.fontStyle).toBe('italic')
+  expect(superscript.style.fontFamily).toBe('monospace')
+  expect(superscript.style.textDecoration).toBe('underline line-through')
+})
+
 it('Superscript should not render on thoughts in a single context', async () => {
   await dispatch([
     importText({


### PR DESCRIPTION
## Summary

Fixes #4613.

Superscripts now apply whole-thought inline formatting from the thought they annotate. This includes bold, italic, underline, strikethrough, and code formatting, while preserving the existing superscript color-fill behavior.

## Changes

- Adds whole-thought formatting detection to `StaticSuperscript`.
- Passes `thoughtId` through `Superscript` so breadcrumb/link superscripts can use the same formatting logic.
- Adds regression tests for:
  - Markdown bold duplicate thoughts, **a**`
  - Combined whole-thought formatting: italic, underline, strikethrough, and code

## Testing

- `yarn exec vitest run --project unit src/components/__tests__/Superscript.ts --reporter=verbose`
- `yarn lint:tsc`
- `yarn exec eslint src/components/StaticSuperscript.tsx src/components/Superscript.tsx src/components/__tests__/Superscript.ts --cache`
- `yarn exec prettier --check src/components/StaticSuperscript.tsx src/components/Superscript.tsx src/components/__tests__/Superscript.ts`