### PR TITLE
chore: use named Cloudflare tunnel for BrowserStack CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,6 +15,8 @@ on:
 # Serialize BrowserStack runs repo-wide. Every run draws from the same shared parallel-session pool, so
 # overlapping runs (a main push + PR syncs + reruns) can over-subscribe it and fail with session-creation
 # timeouts. Allowing one active run at a time keeps total live sessions within maxInstances.
+# This also guarantees the named `copilot-browserstack` Cloudflare tunnel never has two workflow
+# connectors online simultaneously (a named tunnel must have a single active connector per run).
 # cancel-in-progress: false queues runs instead of cancelling them, so no run is dropped.
 # queue: max extends the queue from the default 1 to the maximum of 100, ensuring runs don't get silently
 # dropped if lots of jobs queue up.
@@ -86,7 +88,11 @@ jobs:
         env:
           USE_HTTPS: ${{ steps.server_mode.outputs.https }}
         run: |
-          yarn servebuild &
+          # Bind 0.0.0.0 (--host) so the app is reachable via the runner's localhost by the
+          # cloudflared connector (which the wdio config starts). Capture the PID and tee output
+          # to serve.log so the readiness loop and the cleanup step can use them.
+          yarn servebuild --host > serve.log 2>&1 &
+          echo "APP_PID=$!" >> "$GITHUB_ENV"
 
           echo "Waiting for server to be ready..."
           for i in {1..30}; do
@@ -101,7 +107,8 @@ jobs:
             fi
             echo "Attempt $i/30: status $HTTP_STATUS"
             if [ $i -eq 30 ]; then
-              echo "Server failed to respond after 30 attempts"
+              echo "Server failed to respond after 30 attempts. Server log:"
+              cat serve.log || true
               exit 1
             fi
             sleep 1
@@ -115,3 +122,27 @@ jobs:
           BROWSERSTACK_BUILD_NAME: 'CI - ${{github.run_id}}'
           BROWSERSTACK_PROJECT_NAME: 'em'
           TUNNEL_TOKEN: ${{env.TUNNEL_TOKEN}}
+          # Presence of this connector token switches the wdio config from the ephemeral quick
+          # tunnel to the named `copilot-browserstack` tunnel (public host browserstack.emthought.cc).
+          # The token is only ever read from this secret and passed to the connector's child env.
+          # Workflow concurrency (group: browserstack) serializes runs, so the named tunnel never
+          # has two connectors online at once.
+          CLOUDFLARE_TUNNEL_TOKEN: ${{secrets.CLOUDFLARE_TUNNEL_TOKEN}}
+
+      # Best-effort cleanup on the ephemeral runner: stop the manually-started app and preserve
+      # the named connector's log for diagnosis. The connector process itself is killed by the
+      # wdio config's onComplete hook.
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -n "$APP_PID" ]; then
+            kill "$APP_PID" 2>/dev/null || true
+          fi
+
+      - name: Upload cloudflared connector log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloudflared-browserstack-log
+          path: cloudflared-browserstack.log
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 local.log
+# cloudflared tunnel diagnostic logs written at runtime by the BrowserStack e2e run
+cloudflared-browserstack.log
+serve.log
 
 .pnp.*
 .yarn/*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,6 +207,28 @@ wdio documentation:
 - https://webdriver.io/docs/configurationfile
 - https://webdriver.io/docs/browserstack-service
 
+#### Cloudflare tunnel for the dev server
+
+BrowserStack's iOS Safari devices load the app over a public HTTPS URL rather than BrowserStack Local, because Safari blocks `localStorage` on self-signed certs. [`wdio.browserstack.conf.ts`](../src/e2e/iOS/config/wdio.browserstack.conf.ts) exposes the local dev server (`https://localhost:3000`) through [`cloudflared`](https://github.com/cloudflare/cloudflared) (the npm binary — no Docker) and sets `CLOUDFLARED_URL` for the test session. There are two tunnel modes, selected automatically by the presence of the `CLOUDFLARE_TUNNEL_TOKEN` env var:
+
+- **Ephemeral quick tunnel** (default — local runs and [`tdd.yml`](../.github/workflows/tdd.yml)): a random `*.trycloudflare.com` URL is created per run and torn down in `onComplete`. Requires no setup.
+- **Named tunnel** (used by [`ios.yml`](../.github/workflows/ios.yml) when `CLOUDFLARE_TUNNEL_TOKEN` is set): a stable connector for the `copilot-browserstack` Cloudflare tunnel is started, serving the fixed public hostname **`https://browserstack.emthought.cc`**. The workflow waits up to five minutes for that hostname to respond before running tests.
+
+> The dev server is served over HTTPS in CI, and Vite only enforces `server.allowedHosts`/`preview.allowedHosts` for **HTTP** servers — so the public hostname does not need to be added to any allowlist.
+
+##### One-time administrator setup for the named tunnel
+
+The named tunnel requires one-time infrastructure and dashboard configuration. This only needs to be done once (and re-run of the workflow if the first attempt times out):
+
+1. **Prerequisite — `emthought.cc` must be an active zone in the same Cloudflare account** as the `copilot-browserstack` tunnel (its nameservers delegated to Cloudflare). The tunnel's Public Hostname domain is chosen from a dropdown of account zones, so without the zone there is nothing to route to. _(If Cloudflare is not the DNS host, instead run `cloudflared tunnel route dns copilot-browserstack browserstack.emthought.cc`, or manually add a CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.)_
+2. Create the GitHub Actions repository secret **`CLOUDFLARE_TUNNEL_TOKEN`** — the tunnel-specific **connector** token from the Cloudflare dashboard (not an API token). Its presence is what switches `ios.yml` to the named tunnel.
+3. Start the **BrowserStack** workflow manually (`workflow_dispatch`).
+4. While it is running, return to the `copilot-browserstack` tunnel in the Cloudflare dashboard. **The connector — and therefore the Public Hostname / Route step — appears only after the workflow run brings a connector online.** The workflow's five-minute public-readiness loop exists precisely to give you time to complete this step on the first run.
+5. Add a **Public Hostname**: subdomain `browserstack`, domain `emthought.cc`, service `https://localhost:3000`, and enable **No TLS Verify** (the origin uses a self-signed cert). Saving it auto-creates the DNS CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.
+6. Save it before the five-minute readiness loop expires. If the run timed out, simply re-run the workflow — subsequent runs connect the already-configured hostname immediately.
+
+Because a named tunnel must have a single active connector per run, `ios.yml` uses a repo-wide `concurrency` group (`browserstack`, `cancel-in-progress: false`) so two runs never connect the same tunnel simultaneously.
+
 Related tests: [/src/e2e/iOS](../src/e2e/iOS)
 
 ## Vitest configuration

--- a/src/e2e/iOS/config/wdio.browserstack.conf.ts
+++ b/src/e2e/iOS/config/wdio.browserstack.conf.ts
@@ -20,6 +20,16 @@ if (!process.env.BROWSERSTACK_ACCESS_KEY) {
 const user = process.env.BROWSERSTACK_USERNAME
 const date = new Date().toISOString().slice(0, 10)
 
+// Fixed public hostname of the named `copilot-browserstack` Cloudflare tunnel. Unlike the
+// ephemeral quick tunnel (random *.trycloudflare.com), the named tunnel always resolves to
+// this stable URL, which an administrator binds to the tunnel via a Public Hostname ingress
+// rule + DNS CNAME (browserstack.emthought.cc -> <tunnel-uuid>.cfargotunnel.com).
+const NAMED_TUNNEL_URL = 'https://browserstack.emthought.cc'
+
+// The named connector's output is teed here so the CI workflow can upload it as a diagnostic
+// artifact when a run fails. Written to the repo root (cwd) where the workflow can find it.
+const CONNECTOR_LOG_PATH = path.resolve(process.cwd(), 'cloudflared-browserstack.log')
+
 let tunnelProcess: ChildProcess | null = null
 
 /**
@@ -106,6 +116,70 @@ async function startTunnel(): Promise<string> {
 }
 
 /**
+ * Starts the named `copilot-browserstack` Cloudflare tunnel connector and resolves once the
+ * public hostname is reachable.
+ *
+ * Unlike the ephemeral quick tunnel, the named tunnel's connector authenticates with a
+ * connector token and serves the fixed hostname NAMED_TUNNEL_URL. We reuse the same
+ * `cloudflared` npm binary (no Docker) to honor the existing architecture.
+ *
+ * The connector token is passed ONLY via the child process's TUNNEL_TOKEN env var (never as a
+ * CLI arg and never logged). It overrides the parent's TUNNEL_TOKEN (the Vite app-gate token)
+ * for the child only, so the two tokens never collide.
+ *
+ * Readiness: cloudflared dials outbound to Cloudflare's edge, and on the first CI run an
+ * administrator must finish binding the Public Hostname in the Cloudflare dashboard. We
+ * therefore poll the public URL for up to 5 minutes. Any HTTP response (including a 403 from
+ * the app gate or a 404) proves connectivity; DNS/TLS/connection failures do not.
+ */
+async function startNamedTunnel(token: string): Promise<string> {
+  // Install the cloudflared binary if not already present
+  if (!fs.existsSync(bin)) {
+    await install(bin)
+  }
+
+  const logStream = fs.createWriteStream(CONNECTOR_LOG_PATH, { flags: 'a' })
+  const proc = spawn(bin, ['tunnel', '--no-autoupdate', '--protocol', 'http2', 'run'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // Child-scoped TUNNEL_TOKEN carries the connector token; it shadows the parent's app-gate
+    // TUNNEL_TOKEN for this process only.
+    env: { ...process.env, TUNNEL_TOKEN: token },
+  })
+  tunnelProcess = proc
+  proc.stdout?.pipe(logStream)
+  proc.stderr?.pipe(logStream)
+
+  // Detect an early connector exit (e.g. an invalid token) so we fail fast instead of polling
+  // the public URL for the full timeout.
+  let exited = false
+  proc.once('exit', () => {
+    exited = true
+  })
+
+  const timeoutMs = 5 * 60 * 1000
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (exited) {
+      throw new Error(
+        `cloudflared connector exited before ${NAMED_TUNNEL_URL} became reachable; see ${CONNECTOR_LOG_PATH}`,
+      )
+    }
+    try {
+      // redirect: 'manual' so a redirect still counts as a reachable HTTP response without
+      // chasing the redirect to another host.
+      await fetch(NAMED_TUNNEL_URL, { redirect: 'manual' })
+      return NAMED_TUNNEL_URL
+    } catch {
+      // DNS/TLS/connection failure — the hostname is not routed yet. Keep waiting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 5000))
+  }
+
+  const log = fs.existsSync(CONNECTOR_LOG_PATH) ? fs.readFileSync(CONNECTOR_LOG_PATH, 'utf8') : ''
+  throw new Error(`Timed out after 5 minutes waiting for ${NAMED_TUNNEL_URL}. Connector log:\n${log}`)
+}
+
+/**
  * WDIO configuration for BrowserStack iOS testing.
  * Uses cloudflared tunnel to expose the local HTTPS dev server via a public
  * URL with a real CA-signed cert, avoiding Safari's self-signed cert restrictions.
@@ -159,9 +233,18 @@ export const config: WebdriverIO.Config = {
   onPrepare: async function () {
     // Start cloudflared tunnel if not already set (e.g. by a CI workflow step)
     if (!process.env.CLOUDFLARED_URL) {
-      const url = await startTunnel()
-      process.env.CLOUDFLARED_URL = url
-      console.info(`cloudflared tunnel: ${url}`)
+      // Named path: when CLOUDFLARE_TUNNEL_TOKEN is present (set by ios.yml), start the
+      // persistent named `copilot-browserstack` connector, which serves the fixed public
+      // hostname. Otherwise (tdd.yml / local runs) fall back to the ephemeral quick tunnel.
+      if (process.env.CLOUDFLARE_TUNNEL_TOKEN) {
+        const url = await startNamedTunnel(process.env.CLOUDFLARE_TUNNEL_TOKEN)
+        process.env.CLOUDFLARED_URL = url
+        console.info(`cloudflared named tunnel: ${url}`)
+      } else {
+        const url = await startTunnel()
+        process.env.CLOUDFLARED_URL = url
+        console.info(`cloudflared tunnel: ${url}`)
+      }
     }
 
     // Append tunnel token to the URL so the Vite token gate allows access


### PR DESCRIPTION
## Summary

Routes the BrowserStack iOS run through the persistent **`copilot-browserstack`** Cloudflare tunnel (public host `https://browserstack.emthought.cc`) instead of an ephemeral `*.trycloudflare.com` quick tunnel. Per the "prefer the current architecture" directive, this reuses the existing in-code tunnel seam (the `cloudflared` npm binary in the wdio config) rather than adding Docker + parallel workflow steps.

## Changes

- **`src/e2e/iOS/config/wdio.browserstack.conf.ts`** — `onPrepare` now branches on `CLOUDFLARE_TUNNEL_TOKEN`:
  - **Named path** (token set → `ios.yml`): starts the named connector via the same `cloudflared` binary (`tunnel --no-autoupdate --protocol http2 run`), with the connector token passed **only** through the child process's `TUNNEL_TOKEN` env (never a CLI arg, never logged). `CLOUDFLARED_URL` is the fixed hostname; the public URL is polled for up to 5 min (any HTTP response — incl. 403/404 — counts; DNS/TLS/connection failures don't). Connector output is teed to `cloudflared-browserstack.log`.
  - **Ephemeral path** (no token): unchanged quick tunnel, so `tdd.yml` and local runs keep working. `onComplete` cleanup is reused for both.
- **`.github/workflows/ios.yml`** — passes `CLOUDFLARE_TUNNEL_TOKEN` to the test step; binds the dev server to `0.0.0.0` (`--host`); prints the serve log on readiness failure; adds an `if: always()` cleanup step that stops the app and (on failure) uploads the connector log artifact; clarifies the concurrency/tunnel relationship in comments.
- **`docs/testing.md`** — documents both tunnel modes and the one-time Cloudflare admin setup, including the **`emthought.cc` zone prerequisite**, connector-first ordering, and the No-TLS-Verify `https://localhost:3000` origin.
- **`.gitignore`** — ignores the runtime `cloudflared-browserstack.log` / `serve.log`.

## Key design notes

- **No app-gate rename** — the connector token is child-scoped, so it never collides with the Vite app-gate `TUNNEL_TOKEN` in the parent process.
- **No allowlist change (req 12 satisfied):** verified in the installed Vite (7.3.1) that host validation middleware is only registered for **HTTP** servers (`config.js` lines 25597 / 35111). Since CI serves HTTPS, `allowedHosts` is not enforced, so the public hostname needs no allowlist entry.
- **Detected app port: 3000** (`servebuild` = `vite preview --port 3000`).

## Deviations from the literal spec (deliberate, per the "prefer current architecture" directive)

- npm `cloudflared` binary instead of the `cloudflare/cloudflared` Docker image (`--network host` note therefore N/A).
- wdio-managed connector instead of a workflow `docker run` step.
- HTTPS self-signed origin + No-TLS-Verify instead of `http://localhost:<port>`.

## Requires human verification / one-time admin action

- `emthought.cc` must be an **active zone in the same Cloudflare account** as the tunnel (Public Hostname dropdown / DNS CNAME route).
- Create the `CLOUDFLARE_TUNNEL_TOKEN` repo secret (connector token), run the workflow, then add the Public Hostname `browserstack.emthought.cc → https://localhost:3000` (No TLS Verify) while the 5-min readiness loop waits. Full steps in `docs/testing.md`.