### PR TITLE
fix(ci): guard Vercel Preview on changed_files

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -20,7 +20,7 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.changed_files > 0
+    if: github.event.pull_request.changed_files > 0
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
## Problem

The Vercel Preview job runs even on PRs with 0 changed files (e.g. #4621).

The job guard was:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.changed_files > 0
```

But the workflow only triggers on **`pull_request_target`**, not `pull_request`. So `github.event_name != 'pull_request'` is always `true`, the `||` short-circuits, and the `changed_files > 0` check is never evaluated. The intended "skip empty PRs" guard never took effect.

## Fix

Since this workflow only ever fires on `pull_request_target`, `github.event.pull_request` is always present, so the event-name clause is unnecessary. Simplified the condition to:

```yaml
if: github.event.pull_request.changed_files > 0
```

Now the deploy is correctly skipped when a PR has no changed files.