### PR TITLE
chore(ci): skip Puppeteer Chrome download during install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ on: workflow_dispatch
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -30,6 +30,11 @@ permissions:
   # and to run `git log` for the prompt version.
   contents: read
 
+env:
+  # Skip Puppeteer's Chrome download on install — the estimate workspace never uses a browser,
+  # saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
+
 jobs:
   backfill:
     runs-on: ubuntu-latest

--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -14,6 +14,11 @@ permissions:
   # acknowledge the correction. Since PR comments share the issues API, commenting also relies on this scope.
   issues: write
 
+env:
+  # Skip Puppeteer's Chrome download on install — the estimate workspace never uses a browser,
+  # saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
+
 jobs:
   estimate-command:
     if: startsWith(github.event.comment.body, '/estimate ')

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -10,6 +10,11 @@ permissions:
   # To read the estimation instructions and samples from .github/instructions/estimate/.
   contents: read
 
+env:
+  # Skip Puppeteer's Chrome download on install — the estimate workspace never uses a browser,
+  # saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
+
 jobs:
   estimate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -27,6 +27,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
   # Activates the console proxy (src/util/consoleProxy.ts), which we need because BrowserStack
   # can't access iOS console logs.
   VITE_BROWSER_CONSOLE_CAPTURE: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   run:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -17,6 +17,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   run:

--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -23,6 +23,9 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
+  # Skip Puppeteer's Chrome download on install — the desktop build never uses the bundled
+  # browser, saving ~20s per install across the build matrix.
+  PUPPETEER_SKIP_DOWNLOAD: true
   # Exposed at workflow level so the macOS keychain-import step can gate on its
   # presence. Empty when the signing secret is unset, in which case macOS builds
   # fall back to ad-hoc signing (see the tauri-action step below).

--- a/.github/workflows/tauri-release-prod.yml
+++ b/.github/workflows/tauri-release-prod.yml
@@ -19,6 +19,9 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
+  # Skip Puppeteer's Chrome download on install — the desktop build never uses the bundled
+  # browser, saving ~20s per install across the build matrix.
+  PUPPETEER_SKIP_DOWNLOAD: true
   # Exposed at workflow level so the macOS keychain-import step can gate on its
   # presence. Empty when the signing secret is unset, in which case macOS builds
   # fall back to ad-hoc signing (see the tauri-action step below).

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -17,6 +17,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
+  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   run:

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -9,6 +9,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
+  # Skip Puppeteer's Chrome download on install — this job never uses the bundled browser,
+  # saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   update-browserslist:

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -15,6 +15,9 @@ env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  # Skip Puppeteer's Chrome download on install — the Vercel build never uses the bundled
+  # browser, saving ~20s per install.
+  PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:
   preview:


### PR DESCRIPTION
## Summary

Puppeteer's postinstall downloads Chrome (~20s) into `~/.cache/puppeteer` on every `yarn` install. **No CI job actually uses that binary**, so this PR sets `PUPPETEER_SKIP_DOWNLOAD=true` at the workflow `env` level in every workflow that installs dependencies — **except `copilot-setup-steps.yml`**, which is the only one that does need it.

## Why it's safe

- The Puppeteer test harness (`src/e2e/puppeteer-environment.ts`) imports **`puppeteer-core`** and calls `puppeteer.connect({ browserWSEndpoint: 'ws://localhost:7566' })`, attaching to the `browserless/chrome` **service container** over CDP. It never launches the downloaded browser.
- There is **no `puppeteer.launch()`** anywhere in `src`/`scripts` — only `.connect()`.
- The one and only consumer of the managed browser is `scripts/shared-chrome.mjs` (via `puppeteer.executablePath()`), which is run **only** by `copilot-setup-steps.yml` — left unchanged so the agent's shared Chrome still works.
- `setup.ts` imports type-only symbols from `puppeteer`; types don't require the binary.

## Workflows changed

`docs`, `estimate-backfill`, `estimate-command`, `estimate-issue-opened`, `ios`, `lint`, `puppeteer`, `tauri-release-main`, `tauri-release-prod`, `tdd`, `test`, `update-browserslist`, `vercel-preview`.

The three `estimate-*` workflows had no top-level `env:` block, so one was added.

## Impact

~20s saved per dependency install across those workflows (the Tauri release matrix installs on 4 platforms × 2 workflows). No behavioral change — the skipped browser was never used by any of these jobs.

## Context

Investigated from a slow "Install npm dependencies" step (59s) where `cache: 'yarn'` was already hitting correctly. The download was part of the Link/build step, not the fetch step the yarn cache covers.