### PR TITLE
chore(ci): extend install composite to remaining workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install npm dependencies 🛠
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Build 🔧
         run: yarn docs

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -73,7 +73,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install npm dependencies
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Build
         run: yarn build

--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -83,7 +83,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install npm dependencies
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Set desktop version (MSI-compatible)
         run: yarn tauri:version

--- a/.github/workflows/tauri-release-prod.yml
+++ b/.github/workflows/tauri-release-prod.yml
@@ -79,7 +79,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install npm dependencies
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Set desktop version (MSI-compatible)
         run: yarn tauri:version

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 22
 
       - name: Install npm dependencies
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Update browserslist database
         run: |

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install npm dependencies
-        run: yarn
+        uses: ./.github/actions/install
 
       - name: Pull Vercel environment
         run: yarn dlx vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"


### PR DESCRIPTION
Extends the shared `./.github/actions/install` composite action (introduced in #4626, already wired into lint/test/puppeteer/tdd) to the six remaining workflows that still ran a bare `yarn` install step.

## What the composite does
- Caches `node_modules` + `.yarn/install-state.gz` keyed on `hashFiles('.yarnrc.yml','yarn.lock')`, collapsing the slow Yarn Link step (native rebuilds + linking + workspace postinstall, ~38s) to a ~9s cache restore on hits.
- Caches `packages/webview/dist` on its own inputs.
- Runs `yarn`, then **always** `yarn build:styles` (regenerates gitignored `styled-system/`, ~5s), and `yarn build:packages` only on a webview-cache miss — guaranteeing the postinstall-generated outputs exist even when Yarn skips postinstall on a cache hit.

## Workflows changed (6)
Each swaps `- run: yarn` → `- uses: ./.github/actions/install` (one-line change per file, nothing else):
- `.github/workflows/ios.yml`
- `.github/workflows/vercel-preview.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/update-browserslist.yml`
- `.github/workflows/tauri-release-main.yml`
- `.github/workflows/tauri-release-prod.yml`

## Deliberately excluded
- `copilot-setup-steps.yml` — out of scope.
- `estimate-backfill.yml`, `estimate-command.yml`, `estimate-issue-opened.yml` — use `yarn install --immutable` and only build the `em-estimate` workspace; the composite's full-repo install/build would be wrong for them.
- `lint.yml`, `test.yml`, `puppeteer.yml`, `tdd.yml` — already wired.

## Notes
- Left each `setup-node` `cache: 'yarn'` in place (ios, vercel-preview): it caches a different path than the composite and still helps on a `node_modules` cache miss.
- ios/vercel/tauri run a full `yarn build` (or vercel build) afterward; the composite's `build:styles`/`build:packages` are redundant-but-idempotent there — expected.
- Most of these six trigger only on schedule/release/push-to-main/dispatch (and vercel/ios use `pull_request_target`, running the base branch's workflow file), so their jobs will not exercise these edits on this PR. All six YAMLs validated as parsing.