### PR TITLE
Fix clickable move alert destination

### DIFF
--- a/src/@types/Alert.ts
+++ b/src/@types/Alert.ts
@@ -1,8 +1,11 @@
+import type { FC } from 'react'
 import { AlertType } from '../constants'
+
+export type AlertValue = string | FC | null
 
 type Alert = {
   alertType?: keyof typeof AlertType
-  value: string | null
+  value: AlertValue
   /** Used to cancel imports. */
   importFileId?: string
   /** Timeout in milliseconds after which alert will be cleared. Default: 5000. Set to null to prevent auto-dismiss. */

--- a/src/actions/alert.ts
+++ b/src/actions/alert.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
-import { FC } from 'react'
-import Alert from '../@types/Alert'
+import type Alert from '../@types/Alert'
+import type { AlertValue } from '../@types/Alert'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
@@ -10,7 +10,7 @@ import clearMulticursors from './clearMulticursors'
 
 interface Options {
   alertType?: keyof typeof AlertType
-  value: string | null
+  value: AlertValue
   // used to cancel imports
   importFileId?: string
   clearDelay?: number | null
@@ -47,7 +47,7 @@ const alertReducer = (state: State, { alertType, value, importFileId, clearDelay
  */
 export const alertActionCreator =
   (
-    value: string | FC | null,
+    value: AlertValue,
     {
       alertType,
       clearDelay,

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -49,7 +49,12 @@ const useDelayedEffect = (callback: () => void, delay: number | null | undefined
 const Alert: FC = () => {
   const alert = useSelector(state => state.alert)
   const alertStoreValue = alertStore.useState()
-  const value = strip(alertStoreValue ?? alert?.value ?? '')
+  const alertValue = alertStoreValue ?? alert?.value ?? null
+  const valueText = typeof alertValue === 'string' ? strip(alertValue) : null
+  const AlertValue = typeof alertValue === 'function' ? alertValue : null
+  const value = valueText ?? (AlertValue ? <AlertValue /> : null)
+  const transitionKey =
+    typeof alertValue === 'string' ? valueText || '' : AlertValue ? AlertValue.name || alert?.alertType || 'alert' : ''
   const iconSize = useSelector(state => 0.78 * state.fontSize)
   const multicursor = useSelector(state => state.alert?.alertType === AlertType.MulticursorActive)
   const dispatch = useDispatch()
@@ -66,7 +71,7 @@ const Alert: FC = () => {
   // if dismissed, set timeout to 0 to remove alert component immediately. Otherwise it will block toolbar interactions until the timeout completes.
   return (
     <Notification
-      transitionKey={value}
+      transitionKey={transitionKey}
       onClose={alert?.clearDelay != null ? onClose : undefined}
       value={alert ? value : null}
       icon={Icon ? <Icon cssRaw={css.raw({ cursor: 'default' })} size={iconSize} fill={token('colors.fg')} /> : null}

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -694,6 +694,7 @@ const Editable = ({
       }
 
       if (suppressFocusStore.getState()) return
+
       // Update editingValueUntrimmedStore with the current value
       editingValueUntrimmedStore.update(value)
 

--- a/src/components/MoveThoughtAlert.tsx
+++ b/src/components/MoveThoughtAlert.tsx
@@ -2,41 +2,49 @@ import { FC } from 'react'
 import { useSelector } from 'react-redux'
 import SimplePath from '../@types/SimplePath'
 import getThoughtById from '../selectors/getThoughtById'
+import ellipsize from '../util/ellipsize'
 import head from '../util/head'
+import headValue from '../util/headValue'
 import isRoot from '../util/isRoot'
 import Link from './Link'
 
 interface MoveThoughtAlertProps {
-  /** Display label for the moved thought or thoughts, e.g. `"a"` or `2 thoughts`. */
+  /** Value of the first moved thought. */
   from: string
+  /** Total number of moved thoughts. Defaults to one. */
+  numThoughts?: number
   /** Destination context path. Root destinations render as home; other destinations render as a clickable thought link. */
   toPath: SimplePath
   /** True when the thought was moved to the top of the destination context. */
   top?: boolean
+  /** Context whose occurrence received the thought when dropping in context view. */
+  contextPath?: SimplePath
 }
 
 /** Alert shown after drag-and-drop moves a thought to another context. */
-const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ from, toPath, top }) => {
+const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ contextPath, from, numThoughts = 1, toPath, top }) => {
   const isRootPath = isRoot(toPath)
   const to = useSelector(state => (isRootPath ? 'home' : getThoughtById(state, head(toPath))?.value || ''))
+  const context = useSelector(state => (contextPath ? headValue(state, contextPath) : null))
+  const alertFrom = numThoughts === 1 ? `"${ellipsize(from)}"` : `${numThoughts} thoughts`
 
   return (
     <span>
-      {from} moved to{top ? ' top of' : ''}{' '}
+      {alertFrom} moved to{top ? ' top of' : ''}{' '}
       {isRootPath ? (
         to
       ) : (
         <>
           &quot;
           <Link
-            charLimit={16}
             simplePath={toPath}
-            label={to}
+            label={ellipsize(to)}
             style={{ cursor: 'pointer', textDecoration: 'underline' }}
           />
           &quot;
         </>
       )}
+      {contextPath ? ` in the context of ${ellipsize(context || 'MISSING_CONTEXT')}` : ''}
       .
     </span>
   )

--- a/src/components/MoveThoughtAlert.tsx
+++ b/src/components/MoveThoughtAlert.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react'
+import SimplePath from '../@types/SimplePath'
+import isRoot from '../util/isRoot'
+import Link from './Link'
+
+interface MoveThoughtAlertProps {
+  from: string
+  inContext?: string
+  to: string
+  toPath: SimplePath
+  top?: boolean
+}
+
+/** Alert shown after drag-and-drop moves a thought to another context. */
+const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ from, inContext = '', to, toPath, top }) => (
+  <span>
+    {from} moved to{top ? ' top of' : ''}{' '}
+    {isRoot(toPath) ? (
+      to
+    ) : (
+      <>
+        &quot;
+        <Link
+          charLimit={16}
+          simplePath={toPath}
+          label={to}
+          style={{ cursor: 'pointer', textDecoration: 'underline' }}
+        />
+        &quot;
+      </>
+    )}
+    {inContext}.
+  </span>
+)
+
+export default MoveThoughtAlert

--- a/src/components/MoveThoughtAlert.tsx
+++ b/src/components/MoveThoughtAlert.tsx
@@ -1,31 +1,45 @@
 import { FC } from 'react'
+import { useSelector } from 'react-redux'
 import SimplePath from '../@types/SimplePath'
+import getThoughtById from '../selectors/getThoughtById'
+import head from '../util/head'
 import isRoot from '../util/isRoot'
 import Link from './Link'
 
 interface MoveThoughtAlertProps {
+  /** Display label for the moved thought or thoughts, e.g. `"a"` or `2 thoughts`. */
   from: string
-  inContext?: string
-  to: string
+  /** Destination context path. Root destinations render as home; other destinations render as a clickable thought link. */
   toPath: SimplePath
+  /** True when the thought was moved to the top of the destination context. */
   top?: boolean
 }
 
 /** Alert shown after drag-and-drop moves a thought to another context. */
-const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ from, inContext = '', to, toPath, top }) => (
-  <span>
-    {from} moved to{top ? ' top of' : ''}{' '}
-    {isRoot(toPath) ? (
-      to
-    ) : (
-      <>
-        &quot;
-        <Link simplePath={toPath} label={to} style={{ cursor: 'pointer', textDecoration: 'underline' }} />
-        &quot;
-      </>
-    )}
-    {inContext}.
-  </span>
-)
+const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ from, toPath, top }) => {
+  const isRootPath = isRoot(toPath)
+  const to = useSelector(state => (isRootPath ? 'home' : getThoughtById(state, head(toPath))?.value || ''))
+
+  return (
+    <span>
+      {from} moved to{top ? ' top of' : ''}{' '}
+      {isRootPath ? (
+        to
+      ) : (
+        <>
+          &quot;
+          <Link
+            charLimit={16}
+            simplePath={toPath}
+            label={to}
+            style={{ cursor: 'pointer', textDecoration: 'underline' }}
+          />
+          &quot;
+        </>
+      )}
+      .
+    </span>
+  )
+}
 
 export default MoveThoughtAlert

--- a/src/components/MoveThoughtAlert.tsx
+++ b/src/components/MoveThoughtAlert.tsx
@@ -20,12 +20,7 @@ const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ from, inContext = '', to,
     ) : (
       <>
         &quot;
-        <Link
-          charLimit={16}
-          simplePath={toPath}
-          label={to}
-          style={{ cursor: 'pointer', textDecoration: 'underline' }}
-        />
+        <Link simplePath={toPath} label={to} style={{ cursor: 'pointer', textDecoration: 'underline' }} />
         &quot;
       </>
     )}

--- a/src/components/MoveThoughtAlert.tsx
+++ b/src/components/MoveThoughtAlert.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { useSelector } from 'react-redux'
+import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import getThoughtById from '../selectors/getThoughtById'
 import ellipsize from '../util/ellipsize'
@@ -18,7 +19,7 @@ interface MoveThoughtAlertProps {
   /** True when the thought was moved to the top of the destination context. */
   top?: boolean
   /** Context whose occurrence received the thought when dropping in context view. */
-  contextPath?: SimplePath
+  contextPath?: Path
 }
 
 /** Alert shown after drag-and-drop moves a thought to another context. */
@@ -36,16 +37,11 @@ const MoveThoughtAlert: FC<MoveThoughtAlertProps> = ({ contextPath, from, numTho
       ) : (
         <>
           &quot;
-          <Link
-            simplePath={toPath}
-            label={ellipsize(to)}
-            style={{ cursor: 'pointer', textDecoration: 'underline' }}
-          />
+          <Link simplePath={toPath} label={ellipsize(to)} style={{ cursor: 'pointer', textDecoration: 'underline' }} />
           &quot;
         </>
       )}
-      {contextPath ? ` in the context of ${ellipsize(context || 'MISSING_CONTEXT')}` : ''}
-      .
+      {contextPath ? ` in the context of ${ellipsize(context || 'MISSING_CONTEXT')}` : ''}.
     </span>
   )
 }

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -4,8 +4,10 @@ import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import clickThought from '../helpers/clickThought'
 import dragAndDropThought from '../helpers/dragAndDropThought'
+import getEditingText from '../helpers/getEditingText'
 import hideHUD from '../helpers/hideHUD'
 import paste from '../helpers/paste'
+import press from '../helpers/press'
 import screenshot from '../helpers/screenshot'
 import simulateDragAndDrop from '../helpers/simulateDragAndDrop'
 import waitForAlertContent from '../helpers/waitForAlertContent'
@@ -326,10 +328,7 @@ describe('drag', () => {
       - d
     `)
 
-    await page.evaluate(() => {
-      const em = window.em as WindowEm
-      em.store.dispatch({ type: 'setCursor', path: null })
-    })
+    await press('Escape')
 
     await dragAndDropThought('d', 'a', {
       position: 'child',
@@ -344,17 +343,12 @@ describe('drag', () => {
     )
     expect(destinationLinkText).toBe('a')
 
-    await page.evaluate(() => {
-      const em = window.em as WindowEm
-      em.store.dispatch({ type: 'setCursor', path: null })
-    })
+    await page.click('[aria-label=nav] [data-testid=home] a')
+    await page.waitForFunction(() => !document.querySelector('[data-editing=true] [data-editable]'))
+    expect(await getEditingText()).toBeUndefined()
 
     await page.click('[data-testid=alert-content] [data-thought-link]')
-
-    await page.waitForFunction(() => {
-      const em = window.em as WindowEm
-      return em.prettyPath(em.store.getState().cursor) === 'a'
-    })
+    expect(await getEditingText()).toBe('a')
   })
 
   it('should allow dropping before first thought in table row', async () => {

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -8,6 +8,7 @@ import hideHUD from '../helpers/hideHUD'
 import paste from '../helpers/paste'
 import screenshot from '../helpers/screenshot'
 import simulateDragAndDrop from '../helpers/simulateDragAndDrop'
+import waitForAlertContent from '../helpers/waitForAlertContent'
 import waitForEditable from '../helpers/waitForEditable'
 import { page } from '../session'
 
@@ -315,6 +316,45 @@ describe('drag', () => {
 
     const image = await screenshot()
     expect(image).toMatchImageSnapshot()
+  })
+
+  it('renders destination link in moved alert', async () => {
+    await paste(`
+      - a
+        - b
+      - c
+      - d
+    `)
+
+    await page.evaluate(() => {
+      const em = window.em as WindowEm
+      em.store.dispatch({ type: 'setCursor', path: null })
+    })
+
+    await dragAndDropThought('d', 'a', {
+      position: 'child',
+      showAlert: true,
+    })
+
+    await waitForAlertContent('"d" moved to "a"')
+
+    const destinationLinkText = await page.$eval(
+      '[data-testid=alert-content] [data-thought-link]',
+      el => el.textContent,
+    )
+    expect(destinationLinkText).toBe('a')
+
+    await page.evaluate(() => {
+      const em = window.em as WindowEm
+      em.store.dispatch({ type: 'setCursor', path: null })
+    })
+
+    await page.click('[data-testid=alert-content] [data-thought-link]')
+
+    await page.waitForFunction(() => {
+      const em = window.em as WindowEm
+      return em.prettyPath(em.store.getState().cursor) === 'a'
+    })
   })
 
   it('should allow dropping before first thought in table row', async () => {

--- a/src/hooks/useDragAndDropSubThought.ts
+++ b/src/hooks/useDragAndDropSubThought.ts
@@ -261,7 +261,7 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
         const alertFrom =
           draggedItems.length === 1 ? `"${ellipsize(thoughtFrom?.value || '')}"` : `${draggedItems.length} thoughts`
 
-        const alertTo = parentId === HOME_TOKEN ? 'home' : thoughtTo?.value || ''
+        const alertTo = parentId === HOME_TOKEN ? 'home' : ellipsize(thoughtTo?.value || '')
 
         const inContext = props.showContexts
           ? ` in the context of ${ellipsize(headValue(state, props.simplePath ?? props.path) || 'MISSING_CONTEXT')}`

--- a/src/hooks/useDragAndDropSubThought.ts
+++ b/src/hooks/useDragAndDropSubThought.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import { useDispatch } from 'react-redux'
@@ -15,6 +16,7 @@ import { importFilesActionCreator as importFiles } from '../actions/importFiles'
 import { longPressActionCreator as longPress } from '../actions/longPress'
 import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { setIsMulticursorExecutingActionCreator as setIsMulticursorExecuting } from '../actions/setIsMulticursorExecuting'
+import MoveThoughtAlert from '../components/MoveThoughtAlert'
 import { AlertType, HOME_TOKEN, LongPressState } from '../constants'
 import attributeEquals from '../selectors/attributeEquals'
 import getNextRank from '../selectors/getNextRank'
@@ -254,17 +256,28 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
         const dropTop = shouldDropAtTop(pathTo)
         const thoughtFrom = getThoughtById(state, head(firstItem.path))
         const thoughtTo = getThoughtById(state, parentId)
+        const toPath = simplifyPath(state, rootedParentOf(state, pathTo))
 
         const alertFrom =
           draggedItems.length === 1 ? `"${ellipsize(thoughtFrom?.value || '')}"` : `${draggedItems.length} thoughts`
 
-        const alertTo = parentId === HOME_TOKEN ? 'home' : `"${ellipsize(thoughtTo?.value || '')}"`
+        const alertTo = parentId === HOME_TOKEN ? 'home' : thoughtTo?.value || ''
 
         const inContext = props.showContexts
           ? ` in the context of ${ellipsize(headValue(state, props.simplePath ?? props.path) || 'MISSING_CONTEXT')}`
           : ''
 
-        store.dispatch(alert(`${alertFrom} moved to${dropTop ? ' top of' : ''} ${alertTo}${inContext}.`))
+        store.dispatch(
+          alert(() =>
+            React.createElement(MoveThoughtAlert, {
+              from: alertFrom,
+              inContext,
+              to: alertTo,
+              toPath,
+              top: dropTop,
+            }),
+          ),
+        )
       }, 100)
     }
   })

--- a/src/hooks/useDragAndDropSubThought.tsx
+++ b/src/hooks/useDragAndDropSubThought.tsx
@@ -256,7 +256,7 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
         store.dispatch(
           alert(() => (
             <MoveThoughtAlert
-              contextPath={props.showContexts ? props.simplePath ?? props.path : undefined}
+              contextPath={props.showContexts ? (props.simplePath ?? props.path) : undefined}
               from={thoughtFrom?.value || ''}
               numThoughts={draggedItems.length}
               toPath={toPath}

--- a/src/hooks/useDragAndDropSubThought.tsx
+++ b/src/hooks/useDragAndDropSubThought.tsx
@@ -28,7 +28,6 @@ import visibleDistanceAboveCursor from '../selectors/visibleDistanceAboveCursor'
 import store from '../stores/app'
 import animateDroppedThought from '../util/animateDroppedThought'
 import appendToPath from '../util/appendToPath'
-import ellipsize from '../util/ellipsize'
 import equalPath from '../util/equalPath'
 import haptics from '../util/haptics'
 import hashPath from '../util/hashPath'
@@ -254,10 +253,17 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
         const thoughtFrom = getThoughtById(state, head(firstItem.path))
         const toPath = simplifyPath(state, rootedParentOf(state, pathTo))
 
-        const alertFrom =
-          draggedItems.length === 1 ? `"${ellipsize(thoughtFrom?.value || '')}"` : `${draggedItems.length} thoughts`
-
-        store.dispatch(alert(() => <MoveThoughtAlert from={alertFrom} toPath={toPath} top={dropTop} />))
+        store.dispatch(
+          alert(() => (
+            <MoveThoughtAlert
+              contextPath={props.showContexts ? props.simplePath ?? props.path : undefined}
+              from={thoughtFrom?.value || ''}
+              numThoughts={draggedItems.length}
+              toPath={toPath}
+              top={dropTop}
+            />
+          )),
+        )
       }, 100)
     }
   })

--- a/src/hooks/useDragAndDropSubThought.tsx
+++ b/src/hooks/useDragAndDropSubThought.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import { useDispatch } from 'react-redux'
@@ -17,7 +16,7 @@ import { longPressActionCreator as longPress } from '../actions/longPress'
 import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { setIsMulticursorExecutingActionCreator as setIsMulticursorExecuting } from '../actions/setIsMulticursorExecuting'
 import MoveThoughtAlert from '../components/MoveThoughtAlert'
-import { AlertType, HOME_TOKEN, LongPressState } from '../constants'
+import { AlertType, LongPressState } from '../constants'
 import attributeEquals from '../selectors/attributeEquals'
 import getNextRank from '../selectors/getNextRank'
 import getPrevRank from '../selectors/getPrevRank'
@@ -34,7 +33,6 @@ import equalPath from '../util/equalPath'
 import haptics from '../util/haptics'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
-import headValue from '../util/headValue'
 import isDescendantPath from '../util/isDescendantPath'
 import isDivider from '../util/isDivider'
 import isDraggedFile from '../util/isDraggedFile'
@@ -252,32 +250,14 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
         const firstItem = draggedItems[0]
         const pathTo = getPathTo(state, firstItem.path)
 
-        const parentId = head(rootedParentOf(state, pathTo))
         const dropTop = shouldDropAtTop(pathTo)
         const thoughtFrom = getThoughtById(state, head(firstItem.path))
-        const thoughtTo = getThoughtById(state, parentId)
         const toPath = simplifyPath(state, rootedParentOf(state, pathTo))
 
         const alertFrom =
           draggedItems.length === 1 ? `"${ellipsize(thoughtFrom?.value || '')}"` : `${draggedItems.length} thoughts`
 
-        const alertTo = parentId === HOME_TOKEN ? 'home' : ellipsize(thoughtTo?.value || '')
-
-        const inContext = props.showContexts
-          ? ` in the context of ${ellipsize(headValue(state, props.simplePath ?? props.path) || 'MISSING_CONTEXT')}`
-          : ''
-
-        store.dispatch(
-          alert(() =>
-            React.createElement(MoveThoughtAlert, {
-              from: alertFrom,
-              inContext,
-              to: alertTo,
-              toPath,
-              top: dropTop,
-            }),
-          ),
-        )
+        store.dispatch(alert(() => <MoveThoughtAlert from={alertFrom} toPath={toPath} top={dropTop} />))
       }, 100)
     }
   })

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -38,7 +38,6 @@ import simplifyPath from '../selectors/simplifyPath'
 import store from '../stores/app'
 import selectionRangeStore from '../stores/selectionRangeStore'
 import appendToPath from '../util/appendToPath'
-import ellipsize from '../util/ellipsize'
 import equalPath from '../util/equalPath'
 import haptics from '../util/haptics'
 import head from '../util/head'
@@ -268,10 +267,11 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
         const firstFromThought = pathToThought(state, draggedItems[0].simplePath)
         if (!firstFromThought) return
 
-        const numThoughts = draggedItems.length
-        const alertFrom = numThoughts === 1 ? `"${ellipsize(firstFromThought.value)}"` : `${numThoughts} thoughts`
-
-        dispatch(alert(() => <MoveThoughtAlert from={alertFrom} toPath={parent} />))
+        dispatch(
+          alert(() => (
+            <MoveThoughtAlert from={firstFromThought.value} numThoughts={draggedItems.length} toPath={parent} />
+          )),
+        )
       }, 100)
     }
   })

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -274,7 +274,7 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
 
         const numThoughts = draggedItems.length
         const alertFrom = numThoughts === 1 ? `"${ellipsize(firstFromThought.value)}"` : `${numThoughts} thoughts`
-        const alertTo = isRoot([parentThought.id]) ? 'home' : parentThought.value
+        const alertTo = isRoot([parentThought.id]) ? 'home' : ellipsize(parentThought.value)
 
         dispatch(alert(() => <MoveThoughtAlert from={alertFrom} to={alertTo} toPath={parent} inContext=' context' />))
       }, 100)

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -19,6 +19,7 @@ import { longPressActionCreator as longPress } from '../actions/longPress'
 import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { setIsMulticursorExecutingActionCreator as setIsMulticursorExecuting } from '../actions/setIsMulticursorExecuting'
 import { isTouch } from '../browser'
+import MoveThoughtAlert from '../components/MoveThoughtAlert'
 import { ThoughtContainerProps } from '../components/Thought'
 import { AlertType, LongPressState } from '../constants'
 import allowTouchToScroll from '../device/allowTouchToScroll'
@@ -273,9 +274,9 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
 
         const numThoughts = draggedItems.length
         const alertFrom = numThoughts === 1 ? `"${ellipsize(firstFromThought.value)}"` : `${numThoughts} thoughts`
-        const alertTo = isRoot([parentThought.id]) ? 'home' : `"${ellipsize(parentThought.value)}"`
+        const alertTo = isRoot([parentThought.id]) ? 'home' : parentThought.value
 
-        dispatch(alert(`${alertFrom} moved to ${alertTo} context.`))
+        dispatch(alert(() => <MoveThoughtAlert from={alertFrom} to={alertTo} toPath={parent} inContext=' context' />))
       }, 100)
     }
   })

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -29,7 +29,6 @@ import findDescendant from '../selectors/findDescendant'
 import getNextRank from '../selectors/getNextRank'
 import getRankAfter from '../selectors/getRankAfter'
 import getRankBefore from '../selectors/getRankBefore'
-import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursor from '../selectors/hasMulticursor'
 import isBefore from '../selectors/isBefore'
 import isContextViewActive from '../selectors/isContextViewActive'
@@ -266,17 +265,13 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
       // wait until after MultiGesture has cleared the error so this alert does not get cleared
       setTimeout(() => {
         const state = getState()
-        const parentThought = getThoughtById(state, head(parentOf(props.simplePath)))
-        if (!parentThought) return
-
         const firstFromThought = pathToThought(state, draggedItems[0].simplePath)
         if (!firstFromThought) return
 
         const numThoughts = draggedItems.length
         const alertFrom = numThoughts === 1 ? `"${ellipsize(firstFromThought.value)}"` : `${numThoughts} thoughts`
-        const alertTo = isRoot([parentThought.id]) ? 'home' : ellipsize(parentThought.value)
 
-        dispatch(alert(() => <MoveThoughtAlert from={alertFrom} to={alertTo} toPath={parent} inContext=' context' />))
+        dispatch(alert(() => <MoveThoughtAlert from={alertFrom} toPath={parent} />))
       }, 100)
     }
   })


### PR DESCRIPTION
## Summary

Fixes #4610

## Implementation
- Allows alerts to render React components while preserving existing string alerts.
- Adds `MoveThoughtAlert` to render the drag/drop destination as a clickable thought link.
- Keeps the cursor on the moved thought after drop, e.g. `a/d` after dragging `d` into `a`.
- Suppresses the immediate post-drop focus/click so the destination does not steal the cursor.
- Clicking the destination link in the alert moves the cursor to that destination thought.

## Testing
- `yarn tsc --noEmit`
- Focused ESLint on touched files