### PR TITLE
ci: deploy Vercel production via GitHub Actions

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -1,0 +1,68 @@
+name: Vercel Production
+
+# Deploy production from GitHub Actions on every push to main, so the deployment
+# no longer depends on the merged commit's author (Vercel's Git integration
+# attributes/gates deploys by the pushing user). Vercel's own Git auto-deploy for
+# main is disabled in vercel.json (git.deploymentEnabled.main = false) to avoid a
+# duplicate production deployment. Never runs on pull_request events.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy ${{ matrix.project }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Deploy each Vercel project independently; one failing project must not
+      # block the other.
+      fail-fast: false
+      matrix:
+        project: [em, em-ai]
+
+    # Serialize production deploys per project without cancelling an in-flight
+    # deploy, so overlapping pushes to main queue rather than race.
+    concurrency:
+      group: vercel-production-${{ matrix.project }}
+      cancel-in-progress: false
+
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      # Each project has its own project ID; org and token are shared. Both
+      # secrets are referenced statically (no dynamic secrets indexing) and
+      # selected by the matrix value.
+      VERCEL_PROJECT_ID: ${{ matrix.project == 'em' && secrets.VERCEL_PROJECT_ID_EM || secrets.VERCEL_PROJECT_ID_EM_AI }}
+      # Skip Puppeteer's Chrome download on install — the Vercel build never uses
+      # the bundled browser, saving ~20s per install.
+      PUPPETEER_SKIP_DOWNLOAD: true
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install npm dependencies
+        uses: ./.github/actions/install
+
+      - name: Pull Vercel environment
+        run: yarn dlx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build
+        run: yarn dlx vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy
+        run: yarn dlx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "git": {
     "deploymentEnabled": {
       "**": false,
-      "main": true
+      "main": false
     }
   },
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],


### PR DESCRIPTION
## Summary

Move production deployments off Vercel's Git integration and onto GitHub Actions, so a production deploy no longer depends on the merged commit's author (Vercel's Git integration attributes and gates deploys by the pushing user, which is why author-less/bot merges failed — see screenshot in the request).

## Changes

- **New `.github/workflows/vercel-production.yml`**
  - Triggers on `push` to `main` only — never on `pull_request` events.
  - `strategy.matrix` over both Vercel projects (`em`, `em-ai`), `fail-fast: false` so one project can't block the other.
  - Each project gets its own `VERCEL_PROJECT_ID`; `VERCEL_ORG_ID` and `VERCEL_TOKEN` are shared. The project ID is selected via a matrix conditional using **static** secret references (no dynamic `secrets[...]` indexing).
  - Per-project `concurrency` group (no cancel-in-progress) so overlapping pushes queue instead of race.
  - Runs `vercel pull --environment=production`, `vercel build --prod`, `vercel deploy --prebuilt --prod`, reusing the repo's conventions: `corepack`, `actions/setup-node@v6` Node 22 + yarn cache, and the local `./.github/actions/install` composite (mirrors `vercel-preview.yml`).
- **`vercel.json`**: set `git.deploymentEnabled.main` to `false` (was `true`) to disable Vercel's automatic production deploy and avoid a **duplicate** production deployment. `"**": false` and all other keys are preserved, so preview deployments (driven by `vercel-preview.yml`) are unchanged.

## Validation

- Workflow validated with `actionlint` (pass) and YAML/JSON parse checks.

## Required GitHub Actions secrets

An administrator must configure these repository secrets (maintainer-owned; never committed):

| Secret | Purpose | Shared? |
| --- | --- | --- |
| `VERCEL_TOKEN` | Maintainer-owned Vercel auth token | Shared by both projects |
| `VERCEL_ORG_ID` | Vercel organization/team ID | Shared by both projects |
| `VERCEL_PROJECT_ID_EM` | Project ID for the `em` Vercel project | `em` only |
| `VERCEL_PROJECT_ID_EM_AI` | Project ID for the `em-ai` Vercel project | `em-ai` only |

> Note: `VERCEL_TOKEN` and `VERCEL_ORG_ID` are already used by `vercel-preview.yml`. The two `VERCEL_PROJECT_ID_*` secrets are new (the preview workflow currently uses a single `VERCEL_PROJECT_ID`).