### PR TITLE
Only set inputmode=none when keyboard is closed

### DIFF
--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import Thunk from '../@types/Thunk'
-import { isTouch } from '../browser'
+import { isSafari, isTouch } from '../browser'
 import { ColorToken } from '../colors.config'
 import * as selection from '../device/selection'
 import getThoughtById from '../selectors/getThoughtById'
@@ -50,7 +50,14 @@ export const formatSelectionActionCreator =
         state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
       )
       const savedSelection = selection.save()
+      const inputMode = contentEditable.getAttribute('inputmode')
+      const editable = contentEditable as HTMLElement
+
+      // Prevent the virtual keyboard from opening when the editable is focused
+      if (isTouch && isSafari()) editable.setAttribute('inputmode', 'none')
+
       // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
+      editable.focus({ preventScroll: true })
       selection.select(contentEditable)
       if (!(command === 'backColor' && color === 'bg' && !hasCustomBackgroundColor)) {
         document.execCommand(command, false, color ? colors[color] : '')
@@ -66,6 +73,8 @@ export const formatSelectionActionCreator =
       } else {
         selection.clear()
       }
+
+      if (isTouch && isSafari()) contentEditable.setAttribute('inputmode', inputMode ?? '')
     }
     // format selected text only
     else {

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -54,7 +54,7 @@ export const formatSelectionActionCreator =
       const editable = contentEditable as HTMLElement
 
       // Prevent the virtual keyboard from opening when the editable is focused
-      if (isTouch && isSafari()) editable.setAttribute('inputmode', 'none')
+      if (isTouch && isSafari() && !state.isKeyboardOpen) editable.setAttribute('inputmode', 'none')
 
       // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
       editable.focus({ preventScroll: true })
@@ -74,7 +74,7 @@ export const formatSelectionActionCreator =
         selection.clear()
       }
 
-      if (isTouch && isSafari()) contentEditable.setAttribute('inputmode', inputMode ?? '')
+      if (isTouch && isSafari() && !state.isKeyboardOpen) contentEditable.setAttribute('inputmode', inputMode ?? '')
     }
     // format selected text only
     else {

--- a/src/e2e/iOS/__tests__/format.ts
+++ b/src/e2e/iOS/__tests__/format.ts
@@ -1,0 +1,29 @@
+/**
+ * IOS Safari text formatting tests.
+ * Uses WDIO test runner with Mocha framework.
+ */
+import hideKeyboardByTappingDone from '../helpers/hideKeyboardByTappingDone'
+import newThought from '../helpers/newThought'
+import tap from '../helpers/tap.js'
+
+describe('Format', () => {
+  it('applying bold to an unfocused cursor thought does not open the keyboard', async () => {
+    // 1. Create a new thought 'Thought One'.
+    await newThought('Thought One')
+
+    // 2. Make it the cursor thought but not focused: dismiss the keyboard, which blurs the
+    // editable (isKeyboardOpen → false) while leaving the cursor set on the thought.
+    await hideKeyboardByTappingDone()
+
+    // 3. Measure the scroll position of the viewport before formatting.
+    const scrollBefore = await browser.execute(() => window.scrollY)
+
+    // 4. Apply bold by tapping the Bold toolbar icon.
+    const boldButton = await browser.$('[data-testid="toolbar-icon"][aria-label="Bold"]').getElement()
+    await tap(boldButton, { y: 60 })
+
+    // 5. Measure the scroll position again and ensure it did not change (#3999).
+    const scrollAfter = await browser.execute(() => window.scrollY)
+    expect(scrollAfter).toBe(scrollBefore)
+  })
+})


### PR DESCRIPTION
Fixes #4606 and #3999

Apply `inputmode=none` to the editable when the keyboard is already open has the opposite effect so the original issue reported in #3999. It briefly starts to close the keyboard, which causes the flicker. Now, it will only change that attribute when the `state.isKeyboardOpen` is false.

## Attempted test coverage

- no keyboard-closing action is dispatched since the state logic doesn't see the keyboard as closing at any point
- `isKeyboardShown` helper using `browser.isKeyboardShown()` detects no change during or after the bold button tap
- a viewport probe monitoring the viewport size detects no change during or after the bold button tap

No matter what testing strategy we landed on, it would be pretty timing-dependent. It doesn't seem like there's anything that BrowserStack detects as a change during the keyboard flicker. Let me know if you have any suggestions.