### PR TITLE
feat: reusable persistent debug logging infrastructure

### DIFF
--- a/src/components/AppComponent.tsx
+++ b/src/components/AppComponent.tsx
@@ -16,6 +16,7 @@ import isTutorial from '../selectors/isTutorial'
 import theme from '../selectors/theme'
 import themeColors from '../selectors/themeColors'
 import store from '../stores/app'
+import debugLog from '../util/debugLog'
 import isDocumentEditable from '../util/isDocumentEditable'
 import Alert from './Alert'
 import CommandCenter from './CommandCenter/CommandCenter'
@@ -123,7 +124,14 @@ const AppComponent: FC = () => {
   const fontSize = useSelector(state => state.fontSize)
   const showModal = useSelector(state => state.showModal)
   const tutorial = useSelector(isTutorial)
+  const debugCrashLog = useSelector(getUserSetting(Settings.debugCrashLog))
   const rootRef = useRef<HTMLDivElement>(null)
+
+  // Mirror the Debug Logging setting into the persistent debug log. Kept here (a single always-mounted
+  // top-level effect) so the logger stays decoupled from the Redux store.
+  useEffect(() => {
+    debugLog.setEnabled(debugCrashLog)
+  }, [debugCrashLog])
 
   useEffect(() => {
     WebviewBackground.changeBackgroundColor({ color: colors.bg })

--- a/src/components/modals/Settings.tsx
+++ b/src/components/modals/Settings.tsx
@@ -6,8 +6,10 @@ import { fontSizeActionCreator } from '../../actions/fontSize'
 import { showModalActionCreator as showModal } from '../../actions/showModal'
 import { toggleUserSettingActionCreator as toggleUserSetting } from '../../actions/toggleUserSetting'
 import { DEFAULT_FONT_SIZE, MAX_FONT_SIZE, MIN_FONT_SIZE, Settings } from '../../constants'
+import copy from '../../device/copy'
 import globals from '../../globals'
 import getUserSetting from '../../selectors/getUserSetting'
+import debugLog from '../../util/debugLog'
 import fastClick from '../../util/fastClick'
 import haptics from '../../util/haptics'
 import storage from '../../util/storage'
@@ -113,6 +115,40 @@ const FontSize = () => {
   )
 }
 
+/** Controls for the persistent debug log: copy the captured entries to the clipboard or clear them. Only rendered when Debug Logging is enabled. */
+const DebugLog = () => {
+  const enabled = useSelector(getUserSetting(Settings.debugCrashLog))
+  const [status, setStatus] = useState<string | null>(null)
+
+  if (!enabled) return null
+
+  return (
+    <div className={css({ marginTop: '1em' })}>
+      <a
+        {...fastClick(() => {
+          const text = debugLog.format()
+          copy(text)
+          setStatus(text ? `Copied ${debugLog.read().length} entries` : 'Log is empty')
+        })}
+        className={extendTapRecipe()}
+      >
+        Copy debug log
+      </a>
+      <span className={css({ margin: '0 0.5em', color: 'dim' })}>·</span>
+      <a
+        {...fastClick(() => {
+          debugLog.clear()
+          setStatus('Cleared')
+        })}
+        className={extendTapRecipe()}
+      >
+        Clear debug log
+      </a>
+      {status ? <span className={css({ marginLeft: '0.5em', color: 'dim' })}> ({status})</span> : null}
+    </div>
+  )
+}
+
 /** User settings modal. */
 const ModalSettings = () => {
   const dispatch = useDispatch()
@@ -163,6 +199,14 @@ const ModalSettings = () => {
         <Setting settingsKey={Settings.leftHanded} title='Left Handed'>
           Moves the scroll zone to the left side of the screen and the gesture zone to the right.
         </Setting>
+
+        <Setting settingsKey={Settings.debugCrashLog} title='Debug Logging'>
+          Records a rolling log of app events to help diagnose rare, hard-to-reproduce bugs (such as freezes).
+          Everything is stored locally on this device and nothing is transmitted. Leave this off unless a developer asks
+          you to enable it. Use “Copy debug log” to share the captured log.
+        </Setting>
+
+        <DebugLog />
 
         <a
           className={css({ color: 'error' })}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -482,6 +482,7 @@ export enum LongPressState {
 // User settings that can be saved to /EM/Settings/
 // See Settings modal for full descriptions.
 export enum Settings {
+  debugCrashLog = 'debugCrashLog',
   disableGestureTracing = 'disableGestureTracing',
   experienceMode = 'experienceMode',
   hideScrollZone = 'hideScrollZone',

--- a/src/redux-middleware/__tests__/loggerMiddleware.ts
+++ b/src/redux-middleware/__tests__/loggerMiddleware.ts
@@ -1,0 +1,36 @@
+import debugLog from '../../util/debugLog'
+import loggerMiddleware from '../loggerMiddleware'
+
+/** A pass-through next handler for the middleware. */
+const next = (action: unknown) => action
+
+/** Invokes the logger middleware for a single action with a no-op store and next. */
+const invoke = (action: unknown) => {
+  // the middleware only uses next(action); store api is unused
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  loggerMiddleware({} as any)(next)(action as any)
+}
+
+beforeEach(() => {
+  debugLog.setEnabled(false)
+  debugLog.clear()
+})
+
+afterEach(() => {
+  debugLog.setEnabled(false)
+})
+
+it('does not capture actions when debug logging is disabled', () => {
+  invoke({ type: 'editThought', foo: 'bar' })
+  expect(debugLog.read()).toEqual([])
+})
+
+it('captures every action when debug logging is enabled', () => {
+  debugLog.setEnabled(true)
+  debugLog.clear()
+  invoke({ type: 'editThought', newValue: 'hello' })
+  const actionEntries = debugLog.read().filter(e => e.type === 'action')
+  expect(actionEntries.length).toBe(1)
+  expect(actionEntries[0].actionType).toBe('editThought')
+  expect(actionEntries[0].payload).toContain('hello')
+})

--- a/src/redux-middleware/loggerMiddleware.ts
+++ b/src/redux-middleware/loggerMiddleware.ts
@@ -1,15 +1,32 @@
 import { Dispatch, Middleware, UnknownAction } from 'redux'
 import State from '../@types/State'
 import testFlags from '../e2e/testFlags'
+import debugLog from '../util/debugLog'
 
-/** Redux Middleware for logging all actions when testFlags.logActions is set to true. Useful for remote debugging when Redux Developer Tools are not available. */
+/** Redux Middleware for logging all actions. Logs to the console when testFlags.logActions is set (useful for e2e/remote debugging when Redux Developer Tools are not available), and captures every action into the persistent debugLog when it is enabled (see the Debug Logging setting). */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loggerMiddleware: Middleware<any, State, Dispatch> = () => {
   return next => action => {
     next(action)
 
+    const type = (action as UnknownAction).type
+
     if (testFlags.logActions) {
-      console.info((action as UnknownAction).type, action)
+      console.info(type, action)
+    }
+
+    // Capture every dispatched action into the persistent rolling log. This middleware runs after the thunk
+    // middleware, so `action` is always a resolved plain action with a `type`. The payload is stringified (and
+    // truncated by debugLog's field cap) so large actions such as updateThoughts cannot blow the buffer.
+    if (debugLog.isEnabled() && action && typeof action === 'object') {
+      const { type: _type, ...payload } = action as UnknownAction
+      let payloadStr: string
+      try {
+        payloadStr = JSON.stringify(payload)
+      } catch {
+        payloadStr = String(payload)
+      }
+      debugLog.log('action', { actionType: type ?? 'unknown', payload: payloadStr })
     }
   }
 }

--- a/src/util/__tests__/debugLog.ts
+++ b/src/util/__tests__/debugLog.ts
@@ -1,0 +1,129 @@
+import { vi } from 'vitest'
+import debugLog from '../debugLog'
+import storage from '../storage'
+
+beforeEach(() => {
+  localStorage.clear()
+  debugLog.setEnabled(false)
+  debugLog.clear()
+})
+
+afterEach(() => {
+  debugLog.setEnabled(false)
+  vi.restoreAllMocks()
+})
+
+describe('enabled gate', () => {
+  it('log is a no-op when disabled', () => {
+    debugLog.log('test', { a: 1 })
+    expect(debugLog.read()).toEqual([])
+  })
+
+  it('records entries when enabled', () => {
+    debugLog.setEnabled(true)
+    debugLog.log('test', { a: 1 })
+    const entries = debugLog.read()
+    const last = entries[entries.length - 1]
+    expect(last.type).toBe('test')
+    expect(last.a).toBe(1)
+  })
+
+  it('records a session marker when enabled', () => {
+    debugLog.setEnabled(true)
+    expect(debugLog.read().some(e => e.type === 'session')).toBe(true)
+  })
+
+  it('setEnabled is idempotent (no duplicate session markers)', () => {
+    debugLog.setEnabled(true)
+    debugLog.setEnabled(true)
+    expect(debugLog.read().filter(e => e.type === 'session').length).toBe(1)
+  })
+})
+
+describe('common envelope', () => {
+  it('assigns a monotonically increasing seq', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('a')
+    debugLog.log('b')
+    const entries = debugLog.read()
+    expect(entries[0].seq).toBe(0)
+    expect(entries[1].seq).toBe(1)
+  })
+})
+
+describe('capacity', () => {
+  it('trims to the capacity, keeping the most recent entries', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    for (let i = 0; i < 600; i++) {
+      debugLog.log('n', { i })
+    }
+    const entries = debugLog.read()
+    expect(entries.length).toBe(500)
+    // the oldest 100 were dropped, so the first retained entry is #100
+    expect(entries[0].i).toBe(100)
+    expect(entries[entries.length - 1].i).toBe(599)
+  })
+})
+
+describe('field cap', () => {
+  it('truncates over-long string fields', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    const long = 'x'.repeat(5000)
+    debugLog.log('big', { value: long })
+    const last = debugLog.read().slice(-1)[0]
+    expect((last.value as string).length).toBeLessThan(long.length)
+    expect(last.value as string).toContain('…')
+  })
+})
+
+describe('persistence', () => {
+  it('persists entries to localStorage synchronously', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('persisted')
+    const raw = storage.getItem('debugLog')
+    expect(raw).toBeTruthy()
+    expect((JSON.parse(raw!) as { type: string }[]).some(e => e.type === 'persisted')).toBe(true)
+  })
+
+  it('hydrates a prior session log on module load', async () => {
+    // seed localStorage as if a prior (crashed) session had persisted a log
+    localStorage.setItem('debugLog', JSON.stringify([{ seq: 0, t: 1, dt: 0, type: 'prior' }]))
+    vi.resetModules()
+    const fresh = (await import('../debugLog')).default
+    expect(fresh.read().some(e => e.type === 'prior')).toBe(true)
+  })
+
+  it('never throws when localStorage.setItem fails (e.g. quota exceeded)', () => {
+    debugLog.setEnabled(true)
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError')
+    })
+    expect(() => debugLog.log('overflow', { value: 'y'.repeat(1000) })).not.toThrow()
+  })
+})
+
+describe('clear', () => {
+  it('empties the buffer and removes the localStorage key', () => {
+    debugLog.setEnabled(true)
+    debugLog.log('x')
+    debugLog.clear()
+    expect(debugLog.read()).toEqual([])
+    expect(storage.getItem('debugLog')).toBeNull()
+  })
+})
+
+describe('format', () => {
+  it('renders a one-line-per-entry text block', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('input', { data: ' ' })
+    const text = debugLog.format()
+    expect(text).toContain('input')
+    expect(text).toContain('#0')
+    expect(text).toContain('"data":" "')
+  })
+})

--- a/src/util/debugLog.ts
+++ b/src/util/debugLog.ts
@@ -1,0 +1,178 @@
+import storage from './storage'
+
+/** The localStorage key under which the rolling debug log is persisted. */
+const DEBUG_LOG_KEY = 'debugLog'
+
+/** Maximum number of entries retained in the rolling buffer. Older entries are dropped first. */
+const DEBUG_LOG_CAPACITY = 500
+
+/** Maximum length of any single stringified field. Longer values are truncated to protect the ~5MB localStorage quota. */
+const FIELD_MAX_LENGTH = 2000
+
+/** Minimum interval between `frame` heartbeat entries so requestAnimationFrame does not flood the buffer. */
+const FRAME_HEARTBEAT_THROTTLE_MS = 500
+
+/** A single rolling-log entry. `seq`, `t`, `dt`, and `type` form a common envelope; all other fields are event-specific. */
+interface DebugLogEntry {
+  /** Monotonic sequence number. Gaps or a rapidly climbing counter reveal dropped entries or a runaway loop. */
+  seq: number
+  /** Wall-clock timestamp (Date.now()), so entries remain readable after a device restart. */
+  t: number
+  /** Milliseconds since the previous entry (high-resolution). A cadence collapsing toward 0 indicates a tight loop. */
+  dt: number
+  /** Short event tag, e.g. 'input', 'action', 'guard', 'frame'. */
+  type: string
+  [key: string]: unknown
+}
+
+/** Loads any previously persisted entries from localStorage so a prior session's log survives a reload or device restart for retrieval. Never throws. */
+const hydrate = (): DebugLogEntry[] => {
+  try {
+    const raw = storage.getItem(DEBUG_LOG_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as DebugLogEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+// in-memory source of truth; avoids parsing localStorage on every log() call
+let entries: DebugLogEntry[] = hydrate()
+// whether logging is currently active; when false, log() is a no-op with zero cost
+let enabled = false
+// monotonic sequence counter
+let seq = entries.length > 0 ? entries[entries.length - 1].seq + 1 : 0
+// performance.now() of the previous entry, used to compute dt
+let lastTime = 0
+// requestAnimationFrame handle for the frame heartbeat
+let frameId: number | null = null
+// performance.now() of the last emitted frame heartbeat, used to throttle it
+let lastFrameLogged = 0
+
+/** Truncates over-long string fields so a single pathological value cannot exhaust the localStorage quota. */
+const capFields = (fields?: Record<string, unknown>): Record<string, unknown> => {
+  if (!fields) return {}
+  const capped: Record<string, unknown> = {}
+  Object.keys(fields).forEach(key => {
+    const value = fields[key]
+    capped[key] =
+      typeof value === 'string' && value.length > FIELD_MAX_LENGTH
+        ? `${value.slice(0, FIELD_MAX_LENGTH)}…(+${value.length - FIELD_MAX_LENGTH})`
+        : value
+  })
+  return capped
+}
+
+/** Persists the in-memory buffer to localStorage synchronously. On quota errors, drops the oldest half and retries once, then gives up silently. Never throws. */
+const persist = (): void => {
+  try {
+    storage.setItem(DEBUG_LOG_KEY, JSON.stringify(entries))
+  } catch {
+    // Most likely a quota error. Drop the oldest half and retry once so the most recent (most relevant) entries survive.
+    entries.splice(0, Math.ceil(entries.length / 2))
+    try {
+      storage.setItem(DEBUG_LOG_KEY, JSON.stringify(entries))
+    } catch {
+      // Give up silently; logging must never interfere with the app.
+    }
+  }
+}
+
+/** Appends an entry to the rolling buffer and persists it synchronously. No-op when logging is disabled. Never throws, so instrumentation can never worsen a freeze or break editing. */
+const log = (type: string, fields?: Record<string, unknown>): void => {
+  if (!enabled) return
+  try {
+    const now = performance.now()
+    const dt = lastTime === 0 ? 0 : Math.round(now - lastTime)
+    lastTime = now
+    entries.push({ seq: seq++, t: Date.now(), dt, type, ...capFields(fields) })
+    if (entries.length > DEBUG_LOG_CAPACITY) {
+      entries.splice(0, entries.length - DEBUG_LOG_CAPACITY)
+    }
+    persist()
+  } catch {
+    // Logging must never throw.
+  }
+}
+
+/** The frame heartbeat loop. Records a throttled `frame` entry on each animation frame while logging is enabled. If the log stops but the last `frame` timestamp is stale, the freeze was a synchronous JS loop (rAF never fired again); if `frame` keeps ticking past the last event, the hang is at the native/WebKit layer. */
+const frameLoop = (): void => {
+  if (!enabled) return
+  const now = performance.now()
+  if (now - lastFrameLogged >= FRAME_HEARTBEAT_THROTTLE_MS) {
+    lastFrameLogged = now
+    log('frame')
+  }
+  frameId = requestAnimationFrame(frameLoop)
+}
+
+/** Starts the requestAnimationFrame heartbeat. No-op if unavailable (e.g. SSR). */
+const startFrameHeartbeat = (): void => {
+  if (typeof requestAnimationFrame !== 'function' || frameId != null) return
+  lastFrameLogged = 0
+  frameId = requestAnimationFrame(frameLoop)
+}
+
+/** Stops the requestAnimationFrame heartbeat. */
+const stopFrameHeartbeat = (): void => {
+  if (frameId != null && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(frameId)
+  }
+  frameId = null
+}
+
+/** Returns a copy of the current buffer, including any entries hydrated from a prior session. */
+const read = (): DebugLogEntry[] => [...entries]
+
+/** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. */
+const format = (): string =>
+  entries
+    .map(({ seq, t, dt, type, ...fields }) => {
+      const fieldStr = Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : ''
+      return `[${new Date(t).toISOString()}] +${dt}ms #${seq} ${type}${fieldStr}`
+    })
+    .join('\n')
+
+/** Empties the buffer and removes it from localStorage. */
+const clear = (): void => {
+  entries = []
+  seq = 0
+  lastTime = 0
+  try {
+    storage.removeItem(DEBUG_LOG_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** Returns whether logging is currently active. */
+const isEnabled = (): boolean => enabled
+
+/** Enables or disables logging. Enabling records a session marker (environment metadata) and starts the frame heartbeat; disabling stops the heartbeat. Idempotent. */
+const setEnabled = (value: boolean): void => {
+  if (value === enabled) return
+  enabled = value
+  if (enabled) {
+    log('session', {
+      ua: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+      screen: typeof window !== 'undefined' && window.screen ? `${window.screen.width}x${window.screen.height}` : '',
+      mode: import.meta.env.MODE,
+    })
+    startFrameHeartbeat()
+  } else {
+    stopFrameHeartbeat()
+  }
+}
+
+/** A synchronous, bounded, persistent rolling debug log for diagnosing catastrophic bugs (e.g. freezes) that survive a device restart, where console logging is unavailable. See src/util/debugLog.ts. */
+const debugLog = {
+  clear,
+  format,
+  isEnabled,
+  log,
+  read,
+  setEnabled,
+}
+
+export default debugLog


### PR DESCRIPTION
## Summary

Adds a **reusable, synchronous, bounded, persistent rolling debug log** for diagnosing catastrophic bugs (e.g. the iOS autocorrect freeze in #4607) that survive a device restart — where console logging is unavailable because the remote inspector isn't attached at the moment of the freeze.

This is **PR 1 of 2**: general-purpose infrastructure, off by default. The #4607-specific `Editable` instrumentation that consumes it will follow in a stacked PR.

## Why localStorage

`localStorage` writes are **synchronous**, so each entry is durably persisted the instant it is recorded — before the *next* operation can freeze the main thread. IndexedDB is async and may never flush during a hang. The log can then be retrieved after the device restart.

## What's included

- **`src/util/debugLog.ts`** — ring-buffer logger singleton:
  - `enabled` no-op gate (zero cost when off), capacity trim (500), per-field char cap (quota safety), `log()` wrapped so it **never throws**.
  - In-memory buffer hydrated from `localStorage` on load, so a **prior (crashed) session's log survives** for retrieval.
  - Common entry envelope `{ seq, t, dt, type, ... }`.
  - **`frame` heartbeat** (`requestAnimationFrame`): if the log stops but the last `frame` timestamp is stale → the freeze was a **synchronous JS loop**; if `frame` keeps ticking past the last event → a **native/WebKit hang**.
- **`loggerMiddleware`** — captures **every** dispatched Redux action (`actionType` + capped payload) when enabled. It runs after `thunk`, so it sees resolved plain actions.
- **Settings modal** — a new **Debug Logging** toggle (off by default) plus **Copy debug log** / **Clear debug log** controls for retrieval.
- **`AppComponent`** — a single top-level effect mirrors the setting into `debugLog.setEnabled` (keeps the util decoupled from the store).
- **Unit tests** for the logger (gate, capacity, field cap, hydration, quota-safety, clear, format) and the middleware.

## Privacy

Entries are captured only while the toggle is **ON**, only in the local browser, and **nothing is transmitted**. The user copies the log out manually. Disabled = zero added work on the edit/dispatch path, so this is safe to ship to production ahead of any fix.

## Testing

- `yarn lint` ✅
- `yarn test` (new files) ✅ — 14 tests pass