### PR TITLE
Fix empty colored thought bullet color

### DIFF
--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -295,10 +295,12 @@ const Bullet = ({
   const persistedFill = useSelector(state => getThoughtFill(state, thoughtId))
   const isEmpty = useSelector(state => getThoughtById(state, thoughtId)?.value === '')
   const activeCommandFill = commandStateStore.useSelector(state => {
+    if (!isEditing || !isEmpty) return undefined
+
     const fill = state.backColor || state.foreColor
     return typeof fill === 'string' ? fill : undefined
   })
-  const fill = persistedFill || (isEditing && isEmpty ? activeCommandFill : undefined)
+  const fill = persistedFill || activeCommandFill
 
   const isExpanded = useSelector(state => !!state.expanded[hashPath(path)])
   const isBulletExpanded = isCursorParent || isCursorGrandparent || isEditing || isExpanded

--- a/src/components/Bullet.tsx
+++ b/src/components/Bullet.tsx
@@ -18,6 +18,7 @@ import getThoughtFill from '../selectors/getThoughtFill'
 import isContextViewActive from '../selectors/isContextViewActive'
 import isMulticursorPath from '../selectors/isMulticursorPath'
 import rootedParentOf from '../selectors/rootedParentOf'
+import commandStateStore from '../stores/commandStateStore'
 import calculateCursorOverlayRadius from '../util/calculateCursorOverlayRadius'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
@@ -291,7 +292,13 @@ const Bullet = ({
     return children.length < Object.keys(thought.childrenMap).length
   })
 
-  const fill = useSelector(state => getThoughtFill(state, thoughtId))
+  const persistedFill = useSelector(state => getThoughtFill(state, thoughtId))
+  const isEmpty = useSelector(state => getThoughtById(state, thoughtId)?.value === '')
+  const activeCommandFill = commandStateStore.useSelector(state => {
+    const fill = state.backColor || state.foreColor
+    return typeof fill === 'string' ? fill : undefined
+  })
+  const fill = persistedFill || (isEditing && isEmpty ? activeCommandFill : undefined)
 
   const isExpanded = useSelector(state => !!state.expanded[hashPath(path)])
   const isBulletExpanded = isCursorParent || isCursorGrandparent || isEditing || isExpanded

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -7,9 +7,12 @@ import extractColor from '../helpers/extractColor'
 import getBulletColor from '../helpers/getBulletColor'
 import getEditingText from '../helpers/getEditingText'
 import getSuperscriptColor from '../helpers/getSuperScriptColor'
+import keyboard from '../helpers/keyboard'
+import newThought from '../helpers/newThought'
 import paste from '../helpers/paste'
 import press from '../helpers/press'
 import setSelection from '../helpers/setSelection'
+import waitForEditable from '../helpers/waitForEditable'
 import { page } from '../session'
 
 /** Click the first note. Assumes that there will be only a single note. */
@@ -17,6 +20,22 @@ const clickFirstNote = () => click('[aria-label="note-editable"]')
 
 /** Retrieve the innerHTML of the first note on the page. Assumes that there will be only a single note. */
 const getFirstNoteText = () => page.evaluate(() => document.querySelector('[aria-label="note-editable"]')?.innerHTML)
+
+/** Selects all contents of the editable cursor thought, including nested formatting tags. */
+const selectAllEditingText = () =>
+  page.evaluate(() => {
+    const editable = document.querySelector('[data-editing=true] [data-editable]')
+    if (!editable) throw new Error('No editing editable found')
+
+    const range = document.createRange()
+    range.selectNodeContents(editable)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+  })
+
+/** Waits one frame for selectionchange-driven command state to propagate. */
+const nextFrame = () => page.evaluate(() => new Promise(requestAnimationFrame))
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
 
@@ -38,6 +57,65 @@ it('Set the text color of the text and bullet', async () => {
   expect(rgbToHex(bulletColor!)).toBe(rgbaToHex(colors.light.blue))
   expect(result?.color).toBe(rgbaToHex(colors.light.blue))
   expect(result?.backgroundColor).toBe(null)
+})
+
+it('Bullet keeps the font color after deleting all text without moving the cursor', async () => {
+  await newThought('hello')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="red"]')
+  await waitForEditable('<font color="#ff573d">hello</font>')
+
+  const bulletColorBeforeDelete = await getBulletColor()
+  expect(rgbToHex(bulletColorBeforeDelete!)).toBe(rgbaToHex(colors.light.red))
+
+  await selectAllEditingText()
+  await press('Backspace')
+  await waitForEditable('')
+  await nextFrame()
+
+  const bulletColorAfterDelete = await getBulletColor()
+  expect(rgbToHex(bulletColorAfterDelete!)).toBe(rgbaToHex(colors.light.red))
+
+  await keyboard.type('a')
+  await waitForEditable('<font color="#ff573d">a</font>')
+
+  const bulletColorAfterTyping = await getBulletColor()
+  expect(rgbToHex(bulletColorAfterTyping!)).toBe(rgbaToHex(colors.light.red))
+})
+
+it('Bullet clears the font color after deleting all text and moving the cursor away', async () => {
+  await newThought('hello')
+
+  await click('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+  await click('[aria-label="text color swatches"] [aria-label="red"]')
+  await waitForEditable('<font color="#ff573d">hello</font>')
+
+  await selectAllEditingText()
+  await press('Backspace')
+  await waitForEditable('')
+  await nextFrame()
+
+  const bulletColorAfterDelete = await getBulletColor()
+  expect(rgbToHex(bulletColorAfterDelete!)).toBe(rgbaToHex(colors.light.red))
+
+  await press('Enter')
+  await nextFrame()
+
+  const newThoughtBulletColor = await getBulletColor()
+  expect(newThoughtBulletColor).toBe(null)
+
+  await press('ArrowUp')
+  await nextFrame()
+
+  const emptyThoughtBulletColor = await getBulletColor()
+  expect(emptyThoughtBulletColor).toBe(null)
+
+  await keyboard.type('a')
+  await waitForEditable('a')
+
+  const bulletColorAfterTyping = await getBulletColor()
+  expect(bulletColorAfterTyping).toBe(null)
 })
 
 it('Bullet keeps the font color after applying Upper Case', async () => {

--- a/src/stores/commandStateStore.ts
+++ b/src/stores/commandStateStore.ts
@@ -1,7 +1,11 @@
 import CommandState from '../@types/CommandState'
+import FormattingCommand from '../@types/FormattingCommand'
+import State from '../@types/State'
 import * as selection from '../device/selection'
 import pathToThought from '../selectors/pathToThought'
+import themeColors from '../selectors/themeColors'
 import getCommandState from '../util/getCommandState'
+import rgbToHex from '../util/rgbToHex'
 import store from './app'
 import reactMinistore from './react-ministore'
 
@@ -29,14 +33,45 @@ export const resetCommandState = () => {
   })
 }
 
+/** Returns true if two color values resolve to the same hex color. */
+const equalColor = (a: string, b: string) => {
+  try {
+    return rgbToHex(a).toLowerCase() === rgbToHex(b).toLowerCase()
+  } catch {
+    return a.trim().toLowerCase() === b.trim().toLowerCase()
+  }
+}
+
+/** Returns the active command color if it is not one of the default editor colors. */
+const getCustomCommandColor = (command: 'foreColor' | 'backColor', defaults: string[]) => {
+  if (typeof document === 'undefined' || typeof document.queryCommandValue !== 'function') return undefined
+
+  const color = document.queryCommandValue(command)
+  return color && !defaults.some(defaultColor => equalColor(color, defaultColor)) ? color : undefined
+}
+
+/** Gets active foreground/background colors from the browser command state for an empty thought selection. */
+const getActiveEmptySelectionColors = (state: State): Partial<CommandState> => {
+  const colors = themeColors(state)
+  const defaultColors = [colors.bg, colors.fg, colors.fgNote]
+
+  return {
+    [FormattingCommand.foreColor]: getCustomCommandColor('foreColor', defaultColors),
+    [FormattingCommand.backColor]: getCustomCommandColor('backColor', defaultColors),
+  }
+}
+
 /** Updates the command state to the current selection/thought. If there is an active selection, this uses document.queryCommandState to get the command state from the DOM. This detects a formatting style that has been enabled, but not yet entered (i.e. the next character typed will be bold). If there is no selection, this parses the cursor thought's value and sets a formatting state only if it applies to the entire thought. */
 export const updateCommandState = () => {
   const state = store.getState()
   if (!state.cursor) return
-  const action =
-    selection.isActive() && selection.isThought()
-      ? getCommandState(selection.html() ?? '')
-      : getCommandState(pathToThought(state, state.cursor)?.value ?? '')
+  const selectionIsActiveThought = selection.isActive() && selection.isThought()
+  const action = selectionIsActiveThought
+    ? {
+        ...getCommandState(selection.html() ?? ''),
+        ...(!selection.text()?.length ? getActiveEmptySelectionColors(state) : {}),
+      }
+    : getCommandState(pathToThought(state, state.cursor)?.value ?? '')
   commandStateStore.update(action)
 }
 


### PR DESCRIPTION
## Summary
Fixes cybersemics/em#4639


## Changes

- Preserve the active foreground/background color when a colored thought is emptied without moving the cursor.
- Use the active command color as the bullet fill only for the currently edited empty thought.
- Add Puppeteer regressions for both expected behaviors:
  - empty colored thought keeps its bullet color while the cursor stays there
  - moving away and back clears the bullet/text color

## Testing

- `node node_modules/typescript/bin/tsc`
- `node node_modules/prettier/bin/prettier.cjs --check src/stores/commandStateStore.ts src/components/Bullet.tsx src/e2e/puppeteer/__tests__/color.ts`
- `node node_modules/vitest/vitest.mjs run src/util/__tests__/getCommandState.ts --project unit`
- Local Vite + Chrome browser probes for both issue paths