### PR TITLE
chore(ci): bump actions/cache v4 -> v5 for Node 24

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Restore node_modules cache
       id: cache-node-modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           node_modules
@@ -29,7 +29,7 @@ runs:
 
     - name: Restore packages/webview build cache
       id: cache-webview
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: packages/webview/dist
         key: ${{ runner.os }}-webview-v1-${{ hashFiles('packages/webview/src/**', 'packages/webview/scripts/**', 'packages/webview/rollup.config.mjs', 'packages/webview/tsconfig.json', 'packages/webview/package.json') }}


### PR DESCRIPTION
## Summary

`actions/cache@v4` runs on the deprecated Node.js 20 runtime and was being force-migrated to Node.js 24 by the GitHub Actions runner, producing a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4.

`actions/cache@v5.0.0` is the release that natively targets the Node.js 24 runtime, resolving the warning.

## Changes

- Bump both `actions/cache` references in `.github/actions/install/action.yml` from `@v4` to `@v5`.

## Notes

- `v5` requires Actions Runner ≥ `2.327.1` — satisfied by GitHub-hosted runners.
- No cache-key or behavior changes; caching semantics are unchanged.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/