### PR TITLE
feat(ci): post Puppeteer snapshot diffs inline in a PR comment

### DIFF
--- a/.github/workflows/puppeteer-diff-comment.yml
+++ b/.github/workflows/puppeteer-diff-comment.yml
@@ -1,0 +1,266 @@
+# Posts Puppeteer visual-regression diff images inline in a PR comment.
+#
+# This is the privileged half of a two-workflow pair. The `Puppeteer` workflow
+# (puppeteer.yml) runs the tests on the `pull_request` trigger — which gives fork
+# PRs a read-only token that cannot push a branch or comment. It uploads the diff
+# PNGs (on failure) and the PR number as artifacts. This workflow then runs on
+# `workflow_run` in the **base-repo context**, where it has a write token, hosts
+# the images on the `snapshot-diffs` orphan branch, and upserts the PR comment.
+#
+# SECURITY: the triggering run's artifacts are produced by untrusted fork code, so
+# every value read from them is untrusted input. This job therefore:
+#   - never checks out or executes PR code (data only);
+#   - uses least-privilege permissions;
+#   - verifies the PR head sha matches the workflow_run head sha (anti-spoofing);
+#   - safely extracts artifacts (no path traversal, PNG-only, size/count caps);
+#   - builds the comment from a fixed URL pattern with sanitized labels.
+name: Puppeteer Diff Comment
+
+on:
+  workflow_run:
+    workflows: ['Puppeteer']
+    types: [completed]
+
+permissions:
+  contents: write # push the snapshot-diffs orphan branch
+  pull-requests: write # upsert the PR comment
+  actions: read # download artifacts from the triggering run
+
+# Serialize per source branch so concurrent runs don't race on the branch push.
+concurrency:
+  group: puppeteer-diff-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  comment:
+    name: Post diff comment
+    runs-on: ubuntu-latest
+    # Only for PR-triggered runs that actually ran the tests (success => resolved
+    # path, failure => diffs to post). Skipped/cancelled runs produce no artifacts.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+
+    steps:
+      # Download ALL artifacts from the triggering run. Cross-run download requires
+      # run-id + github-token. pr-number is always present for PR runs; __diff_output__
+      # is present only when a snapshot test failed.
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifacts
+
+      # Resolve the PR number from the artifact and verify it against the
+      # workflow_run head sha so a crafted pr-number.txt cannot target another PR.
+      - name: Resolve and verify PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const file = 'artifacts/pr-number/pr-number.txt'
+            if (!fs.existsSync(file)) {
+              core.info('No pr-number artifact found; nothing to do.')
+              return
+            }
+            const raw = fs.readFileSync(file, 'utf8').trim()
+            if (!/^[0-9]+$/.test(raw)) {
+              core.setFailed(`Refusing to proceed: pr-number artifact is not a plain integer (${JSON.stringify(raw)}).`)
+              return
+            }
+            const prNumber = Number(raw)
+            const headSha = context.payload.workflow_run.head_sha
+            const { owner, repo } = context.repo
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
+            // Anti-spoofing: the PR the images claim to belong to must be the one
+            // whose head commit actually triggered the test run.
+            if (pr.head.sha !== headSha) {
+              core.setFailed(
+                `Aborting: PR #${prNumber} head sha ${pr.head.sha} does not match the ` +
+                  `workflow_run head sha ${headSha}. This likely indicates a spoofed pr-number artifact.`,
+              )
+              return
+            }
+            core.setOutput('number', String(prNumber))
+            core.setOutput('author', pr.user ? pr.user.login : '')
+
+      # Safely stage diff PNGs, host them on the snapshot-diffs orphan branch, and
+      # emit a manifest for the comment step. Only this PR's folder is touched; on
+      # the resolved (no-diff) path the folder is pruned.
+      - name: Publish diffs to snapshot-diffs branch
+        id: publish
+        if: steps.pr.outputs.number
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          BRANCH: snapshot-diffs
+          SRC: artifacts/__diff_output__
+          MANIFEST: ${{ github.workspace }}/committed-images.txt
+        run: |
+          set -euo pipefail
+
+          MAX_FILES=50
+          MAX_BYTES=$((5 * 1024 * 1024))
+
+          # 1. Safely collect PNGs into a staging dir, rejecting path traversal,
+          #    disallowed filename characters, non-PNGs, oversized files, and
+          #    anything beyond the count cap.
+          STAGE="$(mktemp -d)"
+          : > "$MANIFEST"
+          count=0
+          if [ -d "$SRC" ]; then
+            while IFS= read -r -d '' f; do
+              rel="${f#"$SRC"/}"
+              case "$rel" in
+                *..* | /*)
+                  echo "Rejecting unsafe path: $rel"
+                  continue
+                  ;;
+              esac
+              if printf '%s' "$rel" | grep -qE '[^A-Za-z0-9._/-]'; then
+                echo "Rejecting filename with disallowed characters: $rel"
+                continue
+              fi
+              size="$(stat -c%s "$f")"
+              if [ "$size" -gt "$MAX_BYTES" ]; then
+                echo "Rejecting oversized file ($size bytes): $rel"
+                continue
+              fi
+              count=$((count + 1))
+              if [ "$count" -gt "$MAX_FILES" ]; then
+                echo "Reached file count cap ($MAX_FILES); ignoring remaining diffs."
+                count="$MAX_FILES"
+                break
+              fi
+              mkdir -p "$STAGE/$(dirname "$rel")"
+              cp "$f" "$STAGE/$rel"
+              printf '%s\n' "$rel" >> "$MANIFEST"
+            done < <(find "$SRC" -type f -name '*.png' -print0)
+          fi
+          echo "collected=$count" >> "$GITHUB_OUTPUT"
+          echo "Collected $count diff image(s)."
+
+          # 2. Publish to the orphan branch. Recompute from the latest remote state
+          #    on each attempt so concurrent PRs (each touching a distinct pr-<n>/
+          #    folder) reconcile via a simple fast-forward push + retry.
+          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          publish() {
+            local work
+            work="$(mktemp -d)"
+            cd "$work"
+            git init -q
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git remote add origin "$REMOTE"
+            if git fetch -q origin "$BRANCH"; then
+              git checkout -q -b "$BRANCH" FETCH_HEAD
+            else
+              git checkout -q --orphan "$BRANCH"
+              git reset -q --hard || true
+              find . -maxdepth 1 ! -name .git ! -name . -exec rm -rf {} +
+            fi
+
+            # Keep only the latest run per PR.
+            rm -rf "pr-$PR"
+            if [ "$count" -gt 0 ]; then
+              mkdir -p "pr-$PR/$RUN_ID"
+              cp -R "$STAGE/." "pr-$PR/$RUN_ID/"
+            fi
+
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No branch changes to publish."
+              return 0
+            fi
+            git commit -q -m "chore(snapshot-diffs): PR #$PR run $RUN_ID"
+            git push -q origin "HEAD:refs/heads/$BRANCH"
+          }
+
+          published=false
+          for attempt in 1 2 3 4 5; do
+            if publish; then
+              published=true
+              break
+            fi
+            echo "Publish attempt $attempt failed; retrying after backoff."
+            sleep $((RANDOM % 5 + 1))
+          done
+          if [ "$published" != true ]; then
+            echo "Failed to publish diffs to $BRANCH after multiple attempts." >&2
+            exit 1
+          fi
+
+      # Upsert the PR comment. Renders diffs inline from fixed raw URLs, or a
+      # resolved message when the latest run had no diffs.
+      - name: Upsert PR comment
+        if: steps.pr.outputs.number
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ steps.pr.outputs.number }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          COLLECTED: ${{ steps.publish.outputs.collected }}
+        with:
+          script: |
+            const fs = require('fs')
+            const { owner, repo } = context.repo
+            const marker = '<!-- puppeteer-diff -->'
+            const prNumber = Number(process.env.PR)
+            const runId = process.env.RUN_ID
+            const runUrl = process.env.RUN_URL
+            const author = process.env.AUTHOR
+            const collected = Number(process.env.COLLECTED || '0')
+
+            // HTML-escape defensively (filenames are already allowlisted upstream).
+            const esc = s =>
+              String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c])
+
+            let body
+            if (collected > 0) {
+              const manifest = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/committed-images.txt`, 'utf8')
+              const rels = manifest.split('\n').map(l => l.trim()).filter(Boolean)
+              const base = `https://raw.githubusercontent.com/${owner}/${repo}/snapshot-diffs/pr-${prNumber}/${runId}`
+              const blocks = rels
+                .map(rel => {
+                  const url = `${base}/${rel.split('/').map(encodeURIComponent).join('/')}`
+                  const label = esc(rel.replace('/__diff_output__/', ' / '))
+                  return `**${label}**\n\n<img src="${url}" alt="${label}" width="900" />`
+                })
+                .join('\n\n')
+              const authorNote = author ? ` by @${esc(author)}` : ''
+              body = [
+                marker,
+                '### 🖼️ Puppeteer snapshot diffs',
+                '',
+                `⚠️ Auto-generated, **unverified** diff images from PR #${prNumber}${authorNote} (run ${runId}).`,
+                '',
+                `<details open><summary>${rels.length} changed snapshot(s)</summary>`,
+                '',
+                blocks,
+                '',
+                '</details>',
+                '',
+                `[View workflow run](${runUrl})`,
+              ].join('\n')
+            } else {
+              body = [
+                marker,
+                '### 🖼️ Puppeteer snapshot diffs',
+                '',
+                `✅ No snapshot diffs in the latest run (${runId}). Any previously reported diffs have been cleared.`,
+                '',
+                `[View workflow run](${runUrl})`,
+              ].join('\n')
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber })
+            const existing = comments.find(c => c.body && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body })
+            }

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -66,3 +66,18 @@ jobs:
           name: __diff_output__
           path: src/e2e/puppeteer/__tests__/__image_snapshots__/**/__diff_output__/
           if-no-files-found: ignore
+
+      # Carry the PR number to the privileged workflow_run job. github.event.workflow_run.pull_requests
+      # is empty for fork PRs, so the number must be passed via an artifact. Uploaded on every PR run
+      # (success or failure) so the comment can be posted on failure and pruned/resolved on success.
+      - name: Save PR number
+        if: always() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR number artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          path: pr-number.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

When Puppeteer visual-regression tests fail, the diff PNGs are currently uploaded as a zipped artifact that reviewers must download and unzip. This adds a workflow that shows those diff images **inline in a PR comment** instead.

There is no GitHub API to attach an image directly to a comment (the `body` is markdown text, and `data:` URIs are stripped by GitHub's image proxy). So the images must first be hosted at a public URL. This uses a dedicated **`snapshot-diffs` orphan branch** and embeds `raw.githubusercontent.com` URLs — no third-party services, only `GITHUB_TOKEN`.

## How it works (two-workflow design)

Fork PRs get a **read-only** token on the `pull_request` trigger, so the test job can't push a branch or comment. The work is therefore split:

1. **`puppeteer.yml`** (edited) — runs the tests. On failure it uploads the diff PNGs (unchanged), and it now also uploads the **PR number** as an artifact (needed because `workflow_run.pull_requests` is empty for fork PRs).
2. **`puppeteer-diff-comment.yml`** (new) — triggered by `workflow_run` in the **base-repo context** (write token). It downloads the artifacts, commits the diff PNGs to the `snapshot-diffs` orphan branch (latest run per PR only), and upserts a PR comment embedding them inline. When a later run has no diffs, it prunes the PR's folder and updates the comment to a "resolved" state.

The artifact upload is kept — it's the transport between the two workflows.

## Security hardening

The privileged `workflow_run` job consumes artifacts produced by untrusted fork code, so every value from them is treated as untrusted:

- **No PR code execution** — the job only downloads artifacts (data) and runs our own trusted steps; it never checks out PR code.
- **Least privilege** — `contents: write`, `pull-requests: write`, `actions: read`.
- **Anti-spoofing** — asserts `pr.head.sha === workflow_run.head_sha` before commenting, so a crafted `pr-number.txt` can't post images onto someone else's PR.
- **Safe extraction** — rejects `../`/absolute paths, allowlists `*.png`, and caps per-file size (5 MB) and total count (50).
- **Markdown sanitization** — fixed image `src` pattern + allowlisted/HTML-escaped filename labels; no untrusted HTML passed through.
- **Provenance labeling** — the comment states the images are auto-generated and unverified.

## Validation

- `actionlint` passes clean on both workflows (includes shellcheck of the embedded bash).
- Both `github-script` blocks pass `node --check`.
- Dry-ran the extraction + URL/label logic against a mock diff tree, including malicious entries (rejected as expected).
- `prettier` clean.

## Caveat

`workflow_run` workflows only run from the copy of the file on the **default branch**, so this cannot be exercised end-to-end on this PR itself — it activates on the next failing PR after merge. Validated here via linting and logic review.