### PR TITLE
feat(estimate): self-consistency voting, richer JSON, eval harness; switch to gpt-5.6-terra

### DIFF
--- a/.github/instructions/estimate/estimate.instructions.md
+++ b/.github/instructions/estimate/estimate.instructions.md
@@ -31,7 +31,11 @@ You are an issue estimation assistant for the `em` project, a TypeScript/React/R
 
 ## Output Requirements
 
-- Output ONLY a valid JSON object.
-- Format: `{"estimate": "<CATEGORY>"}`
-- CATEGORY must be exactly one of: XXS, XS, S, M, L, XL, XXL
-- Do not include any explanation, markdown, or additional text.
+- Output ONLY a valid JSON object with these fields, in this order:
+  - `rationale`: a brief (one- or two-sentence) explanation of the estimate. Comes first so you reason before committing to a bucket.
+  - `estimate`: the chosen category. Required.
+  - `confidence`: your confidence in the estimate — exactly one of `high`, `medium`, `low`.
+  - `secondChoice`: the next most likely category if you are uncertain. Optional.
+- Format: `{"rationale": "<brief reasoning>", "estimate": "<CATEGORY>", "confidence": "high|medium|low", "secondChoice": "<CATEGORY>"}`
+- CATEGORY (for `estimate` and `secondChoice`) must be exactly one of: XXS, XS, S, M, L, XL, XXL
+- Do not include any markdown or text outside the JSON object.

--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -7,3 +7,8 @@ EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=
 # OpenAI API key used for the estimation inference call.
 OPENAI_API_KEY=
+# Inference tuning (all optional; defaults shown):
+# ESTIMATE_MODEL=gpt-5.6-terra          # OpenAI model used for estimation.
+# ESTIMATE_VOTES=5                       # Self-consistency samples drawn per estimate (Chat Completions `n`).
+# ESTIMATE_REASONING_EFFORT=            # Reasoning effort for reasoning models (none|low|medium|high|xhigh|max). Sent only when set.
+# ESTIMATE_TEMPERATURE=                  # Sent only when set; most reasoning models reject a non-default temperature.

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -22,6 +22,19 @@ yarn backfill --dry 10
 
 Dry-run flags: `--dry` skips both the model call and the Everhour write; `--dry-ai` skips only the model call; `--dry-everhour` skips only the Everhour write (and the issue audit comment).
 
+## Evaluation
+
+The estimator draws multiple independent samples per issue (self-consistency voting via the Chat Completions `n` parameter) and reports the modal category, so each estimate carries an `agreement` score (fraction of votes that agreed) and a self-reported `confidence`. Both are surfaced in the audit comment.
+
+To measure accuracy, run the leave-one-out harness. For each labeled sample it rebuilds the prompt from every _other_ sample, estimates the held-out issue, and compares to the known-correct category. It reports exact-bucket and ±1-bucket accuracy, a confusion matrix, and a calibration breakdown. It makes model calls but never writes to Everhour.
+
+```bash
+cd scripts/estimate
+yarn evaluate
+```
+
+Inference is tunable via `ESTIMATE_*` env vars (see `.env.example`): `ESTIMATE_MODEL`, `ESTIMATE_VOTES`, `ESTIMATE_REASONING_EFFORT`, `ESTIMATE_TEMPERATURE`.
+
 Manual correction (via issue comment)
 
 ```md

--- a/scripts/estimate/package.json
+++ b/scripts/estimate/package.json
@@ -7,6 +7,7 @@
     "backfill": "node src/backfill.ts",
     "build": "tsc --noEmit",
     "command": "node src/command.ts",
+    "evaluate": "node src/evaluate.ts",
     "format": "prettier --write .",
     "issue": "node src/issue.ts",
     "typecheck": "tsc --noEmit"

--- a/scripts/estimate/src/__tests__/evaluate.ts
+++ b/scripts/estimate/src/__tests__/evaluate.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { type EvalRow, bucketDistance, computeMetrics } from '../evaluate.ts'
+
+describe('bucketDistance', () => {
+  it('is 0 for the same category', () => {
+    expect(bucketDistance('M', 'M')).toBe(0)
+  })
+
+  it('is 1 for adjacent categories', () => {
+    expect(bucketDistance('S', 'M')).toBe(1)
+    expect(bucketDistance('M', 'S')).toBe(1)
+  })
+
+  it('measures ordinal distance across the scale', () => {
+    expect(bucketDistance('XXS', 'XXL')).toBe(6)
+    expect(bucketDistance('XS', 'L')).toBe(3)
+  })
+})
+
+describe('computeMetrics', () => {
+  const rows: EvalRow[] = [
+    { expected: 'S', predicted: 'S', agreement: 1, confidence: 'high' }, // exact
+    { expected: 'M', predicted: 'S', agreement: 0.6, confidence: 'medium' }, // ±1
+    { expected: 'L', predicted: 'XXS', agreement: 0.4, confidence: 'low' }, // far miss
+    { expected: 'M', predicted: 'M', agreement: 0.8, confidence: 'high' }, // exact
+  ]
+
+  it('computes exact-bucket accuracy', () => {
+    const m = computeMetrics(rows)
+    expect(m.exact.count).toBe(2)
+    expect(m.exact.fraction).toBeCloseTo(0.5)
+  })
+
+  it('computes ±1-bucket accuracy (includes exact and adjacent)', () => {
+    const m = computeMetrics(rows)
+    // S→S (0), M→S (1), L→XXS (5), M→M (0) → 3 within 1
+    expect(m.within1.count).toBe(3)
+    expect(m.within1.fraction).toBeCloseTo(0.75)
+  })
+
+  it('builds a confusion matrix keyed expected → predicted', () => {
+    const m = computeMetrics(rows)
+    expect(m.confusion['M']).toEqual({ S: 1, M: 1 })
+    expect(m.confusion['S']).toEqual({ S: 1 })
+    expect(m.confusion['L']).toEqual({ XXS: 1 })
+  })
+
+  it('groups calibration by agreement tier and confidence level', () => {
+    const m = computeMetrics(rows)
+    expect(m.calibration['confidence:high']).toEqual({ total: 2, exact: 2 })
+    expect(m.calibration['confidence:low']).toEqual({ total: 1, exact: 0 })
+    expect(m.calibration['agreement≥0.8']).toEqual({ total: 2, exact: 2 })
+    expect(m.calibration['agreement<0.5']).toEqual({ total: 1, exact: 0 })
+  })
+
+  it('handles an empty row set without dividing by zero', () => {
+    const m = computeMetrics([])
+    expect(m.total).toBe(0)
+    expect(m.exact.fraction).toBe(0)
+    expect(m.within1.fraction).toBe(0)
+  })
+})

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -116,7 +116,7 @@ const processTask = async ({
   // write was dry-run — a dry Everhour run must not post a comment claiming an estimate was recorded.
   if (!estimate || dryRunEverhour) return
 
-  const { category, hours } = estimate
+  const { category, hours, confidence, agreement } = estimate
 
   // Log the estimate first: it has already been written to Everhour by estimateIssue, so it must be
   // reported even if the best-effort audit comment below fails. Logging after the POST risked losing
@@ -127,7 +127,7 @@ const processTask = async ({
 
   // Leave an audit comment on the GitHub issue. Best-effort: a comment failure must not abort the
   // backfill run or discard the estimate already recorded, so failures are warned, not thrown.
-  const commentBody = `Everhour estimate: ${category} / ${hours}h\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}\nSource: backfill`
+  const commentBody = `Everhour estimate: ${category} / ${hours}h\nConfidence: ${confidence} (agreement ${Math.round(agreement * 100)}%)\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}\nSource: backfill`
   try {
     const commentResp = await fetch(
       `https://api.github.com/repos/${owner}/${repoName}/issues/${issue.number}/comments`,

--- a/scripts/estimate/src/evaluate.ts
+++ b/scripts/estimate/src/evaluate.ts
@@ -1,0 +1,172 @@
+/**
+ * Leave-one-out evaluation harness for the estimator. For each labeled sample, rebuilds the prompt
+ * from every OTHER sample, runs the full inference + voting pipeline on the held-out issue, and
+ * compares the predicted category to the known-correct `expected`. Reports exact-bucket accuracy,
+ * ±1-bucket accuracy, a confusion matrix, and a calibration breakdown (accuracy by vote agreement
+ * and by self-reported confidence).
+ *
+ * This is the "ruler" for the estimator: run it before and after a prompt/model/voting change to
+ * confirm the change actually helps. Offline — it makes model calls but never writes to Everhour.
+ *
+ * Run manually (needs OPENAI_API_KEY): cd scripts/estimate && yarn evaluate
+ */
+import 'dotenv/config'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { ESTIMATE_CATEGORIES, type EstimateCategory } from './everhour/estimates.ts'
+import buildPrompt from './lib/buildPrompt.ts'
+import inference from './lib/inference.ts'
+import loadInstructions from './lib/loadInstructions.ts'
+import loadSamples, { type EstimateSample } from './lib/loadSamples.ts'
+import tallyVotes from './lib/tallyVotes.ts'
+
+/** One graded prediction from the leave-one-out run. */
+export interface EvalRow {
+  issue?: number
+  expected: EstimateCategory
+  predicted: EstimateCategory
+  agreement: number
+  confidence: 'high' | 'medium' | 'low'
+}
+
+/** Aggregate metrics computed from a set of graded predictions. */
+export interface EvalMetrics {
+  total: number
+  /** Count and fraction of predictions that hit the exact bucket. */
+  exact: { count: number; fraction: number }
+  /** Count and fraction of predictions within one bucket of the expected category. */
+  within1: { count: number; fraction: number }
+  /** confusion[expected][predicted] = count. */
+  confusion: Record<string, Record<string, number>>
+  /** Accuracy grouped by a calibration key (agreement tier or confidence level). */
+  calibration: Record<string, { total: number; exact: number }>
+}
+
+/**
+ * Ordinal distance between two categories on the XXS<XS<S<M<L<XL<XXL scale. 0 = exact match,
+ * 1 = adjacent bucket, etc. Used to distinguish near-misses from wild misses.
+ */
+export const bucketDistance = (a: EstimateCategory, b: EstimateCategory): number =>
+  Math.abs(ESTIMATE_CATEGORIES.indexOf(a) - ESTIMATE_CATEGORIES.indexOf(b))
+
+/** Buckets a 0–1 agreement score into a coarse calibration tier. */
+const agreementTier = (agreement: number): string =>
+  agreement >= 0.8 ? 'agreement≥0.8' : agreement >= 0.5 ? 'agreement 0.5–0.8' : 'agreement<0.5'
+
+/** Computes exact/±1 accuracy, a confusion matrix, and a calibration breakdown from graded rows. */
+export const computeMetrics = (rows: EvalRow[]): EvalMetrics => {
+  const total = rows.length
+  const exactCount = rows.filter(r => r.predicted === r.expected).length
+  const within1Count = rows.filter(r => bucketDistance(r.predicted, r.expected) <= 1).length
+
+  const confusion: Record<string, Record<string, number>> = {}
+  for (const r of rows) {
+    confusion[r.expected] ??= {}
+    confusion[r.expected][r.predicted] = (confusion[r.expected][r.predicted] ?? 0) + 1
+  }
+
+  const calibration: Record<string, { total: number; exact: number }> = {}
+  const bump = (key: string, isExact: boolean) => {
+    calibration[key] ??= { total: 0, exact: 0 }
+    calibration[key].total += 1
+    calibration[key].exact += isExact ? 1 : 0
+  }
+  for (const r of rows) {
+    const isExact = r.predicted === r.expected
+    bump(agreementTier(r.agreement), isExact)
+    bump(`confidence:${r.confidence}`, isExact)
+  }
+
+  return {
+    total,
+    exact: { count: exactCount, fraction: total ? exactCount / total : 0 },
+    within1: { count: within1Count, fraction: total ? within1Count / total : 0 },
+    confusion,
+    calibration,
+  }
+}
+
+/** Runs leave-one-out inference over all samples and returns the graded rows. */
+const runLeaveOneOut = async (
+  samples: EstimateSample[],
+  instructions: string,
+  openaiApiKey: string,
+): Promise<EvalRow[]> => {
+  const rows: EvalRow[] = []
+  for (let i = 0; i < samples.length; i++) {
+    const target = samples[i]
+    const others = samples.filter((_, j) => j !== i)
+    const prompt = buildPrompt(others, target.input)
+    const outputs = await inference({ apiKey: openaiApiKey, prompt, instructions })
+    const vote = tallyVotes(outputs)
+    rows.push({
+      issue: target.source?.issue,
+      expected: target.expected as EstimateCategory,
+      predicted: vote.estimate,
+      agreement: vote.agreement,
+      confidence: vote.confidence,
+    })
+    console.info(
+      `  ${target.source?.issue ? `#${target.source.issue}` : `sample ${i + 1}`}: expected ${target.expected}, predicted ${vote.estimate} (agreement ${Math.round(vote.agreement * 100)}%, confidence ${vote.confidence})`,
+    )
+  }
+  return rows
+}
+
+/** Renders the metrics summary as human-readable text. */
+const formatReport = (metrics: EvalMetrics): string => {
+  const lines: string[] = []
+  lines.push('')
+  lines.push('=== Estimator leave-one-out evaluation ===')
+  lines.push(`Samples: ${metrics.total}`)
+  lines.push(
+    `Exact-bucket accuracy: ${metrics.exact.count}/${metrics.total} (${Math.round(metrics.exact.fraction * 100)}%)`,
+  )
+  lines.push(
+    `±1-bucket accuracy:    ${metrics.within1.count}/${metrics.total} (${Math.round(metrics.within1.fraction * 100)}%)`,
+  )
+
+  lines.push('')
+  lines.push('Confusion (expected → predicted):')
+  for (const expected of ESTIMATE_CATEGORIES) {
+    const row = metrics.confusion[expected]
+    if (!row) continue
+    const cells = ESTIMATE_CATEGORIES.filter(p => row[p]).map(p => `${p}×${row[p]}`)
+    lines.push(`  ${expected.padEnd(4)} → ${cells.join(', ')}`)
+  }
+
+  lines.push('')
+  lines.push('Calibration (exact accuracy by group):')
+  for (const [key, { total, exact }] of Object.entries(metrics.calibration)) {
+    lines.push(`  ${key.padEnd(18)}: ${exact}/${total} (${Math.round((total ? exact / total : 0) * 100)}%)`)
+  }
+
+  return lines.join('\n')
+}
+
+const main = async () => {
+  const openaiApiKey = process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+
+  // Resolve the repo root from this file's location (scripts/estimate/src/evaluate.ts → repo root)
+  // so instructions/samples load correctly regardless of the current working directory.
+  const repoRoot =
+    process.env.GITHUB_WORKSPACE ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+
+  const instructions = loadInstructions(repoRoot)
+  const samples = loadSamples(repoRoot)
+  if (samples.length === 0) throw new Error('No samples found to evaluate.')
+
+  console.info(`Evaluating ${samples.length} samples (leave-one-out)...`)
+  const rows = await runLeaveOneOut(samples, instructions, openaiApiKey)
+  console.info(formatReport(computeMetrics(rows)))
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(err => {
+    console.error(err)
+    process.exitCode = 1
+  })
+}
+
+export default main

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -82,7 +82,7 @@ const main = async () => {
     taskId: task.id,
   })
   if (!estimate) return
-  const { category, hours } = estimate
+  const { category, hours, confidence, agreement } = estimate
 
   // Get prompt version
   const promptVersion = getPromptVersion(repoRoot)
@@ -94,7 +94,7 @@ const main = async () => {
   )
 
   // Leave an audit comment. Best-effort: a comment failure must not discard the estimate already recorded.
-  const commentBody = `Estimate: ${category} / ${hours}h\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}`
+  const commentBody = `Estimate: ${category} / ${hours}h\nConfidence: ${confidence} (agreement ${Math.round(agreement * 100)}%)\nPrompt version: ${promptVersionLink(owner, repoName, promptVersion)}`
 
   try {
     const commentResp = await fetch(

--- a/scripts/estimate/src/lib/__tests__/buildPrompt.ts
+++ b/scripts/estimate/src/lib/__tests__/buildPrompt.ts
@@ -9,7 +9,9 @@ describe('buildPrompt', () => {
     expect(result).toContain('Fix bug')
     expect(result).toContain('Something is broken')
     expect(result).toContain('bug')
-    expect(result).toContain('{"estimate": "<CATEGORY>"}')
+    expect(result).toContain('"estimate": "<CATEGORY>"')
+    expect(result).toContain('"rationale"')
+    expect(result).toContain('"confidence": "high|medium|low"')
   })
 
   it('includes samples when provided', () => {

--- a/scripts/estimate/src/lib/__tests__/tallyVotes.ts
+++ b/scripts/estimate/src/lib/__tests__/tallyVotes.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import tallyVotes from '../tallyVotes.ts'
+
+/** Builds a raw JSON vote string. */
+const vote = (estimate: string, extra: Record<string, unknown> = {}): string => JSON.stringify({ estimate, ...extra })
+
+describe('tallyVotes', () => {
+  it('returns the unanimous estimate with full agreement', () => {
+    const result = tallyVotes([vote('S'), vote('S'), vote('S')])
+    expect(result.estimate).toBe('S')
+    expect(result.agreement).toBe(1)
+    expect(result.validVotes).toBe(3)
+    expect(result.totalVotes).toBe(3)
+  })
+
+  it('returns the modal estimate and fractional agreement', () => {
+    const result = tallyVotes([vote('S'), vote('M'), vote('M'), vote('L'), vote('S')])
+    // S×2, M×2, L×1 → tie between S and M broken toward the larger bucket (M)
+    expect(result.estimate).toBe('M')
+    expect(result.agreement).toBeCloseTo(2 / 5)
+  })
+
+  it('picks a clear plurality winner', () => {
+    const result = tallyVotes([vote('S'), vote('S'), vote('S'), vote('M'), vote('L')])
+    expect(result.estimate).toBe('S')
+    expect(result.agreement).toBeCloseTo(3 / 5)
+  })
+
+  it('breaks ties toward the larger (more conservative) bucket', () => {
+    const result = tallyVotes([vote('XS'), vote('XL')])
+    expect(result.estimate).toBe('XL')
+    expect(result.agreement).toBe(0.5)
+  })
+
+  it('discards malformed votes and counts agreement over valid votes only', () => {
+    const result = tallyVotes(['not json', vote('M'), '{"bad": true}', vote('M')])
+    expect(result.estimate).toBe('M')
+    expect(result.validVotes).toBe(2)
+    expect(result.totalVotes).toBe(4)
+    expect(result.agreement).toBe(1)
+  })
+
+  it('carries confidence, rationale, and secondChoice from a winning vote', () => {
+    const result = tallyVotes([
+      vote('L', { confidence: 'high', rationale: 'cross-cutting', secondChoice: 'M' }),
+      vote('S'),
+    ])
+    expect(result.estimate).toBe('L')
+    expect(result.confidence).toBe('high')
+    expect(result.rationale).toBe('cross-cutting')
+    expect(result.secondChoice).toBe('M')
+  })
+
+  it('throws when no votes are valid', () => {
+    expect(() => tallyVotes(['nope', '{}', 'also bad'])).toThrow('Failed to validate any estimate vote')
+  })
+})

--- a/scripts/estimate/src/lib/__tests__/validateEstimate.ts
+++ b/scripts/estimate/src/lib/__tests__/validateEstimate.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import validateEstimate from '../validateEstimate.ts'
-import { EstimateCategorySchema, EstimateResponseSchema } from '../validateEstimate.ts'
+import validateEstimate, { EstimateCategorySchema, EstimateResponseSchema, parseEstimate } from '../validateEstimate.ts'
 
 describe('validateEstimate', () => {
-  it('parses valid model output', () => {
+  it('parses valid model output and defaults the richer fields', () => {
     const result = validateEstimate(['{"estimate": "M"}'])
-    expect(result).toEqual({ estimate: 'M' })
+    expect(result.estimate).toBe('M')
+    expect(result.confidence).toBe('medium')
+    expect(result.rationale).toBe('')
   })
 
   it('handles all valid categories', () => {
@@ -16,9 +17,16 @@ describe('validateEstimate', () => {
     }
   })
 
+  it('parses the richer fields when present', () => {
+    const result = validateEstimate([
+      '{"rationale": "small fix", "estimate": "S", "confidence": "high", "secondChoice": "M"}',
+    ])
+    expect(result).toEqual({ rationale: 'small fix', estimate: 'S', confidence: 'high', secondChoice: 'M' })
+  })
+
   it('skips invalid output and uses next valid one', () => {
     const result = validateEstimate(['invalid json', '{"estimate": "S"}'])
-    expect(result).toEqual({ estimate: 'S' })
+    expect(result.estimate).toBe('S')
   })
 
   it('throws after max validation attempts with all invalid', () => {
@@ -31,6 +39,25 @@ describe('validateEstimate', () => {
 
   it('rejects output missing estimate field', () => {
     expect(() => validateEstimate(['{"foo": "bar"}', '{}', '{"other": "M"}'])).toThrow()
+  })
+})
+
+describe('parseEstimate', () => {
+  it('returns the parsed response for valid output', () => {
+    expect(parseEstimate('{"estimate": "L"}')?.estimate).toBe('L')
+  })
+
+  it('returns null for malformed JSON', () => {
+    expect(parseEstimate('not json')).toBeNull()
+  })
+
+  it('returns null for a schema mismatch', () => {
+    expect(parseEstimate('{"estimate": "NOPE"}')).toBeNull()
+    expect(parseEstimate('{}')).toBeNull()
+  })
+
+  it('returns null for an invalid confidence value', () => {
+    expect(parseEstimate('{"estimate": "M", "confidence": "certain"}')).toBeNull()
   })
 })
 
@@ -48,9 +75,9 @@ describe('EstimateCategorySchema', () => {
 })
 
 describe('EstimateResponseSchema', () => {
-  it('parses valid response', () => {
+  it('parses valid response and defaults optional fields', () => {
     const result = EstimateResponseSchema.parse({ estimate: 'L' })
-    expect(result).toEqual({ estimate: 'L' })
+    expect(result).toEqual({ rationale: '', estimate: 'L', confidence: 'medium' })
   })
 
   it('rejects missing estimate', () => {

--- a/scripts/estimate/src/lib/buildPrompt.ts
+++ b/scripts/estimate/src/lib/buildPrompt.ts
@@ -25,7 +25,10 @@ const buildPrompt = (samples: EstimateSample[], issue: IssueInput): string => {
   prompt += `Title: ${issue.title}\n`
   prompt += `Labels: ${issue.labels.join(', ')}\n`
   prompt += `Body:\n${issue.body}\n\n`
-  prompt += 'Respond with only a JSON object: {"estimate": "<CATEGORY>"}\n'
+  prompt +=
+    'Respond with only a JSON object with these fields, in this order: ' +
+    '{"rationale": "<brief reasoning>", "estimate": "<CATEGORY>", "confidence": "high|medium|low", "secondChoice": "<CATEGORY>"}. ' +
+    'Put "rationale" first so you reason before committing to a bucket.\n'
 
   return prompt
 }

--- a/scripts/estimate/src/lib/estimateIssue.ts
+++ b/scripts/estimate/src/lib/estimateIssue.ts
@@ -3,13 +3,21 @@ import { CATEGORY_TO_HOURS, type EstimateCategory, categoryToSeconds } from '../
 import buildPrompt, { type IssueInput } from './buildPrompt.ts'
 import inference from './inference.ts'
 import type { EstimateSample } from './loadSamples.ts'
-import validateEstimate from './validateEstimate.ts'
+import tallyVotes from './tallyVotes.ts'
 
-/** An issue estimate expressed as a category and its equivalent hours and seconds. */
+/** An issue estimate expressed as a category and its equivalent hours and seconds, plus vote confidence signals. */
 export interface Estimate {
   category: EstimateCategory
   hours: number
   seconds: number
+  /** Fraction of valid votes that agreed with the chosen category (0–1). */
+  agreement: number
+  /** Self-reported confidence carried from a winning vote. */
+  confidence: 'high' | 'medium' | 'low'
+  /** Rationale carried from a winning vote, for the audit trail. */
+  rationale: string
+  /** Second-choice category from a winning vote, if provided. */
+  secondChoice?: EstimateCategory
 }
 
 /**
@@ -54,11 +62,15 @@ const estimateIssue = async ({
 
   const prompt = buildPrompt(samples, issue)
   const outputs = await inference({ apiKey: openaiApiKey, prompt, instructions })
-  const { estimate: category } = validateEstimate(outputs)
+  const vote = tallyVotes(outputs)
   const estimate: Estimate = {
-    category,
-    hours: CATEGORY_TO_HOURS[category],
-    seconds: categoryToSeconds(category),
+    category: vote.estimate,
+    hours: CATEGORY_TO_HOURS[vote.estimate],
+    seconds: categoryToSeconds(vote.estimate),
+    agreement: vote.agreement,
+    confidence: vote.confidence,
+    rationale: vote.rationale,
+    secondChoice: vote.secondChoice,
   }
 
   // Write the estimate to Everhour unless the Everhour write is being dry-run.

--- a/scripts/estimate/src/lib/inference.ts
+++ b/scripts/estimate/src/lib/inference.ts
@@ -1,11 +1,16 @@
 // Inference tuning constants, overridable via ESTIMATE_* env vars for experimentation.
-const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-5-mini'
-// Only sent when explicitly set. GPT-5 reasoning models reject a non-default temperature
-// (e.g. 0), so it is omitted by default; determinism is instead handled by the validation
-// retry loop below. Set ESTIMATE_TEMPERATURE to override for models that support it.
+const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-5.6-terra'
+// Number of independent samples to draw per estimate for self-consistency voting. Sent as the
+// Chat Completions `n` parameter, which bills input once and only multiplies the (tiny) output —
+// so voting is cheap here. The modal vote is the estimate; the spread is the confidence signal.
+const VOTES = process.env.ESTIMATE_VOTES != null ? Number(process.env.ESTIMATE_VOTES) : 5
+// Only sent when explicitly set. GPT-5 reasoning models reject a non-default temperature (e.g. 0),
+// so it is omitted by default; sampling diversity for voting comes from `n`, not temperature. Set
+// ESTIMATE_TEMPERATURE to override for models that support it.
 const TEMPERATURE = process.env.ESTIMATE_TEMPERATURE != null ? Number(process.env.ESTIMATE_TEMPERATURE) : undefined
-const MAX_VALIDATION_ATTEMPTS =
-  process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS != null ? Number(process.env.ESTIMATE_MAX_VALIDATION_ATTEMPTS) : 3
+// Optional reasoning effort passthrough for reasoning-capable models (e.g. gpt-5.6-terra supports
+// none|low|medium|high|xhigh|max). Only sent when explicitly set; otherwise the model default applies.
+const REASONING_EFFORT = process.env.ESTIMATE_REASONING_EFFORT
 
 /** Options for the AI inference call. */
 interface CallOptions {
@@ -14,51 +19,42 @@ interface CallOptions {
   prompt: string
   /** Estimation instructions used as the system message. */
   instructions: string
+  /** Number of samples to draw for voting. Defaults to VOTES; overridable per call (e.g. by the eval harness). */
+  votes?: number
 }
 
-/** Calls the OpenAI chat completions API. Returns raw string outputs for validation. */
-const inference = async ({ apiKey, prompt, instructions }: CallOptions): Promise<string[]> => {
-  const outputs: string[] = []
+/**
+ * Calls the OpenAI chat completions API, drawing `votes` independent samples in a single request
+ * via the `n` parameter. Returns the raw string content of every choice (including any malformed
+ * ones) for downstream tallying/validation — aggregation and vote-counting live in tallyVotes.
+ */
+const inference = async ({ apiKey, prompt, instructions, votes = VOTES }: CallOptions): Promise<string[]> => {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      n: votes,
+      ...(TEMPERATURE != null ? { temperature: TEMPERATURE } : {}),
+      ...(REASONING_EFFORT != null ? { reasoning_effort: REASONING_EFFORT } : {}),
+      messages: [
+        { role: 'system', content: instructions },
+        { role: 'user', content: prompt },
+      ],
+      response_format: { type: 'json_object' },
+    }),
+  })
 
-  for (let attempt = 0; attempt < MAX_VALIDATION_ATTEMPTS; attempt++) {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: MODEL,
-        ...(TEMPERATURE != null ? { temperature: TEMPERATURE } : {}),
-        messages: [
-          { role: 'system', content: instructions },
-          { role: 'user', content: prompt },
-        ],
-        response_format: { type: 'json_object' },
-      }),
-    })
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => '')
-      throw new Error(`OpenAI API error ${response.status}: ${body}`)
-    }
-
-    const data = (await response.json()) as { choices: { message: { content: string } }[] }
-    const content = data.choices?.[0]?.message?.content ?? ''
-    outputs.push(content)
-
-    // Try to parse and validate immediately
-    try {
-      const parsed = JSON.parse(content) as Record<string, unknown>
-      if (parsed.estimate) {
-        return outputs
-      }
-    } catch {
-      // continue to next attempt
-    }
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`OpenAI API error ${response.status}: ${body}`)
   }
 
-  return outputs
+  const data = (await response.json()) as { choices: { message: { content: string } }[] }
+  return (data.choices ?? []).map(choice => choice.message?.content ?? '')
 }
 
 export default inference

--- a/scripts/estimate/src/lib/tallyVotes.ts
+++ b/scripts/estimate/src/lib/tallyVotes.ts
@@ -1,0 +1,71 @@
+import { ESTIMATE_CATEGORIES, type EstimateCategory } from '../everhour/estimates.ts'
+import { type EstimateResponse, parseEstimate } from './validateEstimate.ts'
+
+/** Aggregated result of a self-consistency vote across multiple model samples. */
+export interface VoteResult {
+  /** The modal (plurality) estimate category across all valid votes. */
+  estimate: EstimateCategory
+  /** Fraction of valid votes that agreed with the modal estimate (modeCount / validCount), 0–1. */
+  agreement: number
+  /** Number of model samples that produced a valid, schema-conforming estimate. */
+  validVotes: number
+  /** Total number of model samples considered (including malformed ones). */
+  totalVotes: number
+  /** Self-reported confidence carried from a modal-winning vote. */
+  confidence: EstimateResponse['confidence']
+  /** Rationale carried from a modal-winning vote, for the audit trail. */
+  rationale: string
+  /** Second-choice category from a modal-winning vote, if the model provided one. */
+  secondChoice?: EstimateCategory
+}
+
+/** Ordinal index of a category on the XXS<XS<S<M<L<XL<XXL scale. */
+const categoryIndex = (category: EstimateCategory): number => ESTIMATE_CATEGORIES.indexOf(category)
+
+/**
+ * Tallies self-consistency votes from raw model outputs into a single estimate plus an agreement
+ * score. Each raw output is parsed independently; malformed or non-conforming outputs are discarded
+ * (they do not count toward agreement). The modal category wins; ties are broken toward the larger
+ * (more conservative) category, which biases against underestimation. The carried confidence,
+ * rationale, and secondChoice come from a vote that landed on the winning category.
+ *
+ * Throws only when zero votes are valid, preserving the fail-loud behavior of the prior
+ * single-response validation path.
+ */
+const tallyVotes = (rawOutputs: string[]): VoteResult => {
+  const parsed = rawOutputs.map(parseEstimate).filter((r): r is EstimateResponse => r !== null)
+
+  if (parsed.length === 0) {
+    throw new Error(`Failed to validate any estimate vote. Raw outputs: ${JSON.stringify(rawOutputs)}`)
+  }
+
+  // Count votes per category.
+  const counts = new Map<EstimateCategory, number>()
+  for (const { estimate } of parsed) {
+    counts.set(estimate, (counts.get(estimate) ?? 0) + 1)
+  }
+
+  // Pick the modal category, breaking ties toward the larger (more conservative) category.
+  const [estimate, modeCount] = [...counts.entries()].reduce((best, candidate) => {
+    const [bestCat, bestCount] = best
+    const [candCat, candCount] = candidate
+    if (candCount > bestCount) return candidate
+    if (candCount === bestCount && categoryIndex(candCat) > categoryIndex(bestCat)) return candidate
+    return best
+  })
+
+  // Carry the audit fields from a vote that agreed with the winning category.
+  const winning = parsed.find(r => r.estimate === estimate)!
+
+  return {
+    estimate,
+    agreement: modeCount / parsed.length,
+    validVotes: parsed.length,
+    totalVotes: rawOutputs.length,
+    confidence: winning.confidence,
+    rationale: winning.rationale,
+    secondChoice: winning.secondChoice,
+  }
+}
+
+export default tallyVotes

--- a/scripts/estimate/src/lib/validateEstimate.ts
+++ b/scripts/estimate/src/lib/validateEstimate.ts
@@ -3,25 +3,44 @@ import { z } from 'zod'
 /** Valid estimate categories. */
 export const EstimateCategorySchema = z.enum(['XXS', 'XS', 'S', 'M', 'L', 'XL', 'XXL'])
 
-/** Schema for the model response. */
+/** Self-reported confidence level accompanying an estimate. */
+export const ConfidenceSchema = z.enum(['high', 'medium', 'low'])
+
+/**
+ * Schema for the model response. `estimate` is required; the richer fields are optional and
+ * defaulted so a minimal `{ "estimate": "M" }` still validates (resilience against a model that
+ * omits them). `rationale` is requested first in the prompt so the model reasons before committing
+ * to a bucket, but it is not required for a response to be usable.
+ */
 export const EstimateResponseSchema = z.object({
+  rationale: z.string().default(''),
   estimate: EstimateCategorySchema,
+  confidence: ConfidenceSchema.default('medium'),
+  secondChoice: EstimateCategorySchema.optional(),
 })
 
 export type EstimateResponse = z.infer<typeof EstimateResponseSchema>
 
 const MAX_VALIDATION_ATTEMPTS = 3
 
-/** Validates raw model output against the estimate schema. Returns the parsed result or throws after max attempts. */
+/**
+ * Parses and validates a single raw model output against the estimate schema. Returns the parsed
+ * result, or null when the string is not valid JSON or does not match the schema. Non-throwing so
+ * callers that aggregate many votes (tallyVotes) can discard bad choices without aborting.
+ */
+export const parseEstimate = (raw: string): EstimateResponse | null => {
+  try {
+    return EstimateResponseSchema.parse(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+/** Validates raw model output against the estimate schema. Returns the first valid result or throws after max attempts. */
 const validateEstimate = (rawOutputs: string[]): EstimateResponse => {
   for (const raw of rawOutputs.slice(0, MAX_VALIDATION_ATTEMPTS)) {
-    try {
-      const parsed = JSON.parse(raw)
-      const result = EstimateResponseSchema.parse(parsed)
-      return result
-    } catch {
-      continue
-    }
+    const result = parseEstimate(raw)
+    if (result) return result
   }
   throw new Error(
     `Failed to validate estimate after ${MAX_VALIDATION_ATTEMPTS} attempts. Raw outputs: ${JSON.stringify(rawOutputs)}`,


### PR DESCRIPTION
Context: #4591 #4595 #4597

## Plan (architectural, critique passed per `.github/skills/plan/SKILL.md`)

**Goal:** make automated estimates match a human estimate more closely, and produce a measured baseline + confidence signal that later tiers (kNN retrieval, human-review gate) build on. This is **Tier 0**.

**Existing surface area (grounding):** `inference.ts` read only `choices[0]` in a first-valid retry loop (no `n`, comment notes reasoning models reject temperature); `validateEstimate.ts` returned the first valid `{estimate}`; `buildPrompt.ts:28` hardcoded the old output line; `estimateIssue.ts` is the single pipeline seam (`Estimate` type consumed by `issue.ts`/`backfill.ts`); `ESTIMATE_CATEGORIES` already provides the ordered scale. No pre-existing vote/agreement/confidence surface (grepped). `command.ts` does **not** call inference, so the manual-correction path is untouched. Docs: this tool is documented by its own `README.md`, not `docs/`.

**Build vs. extend:** extend `inference.ts` (add `n`), extend the schema + prompt + instructions; introduce two new modules with defended reasons — `tallyVotes.ts` (aggregation is a distinct pure concern from first-valid parsing) and `evaluate.ts` (new offline entry point, reusing the existing loaders/prompt/inference).

**Adjacent behaviour checked:** Everhour write unchanged (still category→seconds); `/estimate` command isolated; audit comments additive only; backfill cost is N× tiny output. Voting counts agreement over *valid* votes and still throws on zero-valid (preserves fail-loud).

## Changes

- **Self-consistency voting** — `inference.ts` draws `n: ESTIMATE_VOTES` (default 5) in one Chat Completions request (input billed once, only the tiny output multiplies) and returns all choices. New pure `tallyVotes.ts` parses each vote, tallies the modal category, computes `agreement = modeCount/validCount`, discards malformed votes, and tie-breaks toward the larger (more conservative) bucket. No dependency on adjustable temperature — diversity comes from `n`.
- **Richer JSON** — schema is now `{ rationale, estimate, confidence, secondChoice }` (rationale first so the model reasons before committing); `estimate` required, the rest optional/defaulted for resilience. Added non-throwing `parseEstimate`. `buildPrompt` and `estimate.instructions.md` updated to match.
- **Confidence surfaced** — `Estimate` carries `agreement`/`confidence`/`rationale`/`secondChoice`; `issue.ts` and `backfill.ts` audit comments show `Confidence: <level> (agreement N%)`. Display only — the human-review **gate** is a later tier.
- **Eval harness** — `evaluate.ts` + `yarn evaluate`: leave-one-out over the labeled samples (rebuild the prompt from every *other* sample, estimate the held-out issue, compare to the known category). Reports exact-bucket %, ±1-bucket %, a confusion matrix, and calibration by agreement/confidence. Makes model calls but **never writes to Everhour**.
- **Model** → default `gpt-5.6-terra` (still `ESTIMATE_MODEL`-overridable); optional `ESTIMATE_REASONING_EFFORT` passthrough (sent only when set).

## Out of scope (deferred to later tiers, per discussion)
kNN similar-issue retrieval, human-review confidence gate, corpus growth/backfill of human Everhour estimates, tracked-hours reconciliation, files-affected two-stage call, fine-tuning.

## Testing
- `yarn typecheck` (tsc) ✅
- `yarn vitest run scripts/estimate` — 77 passed ✅ (new: `tallyVotes`, `parseEstimate`, richer schema, `evaluate` metrics; updated `buildPrompt`/`validateEstimate`)
- `yarn prettier --write` ✅
- Live baseline: run `yarn evaluate` before/after to confirm exact/±1 hold or improve (needs `OPENAI_API_KEY`; not run in CI).