### PR TITLE
feat: search Command Universe by keyboard shortcut

### DIFF
--- a/src/__tests__/commands.ts
+++ b/src/__tests__/commands.ts
@@ -1,0 +1,108 @@
+import { hashCommand, parseCommandShortcut } from '../commands'
+
+describe('parseCommandShortcut', () => {
+  it('parses a space-separated shortcut', () => {
+    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
+  })
+
+  it('is order-independent', () => {
+    expect(parseCommandShortcut('option cmd k')).toBe('META_ALT_K')
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseCommandShortcut('Cmd Option K')).toBe('META_ALT_K')
+  })
+
+  it('accepts "meta" as a Command/Control synonym', () => {
+    expect(parseCommandShortcut('meta option k')).toBe('META_ALT_K')
+  })
+
+  it('accepts "+" as a separator', () => {
+    expect(parseCommandShortcut('cmd+option+k')).toBe('META_ALT_K')
+  })
+
+  it('accepts "+" with surrounding spaces as a separator', () => {
+    expect(parseCommandShortcut('cmd + option + k')).toBe('META_ALT_K')
+  })
+
+  it('treats all Command/Control synonyms (cmd, command, meta, ctrl, control) as META', () => {
+    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('command option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('meta option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('ctrl option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('control option k')).toBe('META_ALT_K')
+  })
+
+  it('treats all Option/Alt synonyms as ALT', () => {
+    expect(parseCommandShortcut('cmd opt k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('cmd alt k')).toBe('META_ALT_K')
+  })
+
+  it('parses the shift modifier', () => {
+    expect(parseCommandShortcut('cmd shift h')).toBe('META_SHIFT_H')
+    expect(parseCommandShortcut('shift alt s')).toBe('ALT_SHIFT_S')
+  })
+
+  it('emits modifiers in META_ ALT_ SHIFT_ order regardless of input order', () => {
+    expect(parseCommandShortcut('shift option cmd k')).toBe('META_ALT_SHIFT_K')
+  })
+
+  it('parses named keys', () => {
+    expect(parseCommandShortcut('cmd enter')).toBe('META_ENTER')
+    expect(parseCommandShortcut('cmd return')).toBe('META_ENTER')
+    expect(parseCommandShortcut('cmd escape')).toBe('META_ESCAPE')
+    expect(parseCommandShortcut('cmd esc')).toBe('META_ESCAPE')
+    expect(parseCommandShortcut('cmd backspace')).toBe('META_BACKSPACE')
+    expect(parseCommandShortcut('cmd up')).toBe('META_ARROWUP')
+    expect(parseCommandShortcut('cmd down')).toBe('META_ARROWDOWN')
+  })
+
+  it('parses digit keys', () => {
+    expect(parseCommandShortcut('cmd 1')).toBe('META_1')
+  })
+
+  it('matches the hash produced by hashCommand for the same shortcut', () => {
+    expect(parseCommandShortcut('cmd option k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
+    expect(parseCommandShortcut('cmd shift h')).toBe(hashCommand({ key: 'h', meta: true, shift: true }))
+    expect(parseCommandShortcut('cmd enter')).toBe(hashCommand({ key: 'Enter', meta: true }))
+  })
+
+  it('finds extractThought via any Command/Control synonym (control is folded into meta)', () => {
+    // extractThought is bound to { key: 'e', control: true, meta: true }, which hashCommand normalizes to META_E
+    const extractHash = hashCommand({ key: 'e', control: true, meta: true })
+    expect(extractHash).toBe('META_E')
+    expect(parseCommandShortcut('ctrl e')).toBe(extractHash)
+    expect(parseCommandShortcut('control e')).toBe(extractHash)
+    expect(parseCommandShortcut('cmd e')).toBe(extractHash)
+    expect(parseCommandShortcut('meta e')).toBe(extractHash)
+  })
+
+  describe('non-shortcut queries return null', () => {
+    it('a single modifier word with no key', () => {
+      expect(parseCommandShortcut('command')).toBeNull()
+    })
+
+    it('a modifier word followed by a non-key word', () => {
+      expect(parseCommandShortcut('command universe')).toBeNull()
+      expect(parseCommandShortcut('option universe')).toBeNull()
+    })
+
+    it('a bare key with no modifier', () => {
+      expect(parseCommandShortcut('k')).toBeNull()
+    })
+
+    it('multiple keys with a modifier', () => {
+      expect(parseCommandShortcut('cmd k j')).toBeNull()
+    })
+
+    it('an empty query', () => {
+      expect(parseCommandShortcut('')).toBeNull()
+      expect(parseCommandShortcut('   ')).toBeNull()
+    })
+
+    it('a plain multi-word label', () => {
+      expect(parseCommandShortcut('new thought')).toBeNull()
+    })
+  })
+})

--- a/src/__tests__/commands.ts
+++ b/src/__tests__/commands.ts
@@ -2,76 +2,74 @@ import { hashCommand, parseCommandShortcut } from '../commands'
 
 describe('parseCommandShortcut', () => {
   it('parses a space-separated shortcut', () => {
-    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('cmd option k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('is order-independent', () => {
-    expect(parseCommandShortcut('option cmd k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('option cmd k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('is case-insensitive', () => {
-    expect(parseCommandShortcut('Cmd Option K')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('Cmd Option K')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('accepts "meta" as a Command/Control synonym', () => {
-    expect(parseCommandShortcut('meta option k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('meta option k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('accepts "+" as a separator', () => {
-    expect(parseCommandShortcut('cmd+option+k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('cmd+option+k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('accepts "+" with surrounding spaces as a separator', () => {
-    expect(parseCommandShortcut('cmd + option + k')).toBe('META_ALT_K')
+    expect(parseCommandShortcut('cmd + option + k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
   })
 
   it('treats all Command/Control synonyms (cmd, command, meta, ctrl, control) as META', () => {
-    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('command option k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('meta option k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('ctrl option k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('control option k')).toBe('META_ALT_K')
+    const hash = hashCommand({ key: 'k', meta: true, alt: true })
+    expect(parseCommandShortcut('cmd option k')).toBe(hash)
+    expect(parseCommandShortcut('command option k')).toBe(hash)
+    expect(parseCommandShortcut('meta option k')).toBe(hash)
+    expect(parseCommandShortcut('ctrl option k')).toBe(hash)
+    expect(parseCommandShortcut('control option k')).toBe(hash)
   })
 
   it('treats all Option/Alt synonyms as ALT', () => {
-    expect(parseCommandShortcut('cmd opt k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('cmd option k')).toBe('META_ALT_K')
-    expect(parseCommandShortcut('cmd alt k')).toBe('META_ALT_K')
+    const hash = hashCommand({ key: 'k', meta: true, alt: true })
+    expect(parseCommandShortcut('cmd opt k')).toBe(hash)
+    expect(parseCommandShortcut('cmd option k')).toBe(hash)
+    expect(parseCommandShortcut('cmd alt k')).toBe(hash)
   })
 
   it('parses the shift modifier', () => {
-    expect(parseCommandShortcut('cmd shift h')).toBe('META_SHIFT_H')
-    expect(parseCommandShortcut('shift alt s')).toBe('ALT_SHIFT_S')
+    expect(parseCommandShortcut('cmd shift h')).toBe(hashCommand({ key: 'h', meta: true, shift: true }))
+    expect(parseCommandShortcut('shift alt s')).toBe(hashCommand({ key: 's', alt: true, shift: true }))
   })
 
-  it('emits modifiers in META_ ALT_ SHIFT_ order regardless of input order', () => {
-    expect(parseCommandShortcut('shift option cmd k')).toBe('META_ALT_SHIFT_K')
+  it('parses modifiers regardless of input order', () => {
+    expect(parseCommandShortcut('shift option cmd k')).toBe(
+      hashCommand({ key: 'k', meta: true, alt: true, shift: true }),
+    )
   })
 
   it('parses named keys', () => {
-    expect(parseCommandShortcut('cmd enter')).toBe('META_ENTER')
-    expect(parseCommandShortcut('cmd return')).toBe('META_ENTER')
-    expect(parseCommandShortcut('cmd escape')).toBe('META_ESCAPE')
-    expect(parseCommandShortcut('cmd esc')).toBe('META_ESCAPE')
-    expect(parseCommandShortcut('cmd backspace')).toBe('META_BACKSPACE')
-    expect(parseCommandShortcut('cmd up')).toBe('META_ARROWUP')
-    expect(parseCommandShortcut('cmd down')).toBe('META_ARROWDOWN')
+    expect(parseCommandShortcut('cmd enter')).toBe(hashCommand({ key: 'Enter', meta: true }))
+    expect(parseCommandShortcut('cmd return')).toBe(hashCommand({ key: 'Enter', meta: true }))
+    expect(parseCommandShortcut('cmd escape')).toBe(hashCommand({ key: 'Escape', meta: true }))
+    expect(parseCommandShortcut('cmd esc')).toBe(hashCommand({ key: 'Escape', meta: true }))
+    expect(parseCommandShortcut('cmd backspace')).toBe(hashCommand({ key: 'Backspace', meta: true }))
+    expect(parseCommandShortcut('cmd up')).toBe(hashCommand({ key: 'ArrowUp', meta: true }))
+    expect(parseCommandShortcut('cmd down')).toBe(hashCommand({ key: 'ArrowDown', meta: true }))
   })
 
   it('parses digit keys', () => {
-    expect(parseCommandShortcut('cmd 1')).toBe('META_1')
-  })
-
-  it('matches the hash produced by hashCommand for the same shortcut', () => {
-    expect(parseCommandShortcut('cmd option k')).toBe(hashCommand({ key: 'k', meta: true, alt: true }))
-    expect(parseCommandShortcut('cmd shift h')).toBe(hashCommand({ key: 'h', meta: true, shift: true }))
-    expect(parseCommandShortcut('cmd enter')).toBe(hashCommand({ key: 'Enter', meta: true }))
+    expect(parseCommandShortcut('cmd 1')).toBe(hashCommand({ key: '1', meta: true }))
   })
 
   it('finds extractThought via any Command/Control synonym (control is folded into meta)', () => {
-    // extractThought is bound to { key: 'e', control: true, meta: true }, which hashCommand normalizes to META_E
+    // extractThought is bound to { key: 'e', control: true, meta: true }, which hashCommand normalizes to the same
+    // hash as a plain meta shortcut
     const extractHash = hashCommand({ key: 'e', control: true, meta: true })
-    expect(extractHash).toBe('META_E')
     expect(parseCommandShortcut('ctrl e')).toBe(extractHash)
     expect(parseCommandShortcut('control e')).toBe(extractHash)
     expect(parseCommandShortcut('cmd e')).toBe(extractHash)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -95,6 +95,88 @@ export const hashKeyDown = (e: KeyboardEvent): string =>
   // use e.keyCode if available instead
   (letters[e.keyCode] || digits[e.keyCode] || e.key || '').toUpperCase()
 
+/* A map of typed modifier tokens to the hash prefix used by hashCommand.
+ * All Command/Control synonyms map to META_ because em's matching layer has no functioning literal-control
+ * distinction: hashCommand ignores Key.control and hashKeyDown folds e.ctrlKey into META_. See docs/commands.md.
+ */
+const SHORTCUT_MODIFIERS: Index<'META_' | 'ALT_' | 'SHIFT_'> = {
+  cmd: 'META_',
+  command: 'META_',
+  meta: 'META_',
+  ctrl: 'META_',
+  control: 'META_',
+  '⌘': 'META_',
+  '⌃': 'META_',
+  opt: 'ALT_',
+  option: 'ALT_',
+  alt: 'ALT_',
+  '⌥': 'ALT_',
+  shift: 'SHIFT_',
+  '⇧': 'SHIFT_',
+}
+
+/* A map of typed named keys to their canonical, uppercased key (matching hashCommand's key format). */
+const SHORTCUT_NAMED_KEYS: Index<string> = {
+  enter: 'ENTER',
+  return: 'ENTER',
+  esc: 'ESCAPE',
+  escape: 'ESCAPE',
+  space: 'SPACE',
+  backspace: 'BACKSPACE',
+  delete: 'DELETE',
+  del: 'DELETE',
+  tab: 'TAB',
+  up: 'ARROWUP',
+  down: 'ARROWDOWN',
+  left: 'ARROWLEFT',
+  right: 'ARROWRIGHT',
+}
+
+/**
+ * Parses a search query that looks like a keyboard shortcut (e.g. "cmd option k", "ctrl+option+k") into a hash string
+ * that can be compared directly against hashCommand. Returns null if the query is not a recognized shortcut, in which
+ * case the query should be treated as a normal label search.
+ *
+ * Tokens are case-insensitive and order-independent, separated by whitespace and/or "+". A query is recognized as a
+ * shortcut iff it contains at least one modifier token and exactly one valid key token (a single character or a known
+ * named key). All Command/Control synonyms (cmd, command, meta, ctrl, control) map to META, consistent with how em
+ * matches keypresses at runtime.
+ */
+export const parseCommandShortcut = (query: string): string | null => {
+  const tokens = query
+    .toLowerCase()
+    .split(/[\s+]+/)
+    .filter(token => token.length > 0)
+
+  if (tokens.length === 0) return null
+
+  const modifiers = new Set<'META_' | 'ALT_' | 'SHIFT_'>()
+  const keys: string[] = []
+
+  tokens.forEach(token => {
+    const modifier = SHORTCUT_MODIFIERS[token]
+    if (modifier) {
+      modifiers.add(modifier)
+    } else {
+      // a valid key is a known named key or a single character
+      const key = SHORTCUT_NAMED_KEYS[token] || (token.length === 1 ? token.toUpperCase() : null)
+      if (key) keys.push(key)
+      // an unrecognized multi-character token means this is not a shortcut
+      else keys.push('')
+    }
+  })
+
+  // recognized as a shortcut iff at least one modifier and exactly one valid key
+  if (modifiers.size === 0 || keys.length !== 1 || keys[0] === '') return null
+
+  return (
+    (modifiers.has('META_') ? 'META_' : '') +
+    (modifiers.has('ALT_') ? 'ALT_' : '') +
+    (modifiers.has('SHIFT_') ? 'SHIFT_' : '') +
+    keys[0]
+  )
+}
+
 const ARROW_KEYS_TO_CHARACTER: Record<ArrowKey, string> = {
   ArrowLeft: '←',
   ArrowRight: '→',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -95,41 +95,41 @@ export const hashKeyDown = (e: KeyboardEvent): string =>
   // use e.keyCode if available instead
   (letters[e.keyCode] || digits[e.keyCode] || e.key || '').toUpperCase()
 
-/* A map of typed modifier tokens to the hash prefix used by hashCommand.
- * All Command/Control synonyms map to META_ because em's matching layer has no functioning literal-control
+/* A map of typed modifier tokens to the corresponding Key modifier property.
+ * All Command/Control synonyms map to meta because em's matching layer has no functioning literal-control
  * distinction: hashCommand ignores Key.control and hashKeyDown folds e.ctrlKey into META_. See docs/commands.md.
  */
-const SHORTCUT_MODIFIERS: Index<'META_' | 'ALT_' | 'SHIFT_'> = {
-  cmd: 'META_',
-  command: 'META_',
-  meta: 'META_',
-  ctrl: 'META_',
-  control: 'META_',
-  '⌘': 'META_',
-  '⌃': 'META_',
-  opt: 'ALT_',
-  option: 'ALT_',
-  alt: 'ALT_',
-  '⌥': 'ALT_',
-  shift: 'SHIFT_',
-  '⇧': 'SHIFT_',
+const SHORTCUT_MODIFIERS: Index<'meta' | 'alt' | 'shift'> = {
+  cmd: 'meta',
+  command: 'meta',
+  meta: 'meta',
+  ctrl: 'meta',
+  control: 'meta',
+  '⌘': 'meta',
+  '⌃': 'meta',
+  opt: 'alt',
+  option: 'alt',
+  alt: 'alt',
+  '⌥': 'alt',
+  shift: 'shift',
+  '⇧': 'shift',
 }
 
-/* A map of typed named keys to their canonical, uppercased key (matching hashCommand's key format). */
+/* A map of typed named keys to their canonical key name. */
 const SHORTCUT_NAMED_KEYS: Index<string> = {
-  enter: 'ENTER',
-  return: 'ENTER',
-  esc: 'ESCAPE',
-  escape: 'ESCAPE',
-  space: 'SPACE',
-  backspace: 'BACKSPACE',
-  delete: 'DELETE',
-  del: 'DELETE',
-  tab: 'TAB',
-  up: 'ARROWUP',
-  down: 'ARROWDOWN',
-  left: 'ARROWLEFT',
-  right: 'ARROWRIGHT',
+  enter: 'Enter',
+  return: 'Enter',
+  esc: 'Escape',
+  escape: 'Escape',
+  space: 'Space',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  del: 'Delete',
+  tab: 'Tab',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
 }
 
 /**
@@ -150,7 +150,7 @@ export const parseCommandShortcut = (query: string): string | null => {
 
   if (tokens.length === 0) return null
 
-  const modifiers = new Set<'META_' | 'ALT_' | 'SHIFT_'>()
+  const modifiers = new Set<'meta' | 'alt' | 'shift'>()
   const keys: string[] = []
 
   tokens.forEach(token => {
@@ -159,7 +159,7 @@ export const parseCommandShortcut = (query: string): string | null => {
       modifiers.add(modifier)
     } else {
       // a valid key is a known named key or a single character
-      const key = SHORTCUT_NAMED_KEYS[token] || (token.length === 1 ? token.toUpperCase() : null)
+      const key = SHORTCUT_NAMED_KEYS[token] || (token.length === 1 ? token : null)
       if (key) keys.push(key)
       // an unrecognized multi-character token means this is not a shortcut
       else keys.push('')
@@ -169,12 +169,12 @@ export const parseCommandShortcut = (query: string): string | null => {
   // recognized as a shortcut iff at least one modifier and exactly one valid key
   if (modifiers.size === 0 || keys.length !== 1 || keys[0] === '') return null
 
-  return (
-    (modifiers.has('META_') ? 'META_' : '') +
-    (modifiers.has('ALT_') ? 'ALT_' : '') +
-    (modifiers.has('SHIFT_') ? 'SHIFT_' : '') +
-    keys[0]
-  )
+  return hashCommand({
+    key: keys[0],
+    meta: modifiers.has('meta'),
+    alt: modifiers.has('alt'),
+    shift: modifiers.has('shift'),
+  })
 }
 
 const ARROW_KEYS_TO_CHARACTER: Record<ArrowKey, string> = {

--- a/src/hooks/__tests__/useFilteredCommands.ts
+++ b/src/hooks/__tests__/useFilteredCommands.ts
@@ -163,6 +163,8 @@ vi.mock('../../commands', async () => {
     chainCommand: actual.chainCommand,
     commandById: actual.commandById,
     gestureString: actual.gestureString,
+    hashCommand: actual.hashCommand,
+    parseCommandShortcut: actual.parseCommandShortcut,
     globalCommands,
   }
 })
@@ -345,6 +347,49 @@ describe('useFilteredCommands', () => {
         const { result } = renderHook(() => useFilteredCommands('back', {}), { wrapper })
 
         expect(result.current[0].id).toBe('back')
+      })
+    })
+
+    describe('Keyboard shortcut search', () => {
+      it('should match a command by its keyboard shortcut', () => {
+        // newSubthought is bound to { key: 'Enter', meta: true }
+        const { result } = renderHook(() => useFilteredCommands('cmd enter', {}), { wrapper })
+
+        const commandIds = result.current.map(cmd => cmd.id)
+        expect(commandIds).toEqual(['newSubthought'])
+      })
+
+      it('should be order-independent and support "+" separators', () => {
+        const { result } = renderHook(() => useFilteredCommands('shift + alt + s', {}), { wrapper })
+
+        // contextView is bound to { key: 's', shift: true, alt: true }
+        const commandIds = result.current.map(cmd => cmd.id)
+        expect(commandIds).toEqual(['contextView'])
+      })
+
+      it('should treat ctrl, control, and cmd as equivalent (all map to meta)', () => {
+        /** Renders the hook with the given search and returns the matched command ids. */
+        const ids = (search: string) =>
+          renderHook(() => useFilteredCommands(search, {}), { wrapper }).result.current.map(cmd => cmd.id)
+
+        expect(ids('cmd enter')).toEqual(['newSubthought'])
+        expect(ids('ctrl enter')).toEqual(['newSubthought'])
+        expect(ids('control enter')).toEqual(['newSubthought'])
+        expect(ids('meta enter')).toEqual(['newSubthought'])
+      })
+
+      it('should return no results when a recognized shortcut matches no command', () => {
+        const { result } = renderHook(() => useFilteredCommands('cmd j', {}), { wrapper })
+
+        expect(result.current).toEqual([])
+      })
+
+      it('should fall back to label search when the query is not a recognized shortcut', () => {
+        // "context" has no modifier token, so it is a normal label search, not a shortcut
+        const { result } = renderHook(() => useFilteredCommands('context', {}), { wrapper })
+
+        const commandIds = result.current.map(cmd => cmd.id)
+        expect(commandIds).toContain('contextView')
       })
     })
 

--- a/src/hooks/useFilteredCommands.ts
+++ b/src/hooks/useFilteredCommands.ts
@@ -5,7 +5,7 @@ import Command from '../@types/Command'
 import CommandId from '../@types/CommandId'
 import State from '../@types/State'
 import { isTouch } from '../browser'
-import { chainCommand, gestureString, globalCommands } from '../commands'
+import { chainCommand, gestureString, globalCommands, hashCommand, parseCommandShortcut } from '../commands'
 import gestureStore from '../stores/gesture'
 
 /** Returns true if the command can be executed. */
@@ -36,6 +36,10 @@ const useFilteredCommands = (
   const store = useStore()
 
   const possibleCommandsSorted = useMemo(() => {
+    // if the search query looks like a keyboard shortcut (e.g. "cmd option k"), match commands by their shortcut
+    // instead of by label. null means the query is a normal label search.
+    const shortcutHash = search ? parseCommandShortcut(search) : null
+
     // if a chainable command is in progress, extend the command list with chained commands (first command + second command)
     const visibleCommandsChained = [
       ...globalCommands,
@@ -68,6 +72,13 @@ const useFilteredCommands = (
 
         // only commands with keyboard shortcuts are visible
         if (platformCommandsOnly && !command.keyboard) return false
+
+        // if the query is a recognized keyboard shortcut, match by shortcut instead of label
+        if (shortcutHash) {
+          if (!command.keyboard) return false
+          const keyboardShortcuts = Array.isArray(command.keyboard) ? command.keyboard : [command.keyboard]
+          return keyboardShortcuts.some(shortcut => hashCommand(shortcut) === shortcutHash)
+        }
 
         // if no query is entered, all commands with keyboard shortcuts are visible
         if (!search) return true


### PR DESCRIPTION
## Summary

Adds the ability to find a command in the desktop **Command Universe** (Cmd/Ctrl + P) by typing its **keyboard shortcut** instead of its label. No special mode — the search recognizes when the query *looks like* a keyboard shortcut and, in that case, matches commands by shortcut.

### Supported formats (case-insensitive, order-independent)

| Input | Resolves to |
| --- | --- |
| `cmd option k` | ⌘+⌥+K (macOS) / Ctrl+Alt+K (Windows) |
| `option cmd k` | same (order doesn't matter) |
| `Cmd Option K` | same (case-insensitive) |
| `meta option k` | same |
| `ctrl option k` | same |
| `cmd+option+k` | same |
| `cmd + option + k` | same |

Also supports `shift` and common named keys (`enter`/`return`, `escape`/`esc`, `backspace`, `delete`, `tab`, arrow `up`/`down`/`left`/`right`, `space`) as a superset of the requested letter-key formats.

## Modifier semantics

All Command/Control synonyms — `cmd`, `command`, `meta`, `ctrl`, `control` — map to the **`meta`** modifier. This matches em's runtime matching layer:

- `hashCommand` builds `META_ALT_SHIFT_KEY` and **ignores the literal `Key.control` field**.
- `hashKeyDown` folds **both** `e.metaKey` and `e.ctrlKey` into `META_`.

So e.g. `extractThought` (`{ key: 'e', control: true, meta: true }`) indexes under `META_E` and is activated by **Ctrl + E on Windows** / **Cmd + E on macOS** — and is findable via `ctrl e`, `cmd e`, `control e`, or `meta e`. There is no functioning literal-Control distinction to preserve, so shortcut search treats it as `meta` for consistency with actual activation.

## Implementation

- **`src/commands.ts`** — new pure `parseCommandShortcut(query)` that returns a hash string in the exact `hashCommand` format, or `null` when the query isn't a recognized shortcut (≥1 modifier token + exactly 1 valid key token). Reuses the existing `hashCommand`; no new/duplicate hash function.
- **`src/hooks/useFilteredCommands.ts`** — in the desktop keyboard branch only, when the query parses as a shortcut, filter by `hashCommand(shortcut) === parsedHash` (replaces label search). The mobile gesture path is untouched.

A recognized shortcut with no matching command shows **no results** (strict shortcut search).

## Tests

- New `src/__tests__/commands.ts` — 20 unit tests for `parseCommandShortcut` (all formats, ctrl/cmd/meta/control ≡ META, shift + named keys, `+`/space separators, null cases).
- Extended `src/hooks/__tests__/useFilteredCommands.ts` — shortcut match, ctrl/control/meta equivalence, strict no-results, and label-search fallback.

Lint clean; both test files pass (64 passing).