### PR TITLE
Fix undo labels for commands and formatting

### DIFF
--- a/src/@types/Command.ts
+++ b/src/@types/Command.ts
@@ -109,6 +109,9 @@ interface Command {
   /** For toggling commands, a short label that indicates the inverse action from the current state (e.g. "Add to Favorites" and "Remove from Favorites"). */
   labelInverse?: string
 
+  /** Label for undo/redo alerts. Defaults to the command's active label. */
+  undoLabel?: string | ((state: State) => string)
+
   /** A callback that is invoked when the command's toolbar button is long pressed. */
   longPress?: (dispatch: Dispatch) => void
 

--- a/src/@types/MergePrevActionPayload.ts
+++ b/src/@types/MergePrevActionPayload.ts
@@ -3,6 +3,8 @@
 // editThought merge rules in undoRedoEnhancer (#3905).
 interface MergePrevActionPayload {
   mergePrev?: boolean
+  /** User-facing label to show when undoing or redoing the patch created by this action. */
+  undoLabel?: string
 }
 
 export default MergePrevActionPayload

--- a/src/@types/Patch.ts
+++ b/src/@types/Patch.ts
@@ -7,6 +7,8 @@ import ActionType from './ActionType'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface ExtendedOperation<T = any> extends GetOperation<T> {
   actions: ActionType[]
+  /** User-facing label for the undo/redo alert. */
+  undoLabel?: string
 }
 
 type Patch = ExtendedOperation[]

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -9,7 +9,14 @@ import pathToThought from '../selectors/pathToThought'
 import resolveNotePath from '../selectors/resolveNotePath'
 import simplifyPath from '../selectors/simplifyPath'
 import themeColors from '../selectors/themeColors'
-import { mergeBatchEditing } from '../stores/batchEditing'
+import {
+  endBatchEditing,
+  getBatchEditingUndoLabel,
+  isBatchEditing,
+  mergeBatchEditing,
+  setBatchEditingUndoLabel,
+  startBatchEditing,
+} from '../stores/batchEditing'
 import { updateCommandState } from '../stores/commandStateStore'
 import suppressFocusStore from '../stores/suppressFocus'
 import head from '../util/head'
@@ -20,19 +27,39 @@ import { setDescendantActionCreator as setDescendant } from './setDescendant'
 
 const BACKGROUND_COLOR_REGEX = /background-color\s*:\s*[^;]+;?/i
 
+type FormatSelectionCommand =
+  | 'bold'
+  | 'italic'
+  | 'strikethrough'
+  | 'underline'
+  | 'code'
+  | 'foreColor'
+  | 'backColor'
+  | 'removeFormat'
+
+const FORMAT_SELECTION_UNDO_LABELS: Record<FormatSelectionCommand, string> = {
+  bold: 'Bold',
+  italic: 'Italic',
+  strikethrough: 'Strikethrough',
+  underline: 'Underline',
+  code: 'Code',
+  foreColor: 'Text Color',
+  backColor: 'Background Color',
+  removeFormat: 'Clear Formatting',
+}
+
+/** Gets the user-facing undo label for a browser formatting command. */
+const getFormatSelectionUndoLabel = (command: FormatSelectionCommand): string => FORMAT_SELECTION_UNDO_LABELS[command]
+
 /** Format the browser selection or cursor thought as bold, italic, strikethrough, underline. */
 export const formatSelectionActionCreator =
-  (
-    command: 'bold' | 'italic' | 'strikethrough' | 'underline' | 'code' | 'foreColor' | 'backColor' | 'removeFormat',
-    color?: ColorToken,
-  ): Thunk =>
+  (command: FormatSelectionCommand, color?: ColorToken): Thunk =>
   (dispatch, getState) => {
     const state = getState()
     if (!state.cursor) return
     const thought = pathToThought(state, state.cursor)
     if (!thought) return
     const colors = themeColors(state)
-    suppressFocusStore.update(true)
 
     // format whole thought (if there is no selection)
     const contentEditable = document.querySelector(
@@ -42,107 +69,123 @@ export const formatSelectionActionCreator =
     )
     if (!contentEditable) return
 
-    if (
-      (selection.text()?.length === 0 && strip(thought.value).length !== 0) ||
-      selection.text()?.length === strip(thought.value).length
-    ) {
-      // Check the value of the note or thought for a custom background color (#3901)
-      const hasCustomBackgroundColor = BACKGROUND_COLOR_REGEX.test(
-        state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
-      )
-      const savedSelection = selection.save()
-      const inputMode = contentEditable.getAttribute('inputmode')
-      const editable = contentEditable as HTMLElement
+    const wasBatchEditing = isBatchEditing()
+    const undoLabel = getFormatSelectionUndoLabel(command)
+    if (wasBatchEditing) {
+      if (!getBatchEditingUndoLabel()) setBatchEditingUndoLabel(undoLabel)
+    } else {
+      startBatchEditing(undoLabel)
+    }
 
-      // Prevent the virtual keyboard from opening when the editable is focused
-      if (isTouch && isSafari() && !state.isKeyboardOpen) editable.setAttribute('inputmode', 'none')
+    suppressFocusStore.update(true)
 
-      // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
-      editable.focus({ preventScroll: true })
-      selection.select(contentEditable)
-      if (!(command === 'backColor' && color === 'bg' && !hasCustomBackgroundColor)) {
+    try {
+      if (
+        (selection.text()?.length === 0 && strip(thought.value).length !== 0) ||
+        selection.text()?.length === strip(thought.value).length
+      ) {
+        // Check the value of the note or thought for a custom background color (#3901)
+        const hasCustomBackgroundColor = BACKGROUND_COLOR_REGEX.test(
+          state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
+        )
+        const savedSelection = selection.save()
+        const inputMode = contentEditable.getAttribute('inputmode')
+        const editable = contentEditable as HTMLElement
+
+        // Prevent the virtual keyboard from opening when the editable is focused
+        if (isTouch && isSafari() && !state.isKeyboardOpen) editable.setAttribute('inputmode', 'none')
+
+        // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
+        editable.focus({ preventScroll: true })
+        selection.select(contentEditable)
+        if (!(command === 'backColor' && color === 'bg' && !hasCustomBackgroundColor)) {
+          document.execCommand(command, false, color ? colors[color] : '')
+        }
+
+        // Only restore the selection (which keeps the editable focused) when in edit mode.
+        // On mobile, selecting the contentEditable to apply formatting re-focuses it; restoring the selection would
+        // re-open the virtual keyboard even though the user had manually dismissed it. Clearing the selection blurs
+        // the editable so the keyboard stays closed, matching the edit mode invariant (#3996).
+        const editMode = !isTouch || state.isKeyboardOpen
+        if (savedSelection && editMode) {
+          selection.restore(savedSelection)
+        } else {
+          selection.clear()
+        }
+
+        if (isTouch && isSafari() && !state.isKeyboardOpen) contentEditable.setAttribute('inputmode', inputMode ?? '')
+      }
+      // format selected text only
+      else {
         document.execCommand(command, false, color ? colors[color] : '')
+        updateCommandState()
       }
 
-      // Only restore the selection (which keeps the editable focused) when in edit mode.
-      // On mobile, selecting the contentEditable to apply formatting re-focuses it; restoring the selection would
-      // re-open the virtual keyboard even though the user had manually dismissed it. Clearing the selection blurs
-      // the editable so the keyboard stays closed, matching the edit mode invariant (#3996).
-      const editMode = !isTouch || state.isKeyboardOpen
-      if (savedSelection && editMode) {
-        selection.restore(savedSelection)
-      } else {
-        selection.clear()
-      }
+      if (command === 'backColor' || command === 'foreColor') {
+        dispatch((dispatch, getState) => {
+          const state = getState()
+          if (!state.cursor) return
 
-      if (isTouch && isSafari() && !state.isKeyboardOpen) contentEditable.setAttribute('inputmode', inputMode ?? '')
-    }
-    // format selected text only
-    else {
-      document.execCommand(command, false, color ? colors[color] : '')
-      updateCommandState()
-    }
+          // Could be formatting either a thought or a note (#3901)
+          const value = state.noteFocus
+            ? noteValue(state, state.cursor)
+            : getThoughtById(state, head(state.cursor))?.value
+          if (!value) return
 
-    suppressFocusStore.update(false)
+          const path = state.noteFocus ? resolveNotePath(state, state.cursor) : state.cursor
+          if (!path) return
 
-    if (command === 'backColor' || command === 'foreColor') {
-      dispatch((dispatch, getState) => {
-        const state = getState()
-        if (!state.cursor) return
+          // Use DOMParser to remove background-color and unwrap font/span tags that have no meaningful attributes
+          const doc = new DOMParser().parseFromString(value, 'text/html')
 
-        // Could be formatting either a thought or a note (#3901)
-        const value = state.noteFocus
-          ? noteValue(state, state.cursor)
-          : getThoughtById(state, head(state.cursor))?.value
-        if (!value) return
+          for (const el of Array.from(doc.body.querySelectorAll<HTMLElement>('font, span'))) {
+            // Remove background-color if it matches the default background color
+            if (el.style.backgroundColor && rgbToHex(el.style.backgroundColor) === rgbToHex(colors.bg)) {
+              el.style.removeProperty('background-color')
+              if (!el.getAttribute('style')?.trim()) {
+                el.removeAttribute('style')
+              }
+            }
 
-        const path = state.noteFocus ? resolveNotePath(state, state.cursor) : state.cursor
-        if (!path) return
+            // Remove color if it matches the default text color
+            if (el.style.color && rgbToHex(el.style.color) === rgbToHex(state.noteFocus ? colors.fg : colors.fgNote)) {
+              el.style.removeProperty('color')
+            }
 
-        // Use DOMParser to remove background-color and unwrap font/span tags that have no meaningful attributes
-        const doc = new DOMParser().parseFromString(value, 'text/html')
-
-        for (const el of Array.from(doc.body.querySelectorAll<HTMLElement>('font, span'))) {
-          // Remove background-color if it matches the default background color
-          if (el.style.backgroundColor && rgbToHex(el.style.backgroundColor) === rgbToHex(colors.bg)) {
-            el.style.removeProperty('background-color')
-            if (!el.getAttribute('style')?.trim()) {
-              el.removeAttribute('style')
+            // Unwrap tags that have no meaningful style or color attributes
+            if (!el.getAttribute('style')?.trim() && !el.getAttribute('color')?.trim()) {
+              el.replaceWith(...Array.from(el.childNodes))
             }
           }
 
-          // Remove color if it matches the default text color
-          if (el.style.color && rgbToHex(el.style.color) === rgbToHex(state.noteFocus ? colors.fg : colors.fgNote)) {
-            el.style.removeProperty('color')
-          }
+          const newValue = doc.body.innerHTML
+          const batchUndoLabel = getBatchEditingUndoLabel()
 
-          // Unwrap tags that have no meaningful style or color attributes
-          if (!el.getAttribute('style')?.trim() && !el.getAttribute('color')?.trim()) {
-            el.replaceWith(...Array.from(el.childNodes))
-          }
-        }
-
-        const newValue = doc.body.innerHTML
-
-        // Overwrite the value of the thought or note with the stripped value in order to remove background highlighting (#3901)
-        if (newValue !== value)
-          dispatch(
-            state.noteFocus
-              ? setDescendant({
-                  path,
-                  values: [newValue],
-                  mergePrev: mergeBatchEditing(),
-                })
-              : editThought({
-                  cursorOffset: selection.offsetThought() ?? undefined,
-                  oldValue: value,
-                  newValue: newValue,
-                  path: simplifyPath(state, path),
-                  // force the ContentEditable to update
-                  force: true,
-                  mergePrev: mergeBatchEditing(),
-                }),
-          )
-      })
+          // Overwrite the value of the thought or note with the stripped value in order to remove background highlighting (#3901)
+          if (newValue !== value)
+            dispatch(
+              state.noteFocus
+                ? setDescendant({
+                    path,
+                    values: [newValue],
+                    mergePrev: mergeBatchEditing(),
+                    undoLabel: batchUndoLabel,
+                  })
+                : editThought({
+                    cursorOffset: selection.offsetThought() ?? undefined,
+                    oldValue: value,
+                    newValue: newValue,
+                    path: simplifyPath(state, path),
+                    // force the ContentEditable to update
+                    force: true,
+                    mergePrev: mergeBatchEditing(),
+                    undoLabel: batchUndoLabel,
+                  }),
+            )
+        })
+      }
+    } finally {
+      suppressFocusStore.update(false)
+      if (!wasBatchEditing) endBatchEditing()
     }
   }

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -28,7 +28,13 @@ import { setDescendantActionCreator as setDescendant } from './setDescendant'
 const BACKGROUND_COLOR_REGEX = /background-color\s*:\s*[^;]+;?/i
 
 type FormatSelectionCommand =
-  | 'bold' | 'italic' | 'strikethrough' | 'underline' | 'code' | 'foreColor' | 'backColor'
+  | 'bold'
+  | 'italic'
+  | 'strikethrough'
+  | 'underline'
+  | 'code'
+  | 'foreColor'
+  | 'backColor'
   | 'removeFormat'
 
 const FORMAT_SELECTION_UNDO_LABELS: Record<FormatSelectionCommand, string> = {

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -28,13 +28,7 @@ import { setDescendantActionCreator as setDescendant } from './setDescendant'
 const BACKGROUND_COLOR_REGEX = /background-color\s*:\s*[^;]+;?/i
 
 type FormatSelectionCommand =
-  | 'bold'
-  | 'italic'
-  | 'strikethrough'
-  | 'underline'
-  | 'code'
-  | 'foreColor'
-  | 'backColor'
+  | 'bold' | 'italic' | 'strikethrough' | 'underline' | 'code' | 'foreColor' | 'backColor'
   | 'removeFormat'
 
 const FORMAT_SELECTION_UNDO_LABELS: Record<FormatSelectionCommand, string> = {

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -28,8 +28,7 @@ import { setDescendantActionCreator as setDescendant } from './setDescendant'
 const BACKGROUND_COLOR_REGEX = /background-color\s*:\s*[^;]+;?/i
 
 type FormatSelectionCommand =
-  | 'bold' | 'italic' | 'strikethrough' | 'underline' | 'code' | 'foreColor' | 'backColor'
-  | 'removeFormat'
+  'bold' | 'italic' | 'strikethrough' | 'underline' | 'code' | 'foreColor' | 'backColor' | 'removeFormat'
 
 const FORMAT_SELECTION_UNDO_LABELS: Record<FormatSelectionCommand, string> = {
   bold: 'Bold',

--- a/src/actions/formatSelection.ts
+++ b/src/actions/formatSelection.ts
@@ -9,14 +9,7 @@ import pathToThought from '../selectors/pathToThought'
 import resolveNotePath from '../selectors/resolveNotePath'
 import simplifyPath from '../selectors/simplifyPath'
 import themeColors from '../selectors/themeColors'
-import {
-  endBatchEditing,
-  getBatchEditingUndoLabel,
-  isBatchEditing,
-  mergeBatchEditing,
-  setBatchEditingUndoLabel,
-  startBatchEditing,
-} from '../stores/batchEditing'
+import batchEditing, { endBatchEditing, mergeBatchEditing, startBatchEditing } from '../stores/batchEditing'
 import { updateCommandState } from '../stores/commandStateStore'
 import suppressFocusStore from '../stores/suppressFocus'
 import head from '../util/head'
@@ -62,123 +55,124 @@ export const formatSelectionActionCreator =
     )
     if (!contentEditable) return
 
-    const wasBatchEditing = isBatchEditing()
+    // A batch may already be in progress (e.g. one started by the ColorPicker). If so, only fill in a missing undo label;
+    // otherwise start a new batch that this thunk owns and closes at the end.
+    const wasBatchEditing = batchEditing.getState().batching
     const undoLabel = getFormatSelectionUndoLabel(command)
     if (wasBatchEditing) {
-      if (!getBatchEditingUndoLabel()) setBatchEditingUndoLabel(undoLabel)
+      if (!batchEditing.getState().undoLabel) batchEditing.update({ undoLabel })
     } else {
       startBatchEditing(undoLabel)
     }
 
     suppressFocusStore.update(true)
 
-    try {
-      if (
-        (selection.text()?.length === 0 && strip(thought.value).length !== 0) ||
-        selection.text()?.length === strip(thought.value).length
-      ) {
-        // Check the value of the note or thought for a custom background color (#3901)
-        const hasCustomBackgroundColor = BACKGROUND_COLOR_REGEX.test(
-          state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
-        )
-        const savedSelection = selection.save()
-        const inputMode = contentEditable.getAttribute('inputmode')
-        const editable = contentEditable as HTMLElement
+    if (
+      (selection.text()?.length === 0 && strip(thought.value).length !== 0) ||
+      selection.text()?.length === strip(thought.value).length
+    ) {
+      // Check the value of the note or thought for a custom background color (#3901)
+      const hasCustomBackgroundColor = BACKGROUND_COLOR_REGEX.test(
+        state.noteFocus ? (noteValue(state, state.cursor) ?? '') : thought.value,
+      )
+      const savedSelection = selection.save()
+      const inputMode = contentEditable.getAttribute('inputmode')
+      const editable = contentEditable as HTMLElement
 
-        // Prevent the virtual keyboard from opening when the editable is focused
-        if (isTouch && isSafari() && !state.isKeyboardOpen) editable.setAttribute('inputmode', 'none')
+      // Prevent the virtual keyboard from opening when the editable is focused
+      if (isTouch && isSafari() && !state.isKeyboardOpen) editable.setAttribute('inputmode', 'none')
 
-        // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
-        editable.focus({ preventScroll: true })
-        selection.select(contentEditable)
-        if (!(command === 'backColor' && color === 'bg' && !hasCustomBackgroundColor)) {
-          document.execCommand(command, false, color ? colors[color] : '')
-        }
-
-        // Only restore the selection (which keeps the editable focused) when in edit mode.
-        // On mobile, selecting the contentEditable to apply formatting re-focuses it; restoring the selection would
-        // re-open the virtual keyboard even though the user had manually dismissed it. Clearing the selection blurs
-        // the editable so the keyboard stays closed, matching the edit mode invariant (#3996).
-        const editMode = !isTouch || state.isKeyboardOpen
-        if (savedSelection && editMode) {
-          selection.restore(savedSelection)
-        } else {
-          selection.clear()
-        }
-
-        if (isTouch && isSafari() && !state.isKeyboardOpen) contentEditable.setAttribute('inputmode', inputMode ?? '')
-      }
-      // format selected text only
-      else {
+      // Note that we must suppress focus events in the Editable component, otherwise selecting text will set editing:true on mobile.
+      editable.focus({ preventScroll: true })
+      selection.select(contentEditable)
+      if (!(command === 'backColor' && color === 'bg' && !hasCustomBackgroundColor)) {
         document.execCommand(command, false, color ? colors[color] : '')
-        updateCommandState()
       }
 
-      if (command === 'backColor' || command === 'foreColor') {
-        dispatch((dispatch, getState) => {
-          const state = getState()
-          if (!state.cursor) return
+      // Only restore the selection (which keeps the editable focused) when in edit mode.
+      // On mobile, selecting the contentEditable to apply formatting re-focuses it; restoring the selection would
+      // re-open the virtual keyboard even though the user had manually dismissed it. Clearing the selection blurs
+      // the editable so the keyboard stays closed, matching the edit mode invariant (#3996).
+      const editMode = !isTouch || state.isKeyboardOpen
+      if (savedSelection && editMode) {
+        selection.restore(savedSelection)
+      } else {
+        selection.clear()
+      }
 
-          // Could be formatting either a thought or a note (#3901)
-          const value = state.noteFocus
-            ? noteValue(state, state.cursor)
-            : getThoughtById(state, head(state.cursor))?.value
-          if (!value) return
+      if (isTouch && isSafari() && !state.isKeyboardOpen) contentEditable.setAttribute('inputmode', inputMode ?? '')
+    }
+    // format selected text only
+    else {
+      document.execCommand(command, false, color ? colors[color] : '')
+      updateCommandState()
+    }
 
-          const path = state.noteFocus ? resolveNotePath(state, state.cursor) : state.cursor
-          if (!path) return
+    suppressFocusStore.update(false)
 
-          // Use DOMParser to remove background-color and unwrap font/span tags that have no meaningful attributes
-          const doc = new DOMParser().parseFromString(value, 'text/html')
+    if (command === 'backColor' || command === 'foreColor') {
+      dispatch((dispatch, getState) => {
+        const state = getState()
+        if (!state.cursor) return
 
-          for (const el of Array.from(doc.body.querySelectorAll<HTMLElement>('font, span'))) {
-            // Remove background-color if it matches the default background color
-            if (el.style.backgroundColor && rgbToHex(el.style.backgroundColor) === rgbToHex(colors.bg)) {
-              el.style.removeProperty('background-color')
-              if (!el.getAttribute('style')?.trim()) {
-                el.removeAttribute('style')
-              }
-            }
+        // Could be formatting either a thought or a note (#3901)
+        const value = state.noteFocus
+          ? noteValue(state, state.cursor)
+          : getThoughtById(state, head(state.cursor))?.value
+        if (!value) return
 
-            // Remove color if it matches the default text color
-            if (el.style.color && rgbToHex(el.style.color) === rgbToHex(state.noteFocus ? colors.fg : colors.fgNote)) {
-              el.style.removeProperty('color')
-            }
+        const path = state.noteFocus ? resolveNotePath(state, state.cursor) : state.cursor
+        if (!path) return
 
-            // Unwrap tags that have no meaningful style or color attributes
-            if (!el.getAttribute('style')?.trim() && !el.getAttribute('color')?.trim()) {
-              el.replaceWith(...Array.from(el.childNodes))
+        // Use DOMParser to remove background-color and unwrap font/span tags that have no meaningful attributes
+        const doc = new DOMParser().parseFromString(value, 'text/html')
+
+        for (const el of Array.from(doc.body.querySelectorAll<HTMLElement>('font, span'))) {
+          // Remove background-color if it matches the default background color
+          if (el.style.backgroundColor && rgbToHex(el.style.backgroundColor) === rgbToHex(colors.bg)) {
+            el.style.removeProperty('background-color')
+            if (!el.getAttribute('style')?.trim()) {
+              el.removeAttribute('style')
             }
           }
 
-          const newValue = doc.body.innerHTML
-          const batchUndoLabel = getBatchEditingUndoLabel()
+          // Remove color if it matches the default text color
+          if (el.style.color && rgbToHex(el.style.color) === rgbToHex(state.noteFocus ? colors.fg : colors.fgNote)) {
+            el.style.removeProperty('color')
+          }
 
-          // Overwrite the value of the thought or note with the stripped value in order to remove background highlighting (#3901)
-          if (newValue !== value)
-            dispatch(
-              state.noteFocus
-                ? setDescendant({
-                    path,
-                    values: [newValue],
-                    mergePrev: mergeBatchEditing(),
-                    undoLabel: batchUndoLabel,
-                  })
-                : editThought({
-                    cursorOffset: selection.offsetThought() ?? undefined,
-                    oldValue: value,
-                    newValue: newValue,
-                    path: simplifyPath(state, path),
-                    // force the ContentEditable to update
-                    force: true,
-                    mergePrev: mergeBatchEditing(),
-                    undoLabel: batchUndoLabel,
-                  }),
-            )
-        })
-      }
-    } finally {
-      suppressFocusStore.update(false)
-      if (!wasBatchEditing) endBatchEditing()
+          // Unwrap tags that have no meaningful style or color attributes
+          if (!el.getAttribute('style')?.trim() && !el.getAttribute('color')?.trim()) {
+            el.replaceWith(...Array.from(el.childNodes))
+          }
+        }
+
+        const newValue = doc.body.innerHTML
+        const batchUndoLabel = batchEditing.getState().undoLabel
+
+        // Overwrite the value of the thought or note with the stripped value in order to remove background highlighting (#3901)
+        if (newValue !== value)
+          dispatch(
+            state.noteFocus
+              ? setDescendant({
+                  path,
+                  values: [newValue],
+                  mergePrev: mergeBatchEditing(),
+                  undoLabel: batchUndoLabel,
+                })
+              : editThought({
+                  cursorOffset: selection.offsetThought() ?? undefined,
+                  oldValue: value,
+                  newValue: newValue,
+                  path: simplifyPath(state, path),
+                  // force the ContentEditable to update
+                  force: true,
+                  mergePrev: mergeBatchEditing(),
+                  undoLabel: batchUndoLabel,
+                }),
+          )
+      })
     }
+
+    if (!wasBatchEditing) endBatchEditing()
   }

--- a/src/actions/redo.ts
+++ b/src/actions/redo.ts
@@ -1,20 +1,19 @@
 /* eslint-disable import/prefer-default-export */
-import { startCase } from 'lodash'
 import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
-import getLatestActionType from '../util/getLastActionType'
+import getLatestActionLabel from '../util/getLastActionLabel'
 import { alertActionCreator as alert } from './alert'
 
 /** Action-creator for redo. */
 export const redoActionCreator = (): Thunk => (dispatch, getState) => {
-  const lastActionType = getLatestActionType(getState().redoPatches)
+  const lastActionLabel = getLatestActionLabel(getState().redoPatches)
 
   dispatch({ type: 'redo' })
 
-  if (!lastActionType) return
+  if (!lastActionLabel) return
 
   dispatch(
-    alert(`Redo: ${startCase(lastActionType)}`, {
+    alert(`Redo: ${lastActionLabel}`, {
       alertType: AlertType.Redo,
     }),
   )

--- a/src/actions/setSortPreference.ts
+++ b/src/actions/setSortPreference.ts
@@ -12,6 +12,7 @@ import appendToPath from '../util/appendToPath'
 import head from '../util/head'
 import keyValueBy from '../util/keyValueBy'
 import reducerFlow from '../util/reducerFlow'
+import sortPreferenceToUndoLabel from '../util/sortPreferenceToUndoLabel'
 import unroot from '../util/unroot'
 import alert from './alert'
 import deleteAttribute from './deleteAttribute'
@@ -147,7 +148,11 @@ const setSortPreference = (
 export const setSortPreferenceActionCreator =
   (payload: Parameters<typeof setSortPreference>[1]): Thunk =>
   dispatch =>
-    dispatch({ type: 'setSortPreference', ...payload })
+    dispatch({
+      type: 'setSortPreference',
+      ...payload,
+      undoLabel: sortPreferenceToUndoLabel(payload.sortPreference),
+    })
 
 export default _.curryRight(setSortPreference, 2)
 

--- a/src/actions/toggleDropdown.ts
+++ b/src/actions/toggleDropdown.ts
@@ -8,10 +8,7 @@ import clearMulticursors from './clearMulticursors'
 type DropdownType = 'colorPicker' | 'letterCase' | 'sortPicker' | 'commandCenter' | 'undoSlider'
 
 type DropdownStateKeys =
-  | 'showColorPicker'
-  | 'showLetterCase'
-  | 'showSortPicker'
-  | 'showCommandCenter'
+  | 'showColorPicker' | 'showLetterCase' | 'showSortPicker' | 'showCommandCenter'
   | 'showUndoSlider'
 
 // Map dropdown types to their state keys

--- a/src/actions/toggleDropdown.ts
+++ b/src/actions/toggleDropdown.ts
@@ -8,7 +8,11 @@ import clearMulticursors from './clearMulticursors'
 type DropdownType = 'colorPicker' | 'letterCase' | 'sortPicker' | 'commandCenter' | 'undoSlider'
 
 type DropdownStateKeys =
-  'showColorPicker' | 'showLetterCase' | 'showSortPicker' | 'showCommandCenter' | 'showUndoSlider'
+  | 'showColorPicker'
+  | 'showLetterCase'
+  | 'showSortPicker'
+  | 'showCommandCenter'
+  | 'showUndoSlider'
 
 // Map dropdown types to their state keys
 const DROPDOWN_STATE_KEYS: Record<DropdownType, DropdownStateKeys> = {

--- a/src/actions/toggleDropdown.ts
+++ b/src/actions/toggleDropdown.ts
@@ -8,8 +8,7 @@ import clearMulticursors from './clearMulticursors'
 type DropdownType = 'colorPicker' | 'letterCase' | 'sortPicker' | 'commandCenter' | 'undoSlider'
 
 type DropdownStateKeys =
-  | 'showColorPicker' | 'showLetterCase' | 'showSortPicker' | 'showCommandCenter'
-  | 'showUndoSlider'
+  'showColorPicker' | 'showLetterCase' | 'showSortPicker' | 'showCommandCenter' | 'showUndoSlider'
 
 // Map dropdown types to their state keys
 const DROPDOWN_STATE_KEYS: Record<DropdownType, DropdownStateKeys> = {

--- a/src/actions/toggleSort.ts
+++ b/src/actions/toggleSort.ts
@@ -12,6 +12,7 @@ import appendToPath from '../util/appendToPath'
 import head from '../util/head'
 import keyValueBy from '../util/keyValueBy'
 import reducerFlow from '../util/reducerFlow'
+import sortPreferenceToUndoLabel from '../util/sortPreferenceToUndoLabel'
 import unroot from '../util/unroot'
 import alert from './alert'
 import deleteAttribute from './deleteAttribute'
@@ -170,8 +171,15 @@ const toggleSort = (
 /** Action-creator for toggleSort. */
 export const toggleSortActionCreator =
   (payload: Parameters<typeof toggleSort>[1]): Thunk =>
-  dispatch =>
-    dispatch({ type: 'toggleSort', ...payload })
+  (dispatch, getState) => {
+    const currentSortPreference = getSortPreference(getState(), head(payload.simplePath))
+    const nextSortPreference = decideNextSortPreference(currentSortPreference)
+    dispatch({
+      type: 'toggleSort',
+      ...payload,
+      undoLabel: sortPreferenceToUndoLabel(nextSortPreference),
+    })
+  }
 
 export default _.curryRight(toggleSort, 2)
 

--- a/src/actions/undo.ts
+++ b/src/actions/undo.ts
@@ -1,20 +1,19 @@
 /* eslint-disable import/prefer-default-export */
-import { startCase } from 'lodash'
 import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
-import getLatestActionType from '../util/getLastActionType'
+import getLatestActionLabel from '../util/getLastActionLabel'
 import { alertActionCreator as alert } from './alert'
 
 /** Action-creator for undo. */
 export const undoActionCreator = (): Thunk => (dispatch, getState) => {
-  const lastActionType = getLatestActionType(getState().undoPatches)
+  const lastActionLabel = getLatestActionLabel(getState().undoPatches)
 
   dispatch({ type: 'undo' })
 
-  if (!lastActionType) return
+  if (!lastActionLabel) return
 
   dispatch(
-    alert(`Undo: ${startCase(lastActionType)}`, {
+    alert(`Undo: ${lastActionLabel}`, {
       alertType: AlertType.Undo,
     }),
   )

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -44,6 +44,7 @@ import head from './util/head'
 import keyValueBy from './util/keyValueBy'
 import parentOf from './util/parentOf'
 import UnreachableError from './util/unreachable'
+import { dispatchWithUndoLabel } from './util/withUndoLabel'
 
 export const globalCommands: Command[] = Object.values(commandsObject)
 
@@ -211,6 +212,13 @@ export const chainCommand = (command1: Command, command2: Command): Command => {
 
 const eventNoop = { preventDefault: noop } as Event
 
+/** Gets the user-facing undo/redo label for a command. */
+const getCommandUndoLabel = (command: Command, state: State) => {
+  if (typeof command.undoLabel === 'function') return command.undoLabel(state)
+  if (command.undoLabel) return command.undoLabel
+  return command.labelInverse && command.isActive?.(state) ? command.labelInverse : command.label
+}
+
 /** Filter the cursors based on the filter type. Cursors are sorted in document order. */
 const filterCursors = (state: State, cursors: Path[], filter: MulticursorFilter = 'all') => {
   switch (filter) {
@@ -291,7 +299,12 @@ export const executeCommand = (
   if (!canExecute) return
 
   // execute single command
-  command.exec(commandStore.dispatch, commandStore.getState, event, { type })
+  command.exec(
+    dispatchWithUndoLabel(commandStore.dispatch, getCommandUndoLabel(command, commandStore.getState())),
+    commandStore.getState,
+    event,
+    { type },
+  )
 }
 
 /** Execute command. Defaults to global store and keyboard shortcuts. */
@@ -346,6 +359,9 @@ export const executeCommandWithMulticursor = (
   const canExecute = filteredPaths.every(path => !command.canExecute || command.canExecute({ ...state, cursor: path }))
   if (!canExecute) return
 
+  const commandUndoLabel = getCommandUndoLabel(command, state)
+  const dispatchWithCommandUndoLabel = dispatchWithUndoLabel(commandStore.dispatch, commandUndoLabel)
+
   // Reverse the order of the cursors if the command has reverse multicursor mode enabled.
   if (multicursor.reverse) {
     filteredPaths.reverse()
@@ -356,21 +372,21 @@ export const executeCommandWithMulticursor = (
   commandStore.dispatch(
     setIsMulticursorExecuting({
       value: true,
-      undoLabel: command.id,
+      undoLabel: commandUndoLabel,
     }),
   )
 
   // If there is a custom execMulticursor function, call it with the filtered multicursors.
   // Otherwise, execute the command once for each of the filtered multicursors.
   if (multicursor.execMulticursor) {
-    multicursor.execMulticursor(filteredPaths, commandStore.dispatch, commandStore.getState)
+    multicursor.execMulticursor(filteredPaths, dispatchWithCommandUndoLabel, commandStore.getState)
   } else {
     for (const path of filteredPaths) {
       // Make sure we have the correct path to the thought in case it was moved during execution.
       const recomputedPath = recomputePath(commandStore.getState(), head(path))
       if (!recomputedPath) continue
 
-      commandStore.dispatch(setCursor({ path: recomputedPath }))
+      dispatchWithCommandUndoLabel(setCursor({ path: recomputedPath }))
       executeCommand(command, { store: commandStore, type, event })
     }
   }
@@ -378,12 +394,12 @@ export const executeCommandWithMulticursor = (
   // Restore the cursor to its original value if not prevented.
   // Note that state.cursor is the old cursor, before any commands were executed.
   if (!multicursor.preventSetCursor && state.cursor) {
-    commandStore.dispatch(setCursor({ path: recomputePath(commandStore.getState(), head(state.cursor)) }))
+    dispatchWithCommandUndoLabel(setCursor({ path: recomputePath(commandStore.getState(), head(state.cursor)) }))
   }
 
   // Restore multicursors
   if (!multicursor.clearMulticursor) {
-    commandStore.dispatch(
+    dispatchWithCommandUndoLabel(
       paths.map(path => (dispatch, getState) => {
         const recomputedPath = recomputePath(getState(), head(path))
         if (!recomputedPath) return
@@ -392,10 +408,10 @@ export const executeCommandWithMulticursor = (
     )
   }
 
-  multicursor.onComplete?.(filteredPaths, commandStore.dispatch, commandStore.getState)
+  multicursor.onComplete?.(filteredPaths, dispatchWithCommandUndoLabel, commandStore.getState)
 
   // Reset isMulticursorExecuting after all operations
-  commandStore.dispatch(setIsMulticursorExecuting({ value: false }))
+  dispatchWithCommandUndoLabel(setIsMulticursorExecuting({ value: false }))
 }
 
 /**

--- a/src/commands/__tests__/undo-label.ts
+++ b/src/commands/__tests__/undo-label.ts
@@ -1,0 +1,145 @@
+import { editThoughtActionCreator as editThoughtRaw } from '../../actions/editThought'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { redoActionCreator as redo } from '../../actions/redo'
+import { setDescendantActionCreator as setDescendant } from '../../actions/setDescendant'
+import { setSortPreferenceActionCreator as setSortPreference } from '../../actions/setSortPreference'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommand } from '../../commands'
+import { HOME_PATH } from '../../constants'
+import contextToPath from '../../selectors/contextToPath'
+import store from '../../stores/app'
+import {
+  endBatchEditing,
+  getBatchEditingUndoLabel,
+  mergeBatchEditing,
+  startBatchEditing,
+} from '../../stores/batchEditing'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import withUndoLabel from '../../util/withUndoLabel'
+import pinCommand from '../pin'
+import toggleDoneCommand from '../toggleDone'
+
+beforeEach(initStore)
+
+/** Dispatches a formatting edit the same way Editable emits editThought after document.execCommand mutates the DOM. */
+const dispatchBatchFormattingEdit = (undoLabel: string, newValue: string) => {
+  const oldValue = 'hello'
+  const path = contextToPath(store.getState(), [oldValue])
+  if (!path) throw new Error('Test thought not found')
+
+  startBatchEditing(undoLabel)
+  try {
+    store.dispatch(
+      editThoughtRaw({
+        path,
+        oldValue,
+        newValue,
+        force: true,
+        mergePrev: mergeBatchEditing(),
+        undoLabel: getBatchEditingUndoLabel(),
+      }),
+    )
+  } finally {
+    endBatchEditing()
+    vi.runOnlyPendingTimers()
+  }
+}
+
+it('uses command undo labels in undo and redo alerts', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - b
+            - c
+    `,
+    }),
+    setCursor(['a', 'b']),
+  ])
+
+  executeCommand(pinCommand, { store })
+
+  store.dispatch(undo())
+  expect(store.getState().alert?.value).toBe('Undo: Pin Thought')
+
+  store.dispatch(redo())
+  expect(store.getState().alert?.value).toBe('Redo: Pin Thought')
+})
+
+it('uses inverse command labels when toggling active commands off', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - =done
+    `,
+    }),
+    setCursor(['a']),
+  ])
+
+  executeCommand(toggleDoneCommand, { store })
+
+  store.dispatch(undo())
+  expect(store.getState().alert?.value).toBe('Undo: Unmark as done')
+})
+
+it('uses explicit undo labels for direct undoable dispatches', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - b
+            - c
+    `,
+    }),
+    setCursor(['a', 'b']),
+  ])
+
+  store.dispatch(
+    withUndoLabel(setDescendant({ path: store.getState().cursor!, values: ['=pin', 'false'] }), 'Pin Thought'),
+  )
+
+  store.dispatch(undo())
+  expect(store.getState().alert?.value).toBe('Undo: Pin Thought')
+})
+
+it('uses sort preference labels instead of internal action names', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - b
+        - a
+    `,
+    }),
+    setSortPreference({
+      simplePath: HOME_PATH,
+      sortPreference: {
+        type: 'Alphabetical',
+        direction: 'Asc',
+      },
+    }),
+  ])
+
+  store.dispatch(undo())
+  expect(store.getState().alert?.value).toBe('Undo: Sort by Alphabetical ↑')
+})
+
+it.each([
+  ['Bold', '<b>hello</b>'],
+  ['Text Color', '<font color="#ff0000">hello</font>'],
+  ['Background Color', '<span style="background-color: rgb(255, 165, 0);">hello</span>'],
+])('uses batch edit labels for %s edits emitted by Editable', (undoLabel, newValue) => {
+  store.dispatch(
+    importText({
+      text: `
+        - hello
+    `,
+    }),
+  )
+
+  dispatchBatchFormattingEdit(undoLabel, newValue)
+
+  store.dispatch(undo())
+  expect(store.getState().alert?.value).toBe(`Undo: ${undoLabel}`)
+})

--- a/src/commands/__tests__/undo-label.ts
+++ b/src/commands/__tests__/undo-label.ts
@@ -8,12 +8,7 @@ import { executeCommand } from '../../commands'
 import { HOME_PATH } from '../../constants'
 import contextToPath from '../../selectors/contextToPath'
 import store from '../../stores/app'
-import {
-  endBatchEditing,
-  getBatchEditingUndoLabel,
-  mergeBatchEditing,
-  startBatchEditing,
-} from '../../stores/batchEditing'
+import batchEditing, { endBatchEditing, mergeBatchEditing, startBatchEditing } from '../../stores/batchEditing'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import withUndoLabel from '../../util/withUndoLabel'
@@ -37,7 +32,7 @@ const dispatchBatchFormattingEdit = (undoLabel: string, newValue: string) => {
         newValue,
         force: true,
         mergePrev: mergeBatchEditing(),
-        undoLabel: getBatchEditingUndoLabel(),
+        undoLabel: batchEditing.getState().undoLabel,
       }),
     )
   } finally {

--- a/src/commands/pin.ts
+++ b/src/commands/pin.ts
@@ -12,6 +12,11 @@ import head from '../util/head'
 const pinCommand: Command = {
   id: 'pin',
   label: 'Pin',
+  undoLabel: state => {
+    const { cursor } = state
+    if (!cursor) return 'Pin Thought'
+    return isPinned(state, head(cursor)) ? 'Unpin Thought' : 'Pin Thought'
+  },
   labelInverse: 'Unpin',
   description: 'Pins open a thought so its subthoughts are always visible.',
   descriptionInverse: 'Unpins a thought so its subthoughts are automatically hidden.',

--- a/src/components/BulletPositioner.tsx
+++ b/src/components/BulletPositioner.tsx
@@ -25,6 +25,7 @@ import hashPath from '../util/hashPath'
 import head from '../util/head'
 import isDivider from '../util/isDivider'
 import parentOf from '../util/parentOf'
+import withUndoLabel from '../util/withUndoLabel'
 
 const isIOSSafari = isTouch && isiPhone && isSafari()
 
@@ -264,17 +265,22 @@ const BulletPositioner = forwardRef<SVGSVGElement, PropsWithChildren<BulletPosit
           const parentChildren = pathParent ? getChildren(state, head(pathParent)) : null
           // if thought is not expanded, set the cursor on the thought
           // if thought is expanded, collapse it by moving the cursor to its parent
-          dispatch([
-            // set pin false on expanded only child
-            ...(isExpanded &&
-            (!pathParent ||
-              parentChildren?.length === 1 ||
-              findDescendant(state, pathParent && head(pathParent), ['=children', '=pin', 'true']))
-              ? [setDescendant({ path: simplePath, values: ['=pin', 'false'] })]
-              : [deleteAttribute({ path: simplePath, value: '=pin' })]),
-            // move cursor
-            setCursor({ path: shouldCollapse ? pathParent : path, preserveMulticursor: true }),
-          ])
+          dispatch(
+            withUndoLabel(
+              [
+                // set pin false on expanded only child
+                ...(isExpanded &&
+                (!pathParent ||
+                  parentChildren?.length === 1 ||
+                  findDescendant(state, pathParent && head(pathParent), ['=children', '=pin', 'true']))
+                  ? [setDescendant({ path: simplePath, values: ['=pin', 'false'] })]
+                  : [deleteAttribute({ path: simplePath, value: '=pin' })]),
+                // move cursor
+                setCursor({ path: shouldCollapse ? pathParent : path, preserveMulticursor: true }),
+              ],
+              'Pin Thought',
+            ),
+          )
         })
       },
       [dispatch, dragHold, path, simplePath],

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../styled-system/css'
 import { token } from '../../styled-system/tokens'
+import Thunk from '../@types/Thunk'
 import { formatSelectionActionCreator as formatSelection } from '../actions/formatSelection'
 import { isTouch } from '../browser'
 import { ColorToken } from '../colors.config'
@@ -9,6 +10,7 @@ import themeColors from '../selectors/themeColors'
 import { endBatchEditing, startBatchEditing } from '../stores/batchEditing'
 import commandStateStore from '../stores/commandStateStore'
 import rgbToHex from '../util/rgbToHex'
+import withUndoLabel from '../util/withUndoLabel'
 import Popover from './Popover'
 import TextColorIcon from './icons/TextColor'
 
@@ -61,11 +63,14 @@ const ColorSwatch: FC<{
 
   /** Toggles the text color to the clicked swatch. If the swatch is already selected, sets text color and background color back to default. */
   const toggleTextColor = () => {
+    const undoLabel = backgroundColor ? 'Background Color' : 'Text Color'
+
     // Batch the foreColor and backColor edits into a single undo step. Starting the batch before the foreColor dispatch
     // ensures that whichever edit lands first anchors the undo step, so re-applying a background color (whose forced black
     // text is a no-op) still forms its own undo step instead of merging into the previous color application (#4620).
-    startBatchEditing()
-    dispatch((dispatch, getState) => {
+    startBatchEditing(undoLabel)
+    /** Applies foreground color so nested dispatches can inherit the swatch's undo label. */
+    const applyForegroundColor: Thunk = (dispatch, getState) => {
       // Note is semi-transparent by default and its color must be reset to that rather than white, which is the fg color for thoughts. (#3902)
       const fgColor = getState().noteFocus ? 'fgNote' : 'fg'
       dispatch(
@@ -74,10 +79,11 @@ const ColorSwatch: FC<{
           selected ? fgColor : color || (backgroundColor && backgroundColor !== 'fg' ? 'black' : 'bg'),
         ),
       )
-    })
+    }
+    dispatch(withUndoLabel(applyForegroundColor, undoLabel))
 
     // Apply background color to the selection
-    dispatch(formatSelection('backColor', selected ? 'bg' : (backgroundColor ?? 'bg')))
+    dispatch(withUndoLabel(formatSelection('backColor', selected ? 'bg' : (backgroundColor ?? 'bg')), undoLabel))
     endBatchEditing()
   }
 

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -42,7 +42,7 @@ import getSetting from '../selectors/getSetting'
 import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursorSelector from '../selectors/hasMulticursor'
 import rootedParentOf from '../selectors/rootedParentOf'
-import { mergeBatchEditing } from '../stores/batchEditing'
+import { getBatchEditingUndoLabel, mergeBatchEditing } from '../stores/batchEditing'
 import editingValueStore from '../stores/editingValue'
 import editingValueUntrimmedStore from '../stores/editingValueUntrimmed'
 import storageModel from '../stores/storageModel'
@@ -336,6 +336,8 @@ const Editable = ({
     // Log the value transition at the point the edit is committed to Redux. Correlates with the 'change' branch that queued it.
     debugLog.log('edit', { oldValue, newValue, rank })
 
+    const undoLabel = getBatchEditingUndoLabel()
+
     dispatch(
       editThought({
         oldValue,
@@ -347,6 +349,7 @@ const Editable = ({
         cursorOffset: cursorOffset ?? selection.offsetThought() ?? undefined,
         force,
         mergePrev: mergeBatchEditing(), // If batch editing is in progress, merge this edit with the previous one in the undo stack (except the first edit of a batch, which starts a new undo step).
+        undoLabel,
       }),
     )
 

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -42,7 +42,7 @@ import getSetting from '../selectors/getSetting'
 import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursorSelector from '../selectors/hasMulticursor'
 import rootedParentOf from '../selectors/rootedParentOf'
-import { getBatchEditingUndoLabel, mergeBatchEditing } from '../stores/batchEditing'
+import batchEditing, { mergeBatchEditing } from '../stores/batchEditing'
 import editingValueStore from '../stores/editingValue'
 import editingValueUntrimmedStore from '../stores/editingValueUntrimmed'
 import storageModel from '../stores/storageModel'
@@ -336,7 +336,7 @@ const Editable = ({
     // Log the value transition at the point the edit is committed to Redux. Correlates with the 'change' branch that queued it.
     debugLog.log('edit', { oldValue, newValue, rank })
 
-    const undoLabel = getBatchEditingUndoLabel()
+    const undoLabel = batchEditing.getState().undoLabel
 
     dispatch(
       editThought({

--- a/src/components/LetterCasePicker.tsx
+++ b/src/components/LetterCasePicker.tsx
@@ -8,6 +8,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import applyLetterCase from '../util/applyLetterCase'
 import fastClick from '../util/fastClick'
 import head from '../util/head'
+import withUndoLabel from '../util/withUndoLabel'
 import Popover from './Popover'
 import LowerCaseIcon from './icons/LowerCaseIcon'
 import SentenceCaseIcon from './icons/SentenceCaseIcon'
@@ -23,7 +24,7 @@ const LetterCasePicker: FC<{ size?: number }> = memo(({ size }) => {
   const toggleLetterCase = (command: LetterCaseType, e: React.MouseEvent | React.TouchEvent) => {
     e.stopPropagation()
     e.preventDefault()
-    dispatch(formatLetterCase(command))
+    dispatch(withUndoLabel(formatLetterCase(command), command.replace(/([a-z])([A-Z])/g, '$1 $2')))
   }
   const selected = useSelector(state => {
     const value = (!!state.cursor && getThoughtById(state, head(state.cursor))?.value) || ''

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -19,7 +19,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import noteValue from '../selectors/noteValue'
 import resolveNotePath from '../selectors/resolveNotePath'
 import store from '../stores/app'
-import { mergeBatchEditing } from '../stores/batchEditing'
+import { getBatchEditingUndoLabel, mergeBatchEditing } from '../stores/batchEditing'
 import equalPathHead from '../util/equalPathHead'
 import head from '../util/head'
 import strip from '../util/strip'
@@ -124,12 +124,14 @@ const Note = React.memo(
           const state = getState()
 
           const targetPath = resolveNotePath(state, path) ?? path
+          const undoLabel = getBatchEditingUndoLabel()
 
           dispatch(
             setDescendant({
               path: targetPath,
               values: [value],
               mergePrev: mergeBatchEditing(), // If batch editing is in progress, merge this edit with the previous one in the undo stack (except the first edit of a batch, which starts a new undo step).
+              undoLabel,
             }),
           )
         })

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -19,7 +19,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import noteValue from '../selectors/noteValue'
 import resolveNotePath from '../selectors/resolveNotePath'
 import store from '../stores/app'
-import { getBatchEditingUndoLabel, mergeBatchEditing } from '../stores/batchEditing'
+import batchEditing, { mergeBatchEditing } from '../stores/batchEditing'
 import equalPathHead from '../util/equalPathHead'
 import head from '../util/head'
 import strip from '../util/strip'
@@ -124,7 +124,7 @@ const Note = React.memo(
           const state = getState()
 
           const targetPath = resolveNotePath(state, path) ?? path
-          const undoLabel = getBatchEditingUndoLabel()
+          const undoLabel = batchEditing.getState().undoLabel
 
           dispatch(
             setDescendant({

--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -158,6 +158,10 @@ it('move cursor from formatted thought to first unformatted thought in descendin
   // Make text bold using the toolbar
   await click('[data-testid="toolbar-icon"][aria-label="Bold"]')
 
+  // Formatting is committed asynchronously from the contenteditable change event. Wait for it before navigating so
+  // ArrowDown cannot race the pending edit in slower CI browsers.
+  await waitUntil(() => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML === '<b>apple</b>')
+
   // Press arrow down to move cursor
   await press('ArrowDown')
 

--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -25,20 +25,15 @@ enum EditThoughtDirection {
   Shorter = 'Shorter',
 }
 
-/** Interface for the setIsMulticursorExecuting action. */
-interface SetIsMulticursorExecutingAction extends Action<'setIsMulticursorExecuting'> {
-  value: boolean
-  undoLabel?: string
-}
-
-/** Type guard to check if an action is a setIsMulticursorExecuting action. */
-function isSetIsMulticursorExecutingAction(action: Action<string>): action is SetIsMulticursorExecutingAction {
-  return action.type === 'setIsMulticursorExecuting'
-}
-
 /** Type guard for editThought action. */
 function isEditThoughtAction(action: UnknownAction): action is UnknownAction & editThoughtPayload {
   return action.type === 'editThought'
+}
+
+/** Gets the user-facing undo/redo label from an action. */
+function getActionUndoLabel(action: UnknownAction): string | undefined {
+  const undoLabel = action.undoLabel
+  return typeof undoLabel === 'string' ? undoLabel : undefined
 }
 
 /** Compare the text contents of the old and new values to determine the direction of the edit.
@@ -118,9 +113,9 @@ const diffState = <T>(newValue: Index<T>, value: Index<T>): Operation[] =>
 /**
  * Append action names to all operations of a Patch.
  */
-const addActionsToPatch = (patch: Operation[], actions: ActionType[]): Patch =>
+const addActionsToPatch = (patch: Operation[], actions: ActionType[], undoLabel?: string): Patch =>
   // TODO: Fix Patch type to support any Operation, not just GetOperation. See Patch.ts.
-  patch.map(operation => ({ ...operation, actions })) as Patch
+  patch.map(operation => ({ ...operation, actions, ...(undoLabel ? { undoLabel } : null) })) as Patch
 
 /**
  * Gets the first action from a patch.
@@ -128,7 +123,7 @@ const addActionsToPatch = (patch: Operation[], actions: ActionType[]): Patch =>
 const getPatchAction = (patch: Patch): ActionType => patch[0]?.actions[0]
 
 /**
- * Returns true if a patch represents an undoable action. A patch's first action may be a non-action label (e.g. a multicursor command's undoLabel), so check all actions in the patch rather than only the first.
+ * Returns true if a patch represents an undoable action. Historical patches may have stored a non-action label at actions[0], so check all actions in the patch rather than only the first.
  */
 const isPatchUndoable = (patch: Patch | undefined): boolean => !!patch?.[0]?.actions.some(isUndoable)
 
@@ -145,7 +140,11 @@ const undoOneReducer = (state: State): State => {
   const lastUndoPatch = nthLast(undoPatches, 1)
   if (!lastUndoPatch) return state
   const newState = produce(state, (state: State) => applyPatch(state, lastUndoPatch).newDocument)
-  const correspondingRedoPatch = addActionsToPatch(diffState(newState as Index, state), [...lastUndoPatch[0]?.actions])
+  const correspondingRedoPatch = addActionsToPatch(
+    diffState(newState as Index, state),
+    [...lastUndoPatch[0]?.actions],
+    lastUndoPatch[0]?.undoLabel,
+  )
   return {
     ...newState,
     redoPatches: [...redoPatches, correspondingRedoPatch],
@@ -163,7 +162,11 @@ const redoOneReducer = (state: State): State => {
   const lastRedoPatch = nthLast(redoPatches, 1)
   if (!lastRedoPatch) return state
   const newState = produce(state, (state: State) => applyPatch(state, lastRedoPatch).newDocument)
-  const correspondingUndoPatch = addActionsToPatch(diffState(newState as Index, state), [...lastRedoPatch[0]?.actions])
+  const correspondingUndoPatch = addActionsToPatch(
+    diffState(newState as Index, state),
+    [...lastRedoPatch[0]?.actions],
+    lastRedoPatch[0]?.undoLabel,
+  )
   return {
     ...newState,
     redoPatches: redoPatches.slice(0, -1),
@@ -363,10 +366,11 @@ const undoRedoReducerEnhancer: StoreEnhancer<any> =
             ...newState.undoPatches.slice(0, -1),
             ...(combinedUndoPatch.length
               ? [
-                  addActionsToPatch(combinedUndoPatch, [
-                    ...(lastUndoPatch && lastUndoPatch.length > 0 ? lastUndoPatch[0]?.actions : []),
-                    actionType,
-                  ]),
+                  addActionsToPatch(
+                    combinedUndoPatch,
+                    [...(lastUndoPatch && lastUndoPatch.length > 0 ? lastUndoPatch[0]?.actions : []), actionType],
+                    lastUndoPatch?.[0]?.undoLabel || getActionUndoLabel(action),
+                  ),
                 ]
               : []),
           ],
@@ -385,11 +389,7 @@ const undoRedoReducerEnhancer: StoreEnhancer<any> =
             redoPatches: [],
             undoPatches: [
               ...newState.undoPatches,
-              addActionsToPatch(undoPatch, [
-                // Override the action label with undoLabel so that the command label is used in the alert on undo/redo of a multicursor command.
-                // TODO: A better solution would add a label to the Patch itself.
-                isSetIsMulticursorExecutingAction(action) ? (action.undoLabel as ActionType) : lastAction.type,
-              ]),
+              addActionsToPatch(undoPatch, [lastAction.type], getActionUndoLabel(action)),
             ],
           }
         : newState

--- a/src/stores/batchEditing.ts
+++ b/src/stores/batchEditing.ts
@@ -6,6 +6,8 @@ interface BatchEditing {
   batching: boolean
   /** Whether at least one edit has been recorded since the current batch started. */
   edited: boolean
+  /** User-facing label to show when undoing or redoing the current batch. */
+  undoLabel?: string
 }
 
 /** A store that signals that multiple execCommand operations are in progress and should be treated as a single edit. While batching, editThought actions
@@ -18,13 +20,13 @@ const batchEditing = ministore<BatchEditing>({ batching: false, edited: false })
 let endBatchTimer: ReturnType<typeof setTimeout> | undefined
 
 /** Starts a batch of edits that should be merged into a single undo step. */
-export const startBatchEditing = () => {
+export const startBatchEditing = (undoLabel?: string) => {
   // Cancel a pending deferred close so the incoming edits are anchored to this fresh batch.
   if (endBatchTimer) {
     clearTimeout(endBatchTimer)
     endBatchTimer = undefined
   }
-  batchEditing.update({ batching: true, edited: false })
+  batchEditing.update({ batching: true, edited: false, undoLabel })
 }
 
 /** Ends the current batch of edits.
@@ -40,8 +42,19 @@ export const endBatchEditing = () => {
   if (endBatchTimer) clearTimeout(endBatchTimer)
   endBatchTimer = setTimeout(() => {
     endBatchTimer = undefined
-    batchEditing.update({ batching: false, edited: false })
+    batchEditing.update({ batching: false, edited: false, undoLabel: undefined })
   })
+}
+
+/** Returns true if batch editing is currently active. */
+export const isBatchEditing = (): boolean => batchEditing.getState().batching
+
+/** Gets the current batch's user-facing undo label, if any. */
+export const getBatchEditingUndoLabel = (): string | undefined => batchEditing.getState().undoLabel
+
+/** Sets the current batch's user-facing undo label. */
+export const setBatchEditingUndoLabel = (undoLabel: string) => {
+  batchEditing.update({ undoLabel })
 }
 
 /** Returns the mergePrev value for an edit dispatched during a possible batch, recording that an edit has occurred. Returns false when not batching or for the

--- a/src/stores/batchEditing.ts
+++ b/src/stores/batchEditing.ts
@@ -46,17 +46,6 @@ export const endBatchEditing = () => {
   })
 }
 
-/** Returns true if batch editing is currently active. */
-export const isBatchEditing = (): boolean => batchEditing.getState().batching
-
-/** Gets the current batch's user-facing undo label, if any. */
-export const getBatchEditingUndoLabel = (): string | undefined => batchEditing.getState().undoLabel
-
-/** Sets the current batch's user-facing undo label. */
-export const setBatchEditingUndoLabel = (undoLabel: string) => {
-  batchEditing.update({ undoLabel })
-}
-
 /** Returns the mergePrev value for an edit dispatched during a possible batch, recording that an edit has occurred. Returns false when not batching or for the
  * first edit in a batch (which starts a new undo step), and true for subsequent edits in the same batch (which merge into it). */
 export const mergeBatchEditing = (): boolean => {

--- a/src/util/getLastActionLabel.ts
+++ b/src/util/getLastActionLabel.ts
@@ -1,0 +1,18 @@
+import { startCase } from 'lodash'
+import Patch from '../@types/Patch'
+import { isNavigation } from './actionMetadata.registry'
+
+/**
+ * Recursively gets the latest user-facing action label from patch history.
+ * Navigation patches are skipped so undo/redo alerts describe the command that caused the change.
+ */
+const getLatestActionLabel = (patchArr: Patch[], n = 1): string | undefined => {
+  const patch = patchArr[patchArr.length - n]
+  const lastActionType = patch?.[0]?.actions[0]
+  if (!lastActionType) return undefined
+  return isNavigation(lastActionType)
+    ? getLatestActionLabel(patchArr, n + 1)
+    : patch[0]?.undoLabel || startCase(lastActionType)
+}
+
+export default getLatestActionLabel

--- a/src/util/series.ts
+++ b/src/util/series.ts
@@ -3,8 +3,8 @@
  *
  * @param fs    An array of funcs that return promises.
  * @example
- *   const urls = ['/url1', '/url2', '/url3']
- *   await series(urls.map(url => () => $.ajax(url)))
+ * const urls = ['/url1', '/url2', '/url3']
+ * await series(urls.map(url => () => $.ajax(url)))
  */
 const series = <T>(fs: ((() => Promise<T> | null) | null)[]): Promise<T[]> =>
   fs.reduce(

--- a/src/util/sortPreferenceToUndoLabel.ts
+++ b/src/util/sortPreferenceToUndoLabel.ts
@@ -1,0 +1,11 @@
+import SortPreference from '../@types/SortPreference'
+
+/** Converts a sort preference into a user-facing undo/redo label. */
+const sortPreferenceToUndoLabel = (sortPreference: SortPreference): string => {
+  if (sortPreference.type === 'None') return 'Sort Manually'
+
+  const direction = sortPreference.direction === 'Asc' ? '\u2191' : sortPreference.direction === 'Desc' ? '\u2193' : ''
+  return `Sort by ${sortPreference.type}${direction ? ` ${direction}` : ''}`
+}
+
+export default sortPreferenceToUndoLabel

--- a/src/util/withUndoLabel.ts
+++ b/src/util/withUndoLabel.ts
@@ -1,0 +1,41 @@
+import { UnknownAction } from 'redux'
+import Dispatch from '../@types/Dispatch'
+import State from '../@types/State'
+import Thunk from '../@types/Thunk'
+
+/** Returns true if the value is a Redux action object. */
+const isActionObject = (value: unknown): value is UnknownAction =>
+  !!value && typeof value === 'object' && 'type' in value
+
+/**
+ * Annotates all Redux actions produced by an action, thunk, or action array with a user-facing undo label.
+ * Explicit labels on nested actions take precedence.
+ */
+const withUndoLabel = <T>(action: T, undoLabel: string): T => {
+  if (Array.isArray(action)) return action.map(item => withUndoLabel(item, undoLabel)) as T
+
+  if (typeof action === 'function') {
+    /** Annotates nested dispatches inside a thunk. */
+    const dispatchWithLabel = (dispatch: Dispatch): Dispatch =>
+      ((action: Parameters<Dispatch>[0]) => dispatch(withUndoLabel(action, undoLabel))) as Dispatch
+
+    return ((dispatch: Dispatch, getState: () => State) =>
+      (action as Thunk)(dispatchWithLabel(dispatch), getState)) as T
+  }
+
+  if (isActionObject(action)) {
+    const actionUndoLabel = action.undoLabel
+    return {
+      ...action,
+      undoLabel: typeof actionUndoLabel === 'string' ? actionUndoLabel : undoLabel,
+    } as T
+  }
+
+  return action
+}
+
+/** Returns a dispatch function that annotates every dispatched action with the given undo label. */
+export const dispatchWithUndoLabel = (dispatch: Dispatch, undoLabel: string): Dispatch =>
+  ((action: Parameters<Dispatch>[0]) => dispatch(withUndoLabel(action, undoLabel))) as Dispatch
+
+export default withUndoLabel


### PR DESCRIPTION
## Summary

Fixes #4609.

Updates undo/redo alert labels so user-facing command names are shown instead of internal action names like `Toggle Attribute`, `Set Descendant`, or `Edit Thought`.

## Changes

- Adds undo label metadata to undo patches.
- Uses command labels for undo/redo alerts, including Pin Thought and inverse command states.
- Labels direct dispatches for pin, letter case, sort, text color, and background color actions.
- Carries formatting/color undo labels through batch editing so async `Editable`/`Note` updates no longer show `Undo: Edit Thought`.
- Adds regression coverage for command labels, pin labels, sort labels, formatting, text color, and background color.

## Verification

- `yarn lint:tsc`
- Targeted ESLint on changed files
- `yarn test src/commands/__tests__/undo-label.ts`
- `yarn test src/commands/__tests__/undo-redo.ts src/commands/__tests__/redo.ts src/commands/__tests__/pin.ts`