### PR TITLE
Dim emoji in Clear Thought placeholder (#4671)

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -370,6 +370,10 @@ const globalCss = defineGlobalStyles({
     content: 'attr(placeholder)',
     cursor: 'text',
   },
+  '[placeholder][data-placeholder-cleared]:empty::before': {
+    color: 'var(--placeholder-color, currentColor)',
+    opacity: 0.5,
+  },
   '[placeholder][data-placeholder-bold]:empty::before': {
     fontWeight: 700,
   },

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -372,7 +372,8 @@ const globalCss = defineGlobalStyles({
   },
   '[placeholder][data-placeholder-cleared]:empty::before': {
     color: 'var(--placeholder-color, currentColor)',
-    opacity: 0.5,
+    // Safari does not fade color emoji with opacity on a pseudo-element, so filter the rendered content instead.
+    filter: 'opacity(0.5)',
   },
   '[placeholder][data-placeholder-bold]:empty::before': {
     fontWeight: 700,

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -937,6 +937,7 @@ const Editable = ({
       innerRef={contentRef}
       aria-label={'editable-' + head(path)}
       data-editable
+      data-placeholder-cleared={isCursorCleared || undefined}
       data-placeholder-bold={placeholderCommandState?.bold || undefined}
       data-placeholder-code={placeholderCommandState?.code || undefined}
       data-placeholder-italic={placeholderCommandState?.italic || undefined}

--- a/src/e2e/puppeteer/__tests__/format.ts
+++ b/src/e2e/puppeteer/__tests__/format.ts
@@ -155,10 +155,12 @@ it('Clear Thought dims emoji in the placeholder (#4671)', async () => {
     const style = getComputedStyle(editable, '::before')
     return {
       content: style.content,
+      filter: style.filter,
       opacity: style.opacity,
     }
   })
 
   expect(placeholderStyle.content).toContain('👋 Hello')
-  expect(placeholderStyle.opacity).toBe('0.5')
+  expect(placeholderStyle.filter).toBe('opacity(0.5)')
+  expect(placeholderStyle.opacity).toBe('1')
 })

--- a/src/e2e/puppeteer/__tests__/format.ts
+++ b/src/e2e/puppeteer/__tests__/format.ts
@@ -140,3 +140,25 @@ it('Clear Thought placeholder inherits whole-thought formatting (#4612)', async 
   expect(Number.parseInt(placeholderStyle.fontWeight, 10)).toBeGreaterThanOrEqual(700)
   expect(placeholderStyle.textDecorationLine).toContain('underline')
 })
+
+it('Clear Thought dims emoji in the placeholder (#4671)', async () => {
+  await paste('- 👋 Hello')
+  await clickThought('👋 Hello')
+
+  await press('c', { ctrl: true, alt: true, shift: true })
+  await page.waitForFunction(() => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML === '')
+
+  const placeholderStyle = await page.evaluate(() => {
+    const editable = document.querySelector('[data-editing=true] [data-editable]')
+    if (!editable) throw new Error('Editing thought not found')
+
+    const style = getComputedStyle(editable, '::before')
+    return {
+      content: style.content,
+      opacity: style.opacity,
+    }
+  })
+
+  expect(placeholderStyle.content).toContain('👋 Hello')
+  expect(placeholderStyle.opacity).toBe('0.5')
+})

--- a/src/recipes/thought.ts
+++ b/src/recipes/thought.ts
@@ -29,6 +29,9 @@ const thoughtRecipe = defineRecipe({
       true: {
         // invert placeholder color if the color is inverted (such as when a background color is applied)
         '[placeholder]:empty::before': { color: { _base: 'var(--placeholder-color, {colors.dimInverse})' } },
+        '[placeholder][data-placeholder-cleared]:empty::before': {
+          color: { _base: 'var(--placeholder-color, currentColor)' },
+        },
       },
     },
     flex: {


### PR DESCRIPTION
## Summary
Fixes #4671

Activating Clear Thought dimmed regular text but left color emoji at full opacity.

CSS text color alpha does not affect native color emoji, so the placeholder’s existing dim color only worked for text.

## Changes

- Mark cleared thought placeholders with a dedicated data attribute.
- Dim the entire placeholder pseudo-element using opacity.
- Preserve placeholder colors, formatting, and inverse-theme behavior.
- Add a Puppeteer regression test covering an emoji-prefixed thought.

## Testing

- Added: `Clear Thought dims emoji in the placeholder (#4671)`