### PR TITLE
Add Settings keyboard shortcut

### DIFF
--- a/src/commands/__tests__/settings.ts
+++ b/src/commands/__tests__/settings.ts
@@ -1,0 +1,21 @@
+import { screen } from '@testing-library/dom'
+import { act } from 'react'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('opens Settings with Cmd + , (#4563)', async () => {
+  const event = new KeyboardEvent('keydown', {
+    key: ',',
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  })
+
+  act(() => window.dispatchEvent(event))
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(event.defaultPrevented).toBe(true)
+  expect(await screen.findByRole('heading', { name: 'Settings' })).toBeVisible()
+})

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -6,6 +6,7 @@ const command: Command = {
   id: 'settings',
   label: 'Settings',
   description: 'Customize your experience of em.',
+  keyboard: { key: ',', meta: true },
   multicursor: false,
   svg: SettingsIcon,
   exec: dispatch => dispatch(showModal({ id: 'settings' })),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -603,7 +603,7 @@ export const COMMAND_GROUPS: {
   },
   {
     title: 'Settings',
-    commands: ['customizeToolbar'],
+    commands: ['settings', 'customizeToolbar'],
   },
   {
     title: 'Help',


### PR DESCRIPTION
## Summary

- Add `Cmd + ,` as the keyboard shortcut for opening Settings.
- List Settings in the Settings command group so the shortcut is discoverable in command help.
- Add regression coverage for keyboard dispatch and modal opening.

Closes #4563

## Testing

- `yarn test src/commands/__tests__/settings.ts --run`
- `yarn lint`
- `yarn test --run` (1,539 passed, 75 skipped)
