### PR TITLE
ci: set allow-unsafe-pr-checkout on pull_request_target checkouts

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+          # v6 (upgraded from v4 in #3981) refuses to check out fork PR code from a
+          # pull_request_target workflow unless this is set. Untrusted fork code is
+          # gated by GitHub's "require approval for outside collaborators" setting.
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
       # `pull_request_target` runs the workflow file from the default branch but checks out the PR's
       # head code. PRs that branched before the HTTPS dev server migration use an HTTP-only dev

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # v6 (added in #4471) refuses to check out fork PR code from a
+          # pull_request_target workflow unless this is set. See the header comment
+          # for why running fork code in this context is intentionally gated.
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Problem

Fork PRs from outside contributors fail at the checkout step with:

> Refusing to check out fork pull request code from a `pull_request_target` workflow. [...] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set `allow-unsafe-pr-checkout: true` on the actions/checkout step.

`actions/checkout` **v6** added this guardrail. Two workflows are triggered by `pull_request_target` and check out the fork's PR head, so both hit it:

- **Vercel Preview** ([.github/workflows/vercel-preview.yml](../blob/main/.github/workflows/vercel-preview.yml)) — checkout upgraded/created at v6 in #4471
- **BrowserStack / iOS** ([.github/workflows/ios.yml](../blob/main/.github/workflows/ios.yml)) — checkout upgraded from v4→v6 in #3981

(The repo has no `actions/checkout@v7`; v6 is the current version and where this behavior was introduced.)

## Fix

Add `allow-unsafe-pr-checkout: true` to the checkout step in both workflows, with a comment citing the PR that set each to v6 and a link to the security docs.

## Safety

This opts into running untrusted fork code in a context with repo secrets. That is safe here because **"require approval for outside collaborators" is enabled** for the repo, so a maintainer reviews each outside-contributor PR before any workflow runs — confirmed by the maintainer. The `vercel-preview.yml` header already documents this gating rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)