### PR TITLE
Fix stale Vite server in puppeteer snapshot tests (#4672)

### DIFF
--- a/src/e2e/puppeteer/test-puppeteer.sh
+++ b/src/e2e/puppeteer/test-puppeteer.sh
@@ -32,7 +32,9 @@ stop_dev_server() {
         # Otherwise, the process can exit here and stop_docker_container will never be called, and the next run will fail because the port is already in use.
         kill $DEV_SERVER_PID || true
     fi
-    [ -n "$DEV_SERVER_LOG" ] && rm -f "$DEV_SERVER_LOG"
+    if [ -n "$DEV_SERVER_LOG" ]; then
+        rm -f "$DEV_SERVER_LOG"
+    fi
 }
 
 cleanup() {

--- a/src/e2e/puppeteer/test-puppeteer.sh
+++ b/src/e2e/puppeteer/test-puppeteer.sh
@@ -32,6 +32,7 @@ stop_dev_server() {
         # Otherwise, the process can exit here and stop_docker_container will never be called, and the next run will fail because the port is already in use.
         kill $DEV_SERVER_PID || true
     fi
+    [ -n "$DEV_SERVER_LOG" ] && rm -f "$DEV_SERVER_LOG"
 }
 
 cleanup() {
@@ -54,10 +55,29 @@ if [ -z "$GITHUB_ACTIONS" ]; then
         sleep 0.1
     done
 
+    # Fail fast if the port is already occupied (e.g. an orphaned Vite server from a previous run).
+    # Without this, Vite would silently move to another port and Puppeteer (hard-coded to :2552)
+    # would test a stale app. See https://github.com/cybersemics/em/issues/4672.
+    if lsof -tiTCP:2552 -sTCP:LISTEN >/dev/null 2>&1; then
+        echo "Error: port 2552 is already in use (likely an orphaned dev server)." >&2
+        echo "Kill it with: kill \$(lsof -tiTCP:2552 -sTCP:LISTEN)" >&2
+        exit 1
+    fi
+
     echo "Starting separate dev server..."
-    PUPPETEER=1 yarn vite --host --port 2552 >/dev/null 2>&1 &
+    # Launch the Vite binary directly (not via `yarn vite`) so DEV_SERVER_PID is the actual server
+    # process and cleanup can reliably kill it. Otherwise `yarn vite` spawns Vite as a child and $!
+    # captures the yarn wrapper, leaving Vite orphaned. --strictPort makes Vite fail rather than
+    # silently move ports. Capture output so startup errors can be surfaced on failure.
+    DEV_SERVER_LOG=$(mktemp)
+    PUPPETEER=1 ./node_modules/.bin/vite --host --port 2552 --strictPort >"$DEV_SERVER_LOG" 2>&1 &
     DEV_SERVER_PID=$!
     while ! nc -z localhost 2552; do
+        if ! kill -0 "$DEV_SERVER_PID" 2>/dev/null; then
+            echo "Error: dev server failed to start." >&2
+            cat "$DEV_SERVER_LOG" >&2
+            exit 1
+        fi
         sleep 0.1
     done
     echo "Server is ready."


### PR DESCRIPTION
## Problem

Fixes #4672. The puppeteer snapshot tests were silently testing a **stale app**, so local code changes never appeared in the diff while CI (starting clean) correctly failed.

Root cause, diagnosed in [this comment](https://github.com/cybersemics/em/issues/4672#issuecomment-5036192641):

1. `test-puppeteer.sh` started Vite with `yarn vite ... &` and saved `$!`. Under Yarn 4 (Berry), `yarn vite` spawns Vite as a **child** process, so `$!` is the yarn wrapper's PID, not Vite's.
2. Cleanup did `kill $DEV_SERVER_PID`, killing only the wrapper and **leaving the real Vite server orphaned** on port 2552.
3. On the next run, port 2552 was occupied, so Vite (without `--strictPort`) **silently moved to 2553**.
4. The readiness check (`nc -z localhost 2552`) succeeded against the *orphaned* server, and Puppeteer — hard-coded to `:2552` — screenshotted the old app.
5. Startup output was redirected to `/dev/null`, hiding any Vite errors.

## Changes

All in `src/e2e/puppeteer/test-puppeteer.sh`:

- **Launch `./node_modules/.bin/vite` directly** (not `yarn vite`) so `DEV_SERVER_PID` is the actual server process and the existing cleanup reliably kills it — no more orphan.
- **Add `--strictPort`** so Vite fails instead of silently hopping to another port.
- **Fail fast if 2552 is already occupied**, before starting, with a copy-pasteable kill command.
- **Stop suppressing startup errors**: capture Vite output to a temp log (cleaned up in `cleanup()`), detect a dead server process during the readiness loop, and print the log + exit non-zero instead of hanging forever.

## Testing notes for reviewers

- Happy path: `yarn test:puppeteer <test>` starts a fresh server and tests current code.
- After a run, `lsof -tiTCP:2552 -sTCP:LISTEN` returns nothing (no orphan left behind).
- With something already on 2552, the script exits immediately with the guard message instead of testing a stale app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)