### PR TITLE
Fix emoji spacing before colored text

### DIFF
--- a/src/components/__tests__/Editable.ts
+++ b/src/components/__tests__/Editable.ts
@@ -78,3 +78,20 @@ it('inserts emoji spacing immediately and allows Backspace at the emoji boundary
 
   expect(editable.textContent).toBe('🧠Hello')
 })
+
+it('inserts emoji spacing immediately before colored text', async () => {
+  act(() => {
+    windowEvent('keydown', { key: 'Enter' })
+  })
+
+  const editable = (await findThoughtByText(''))!
+  expect(editable).toBeVisible()
+
+  editable.innerHTML = '👋<font color="#ff0000">Hello</font>'
+  act(() => {
+    fireEvent.input(editable, { bubbles: true })
+  })
+
+  expect(editable.textContent).toBe('👋 Hello')
+  expect(editable.innerHTML).toBe('👋 <font color="#ff0000">Hello</font>')
+})

--- a/src/util/__tests__/addEmojiSpace.ts
+++ b/src/util/__tests__/addEmojiSpace.ts
@@ -28,3 +28,15 @@ it('only add extra spaces if emojis are followed by non whitespace character.', 
   expect(addEmojiSpace('🐶🐰 Animals')).toEqual('🐶🐰 Animals')
   expect(addEmojiSpace('The Great Gatsby')).toEqual('The Great Gatsby')
 })
+
+it('adds space between an emoji and formatted text', () => {
+  expect(addEmojiSpace('👋<font color="#ff0000">Hello</font>')).toEqual(
+    '👋 <font color="#ff0000">Hello</font>',
+  )
+  expect(addEmojiSpace('<font color="#ff0000">👋Hello</font>')).toEqual(
+    '<font color="#ff0000">👋 Hello</font>',
+  )
+  expect(addEmojiSpace('<b><font color="#ff0000">👋</font>Hello</b>')).toEqual(
+    '<b><font color="#ff0000">👋 </font>Hello</b>',
+  )
+})

--- a/src/util/__tests__/addEmojiSpace.ts
+++ b/src/util/__tests__/addEmojiSpace.ts
@@ -30,12 +30,8 @@ it('only add extra spaces if emojis are followed by non whitespace character.', 
 })
 
 it('adds space between an emoji and formatted text', () => {
-  expect(addEmojiSpace('👋<font color="#ff0000">Hello</font>')).toEqual(
-    '👋 <font color="#ff0000">Hello</font>',
-  )
-  expect(addEmojiSpace('<font color="#ff0000">👋Hello</font>')).toEqual(
-    '<font color="#ff0000">👋 Hello</font>',
-  )
+  expect(addEmojiSpace('👋<font color="#ff0000">Hello</font>')).toEqual('👋 <font color="#ff0000">Hello</font>')
+  expect(addEmojiSpace('<font color="#ff0000">👋Hello</font>')).toEqual('<font color="#ff0000">👋 Hello</font>')
   expect(addEmojiSpace('<b><font color="#ff0000">👋</font>Hello</b>')).toEqual(
     '<b><font color="#ff0000">👋 </font>Hello</b>',
   )

--- a/src/util/addEmojiSpace.ts
+++ b/src/util/addEmojiSpace.ts
@@ -49,9 +49,7 @@ const addEmojiSpace = (html: string): string => {
   if (match && match[0] && match[0].length < text.length) {
     const startsWithNonWhiteSpaceCharacter = /^\S/.test(text.slice(match[0].length))
     const insertionIndex = sourceIndices[match[0].length]
-    return startsWithNonWhiteSpaceCharacter
-      ? `${html.slice(0, insertionIndex)} ${html.slice(insertionIndex)}`
-      : html
+    return startsWithNonWhiteSpaceCharacter ? `${html.slice(0, insertionIndex)} ${html.slice(insertionIndex)}` : html
   }
 
   return html

--- a/src/util/addEmojiSpace.ts
+++ b/src/util/addEmojiSpace.ts
@@ -8,6 +8,31 @@ Note: Some emojis end with zero width joiner or zero width space which don't act
 */
 const emojiGroupRegex = new RegExp(`^(${EMOJI_REGEX.source}){1,}\u200D?\u200B?`)
 
+/**
+ * Returns the visible text and the corresponding insertion index in the source HTML for each character boundary.
+ * Formatting tags are ignored so that leading emojis can be detected without rewriting or normalizing the markup.
+ */
+const getVisibleText = (html: string): { sourceIndices: number[]; text: string } => {
+  const sourceIndices = [0]
+  let text = ''
+
+  for (let i = 0; i < html.length; ) {
+    if (html[i] === '<') {
+      const tagEnd = html.indexOf('>', i + 1)
+      if (tagEnd >= 0) {
+        i = tagEnd + 1
+        continue
+      }
+    }
+
+    text += html[i]
+    i++
+    sourceIndices[text.length] = i
+  }
+
+  return { sourceIndices, text }
+}
+
 /* Note: The above regex uses unicode property escape to match emojis https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes.
   However these emoji property escapes don't account for emoji variant selector (\ufe0f) which can be found in many emojis (example: 🖼️, 🖥️).
   So we add \ufe0f as optional match and also prevent it from being detected as non emoji character.
@@ -17,17 +42,19 @@ const emojiGroupRegex = new RegExp(`^(${EMOJI_REGEX.source}){1,}\u200D?\u200B?`)
  * If a string starts with an emoji or group of emojis followed by a non-whitespace, non-emoji character,
  * then insert a space between the emoji and the character.
  */
-const addEmojiSpace = (text: string): string => {
+const addEmojiSpace = (html: string): string => {
+  const { sourceIndices, text } = getVisibleText(html)
   const match = text.match(emojiGroupRegex)
 
   if (match && match[0] && match[0].length < text.length) {
-    const replaceRegex = new RegExp(`^\\${match[0]}`)
-    const afterEmojis = text.replace(replaceRegex, '')
-    const startsWithNonWhiteSpaceCharacter = /^[^\s]/.test(afterEmojis)
-    return startsWithNonWhiteSpaceCharacter ? text.replace(replaceRegex, `${match[0]} `) : text
+    const startsWithNonWhiteSpaceCharacter = /^\S/.test(text.slice(match[0].length))
+    const insertionIndex = sourceIndices[match[0].length]
+    return startsWithNonWhiteSpaceCharacter
+      ? `${html.slice(0, insertionIndex)} ${html.slice(insertionIndex)}`
+      : html
   }
 
-  return text
+  return html
 }
 
 export default addEmojiSpace

--- a/src/util/addEmojiSpace.ts
+++ b/src/util/addEmojiSpace.ts
@@ -16,7 +16,7 @@ const getVisibleText = (html: string): { sourceIndices: number[]; text: string }
   const sourceIndices = [0]
   let text = ''
 
-  for (let i = 0; i < html.length; ) {
+  for (let i = 0; i < html.length;) {
     if (html[i] === '<') {
       const tagEnd = html.indexOf('>', i + 1)
       if (tagEnd >= 0) {


### PR DESCRIPTION
## Summary

Fixes #4674.

When an emoji is inserted before colored text, the editable value begins with HTML formatting markup such as `<font>`. The emoji-spacing logic checked the raw HTML, so it did not recognize that the visible text started with an emoji.

## Changes

- Detect leading emojis from the visible text while ignoring formatting tags.
- Map the visible emoji boundary back to the original HTML.
- Insert the space without rewriting or removing formatting markup.
- Add utility and component regression tests for colored and nested formatted text.

## Testing

- Targeted unit tests passed: 10/10.
- TypeScript check passed.