### PR TITLE
Fix toolbar unmount while dropdown is open

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -207,7 +207,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
   )
 
   return (
-    <FadeTransition in={!distractionFreeTyping} type='distractionFreeTyping' unmountOnExit>
+    <FadeTransition in={!distractionFreeTyping || showDropdown} type='distractionFreeTyping' unmountOnExit>
       <div
         aria-label='toolbar'
         className={cx(


### PR DESCRIPTION
## Summary

Keep the Toolbar mounted during distraction-free typing whenever Color Picker or Letter Case is open.

## Root cause

Typing activates distraction-free mode after a short delay and begins the Toolbar’s exit transition. The Color Picker can open while that transition is still pending. When the transition completes, `unmountOnExit` removes the Toolbar and Color Picker subtree between `waitForSelector` and `page.click`.

The transition now remains active when either distraction-free typing is disabled or a Toolbar dropdown is open. This fixes the component lifecycle without adding an artificial test delay.

## Validation

- Target Puppeteer regression: 104 consecutive passes
- Complete color Puppeteer file: 22/22 passes
- TypeScript and ESLint passed

Fixes #4678