### PR TITLE
docs: fix introductory comma in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,4 +45,4 @@ Here is an example of a Pull Request where the contributor believed they had com
 
 ## Code of Conduct
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/cybersemics/em/blob/dev/CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/cybersemics/em/blob/dev/CODE-OF-CONDUCT.md). By participating in this project, you agree to abide by its terms.


### PR DESCRIPTION
## Description
This PR adds a missing introductory comma in `CONTRIBUTING.md`.

## Details
Added missing comma after introductory clause (`By participating in this project you agree` $\to$ `By participating in this project, you agree`).