### PR TITLE
docs: capitalize Code of Conduct in CODE-OF-CONDUCT.md

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -72,5 +72,5 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
+For answers to common questions about this Code of Conduct, see
 https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,4 +45,4 @@ Here is an example of a Pull Request where the contributor believed they had com
 
 ## Code of Conduct
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/cybersemics/em/blob/dev/CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/cybersemics/em/blob/dev/CODE-OF-CONDUCT.md). By participating in this project, you agree to abide by its terms.


### PR DESCRIPTION
## Description
This PR fixes proper noun capitalization in `CODE-OF-CONDUCT.md`.

## Details
Capitalized formal document title reference (`this code of conduct` $\to$ `this Code of Conduct`).