### PR TITLE
Show git commit hash under App Version in the footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -217,6 +217,10 @@ const Footer = () => {
         <span className={css({ color: 'dim' })}>App Version: </span>
         {pkg.version}
       </li>
+      <li className={liClass}>
+        <span className={css({ color: 'dim' })}>Commit: </span>
+        <span className={css({ fontStyle: 'monospace' })}>{__COMMIT_HASH__}</span>
+      </li>
     </ul>
   )
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,3 +12,6 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+/** Short git commit hash of the current build, injected at build time via Vite's `define` in vite.config.ts. */
+declare const __COMMIT_HASH__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import basicSsl from '@vitejs/plugin-basic-ssl'
 import react from '@vitejs/plugin-react'
+import { execSync } from 'child_process'
 import type { IncomingMessage, ServerResponse } from 'http'
 import path from 'path'
 import { type Plugin, type PreviewServer, type ViteDevServer, defineConfig } from 'vite'
@@ -8,6 +9,16 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 import { VitePWA } from 'vite-plugin-pwa'
 
 const useHttps = !process.env.HTTP
+
+/** Resolve the short git commit hash of the current build, injected into the app via `define`. Prefers Vercel's build-time env var, falls back to git, then to 'unknown'. */
+const commitHash = (() => {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) return process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7)
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return 'unknown'
+  }
+})()
 
 /**
  * Vite plugin that gates access behind a secret token when TUNNEL_TOKEN is set.
@@ -58,6 +69,9 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
+  },
+  define: {
+    __COMMIT_HASH__: JSON.stringify(commitHash),
   },
   plugins: [
     react(),


### PR DESCRIPTION
## What

Adds a **Commit** row to the footer's debug info, directly under App Version, showing the short git commit hash of the current build.

## Why

App Version comes from `package.json`, but two builds can share the same version, so it can't identify which code is actually deployed. The commit hash pins down the exact build — useful when debugging a production or preview deploy.

## How

- **`vite.config.ts`** — resolves the short hash at build time and injects it as a global constant via Vite's `define`. Precedence: `VERCEL_GIT_COMMIT_SHA` (Vercel builds, truncated to 7 chars) → `git rev-parse --short HEAD` → `'unknown'` fallback.
- **`src/vite-env.d.ts`** — declares the `__COMMIT_HASH__` global for TypeScript.
- **`src/components/Footer.tsx`** — renders `Commit: <hash>` in monospace, matching the adjacent TSID row.

Renders e.g. `Commit: 6be6c78`. The value is replaced with a literal string at build time — no runtime git dependency.

## Notes for reviewer

- No test added: the footer's static debug rows (App Version, TSID) have no existing test coverage, and this is a plain-text display with no logic branches.
- The `'unknown'` fallback mirrors the existing pattern in `scripts/estimate/src/lib/getPromptVersion.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)