### PR TITLE
Split HTML twice to preserve formatting around sentence

### DIFF
--- a/src/actions/__tests__/splitSentences.ts
+++ b/src/actions/__tests__/splitSentences.ts
@@ -1,3 +1,4 @@
+import MimeType from '../../@types/MimeType'
 import newThought from '../../actions/newThought'
 import splitSentences from '../../actions/splitSentences'
 import { HOME_TOKEN } from '../../constants'
@@ -15,11 +16,11 @@ import importText from '../importText'
  * @param thought The thought that needs to be split.
  * @returns The thought string after being split.
  */
-function splitThought(value: string) {
+function splitThought(value: string, format: MimeType = 'text/plain') {
   const steps = [newThought(value), splitSentences()]
 
   const stateNew = reducerFlow(steps)(initialState())
-  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+  const exported = exportContext(stateNew, [HOME_TOKEN], format)
   return exported
 }
 
@@ -782,5 +783,23 @@ describe('dash splitting', () => {
     expect(exported).toBe(`- ${HOME_TOKEN}
   - one
     - 1.`)
+  })
+})
+
+describe('formatting', () => {
+  // https://github.com/cybersemics/em/issues/4229
+  it('preserves formatting on every comma-delimited segment, including segments in the middle', () => {
+    const value = '<font color="#ff573d">Hello, beautiful, people.</font>'
+    const exported = splitThought(value, 'text/html')
+
+    expect(exported).toBe(`<ul>
+  <li>${HOME_TOKEN}  
+    <ul>
+      <li><font color="#ff573d">Hello</font></li>
+      <li><font color="#ff573d">beautiful</font></li>
+      <li><font color="#ff573d">people.</font></li>
+    </ul>
+  </li>
+</ul>`)
   })
 })

--- a/src/util/splitSentence.ts
+++ b/src/util/splitSentence.ts
@@ -87,6 +87,34 @@ interface SplitResult {
 }
 
 /**
+ * Splits HTML at a text offset into the HTML before and after the offset, with formatting tags re-balanced onto both halves.
+ *
+ * @param htmlValue The source HTML.
+ * @param offset The text offset to split at.
+ */
+function splitHtmlAtTextOffset(htmlValue: string, offset: number): { left: string; right: string } {
+  const div = document.createElement('div')
+  div.innerHTML = htmlValue
+
+  const nodeOffset = selection.offsetFromClosestParent(div, offset)
+  if (!nodeOffset?.node) throw new Error(`Unable to map text offset to an HTML node: ${offset}`)
+
+  const range = document.createRange()
+  range.setStart(nodeOffset.node, nodeOffset.offset)
+  range.setEnd(nodeOffset.node, nodeOffset.offset)
+
+  const splitNodesResult = selection.splitNode(div, range)
+  if (!splitNodesResult) return { left: '', right: '' }
+
+  const leftDiv = document.createElement('div')
+  const rightDiv = document.createElement('div')
+  leftDiv.appendChild(splitNodesResult.left.cloneContents())
+  rightDiv.appendChild(splitNodesResult.right.cloneContents())
+
+  return { left: leftDiv.innerHTML, right: rightDiv.innerHTML }
+}
+
+/**
  * Returns HTML between text offsets while preserving valid tag structure.
  *
  * @param htmlValue The source HTML.
@@ -94,22 +122,10 @@ interface SplitResult {
  * @param endOffset Exclusive text offset.
  */
 function sliceHtmlByTextOffsets(htmlValue: string, startOffset: number, endOffset: number): string {
-  const div = document.createElement('div')
-  div.innerHTML = htmlValue
-
-  const start = selection.offsetFromClosestParent(div, startOffset)
-  const end = selection.offsetFromClosestParent(div, endOffset)
-  if (!start?.node || !end?.node) {
-    throw new Error(`Unable to map text offsets to HTML nodes: [${startOffset}, ${endOffset}]`)
-  }
-
-  const range = document.createRange()
-  range.setStart(start.node, start.offset)
-  range.setEnd(end.node, end.offset)
-
-  const fragmentDiv = document.createElement('div')
-  fragmentDiv.appendChild(range.cloneContents())
-  return fragmentDiv.innerHTML
+  // Split at the end offset, then split the left half at the start offset.
+  // A single Range spanning both offsets cannot be used: when both boundaries fall inside the same text node, cloneContents returns a bare text node and all surrounding formatting tags are dropped (#4229). splitNode anchors one boundary at the root so that the formatting ancestors are re-balanced onto each half.
+  const { left } = splitHtmlAtTextOffset(htmlValue, endOffset)
+  return splitHtmlAtTextOffset(left, startOffset).right
 }
 
 /**


### PR DESCRIPTION
Fixes #4229

Extracting the contents out of the middle of a DOM node would miss the tags that wrap it. Splitting twice, once from the start of the node to the end of the sentence, then again from the start of the sentence to the end of the new wrapper, extracts the formatting tags along with the text.