### PR TITLE
ci: use a pool of named Cloudflare tunnels for BrowserStack

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,10 +15,12 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # BrowserStack hub (attachExistingSession.ts) and the heartbeat keepalive
-  # (.github/skills/browser-control-ios/heartbeat.sh) both need outbound access,
-  # as does the cloudflared tunnel (wdio.browserstack.conf.ts) that exposes the
-  # dev server to the BrowserStack device.
-  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: hub-cloud.browserstack.com,hub.browserstack.com,api.browserstack.com,trycloudflare.com
+  # (.github/skills/browser-control-ios/heartbeat.sh) both need outbound access, as does the
+  # Cloudflare tunnel pool (cloudflareTunnelPool.ts) that exposes the dev server to the
+  # BrowserStack device. That pool lives entirely on emthought.cc (a domain we own and control
+  # every tunnel/DNS record on), not the shared trycloudflare.com quick-tunnel domain — allowlisting
+  # trycloudflare.com would allowlist anyone's tunnel, not just ours.
+  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: hub-cloud.browserstack.com,hub.browserstack.com,api.browserstack.com,emthought.cc
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,6 +15,8 @@ on:
 # Serialize BrowserStack runs repo-wide. Every run draws from the same shared parallel-session pool, so
 # overlapping runs (a main push + PR syncs + reruns) can over-subscribe it and fail with session-creation
 # timeouts. Allowing one active run at a time keeps total live sessions within maxInstances.
+# This also guarantees the named `copilot-browserstack` Cloudflare tunnel never has two workflow
+# connectors online simultaneously (a named tunnel must have a single active connector per run).
 # cancel-in-progress: false queues runs instead of cancelling them, so no run is dropped.
 # queue: max extends the queue from the default 1 to the maximum of 100, ensuring runs don't get silently
 # dropped if lots of jobs queue up.
@@ -94,7 +96,11 @@ jobs:
         env:
           USE_HTTPS: ${{ steps.server_mode.outputs.https }}
         run: |
-          yarn servebuild &
+          # Bind 0.0.0.0 (--host) so the app is reachable via the runner's localhost by the
+          # cloudflared connector (which the wdio config starts). Capture the PID and tee output
+          # to serve.log so the readiness loop and the cleanup step can use them.
+          yarn servebuild --host > serve.log 2>&1 &
+          echo "APP_PID=$!" >> "$GITHUB_ENV"
 
           echo "Waiting for server to be ready..."
           for i in {1..30}; do
@@ -109,7 +115,8 @@ jobs:
             fi
             echo "Attempt $i/30: status $HTTP_STATUS"
             if [ $i -eq 30 ]; then
-              echo "Server failed to respond after 30 attempts"
+              echo "Server failed to respond after 30 attempts. Server log:"
+              cat serve.log || true
               exit 1
             fi
             sleep 1
@@ -123,3 +130,27 @@ jobs:
           BROWSERSTACK_BUILD_NAME: 'CI - ${{github.run_id}}'
           BROWSERSTACK_PROJECT_NAME: 'em'
           TUNNEL_TOKEN: ${{env.TUNNEL_TOKEN}}
+          # Presence of this connector token switches the wdio config from the ephemeral quick
+          # tunnel to the named `copilot-browserstack` tunnel (public host browserstack.emthought.cc).
+          # The token is only ever read from this secret and passed to the connector's child env.
+          # Workflow concurrency (group: browserstack) serializes runs, so the named tunnel never
+          # has two connectors online at once.
+          CLOUDFLARE_TUNNEL_TOKEN: ${{secrets.CLOUDFLARE_TUNNEL_TOKEN}}
+
+      # Best-effort cleanup on the ephemeral runner: stop the manually-started app and preserve
+      # the named connector's log for diagnosis. The connector process itself is killed by the
+      # wdio config's onComplete hook.
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -n "$APP_PID" ]; then
+            kill "$APP_PID" 2>/dev/null || true
+          fi
+
+      - name: Upload cloudflared connector log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloudflared-browserstack-log
+          path: cloudflared-browserstack.log
+          if-no-files-found: ignore

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,8 +15,9 @@ on:
 # Serialize BrowserStack runs repo-wide. Every run draws from the same shared parallel-session pool, so
 # overlapping runs (a main push + PR syncs + reruns) can over-subscribe it and fail with session-creation
 # timeouts. Allowing one active run at a time keeps total live sessions within maxInstances.
-# This also guarantees the named `copilot-browserstack` Cloudflare tunnel never has two workflow
-# connectors online simultaneously (a named tunnel must have a single active connector per run).
+# (The Cloudflare tunnel pool tolerates concurrent connectors on its own — see
+# cloudflareTunnelPool.ts's self-verifying claim — so this serialization is purely about the
+# BrowserStack session cap now, not the tunnel.)
 # cancel-in-progress: false queues runs instead of cancelling them, so no run is dropped.
 # queue: max extends the queue from the default 1 to the maximum of 100, ensuring runs don't get silently
 # dropped if lots of jobs queue up.
@@ -55,19 +56,20 @@ jobs:
           allow-unsafe-pr-checkout: true
 
       # `pull_request_target` runs the workflow file from the default branch but checks out the PR's
-      # head code. PRs that branched before the HTTPS dev server migration use an HTTP-only dev
-      # server with no token gate; PRs at or after it use HTTPS + a tunnel-token gate. Detect which
-      # mode the checked-out code is in so the health check probes the right protocol and we only
-      # generate a tunnel token when one is needed.
-      - name: Detect dev server mode
+      # head code, which may predate the tunnel-token gate. Detect whether the checked-out code has
+      # that gate so we only generate a token when one is needed, and only send it when the server
+      # expects it. The gate arrived with the HTTPS dev server migration, so plugin-basic-ssl is the
+      # marker for it. Note this says nothing about the protocol any more: the Serve step forces
+      # HTTP=1, so the dev server is plain HTTP either way.
+      - name: Detect token gate
         id: server_mode
         run: |
           if grep -q "@vitejs/plugin-basic-ssl" vite.config.ts; then
-            echo "https=true" >> "$GITHUB_OUTPUT"
-            echo "Mode: HTTPS"
+            echo "has_token_gate=true" >> "$GITHUB_OUTPUT"
+            echo "Token gate: present"
           else
-            echo "https=false" >> "$GITHUB_OUTPUT"
-            echo "Mode: HTTP (PR predates HTTPS dev server migration)"
+            echo "has_token_gate=false" >> "$GITHUB_OUTPUT"
+            echo "Token gate: absent (PR predates the HTTPS dev server migration)"
           fi
 
       - name: Enable Corepack
@@ -86,7 +88,7 @@ jobs:
         run: yarn build
 
       - name: Generate tunnel token
-        if: steps.server_mode.outputs.https == 'true'
+        if: steps.server_mode.outputs.has_token_gate == 'true'
         run: |
           TOKEN=$(openssl rand -hex 16)
           echo "::add-mask::$TOKEN"
@@ -94,21 +96,25 @@ jobs:
 
       - name: Serve
         env:
-          USE_HTTPS: ${{ steps.server_mode.outputs.https }}
+          HAS_TOKEN_GATE: ${{ steps.server_mode.outputs.has_token_gate }}
         run: |
           # Bind 0.0.0.0 (--host) so the app is reachable via the runner's localhost by the
           # cloudflared connector (which the wdio config starts). Capture the PID and tee output
           # to serve.log so the readiness loop and the cleanup step can use them.
-          yarn servebuild --host > serve.log 2>&1 &
+          # HTTP=1 forces a plain-HTTP origin here: Cloudflare's tunnel already terminates HTTPS at its edge for Safari (a real CA-signed cert on the public hostname), so this local connector-to-origin hop never needs its own TLS.
+          HTTP=1 yarn servebuild --host > serve.log 2>&1 &
           echo "APP_PID=$!" >> "$GITHUB_ENV"
 
           echo "Waiting for server to be ready..."
+          # Code with the gate rejects an untokened request with 403, so the probe has to carry the
+          # token; code without it has no token to carry. Either way the origin is plain HTTP.
+          if [ "$HAS_TOKEN_GATE" = "true" ]; then
+            TOKEN_PARAM="?__token=$TUNNEL_TOKEN"
+          else
+            TOKEN_PARAM=""
+          fi
           for i in {1..30}; do
-            if [ "$USE_HTTPS" = "true" ]; then
-              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -k "https://localhost:3000?__token=$TUNNEL_TOKEN" 2>/dev/null || echo "000")
-            else
-              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000" 2>/dev/null || echo "000")
-            fi
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3000$TOKEN_PARAM" 2>/dev/null || echo "000")
             if [ "$HTTP_STATUS" = "200" ]; then
               echo "Server is ready!"
               break
@@ -130,12 +136,11 @@ jobs:
           BROWSERSTACK_BUILD_NAME: 'CI - ${{github.run_id}}'
           BROWSERSTACK_PROJECT_NAME: 'em'
           TUNNEL_TOKEN: ${{env.TUNNEL_TOKEN}}
-          # Presence of this connector token switches the wdio config from the ephemeral quick
-          # tunnel to the named `copilot-browserstack` tunnel (public host browserstack.emthought.cc).
-          # The token is only ever read from this secret and passed to the connector's child env.
-          # Workflow concurrency (group: browserstack) serializes runs, so the named tunnel never
-          # has two connectors online at once.
-          CLOUDFLARE_TUNNEL_TOKEN: ${{secrets.CLOUDFLARE_TUNNEL_TOKEN}}
+          # A JSON array of { name, hostname, token }, provisioned out-of-band — see
+          # cloudflareTunnelPool.ts. The wdio config checks each tunnel's occupancy before attaching
+          # to it, claims the first one that is genuinely free, and waits for a slot if they are all
+          # busy — so a dead or already-claimed tunnel doesn't block the run.
+          CLOUDFLARE_TUNNEL_POOL: ${{secrets.CLOUDFLARE_TUNNEL_POOL}}
 
       # Best-effort cleanup on the ephemeral runner: stop the manually-started app and preserve
       # the named connector's log for diagnosis. The connector process itself is killed by the

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -598,9 +598,20 @@ jobs:
         if: steps.patch.outputs.empty != 'true'
         run: yarn build
 
+      # Vite app-gate token (see tunnelTokenGate in vite.config.ts). Must be set before Serve
+      # starts the dev server, and passed to the test step below so the wdio config's tunnel-pool
+      # claim (cloudflareTunnelPool.ts) can prove a candidate is answering THIS run's server.
+      - name: Generate tunnel token
+        if: steps.patch.outputs.empty != 'true'
+        run: |
+          TOKEN=$(openssl rand -hex 16)
+          echo "::add-mask::$TOKEN"
+          echo "TUNNEL_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
       - name: Serve
         if: steps.patch.outputs.empty != 'true'
-        run: yarn servebuild &
+        # HTTP=1 forces a plain-HTTP origin here: Cloudflare's tunnel already terminates HTTPS at its edge for Safari (a real CA-signed cert on the public hostname), so this local connector-to-origin hop never needs its own TLS.
+        run: HTTP=1 yarn servebuild &
 
       - name: Run changed iOS tests on base (expect failure)
         if: steps.patch.outputs.empty != 'true'
@@ -610,6 +621,12 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_BUILD_NAME: 'TDD - ${{ github.run_id }}'
           BROWSERSTACK_PROJECT_NAME: 'em'
+          TUNNEL_TOKEN: ${{ env.TUNNEL_TOKEN }}
+          # Same tunnel pool ios.yml uses — see cloudflareTunnelPool.ts. Eliminates this job's
+          # previous fallback to an ephemeral *.trycloudflare.com quick tunnel. Note this means a
+          # TDD run and an ios.yml run can contend for the pool, since they are in different
+          # concurrency groups — that contention is what cloudflareTunnelPool.ts is built to resolve.
+          CLOUDFLARE_TUNNEL_POOL: ${{ secrets.CLOUDFLARE_TUNNEL_POOL }}
         run: |
           IOS_FILES=$(echo "${{ needs.detect.outputs.ios_files }}" | base64 -d)
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 local.log
+# cloudflared tunnel diagnostic logs written at runtime by the BrowserStack e2e run
+cloudflared-browserstack.log
+serve.log
 
 .pnp.*
 .yarn/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ local.log
 # cloudflared tunnel diagnostic logs written at runtime by the BrowserStack e2e run
 cloudflared-browserstack.log
 serve.log
+# contains live connector tokens — output of scripts/provision-cloudflare-tunnel-pool.sh
+cloudflare-tunnel-pool.json
+# operator-only tool for provisioning/topping up the tunnel pool; kept local, not part of the app
+scripts/provision-cloudflare-tunnel-pool.sh
 
 .pnp.*
 .yarn/*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,6 +207,28 @@ wdio documentation:
 - https://webdriver.io/docs/configurationfile
 - https://webdriver.io/docs/browserstack-service
 
+#### Cloudflare tunnel for the dev server
+
+BrowserStack's iOS Safari devices load the app over a public HTTPS URL rather than BrowserStack Local, because Safari blocks `localStorage` on self-signed certs. [`wdio.browserstack.conf.ts`](../src/e2e/iOS/config/wdio.browserstack.conf.ts) exposes the local dev server (`https://localhost:3000`) through [`cloudflared`](https://github.com/cloudflare/cloudflared) (the npm binary — no Docker) and sets `CLOUDFLARED_URL` for the test session. There are two tunnel modes, selected automatically by the presence of the `CLOUDFLARE_TUNNEL_TOKEN` env var:
+
+- **Ephemeral quick tunnel** (default — local runs and [`tdd.yml`](../.github/workflows/tdd.yml)): a random `*.trycloudflare.com` URL is created per run and torn down in `onComplete`. Requires no setup.
+- **Named tunnel** (used by [`ios.yml`](../.github/workflows/ios.yml) when `CLOUDFLARE_TUNNEL_TOKEN` is set): a stable connector for the `copilot-browserstack` Cloudflare tunnel is started, serving the fixed public hostname **`https://browserstack.emthought.cc`**. The workflow waits up to five minutes for that hostname to respond before running tests.
+
+> The dev server is served over HTTPS in CI, and Vite only enforces `server.allowedHosts`/`preview.allowedHosts` for **HTTP** servers — so the public hostname does not need to be added to any allowlist.
+
+##### One-time administrator setup for the named tunnel
+
+The named tunnel requires one-time infrastructure and dashboard configuration. This only needs to be done once (and re-run of the workflow if the first attempt times out):
+
+1. **Prerequisite — `emthought.cc` must be an active zone in the same Cloudflare account** as the `copilot-browserstack` tunnel (its nameservers delegated to Cloudflare). The tunnel's Public Hostname domain is chosen from a dropdown of account zones, so without the zone there is nothing to route to. _(If Cloudflare is not the DNS host, instead run `cloudflared tunnel route dns copilot-browserstack browserstack.emthought.cc`, or manually add a CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.)_
+2. Create the GitHub Actions repository secret **`CLOUDFLARE_TUNNEL_TOKEN`** — the tunnel-specific **connector** token from the Cloudflare dashboard (not an API token). Its presence is what switches `ios.yml` to the named tunnel.
+3. Start the **BrowserStack** workflow manually (`workflow_dispatch`).
+4. While it is running, return to the `copilot-browserstack` tunnel in the Cloudflare dashboard. **The connector — and therefore the Public Hostname / Route step — appears only after the workflow run brings a connector online.** The workflow's five-minute public-readiness loop exists precisely to give you time to complete this step on the first run.
+5. Add a **Public Hostname**: subdomain `browserstack`, domain `emthought.cc`, service `https://localhost:3000`, and enable **No TLS Verify** (the origin uses a self-signed cert). Saving it auto-creates the DNS CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.
+6. Save it before the five-minute readiness loop expires. If the run timed out, simply re-run the workflow — subsequent runs connect the already-configured hostname immediately.
+
+Because a named tunnel must have a single active connector per run, `ios.yml` uses a repo-wide `concurrency` group (`browserstack`, `cancel-in-progress: false`) so two runs never connect the same tunnel simultaneously.
+
 Related tests: [/src/e2e/iOS](../src/e2e/iOS)
 
 ## Vitest configuration

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -209,25 +209,40 @@ wdio documentation:
 
 #### Cloudflare tunnel for the dev server
 
-BrowserStack's iOS Safari devices load the app over a public HTTPS URL rather than BrowserStack Local, because Safari blocks `localStorage` on self-signed certs. [`wdio.browserstack.conf.ts`](../src/e2e/iOS/config/wdio.browserstack.conf.ts) exposes the local dev server (`https://localhost:3000`) through [`cloudflared`](https://github.com/cloudflare/cloudflared) (the npm binary — no Docker) and sets `CLOUDFLARED_URL` for the test session. There are two tunnel modes, selected automatically by the presence of the `CLOUDFLARE_TUNNEL_TOKEN` env var:
+BrowserStack's iOS Safari devices load the app over a public HTTPS URL rather than BrowserStack Local, because Safari blocks `localStorage` on self-signed certs. [`wdio.browserstack.conf.ts`](../src/e2e/iOS/config/wdio.browserstack.conf.ts) exposes the local dev server (`https://localhost:3000`) through a pool of **named Cloudflare Tunnels** on our own domain, `emthought.cc`, using [`cloudflared`](https://github.com/cloudflare/cloudflared) (the npm binary — no Docker). This is used by every path that runs iOS Safari tests: [`ios.yml`](../.github/workflows/ios.yml), the iOS job in [`tdd.yml`](../.github/workflows/tdd.yml), and local/agent `yarn test:ios` runs.
 
-- **Ephemeral quick tunnel** (default — local runs and [`tdd.yml`](../.github/workflows/tdd.yml)): a random `*.trycloudflare.com` URL is created per run and torn down in `onComplete`. Requires no setup.
-- **Named tunnel** (used by [`ios.yml`](../.github/workflows/ios.yml) when `CLOUDFLARE_TUNNEL_TOKEN` is set): a stable connector for the `copilot-browserstack` Cloudflare tunnel is started, serving the fixed public hostname **`https://browserstack.emthought.cc`**. The workflow waits up to five minutes for that hostname to respond before running tests.
+We use a fixed-domain pool rather than the ephemeral `*.trycloudflare.com` quick tunnel `cloudflared` offers out of the box, because that quick-tunnel hostname is random and third-party — allowlisting it in the Copilot agent firewall means allowlisting *anyone's* `trycloudflare.com` tunnel, not just ours. A pool of tunnels on a domain we own lets us allowlist exactly what we need, while still tolerating a dead or already-claimed tunnel (see below).
 
-> The dev server is served over HTTPS in CI, and Vite only enforces `server.allowedHosts`/`preview.allowedHosts` for **HTTP** servers — so the public hostname does not need to be added to any allowlist.
+> The dev server is served over plain **HTTP** in CI (the `Serve` step sets `HTTP=1`; Cloudflare terminates TLS at its edge, so the connector-to-origin hop needs none of its own). Vite enforces `server.allowedHosts`/`preview.allowedHosts` for HTTP servers, so the pool's public hostnames **must** be listed there — `.emthought.cc` appears in both in [`vite.config.ts`](../vite.config.ts). `preview.allowedHosts` does not inherit from `server.allowedHosts`, and `yarn servebuild` (vite preview) is what CI actually runs, so both entries are load-bearing.
 
-##### One-time administrator setup for the named tunnel
+##### How a run claims a tunnel
 
-The named tunnel requires one-time infrastructure and dashboard configuration. This only needs to be done once (and re-run of the workflow if the first attempt times out):
+[`cloudflareTunnelPool.ts`](../src/e2e/iOS/config/cloudflareTunnelPool.ts) exports `findFirstAvailableTunnel(pool, appGateToken)`, called from `wdio.browserstack.conf.ts`'s `onPrepare`. `pool` comes from the `CLOUDFLARE_TUNNEL_POOL` env var (a JSON array of `{ name, hostname, token }`); `appGateToken` is the per-run `TUNNEL_TOKEN` (the Vite app-gate secret — see `tunnelTokenGate` in [`vite.config.ts`](../vite.config.ts)).
 
-1. **Prerequisite — `emthought.cc` must be an active zone in the same Cloudflare account** as the `copilot-browserstack` tunnel (its nameservers delegated to Cloudflare). The tunnel's Public Hostname domain is chosen from a dropdown of account zones, so without the zone there is nothing to route to. _(If Cloudflare is not the DNS host, instead run `cloudflared tunnel route dns copilot-browserstack browserstack.emthought.cc`, or manually add a CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.)_
-2. Create the GitHub Actions repository secret **`CLOUDFLARE_TUNNEL_TOKEN`** — the tunnel-specific **connector** token from the Cloudflare dashboard (not an API token). Its presence is what switches `ios.yml` to the named tunnel.
-3. Start the **BrowserStack** workflow manually (`workflow_dispatch`).
-4. While it is running, return to the `copilot-browserstack` tunnel in the Cloudflare dashboard. **The connector — and therefore the Public Hostname / Route step — appears only after the workflow run brings a connector online.** The workflow's five-minute public-readiness loop exists precisely to give you time to complete this step on the first run.
-5. Add a **Public Hostname**: subdomain `browserstack`, domain `emthought.cc`, service `https://localhost:3000`, and enable **No TLS Verify** (the origin uses a self-signed cert). Saving it auto-creates the DNS CNAME `browserstack.emthought.cc → <tunnel-uuid>.cfargotunnel.com`.
-6. Save it before the five-minute readiness loop expires. If the run timed out, simply re-run the workflow — subsequent runs connect the already-configured hostname immediately.
+A named tunnel accepts multiple simultaneous connectors (that's Cloudflare's HA design) and the edge load-balances **per request** across all of them. So once a run has attached its own connector it can no longer tell whether a hostname is exclusively its own: a `200` might be its own server and a `403` someone else's, at random. A single successful probe proves nothing — confirmed empirically, where two concurrent runs both got a clean `200` on the same tunnel and then had cross-talk for the rest of their sessions.
 
-Because a named tunnel must have a single active connector per run, `ios.yml` uses a repo-wide `concurrency` group (`browserstack`, `cancel-in-progress: false`) so two runs never connect the same tunnel simultaneously.
+The fix is to ask **before** attaching. For each candidate, in turn, the run requests `https://<hostname>/__tunnel-status` with no connector of its own in the mix, so anything that answers is unambiguously another run:
+
+- **`530`** (Cloudflare error 1033, no connector registered) — nobody home, the candidate is free.
+- **`200`** — an em instance is already answering; the payload carries its `GITHUB_RUN_ID`, so the log names the occupying run (and a run can recognise its own leftover connector rather than mistaking it for a competitor).
+- **`403`** — an em instance is answering but predates the status route; still occupied.
+
+Only then does the run attach its connector, and it requires a burst of consecutive successful token probes (each over a fresh connection, since a pooled one would re-test the same backend every time) before trusting the claim. The pre-check is not a lock — two runs can see the same tunnel free in the same instant — so the burst remains as the backstop for that race.
+
+If every tunnel is occupied the run waits, rescanning the pool every 10s for up to 45 minutes, rather than failing immediately. The starting index is derived from `GITHUB_RUN_ID` (or the PID locally) so concurrent runs spread across the pool instead of all racing for the first entry.
+
+This means `ios.yml`, `tdd.yml`, and local/agent runs can safely run concurrently against the same pool without a shared cross-workflow lock — each just claims whichever tunnel is free. (The `browserstack` concurrency group in `ios.yml` still exists, but purely because of BrowserStack's own shared parallel-session cap, not the tunnel.)
+
+##### One-time setup: provisioning the pool
+
+> The provisioning script is deliberately **not committed** — it is an operator tool for whoever administers the pool, not part of the app, and it is gitignored. Ask the pool administrator for a copy if you need to create or top up tunnels; nothing in normal development or CI requires it.
+
+Requires an **Account**-scoped Cloudflare permission grant including `Cloudflare One Connector: cloudflared Write` (Tunnel management is an account resource, not zone-scoped — a zone-scoped grant like the one used for `emthought.cc`'s bot/firewall settings does not cover it).
+
+1. `cloudflared tunnel login`, authorizing the `emthought.cc` zone.
+2. Run `provision-cloudflare-tunnel-pool.sh` (defaults to 20 tunnels named `browserstack-01.emthought.cc` … `browserstack-20.emthought.cc`). It creates each tunnel, routes its DNS CNAME, and fetches its connector token via the CLI — no dashboard steps, no timing-sensitive "catch the connector while it's live" dance.
+3. The script writes `cloudflare-tunnel-pool.json` (gitignored — it contains live tokens). Set its contents as the GitHub Actions secret `CLOUDFLARE_TUNNEL_POOL`: `gh secret set CLOUDFLARE_TUNNEL_POOL < cloudflare-tunnel-pool.json`.
+4. Re-run the script (same or a larger `POOL_SIZE`) any time to top up the pool — it reuses tunnels that already exist rather than recreating them.
 
 Related tests: [/src/e2e/iOS](../src/e2e/iOS)
 

--- a/src/e2e/iOS/config/cloudflareTunnelPool.ts
+++ b/src/e2e/iOS/config/cloudflareTunnelPool.ts
@@ -1,0 +1,292 @@
+import { type ChildProcess, spawn } from 'child_process'
+import { bin, install } from 'cloudflared'
+import fs from 'fs'
+import https from 'https'
+import path from 'path'
+
+/** One named Cloudflare Tunnel in the pool: a CLI-created tunnel routed to `${hostname}`, with its connector token. */
+export interface TunnelCandidate {
+  name: string
+  hostname: string
+  token: string
+}
+
+const CONNECTOR_LOG_PATH = path.resolve(process.cwd(), 'cloudflared-browserstack.log')
+const CLAIM_TIMEOUT_MS = 30000
+const POLL_INTERVAL_MS = 1000
+// A named tunnel can have multiple connectors registered at once, and Cloudflare's edge
+// load-balances PER REQUEST across all of them — so one 200 proves nothing about where the next
+// request goes. Once we see a first success, we require this many more consecutive successes
+// (spaced out) before trusting the candidate as genuinely exclusive.
+const VERIFY_BURST_COUNT = 5
+const VERIFY_INTERVAL_MS = 400
+// Unauthenticated status route served by tunnelTokenGate (vite.config.ts), so a run can ask "is
+// anyone already answering on this hostname, and if so which run?" BEFORE attaching its own
+// connector. See checkOccupancy for why asking first is the whole trick.
+const TUNNEL_STATUS_PATH = '/__tunnel-status'
+// How long to keep waiting for a fully-occupied pool to free up before giving up, and how long to
+// pause between full rescans while waiting. The wait has to outlast however long another run holds
+// its tunnel — observed BrowserStack test steps have run 18-20 min, and a run can be queued behind
+// more than one of those, so a ceiling near 20 min would expire just as a slot came free.
+const POOL_WAIT_TIMEOUT_MS = 45 * 60 * 1000
+const POOL_RESCAN_INTERVAL_MS = 10000
+
+/** Parses the CLOUDFLARE_TUNNEL_POOL env var: a JSON array of `{ name, hostname, token }`. */
+export function parseTunnelPool(json: string): TunnelCandidate[] {
+  const pool: unknown = JSON.parse(json)
+  const isValid =
+    Array.isArray(pool) &&
+    pool.length > 0 &&
+    pool.every((c: unknown) => {
+      const candidate = c as Record<string, unknown>
+      return (
+        candidate &&
+        typeof candidate === 'object' &&
+        typeof candidate.name === 'string' &&
+        typeof candidate.hostname === 'string' &&
+        typeof candidate.token === 'string'
+      )
+    })
+  if (!isValid) {
+    throw new Error('CLOUDFLARE_TUNNEL_POOL must be a non-empty JSON array of { name, hostname, token }')
+  }
+  return pool as TunnelCandidate[]
+}
+
+/** A run-varying (not always-zero) starting index, so concurrent runs don't all race for the same tunnel first. */
+function startingOffset(poolSize: number): number {
+  const seed = process.env.GITHUB_RUN_ID || process.env.GITHUB_RUN_ATTEMPT || String(process.pid)
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) >>> 0
+  return hash % poolSize
+}
+
+/**
+ * Performs one GET over a brand-new connection, resolving to its status code and (truncated) body,
+ * or null if the request never completed.
+ *
+ * Uses a plain https.request with agent: false instead of fetch — fetch's pooled/keep-alive
+ * connection reuses the same underlying connection across calls, and if Cloudflare's edge sticks
+ * a connection to one backend connector for its lifetime (which the data here says it does),
+ * every probe after the first is just re-testing the same connection and can never reveal a
+ * different backend. Passing agent: false forces a brand new connection each call, giving each
+ * probe an independent chance to land on whichever backend is actually live right now.
+ */
+async function requestOnce(url: string): Promise<{ statusCode: number; body: string } | null> {
+  return new Promise(resolve => {
+    const req = https.request(url, { method: 'GET', agent: false, timeout: 5000 }, res => {
+      let body = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk: string) => {
+        // The status payload is tiny; Cloudflare's HTML error pages are not. Cap what we buffer.
+        if (body.length < 2048) body += chunk
+      })
+      res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body }))
+    })
+    req.on('error', () => resolve(null))
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(null)
+    })
+    req.end()
+  })
+}
+
+/** Sends one app-gate-token request and reports whether it got a genuine 200. */
+async function probeOnce(checkUrl: string): Promise<boolean> {
+  const res = await requestOnce(checkUrl)
+  return res?.statusCode === 200
+}
+
+/** What a pre-attach probe found on a hostname. `unknown` means the edge answered in a way we can't classify. */
+type Occupancy = { state: 'free' } | { state: 'taken'; reason: string } | { state: 'unknown'; reason: string }
+
+/**
+ * Asks whether a tunnel is already in use — WITHOUT attaching our own connector first.
+ *
+ * That ordering is the entire point. A named tunnel accepts multiple simultaneous connectors and
+ * Cloudflare load-balances per request across all of them, so once we've attached, a 200 might be
+ * our own server and a 403 might be someone else's, at random — the test can no longer distinguish
+ * them. Before we attach we aren't in the mix, so anything that answers at all is unambiguously
+ * another run.
+ *
+ * Cloudflare returns 530 (error 1033) for a named tunnel with no connector registered, which is a
+ * clean "nobody home". Verified empirically against all five pool hostnames while idle.
+ */
+async function checkOccupancy(hostname: string): Promise<Occupancy> {
+  const res = await requestOnce(`https://${hostname}${TUNNEL_STATUS_PATH}`)
+  if (!res) return { state: 'unknown', reason: 'no response from the Cloudflare edge' }
+  // 530/1033: the tunnel exists but has no connector attached.
+  if (res.statusCode === 530) return { state: 'free' }
+  if (res.statusCode === 200) {
+    const run = /"run"\s*:\s*"([^"]*)"/.exec(res.body)?.[1]
+    const ours = run && run === (process.env.GITHUB_RUN_ID || '')
+    return {
+      state: 'taken',
+      reason: ours
+        ? `a connector from this same run (${run}) is still attached — likely a leftover from a previous attempt`
+        : run
+          ? `in use by run ${run}`
+          : 'an em instance is already answering',
+    }
+  }
+  // A 403 is the token gate rejecting us, which still means someone's em is live on the other end.
+  // (Also what an em without the status route returns, so treat it the same way.)
+  if (res.statusCode === 403) return { state: 'taken', reason: 'an em instance is already answering' }
+  return { state: 'unknown', reason: `unexpected status ${res.statusCode}` }
+}
+
+/**
+ * Starts a connector for one candidate and waits for THIS run's dev server to answer through
+ * its public hostname.
+ *
+ * A named tunnel accepts multiple simultaneous connectors (that's Cloudflare's HA design), and
+ * Cloudflare's edge load-balances PER REQUEST across every connector currently registered for
+ * that tunnel — so even a single genuine 200 back (this run's Vite server recognizing its own
+ * app-gate token — see tunnelTokenGate in vite.config.ts) does NOT prove the hostname is
+ * exclusively ours: the very next request could land on a different run's connector instead.
+ * Confirmed empirically — two real concurrent runs both got an initial 200 on the same tunnel,
+ * then had real cross-talk for the rest of their sessions. So after the first success we require
+ * VERIFY_BURST_COUNT more consecutive successes before trusting the claim; any failure among
+ * them means another connector is live here too, and we give up on this candidate entirely
+ * (not retry it — we already have proof it's shared).
+ */
+async function claim(
+  candidate: TunnelCandidate,
+  appGateToken: string,
+): Promise<{ url: string; process: ChildProcess }> {
+  if (!fs.existsSync(bin)) {
+    await install(bin)
+  }
+
+  const logStream = fs.createWriteStream(CONNECTOR_LOG_PATH, { flags: 'a' })
+  logStream.write(`\n--- claiming ${candidate.name} (${candidate.hostname}) ---\n`)
+
+  // http:// here matches the origin the CI "Serve" step starts with HTTP=1 — Cloudflare's tunnel already
+  // terminates HTTPS at its edge for Safari (a real CA-signed cert on the public hostname), so this local
+  // connector-to-origin hop never needs its own TLS. (Also: these are remotely-managed tunnels, so this
+  // --url is only a fallback — Cloudflare's stored ingress config for the hostname takes precedence, and
+  // must point at the same http://localhost:3000 origin.)
+  const proc = spawn(
+    bin,
+    ['tunnel', '--no-autoupdate', '--protocol', 'http2', 'run', '--url', 'http://localhost:3000'],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Child-scoped TUNNEL_TOKEN carries this candidate's connector token; it shadows the
+      // parent's TUNNEL_TOKEN (the Vite app-gate token) for this process only, same seam PR
+      // #4622 established.
+      env: { ...process.env, TUNNEL_TOKEN: candidate.token },
+    },
+  )
+  proc.stdout?.pipe(logStream)
+  proc.stderr?.pipe(logStream)
+
+  let exited = false
+  proc.once('exit', () => {
+    exited = true
+  })
+
+  const checkUrl = `https://${candidate.hostname}/?__token=${appGateToken}`
+  const start = Date.now()
+  try {
+    while (Date.now() - start < CLAIM_TIMEOUT_MS) {
+      if (exited) {
+        throw new Error(`connector for ${candidate.name} exited before claim`)
+      }
+      if (await probeOnce(checkUrl)) {
+        for (let i = 0; i < VERIFY_BURST_COUNT; i++) {
+          await new Promise(resolve => setTimeout(resolve, VERIFY_INTERVAL_MS))
+          if (!(await probeOnce(checkUrl))) {
+            throw new Error(
+              `${candidate.name} answered once but failed verification ${i + 1}/${VERIFY_BURST_COUNT} — ` +
+                `another connector is live on this hostname too (Cloudflare is load-balancing between them)`,
+            )
+          }
+        }
+        return { url: `https://${candidate.hostname}`, process: proc }
+      }
+      // Any other status (a different run's 403, a 404, etc.) means occupied or not ready yet.
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+    throw new Error(`timed out waiting for ${candidate.hostname} to answer with this run's app-gate token`)
+  } catch (err) {
+    if (!proc.killed) proc.kill()
+    throw err
+  }
+}
+
+/**
+ * Claims one tunnel from the pool, waiting for a slot if every tunnel is currently busy.
+ *
+ * Each pass asks every tunnel whether it's occupied (checkOccupancy — a single cheap request, no
+ * connector attached) and only tries to claim the ones that look free. That makes skipping a busy
+ * tunnel cost one request rather than a full CLAIM_TIMEOUT_MS of attaching and waiting, so a whole
+ * pool can be scanned in about a second.
+ *
+ * The pre-check is not a lock: two runs can see the same tunnel free in the same instant and both
+ * attach. The verification burst inside claim() is the backstop for that narrow race — the
+ * pre-check does the routine work, the burst catches the straggler.
+ *
+ * Candidates are visited from a run-varying offset so simultaneous runs don't queue up in the same
+ * order. Returns the winning candidate's public URL and its connector process; the caller is
+ * responsible for killing that process on completion.
+ */
+export async function findFirstAvailableTunnel(
+  pool: TunnelCandidate[],
+  appGateToken: string,
+): Promise<{ url: string; name: string; process: ChildProcess }> {
+  const offset = startingOffset(pool.length)
+  const deadline = Date.now() + POOL_WAIT_TIMEOUT_MS
+  let errors: string[] = []
+  let waiting = false
+
+  while (true) {
+    // Errors only describe the pass that produced them — otherwise a long wait accumulates one
+    // entry per tunnel per rescan and the final message becomes unreadable.
+    errors = []
+
+    for (let i = 0; i < pool.length; i++) {
+      const candidate = pool[(offset + i) % pool.length]
+      const occupancy = await checkOccupancy(candidate.hostname)
+
+      if (occupancy.state === 'taken') {
+        console.info(`cloudflared tunnel: ${candidate.name} busy (${occupancy.reason}), skipping`)
+        errors.push(`${candidate.name}: ${occupancy.reason}`)
+        continue
+      }
+      if (occupancy.state === 'unknown') {
+        // Don't let an unclassifiable edge response deadlock the whole pool — attempt the claim and
+        // let the verification burst be the judge.
+        console.info(
+          `cloudflared tunnel: ${candidate.name} pre-check inconclusive (${occupancy.reason}), trying anyway`,
+        )
+      }
+
+      try {
+        const { url, process: proc } = await claim(candidate, appGateToken)
+        console.info(`cloudflared tunnel: claimed ${candidate.name} (${candidate.hostname})`)
+        return { url, name: candidate.name, process: proc }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.info(`cloudflared tunnel: ${candidate.name} unavailable (${message}), trying next candidate...`)
+        errors.push(`${candidate.name}: ${message}`)
+      }
+    }
+
+    if (Date.now() >= deadline) break
+
+    if (!waiting) {
+      console.info(
+        `cloudflared tunnel: all ${pool.length} tunnels in the pool are busy — waiting up to ` +
+          `${Math.round(POOL_WAIT_TIMEOUT_MS / 60000)} min for one to free up...`,
+      )
+      waiting = true
+    }
+    await new Promise(resolve => setTimeout(resolve, POOL_RESCAN_INTERVAL_MS))
+  }
+
+  throw new Error(
+    `All ${pool.length} tunnels in the pool were still unavailable after waiting ` +
+      `${Math.round(POOL_WAIT_TIMEOUT_MS / 60000)} min:\n${errors.join('\n')}`,
+  )
+}

--- a/src/e2e/iOS/config/wdio.browserstack.conf.ts
+++ b/src/e2e/iOS/config/wdio.browserstack.conf.ts
@@ -20,6 +20,16 @@ if (!process.env.BROWSERSTACK_ACCESS_KEY) {
 const user = process.env.BROWSERSTACK_USERNAME
 const date = new Date().toISOString().slice(0, 10)
 
+// Fixed public hostname of the named `copilot-browserstack` Cloudflare tunnel. Unlike the
+// ephemeral quick tunnel (random *.trycloudflare.com), the named tunnel always resolves to
+// this stable URL, which an administrator binds to the tunnel via a Public Hostname ingress
+// rule + DNS CNAME (browserstack.emthought.cc -> <tunnel-uuid>.cfargotunnel.com).
+const NAMED_TUNNEL_URL = 'https://browserstack.emthought.cc'
+
+// The named connector's output is teed here so the CI workflow can upload it as a diagnostic
+// artifact when a run fails. Written to the repo root (cwd) where the workflow can find it.
+const CONNECTOR_LOG_PATH = path.resolve(process.cwd(), 'cloudflared-browserstack.log')
+
 let tunnelProcess: ChildProcess | null = null
 
 /**
@@ -106,6 +116,70 @@ async function startTunnel(): Promise<string> {
 }
 
 /**
+ * Starts the named `copilot-browserstack` Cloudflare tunnel connector and resolves once the
+ * public hostname is reachable.
+ *
+ * Unlike the ephemeral quick tunnel, the named tunnel's connector authenticates with a
+ * connector token and serves the fixed hostname NAMED_TUNNEL_URL. We reuse the same
+ * `cloudflared` npm binary (no Docker) to honor the existing architecture.
+ *
+ * The connector token is passed ONLY via the child process's TUNNEL_TOKEN env var (never as a
+ * CLI arg and never logged). It overrides the parent's TUNNEL_TOKEN (the Vite app-gate token)
+ * for the child only, so the two tokens never collide.
+ *
+ * Readiness: cloudflared dials outbound to Cloudflare's edge, and on the first CI run an
+ * administrator must finish binding the Public Hostname in the Cloudflare dashboard. We
+ * therefore poll the public URL for up to 5 minutes. Any HTTP response (including a 403 from
+ * the app gate or a 404) proves connectivity; DNS/TLS/connection failures do not.
+ */
+async function startNamedTunnel(token: string): Promise<string> {
+  // Install the cloudflared binary if not already present
+  if (!fs.existsSync(bin)) {
+    await install(bin)
+  }
+
+  const logStream = fs.createWriteStream(CONNECTOR_LOG_PATH, { flags: 'a' })
+  const proc = spawn(bin, ['tunnel', '--no-autoupdate', '--protocol', 'http2', 'run'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // Child-scoped TUNNEL_TOKEN carries the connector token; it shadows the parent's app-gate
+    // TUNNEL_TOKEN for this process only.
+    env: { ...process.env, TUNNEL_TOKEN: token },
+  })
+  tunnelProcess = proc
+  proc.stdout?.pipe(logStream)
+  proc.stderr?.pipe(logStream)
+
+  // Detect an early connector exit (e.g. an invalid token) so we fail fast instead of polling
+  // the public URL for the full timeout.
+  let exited = false
+  proc.once('exit', () => {
+    exited = true
+  })
+
+  const timeoutMs = 5 * 60 * 1000
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (exited) {
+      throw new Error(
+        `cloudflared connector exited before ${NAMED_TUNNEL_URL} became reachable; see ${CONNECTOR_LOG_PATH}`,
+      )
+    }
+    try {
+      // redirect: 'manual' so a redirect still counts as a reachable HTTP response without
+      // chasing the redirect to another host.
+      await fetch(NAMED_TUNNEL_URL, { redirect: 'manual' })
+      return NAMED_TUNNEL_URL
+    } catch {
+      // DNS/TLS/connection failure — the hostname is not routed yet. Keep waiting.
+    }
+    await new Promise(resolve => setTimeout(resolve, 5000))
+  }
+
+  const log = fs.existsSync(CONNECTOR_LOG_PATH) ? fs.readFileSync(CONNECTOR_LOG_PATH, 'utf8') : ''
+  throw new Error(`Timed out after 5 minutes waiting for ${NAMED_TUNNEL_URL}. Connector log:\n${log}`)
+}
+
+/**
  * WDIO configuration for BrowserStack iOS testing.
  * Uses cloudflared tunnel to expose the local HTTPS dev server via a public
  * URL with a real CA-signed cert, avoiding Safari's self-signed cert restrictions.
@@ -159,9 +233,18 @@ export const config: WebdriverIO.Config = {
   onPrepare: async function () {
     // Start cloudflared tunnel if not already set (e.g. by a CI workflow step)
     if (!process.env.CLOUDFLARED_URL) {
-      const url = await startTunnel()
-      process.env.CLOUDFLARED_URL = url
-      console.info(`cloudflared tunnel: ${url}`)
+      // Named path: when CLOUDFLARE_TUNNEL_TOKEN is present (set by ios.yml), start the
+      // persistent named `copilot-browserstack` connector, which serves the fixed public
+      // hostname. Otherwise (tdd.yml / local runs) fall back to the ephemeral quick tunnel.
+      if (process.env.CLOUDFLARE_TUNNEL_TOKEN) {
+        const url = await startNamedTunnel(process.env.CLOUDFLARE_TUNNEL_TOKEN)
+        process.env.CLOUDFLARED_URL = url
+        console.info(`cloudflared named tunnel: ${url}`)
+      } else {
+        const url = await startTunnel()
+        process.env.CLOUDFLARED_URL = url
+        console.info(`cloudflared tunnel: ${url}`)
+      }
     }
 
     // Append tunnel token to the URL so the Vite token gate allows access

--- a/src/e2e/iOS/config/wdio.browserstack.conf.ts
+++ b/src/e2e/iOS/config/wdio.browserstack.conf.ts
@@ -1,8 +1,7 @@
-import { type ChildProcess, spawn } from 'child_process'
-import { bin, install } from 'cloudflared'
+import { type ChildProcess } from 'child_process'
 import dotenv from 'dotenv'
-import fs from 'fs'
 import path from 'path'
+import { findFirstAvailableTunnel, parseTunnelPool } from './cloudflareTunnelPool'
 import baseConfig from './wdio.base.conf.js'
 
 // Load .env.test.local before checking env vars since this file is imported
@@ -20,173 +19,19 @@ if (!process.env.BROWSERSTACK_ACCESS_KEY) {
 const user = process.env.BROWSERSTACK_USERNAME
 const date = new Date().toISOString().slice(0, 10)
 
-// Fixed public hostname of the named `copilot-browserstack` Cloudflare tunnel. Unlike the
-// ephemeral quick tunnel (random *.trycloudflare.com), the named tunnel always resolves to
-// this stable URL, which an administrator binds to the tunnel via a Public Hostname ingress
-// rule + DNS CNAME (browserstack.emthought.cc -> <tunnel-uuid>.cfargotunnel.com).
-const NAMED_TUNNEL_URL = 'https://browserstack.emthought.cc'
-
-// The named connector's output is teed here so the CI workflow can upload it as a diagnostic
-// artifact when a run fails. Written to the repo root (cwd) where the workflow can find it.
-const CONNECTOR_LOG_PATH = path.resolve(process.cwd(), 'cloudflared-browserstack.log')
-
 let tunnelProcess: ChildProcess | null = null
 
 /**
- * Starts a cloudflared tunnel and returns the public HTTPS URL.
- * Safari blocks localStorage on self-signed HTTPS, so we use cloudflared
- * to get a real CA-signed cert (*.trycloudflare.com).
- */
-async function startTunnel(): Promise<string> {
-  // Install the cloudflared binary if not already present
-  if (!fs.existsSync(bin)) {
-    await install(bin)
-  }
-
-  return new Promise((resolve, reject) => {
-    const proc = spawn(bin, ['tunnel', '--url', 'https://localhost:3000', '--no-tls-verify'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    tunnelProcess = proc
-
-    let output = ''
-    let settled = false
-
-    // Use a wrapper object so cleanup can reference timeout before it's assigned
-    const state = { timeout: undefined as NodeJS.Timeout | undefined }
-
-    /** Remove all listeners and cancel the timeout after the Promise settles. */
-    const cleanup = () => {
-      if (state.timeout !== undefined) clearTimeout(state.timeout)
-      proc.stdout?.removeAllListeners('data')
-      proc.stderr?.removeAllListeners('data')
-      proc.removeAllListeners('error')
-      proc.removeAllListeners('exit')
-    }
-
-    /** Resolve once and release listeners. */
-    const resolveAndCleanup = (url: string) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      resolve(url)
-    }
-
-    /** Reject once, terminate the child, and release listeners. */
-    const rejectAndCleanup = (error: Error) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      if (!proc.killed) {
-        proc.kill()
-      }
-      if (tunnelProcess === proc) {
-        tunnelProcess = null
-      }
-      reject(error)
-    }
-
-    /** Scan cloudflared output for the tunnel URL. */
-    const onData = (data: Buffer) => {
-      output += data.toString()
-      const match = output.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/)
-      return match ? resolveAndCleanup(match[0]) : null
-    }
-
-    /** Reject if cloudflared exits before printing the tunnel URL. */
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
-      rejectAndCleanup(
-        new Error(
-          `cloudflared exited before tunnel URL was available${code !== null ? ` (code ${code})` : ''}${signal ? ` (signal ${signal})` : ''}`,
-        ),
-      )
-
-    /** Reject on process startup errors. */
-    const onError = (err: Error) => rejectAndCleanup(new Error(`Failed to start cloudflared: ${err.message}`))
-
-    state.timeout = setTimeout(() => {
-      rejectAndCleanup(new Error('cloudflared tunnel timed out'))
-    }, 30000)
-
-    proc.stdout?.on('data', onData)
-    proc.stderr?.on('data', onData)
-    proc.once('error', onError)
-    proc.once('exit', onExit)
-  })
-}
-
-/**
- * Starts the named `copilot-browserstack` Cloudflare tunnel connector and resolves once the
- * public hostname is reachable.
- *
- * Unlike the ephemeral quick tunnel, the named tunnel's connector authenticates with a
- * connector token and serves the fixed hostname NAMED_TUNNEL_URL. We reuse the same
- * `cloudflared` npm binary (no Docker) to honor the existing architecture.
- *
- * The connector token is passed ONLY via the child process's TUNNEL_TOKEN env var (never as a
- * CLI arg and never logged). It overrides the parent's TUNNEL_TOKEN (the Vite app-gate token)
- * for the child only, so the two tokens never collide.
- *
- * Readiness: cloudflared dials outbound to Cloudflare's edge, and on the first CI run an
- * administrator must finish binding the Public Hostname in the Cloudflare dashboard. We
- * therefore poll the public URL for up to 5 minutes. Any HTTP response (including a 403 from
- * the app gate or a 404) proves connectivity; DNS/TLS/connection failures do not.
- */
-async function startNamedTunnel(token: string): Promise<string> {
-  // Install the cloudflared binary if not already present
-  if (!fs.existsSync(bin)) {
-    await install(bin)
-  }
-
-  const logStream = fs.createWriteStream(CONNECTOR_LOG_PATH, { flags: 'a' })
-  const proc = spawn(bin, ['tunnel', '--no-autoupdate', '--protocol', 'http2', 'run'], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    // Child-scoped TUNNEL_TOKEN carries the connector token; it shadows the parent's app-gate
-    // TUNNEL_TOKEN for this process only.
-    env: { ...process.env, TUNNEL_TOKEN: token },
-  })
-  tunnelProcess = proc
-  proc.stdout?.pipe(logStream)
-  proc.stderr?.pipe(logStream)
-
-  // Detect an early connector exit (e.g. an invalid token) so we fail fast instead of polling
-  // the public URL for the full timeout.
-  let exited = false
-  proc.once('exit', () => {
-    exited = true
-  })
-
-  const timeoutMs = 5 * 60 * 1000
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    if (exited) {
-      throw new Error(
-        `cloudflared connector exited before ${NAMED_TUNNEL_URL} became reachable; see ${CONNECTOR_LOG_PATH}`,
-      )
-    }
-    try {
-      // redirect: 'manual' so a redirect still counts as a reachable HTTP response without
-      // chasing the redirect to another host.
-      await fetch(NAMED_TUNNEL_URL, { redirect: 'manual' })
-      return NAMED_TUNNEL_URL
-    } catch {
-      // DNS/TLS/connection failure — the hostname is not routed yet. Keep waiting.
-    }
-    await new Promise(resolve => setTimeout(resolve, 5000))
-  }
-
-  const log = fs.existsSync(CONNECTOR_LOG_PATH) ? fs.readFileSync(CONNECTOR_LOG_PATH, 'utf8') : ''
-  throw new Error(`Timed out after 5 minutes waiting for ${NAMED_TUNNEL_URL}. Connector log:\n${log}`)
-}
-
-/**
  * WDIO configuration for BrowserStack iOS testing.
- * Uses cloudflared tunnel to expose the local HTTPS dev server via a public
- * URL with a real CA-signed cert, avoiding Safari's self-signed cert restrictions.
+ * Uses a pool of named Cloudflare Tunnels (see cloudflareTunnelPool.ts) to expose the local
+ * HTTPS dev server via a public URL with a real CA-signed cert, avoiding Safari's self-signed
+ * cert restrictions.
  *
  * Prerequisites:
  * 1. Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY env vars.
- * 2. Start the app: yarn start (on port 3000).
+ * 2. Set CLOUDFLARE_TUNNEL_POOL to a JSON array of { name, hostname, token } (provisioned out-of-band — see docs/testing.md).
+ * 3. Set TUNNEL_TOKEN to a per-run secret (the Vite app-gate token — see vite.config.ts).
+ * 4. Start the app: yarn start (on port 3000).
  *
  * Run: yarn test:ios:browserstack.
  */
@@ -231,29 +76,44 @@ export const config: WebdriverIO.Config = {
   ],
 
   onPrepare: async function () {
-    // Start cloudflared tunnel if not already set (e.g. by a CI workflow step)
-    if (!process.env.CLOUDFLARED_URL) {
-      // Named path: when CLOUDFLARE_TUNNEL_TOKEN is present (set by ios.yml), start the
-      // persistent named `copilot-browserstack` connector, which serves the fixed public
-      // hostname. Otherwise (tdd.yml / local runs) fall back to the ephemeral quick tunnel.
-      if (process.env.CLOUDFLARE_TUNNEL_TOKEN) {
-        const url = await startNamedTunnel(process.env.CLOUDFLARE_TUNNEL_TOKEN)
-        process.env.CLOUDFLARED_URL = url
-        console.info(`cloudflared named tunnel: ${url}`)
-      } else {
-        const url = await startTunnel()
-        process.env.CLOUDFLARED_URL = url
-        console.info(`cloudflared tunnel: ${url}`)
+    try {
+      // Claim a tunnel from the pool if not already set (e.g. by a CI workflow step)
+      if (!process.env.CLOUDFLARED_URL) {
+        if (!process.env.CLOUDFLARE_TUNNEL_POOL) {
+          throw new Error(
+            'CLOUDFLARE_TUNNEL_POOL is not set. The pool is provisioned out-of-band by whoever administers ' +
+              'it; set CLOUDFLARE_TUNNEL_POOL to that JSON output (see docs/testing.md).',
+          )
+        }
+        if (!process.env.TUNNEL_TOKEN) {
+          throw new Error('TUNNEL_TOKEN (the per-run Vite app-gate token) must be set to claim a tunnel from the pool.')
+        }
+
+        const pool = parseTunnelPool(process.env.CLOUDFLARE_TUNNEL_POOL)
+        const claimed = await findFirstAvailableTunnel(pool, process.env.TUNNEL_TOKEN)
+        tunnelProcess = claimed.process
+        process.env.CLOUDFLARED_URL = claimed.url
+        console.info(`cloudflared tunnel: ${claimed.name} (${claimed.url})`)
       }
-    }
 
-    // Append tunnel token to the URL so the Vite token gate allows access
-    if (process.env.TUNNEL_TOKEN && process.env.CLOUDFLARED_URL) {
-      const sep = process.env.CLOUDFLARED_URL.includes('?') ? '&' : '?'
-      process.env.CLOUDFLARED_URL = `${process.env.CLOUDFLARED_URL}${sep}__token=${process.env.TUNNEL_TOKEN}`
-    }
+      // Append tunnel token to the URL so the Vite token gate allows access
+      if (process.env.TUNNEL_TOKEN && process.env.CLOUDFLARED_URL) {
+        const sep = process.env.CLOUDFLARED_URL.includes('?') ? '&' : '?'
+        process.env.CLOUDFLARED_URL = `${process.env.CLOUDFLARED_URL}${sep}__token=${process.env.TUNNEL_TOKEN}`
+      }
 
-    await baseConfig.onPrepare()
+      await baseConfig.onPrepare()
+    } catch (err) {
+      // Exit rather than rethrow. WebdriverIO logs a failed launcher hook and then starts the
+      // workers regardless, so a misconfigured run proceeds to open a device against a URL that
+      // was never set — every spec then fails on an opaque origin ("The operation is insecure",
+      // "em.testHelpers is undefined", editable timeouts), each retried, burning a full ~20 min
+      // BrowserStack build. All of it traces back to here, but the real cause ends up buried at
+      // the top of a thousand lines of consequences. Exiting makes it the last thing printed.
+      if (tunnelProcess) tunnelProcess.kill()
+      console.error(`\ncloudflared tunnel setup failed: ${err instanceof Error ? err.message : String(err)}\n`)
+      process.exit(1)
+    }
   },
 
   onComplete: function () {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,17 @@ function tunnelTokenGate(): Plugin | undefined {
   /** Middleware that allows requests bearing a valid token (via cookie or query param) and rejects all others. */
   const gate = (server: ViteDevServer | PreviewServer) => {
     server.middlewares.use((req: IncomingMessage, res: ServerResponse, next: () => void) => {
+      // Unauthenticated occupancy probe, answered before the token check. A run about to claim a
+      // Cloudflare tunnel needs to know whether anyone is already answering on that hostname, and
+      // it can't authenticate as whoever that would be. Deliberately exposes nothing but the CI run
+      // id, which is already public in the workflow logs. See checkOccupancy in
+      // src/e2e/iOS/config/cloudflareTunnelPool.ts.
+      if ((req.url || '').split('?')[0] === '/__tunnel-status') {
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ em: true, run: process.env.GITHUB_RUN_ID || '' }))
+        return
+      }
       // Accept an existing session cookie set on a previous authenticated request.
       const cookieHeader = req.headers.cookie || ''
       if (cookieHeader.split(';').some(c => c.trim() === `${cookieName}=${token}`)) {
@@ -110,8 +121,9 @@ export default defineConfig({
     tunnelTokenGate(),
   ],
   server: {
-    // Allow bs-local.com for BrowserStack local testing
-    allowedHosts: ['bs-local.com'],
+    // Allow bs-local.com for BrowserStack local testing, and the Cloudflare tunnel pool's
+    // hostnames (leading dot matches all *.emthought.cc subdomains) for BrowserStack iOS Safari.
+    allowedHosts: ['bs-local.com', '.emthought.cc'],
     ...(process.env.PUPPETEER
       ? {
           hmr: {
@@ -121,5 +133,10 @@ export default defineConfig({
           },
         }
       : {}),
+  },
+  preview: {
+    // `yarn servebuild` (vite preview) is what ios.yml/tdd.yml actually run behind the tunnel —
+    // preview.allowedHosts doesn't inherit server.allowedHosts, so it needs its own entry too.
+    allowedHosts: ['.emthought.cc'],
   },
 })


### PR DESCRIPTION
**Builds on PR #4622.** That PR can be closed after this one is merged.

## Background

Allowlisting `trycloudflare.com` in the CI firewall allowlists *anyone's* Cloudflare tunnel, not just ours — the hostname is random and third-party, so the allowlist grants no meaningful boundary. Tunnels on a domain we control let us allowlist exactly what we need.

This pull request fully replaces the ephemeral `*.trycloudflare.com` quick tunnel with a **pool of named Cloudflare tunnels** on `emthought.cc`, a domain we own, and gives runs a way to claim one safely when several are in flight at once.

`tdd.yml` also moves onto the pool, replacing its own separate quick-tunnel fallback, which removes the last `trycloudflare.com` reference in CI.

## Relationship to #4622

#4622 established the named-tunnel approach and the `TUNNEL_TOKEN` app-gate seam. This branch is built on top of it rather than alongside it, because the two would conflict heavily in `wdio.browserstack.conf.ts`.

The single named tunnel in #4622 works, but serialises everything: a named tunnel can only be safely used by one run at a time, so `ios.yml` had to stay behind a repo-wide concurrency group, and `tdd.yml` couldn't share it at all. A pool removes that constraint.

**Reviewers:** the first commit is Raine's, unchanged. Only the second commit is new here.

## Tunnel pool

Rather than a single tunnel on `emthought.cc`, we have _five_ in a pool. This enables concurrency:

```
- em-browserstack-0.emthought.cc
- em-browserstack-1.emthought.cc
- em-browserstack-2.emthought.cc
- em-browserstack-3.emthought.cc
- em-browserstack-4.emthought.cc
```

A new module, `src/e2e/iOS/config/cloudflareTunnelPool`, assigns runs a guaranteed-free tunnel it can use for the duration of the run. If all five tunnels are occupied (unlikely due to current concurrency limits on iOS actions in the repo), we wait for a slot to become available for up to 45 minutes. More tunnels can easily be added to the pool.

HTTP response codes are used to probe the status of the tunnel:

| Probe of `https://<host>/__tunnel-status` | Meaning |
|---|---|
| `530` (Cloudflare 1033) | no connector registered — free |
| `200` | an em instance is answering; payload carries its `GITHUB_RUN_ID`, so logs name the occupying run |
| `403` | an em instance answering that predates the status route — still occupied |


## Testing

Tested on a private repo, all green. Forced a contention event to test that the pool mechanism works:

```
15:37:02  A  claimed em-browserstack-0
15:37:09  B  em-browserstack-0 busy (in use by run 30374094139), skipping
15:37:09  B  all 1 tunnels in the pool are busy — waiting up to 45 min for one to free up...
          B  [19 rescans, ~10.2s apart]
15:40:18  B  claimed em-browserstack-0
```

B identified the occupant *by run ID*, declined to attach, waited 3m09s, and claimed the tunnel cleanly once A disconnected. This is exactly the behavior we want.

## Notes

- `ios.yml`'s `concurrency` block is untouched. This PR just adds the pool *without* altering CI's concurrency behavior, to make sure we're prepared if concurrency is ever desired, while also covering a case like e.g. a TDD run and an `ios.yml` run competing for a tunnel.

- Copilot's cloud agent session uses BrowserStack Local's tunnel (bs-local.com) and doesn't use this tunnel pool. The tunnel pool is primarily used for BrowserStack *CI runs*. 

## Before merging

- [x] **Set the `CLOUDFLARE_TUNNEL_POOL` secret on this repo.** I will send this secret via a secure channel – it contains all five tunnels and their tunnel tokens.