### PR TITLE
Use state.noteFocus to set letter case on note or thought

### DIFF
--- a/src/actions/__tests__/formatLetterCase.ts
+++ b/src/actions/__tests__/formatLetterCase.ts
@@ -1,0 +1,81 @@
+import { act } from 'react'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import dispatch from '../../test-helpers/dispatch'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../test-helpers/setCursorFirstMatch'
+import { formatLetterCaseActionCreator as formatLetterCase } from '../formatLetterCase'
+import { importTextActionCreator as importText } from '../importText'
+import { setCursorActionCreator as setCursor } from '../setCursor'
+
+beforeEach(initStore)
+
+it('applies letter case to the thought when the caret is on the thought', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - Hello World
+          - =note
+            - Hello Note
+      `,
+    }),
+    setCursorFirstMatch(['Hello World']),
+  ])
+
+  await dispatch(formatLetterCase('UpperCase'))
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - HELLO WORLD
+    - =note
+      - Hello Note`)
+})
+
+it('applies letter case to the note when the caret is on the note', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - Hello World
+          - =note
+            - Hello Note
+      `,
+    }),
+    setCursorFirstMatch(['Hello World']),
+  ])
+
+  await dispatch(setCursor({ path: store.getState().cursor, noteFocus: true }))
+
+  await dispatch(formatLetterCase('UpperCase'))
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - Hello World
+    - =note
+      - HELLO NOTE`)
+})
+
+it('preserves note focus after applying letter case to the note', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - Hello World
+          - =note
+            - Hello Note
+      `,
+    }),
+    setCursorFirstMatch(['Hello World']),
+  ])
+
+  await dispatch(setCursor({ path: store.getState().cursor, noteFocus: true }))
+
+  await dispatch(formatLetterCase('UpperCase'))
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(store.getState().noteFocus).toBe(true)
+})

--- a/src/actions/formatLetterCase.ts
+++ b/src/actions/formatLetterCase.ts
@@ -28,7 +28,7 @@ export const formatLetterCaseActionCreator =
     const offset = selection.offsetThought()
     const cursorSimplePath = simplifyPath(state, cursor)
     const editActions = paths.flatMap(path => {
-      const value = state.noteFocus ? noteValue(state, cursor) : getThoughtById(state, head(cursor))?.value
+      const value = state.noteFocus ? noteValue(state, cursor) : getThoughtById(state, head(path))?.value
 
       if (!value) return []
 

--- a/src/actions/formatLetterCase.ts
+++ b/src/actions/formatLetterCase.ts
@@ -55,5 +55,6 @@ export const formatLetterCaseActionCreator =
 
     // noteFocus doesn't respect cursorOffset, so better to avoid setting the cursor when the caret is on a note (#4469)
     // It shouldn't be possible to have noteFocus be true with the keyboard closed, so setCursor shouldn't be necessary for notes.
+    // It seems like the caret goes to the end of the note anyway when its value is replaced.
     if (!state.noteFocus) dispatch(setCursor({ path: cursorSimplePath, offset }))
   }

--- a/src/actions/formatLetterCase.ts
+++ b/src/actions/formatLetterCase.ts
@@ -2,12 +2,16 @@
 import LetterCaseType from '../@types/LetterCaseType'
 import Thunk from '../@types/Thunk'
 import * as selection from '../device/selection'
+import getThoughtById from '../selectors/getThoughtById'
 import hasMulticursor from '../selectors/hasMulticursor'
-import pathToThought from '../selectors/pathToThought'
+import noteValue from '../selectors/noteValue'
+import resolveNotePath from '../selectors/resolveNotePath'
 import simplifyPath from '../selectors/simplifyPath'
 import applyLetterCase from '../util/applyLetterCase'
+import head from '../util/head'
 import { editThoughtActionCreator as editThought } from './editThought'
 import { setCursorActionCreator as setCursor } from './setCursor'
+import { setDescendantActionCreator as setDescendant } from './setDescendant'
 
 /** Format the browser selection or cursor thought based on the specified letter case change. */
 export const formatLetterCaseActionCreator =
@@ -17,24 +21,37 @@ export const formatLetterCaseActionCreator =
     const cursor = state.cursor
     if (!cursor) return
 
-    const paths = hasMulticursor(state) ? Object.values(state.multicursors) : [cursor]
+    // when the caret is on a note, format the note instead of the thought (#4469)
+    // resolveNotePath returns null if the thought has no note, in which case there is nothing to format
+    const targetPath = state.noteFocus ? resolveNotePath(state, cursor) : cursor
+    const paths = hasMulticursor(state) ? Object.values(state.multicursors) : targetPath ? [targetPath] : []
     const offset = selection.offsetThought()
     const cursorSimplePath = simplifyPath(state, cursor)
     const editActions = paths.flatMap(path => {
-      const thought = pathToThought(state, path)
-      return thought
+      const value = state.noteFocus ? noteValue(state, cursor) : getThoughtById(state, head(cursor))?.value
+
+      if (!value) return []
+
+      const newValue = applyLetterCase(command, value)
+
+      return state.noteFocus
         ? [
+            setDescendant({
+              path,
+              values: [newValue],
+            }),
+          ]
+        : [
             editThought({
-              oldValue: thought.value,
-              newValue: applyLetterCase(command, thought.value),
+              oldValue: value,
+              newValue,
               path: simplifyPath(state, path),
               force: true,
             }),
           ]
-        : []
     })
 
     dispatch(editActions)
 
-    dispatch(setCursor({ path: cursorSimplePath, offset }))
+    dispatch(setCursor({ path: cursorSimplePath, offset, noteFocus: state.noteFocus }))
   }

--- a/src/actions/formatLetterCase.ts
+++ b/src/actions/formatLetterCase.ts
@@ -53,5 +53,7 @@ export const formatLetterCaseActionCreator =
 
     dispatch(editActions)
 
-    dispatch(setCursor({ path: cursorSimplePath, offset, noteFocus: state.noteFocus }))
+    // noteFocus doesn't respect cursorOffset, so better to avoid setting the cursor when the caret is on a note (#4469)
+    // It shouldn't be possible to have noteFocus be true with the keyboard closed, so setCursor shouldn't be necessary for notes.
+    if (!state.noteFocus) dispatch(setCursor({ path: cursorSimplePath, offset }))
   }


### PR DESCRIPTION
Fixes #4469

`formatLetterCase` was not taking `state.noteFocus` into account. If that value is true, it just needed to fetch the value using `noteValue`, call `setDescendant` instead of `editThought`, and skip the `setCursor` action in order to keep focus on the note.