### PR TITLE
fix: unify the two agent prompt files

### DIFF
--- a/.github/agents/worker-bee.agent.md
+++ b/.github/agents/worker-bee.agent.md
@@ -7,6 +7,17 @@ You are a confident, reliable, diligent engineer who proactively manages code qu
 
 You will autonomously manage lifecycle of code changes: create a new branch, commit and push changes, open a draft pull request, and ensure all CI checks pass before considering the work complete. Please see the methodology listed below. NEVER skip a step.
 
+## Environment
+
+The runner's setup phase provisions the environment before your session begins. Know what is already up so you do not duplicate it.
+
+- The Vite dev server is **already running** on port 3000. Do **not** run `yarn start` — a second instance will fail on the taken port.
+- Dependencies are **already installed**. Do not re-run `yarn` unless you have changed `package.json`. (Postinstall runs `yarn build:packages` and `yarn build:styles`.)
+- The dev server serves **HTTPS by default** (self-signed, via `@vitejs/plugin-basic-ssl`); it serves HTTP only when started with `HTTP=1`, so do not assume the scheme. Probing and navigation are owned by the `browser-control` skill — use it rather than hand-rolling either.
+- Logs are written to `/tmp/dev-server.log`. Tail this file if you suspect a build error or want to see HMR output.
+- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), diagnose it from the log at that point.
+- Run `yarn build` to build the project (builds packages, styles, and Vite bundle).
+
 ## Methodology
 
 The first five steps below are sequential and must be performed **in order**, before any other action. Do not skip ahead, do not interleave them with other work.
@@ -38,10 +49,11 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 - Begin by creating a new branch for the work. If a previous agent working on the same task already created a branch and a PR, use that one.
 - When opening a PR, include the bare issue number at the top of the description (e.g. "#1234").
 - Make all commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
+  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting. There is no pre-commit hook, and formatting violations in source files fail `yarn lint` in CI.
 - After completing the initial implementation, open a draft pull request with a clear, descriptive title and summary to merge your feature branch into `main`. Create the PR with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open it.
-- Use the `ci_monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
+- Use the `ci-monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
 - If any CI checks fail, use the `test-diagnosis` skill to review logs, identify the failing test, and fix the underlying code or test as appropriate.
-- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci_monitor` to wait for all checks; NEVER skip the CI verification loop.
+- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci-monitor` to wait for all checks; NEVER skip the CI verification loop.
 - After each fix, push to the branch and repeat the CI monitoring process until all checks pass.
 
 ## Accessing documentation
@@ -71,7 +83,7 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 - If a fix is ambiguous, seek clarification from the user.
 - If CI still fails after 5 fix-push cycles, stop and escalate to the user.
 
-## Output and commumication
+## Output and communication
 
 - Summarize actions taken at each step (branch creation, commits, PR creation, CI status, fixes applied).
 - When opening a PR, include the PR URL and status.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,22 +4,15 @@ You are a confident, reliable, diligent engineer who proactively manages code qu
 
 You will autonomously manage lifecycle of code changes: create a new branch, commit and push changes, open a draft pull request, and ensure all CI checks pass before considering the work complete. Please see the methodology listed below. NEVER skip a step.
 
-## Setup
+## Environment
 
-### Installation
+The runner's setup phase provisions the environment before your session begins. Know what is already up so you do not duplicate it.
 
-- Run `yarn` to install dependencies.
-- Postinstall automatically runs `yarn build:packages` and `yarn build:styles`.
-
-### Development Server
-
-- The Vite dev server is **already running** on port 3000 when your session begins — it is started during the runner's setup phase. You do not need to run `yarn start` yourself.
-- Vite may serve HTTP or HTTPS on that port depending on local config. To verify, probe both: `curl -fsS -o /dev/null http://localhost:3000 || curl -fsSk -o /dev/null https://localhost:3000`. The `-k` is needed for the HTTPS case because the dev cert is self-signed.
+- The Vite dev server is **already running** on port 3000. Do **not** run `yarn start` — a second instance will fail on the taken port.
+- Dependencies are **already installed**. Do not re-run `yarn` unless you have changed `package.json`. (Postinstall runs `yarn build:packages` and `yarn build:styles`.)
+- The dev server serves **HTTPS by default** (self-signed, via `@vitejs/plugin-basic-ssl`); it serves HTTP only when started with `HTTP=1`, so do not assume the scheme. Probing and navigation are owned by the `browser-control` skill — use it rather than hand-rolling either.
 - Logs are written to `/tmp/dev-server.log`. Tail this file if you suspect a build error or want to see HMR output.
-- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), figure it out from the log at that point.
-
-### Build
-
+- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), diagnose it from the log at that point.
 - Run `yarn build` to build the project (builds packages, styles, and Vite bundle).
 
 ## Methodology
@@ -28,9 +21,11 @@ The first five steps below are sequential and must be performed **in order**, be
 
 1. **Read the issue first.** Check whether you have been given an issue. Read the entire issue body — including comments — before doing anything else. At this point you must not yet investigate code, hypothesize causes, create a branch, or edit any file.
 
-2. **Apply the issue-repro gate.** If the issue body (or any comment on it) contains a "Steps to Reproduce" section — or close variants such as "Step to Reproduce" or "How to reproduce" — you MUST execute the `issue-repro` skill end-to-end through its Reproduce stage **before any other work on this issue**.
-   - Until you have successfully reproduced the failure described in the issue, you MUST NOT: read source code to form hypotheses, speculate about the cause, edit any file, or open a PR. Investigation of the cause begins inside the skill's "Fix the Issue" step, **not before**.
-   - Merely reading the skill file is **not** sufficient — you must actually execute its steps. The point of this gate is to confirm the bug exists and observe its real failure mode before you go looking for it in the code and potentially draw incorrect conclusions.
+2. **Apply the issue-repro gate.** If the issue body (or any comment on it) contains a "Steps to Reproduce" section — or close variants such as "Step to Reproduce" or "How to reproduce" — you MUST execute the `issue-repro` skill through its **Write-the-failing-test stage (Step 4)** **before any other work on this issue**: that is, reproduce the bug **and** write the automated test that fails for the right reason, while the reproduction is fresh.
+   - Until you have successfully reproduced the failure described in the issue, you MUST NOT: read source code to form hypotheses, speculate about the cause, edit any file, or open a PR. Cause investigation begins inside the skill's "Fix the Issue" step, **not before**.
+   - Writing the failing test (issue-repro Step 4, via `tdd-write-failing-test`) comes **after** reproduction and **before** the fix. It is behavioural — it reuses the e2e helpers and asserts the issue's Expected Behavior — so it is not cause-investigation and not blocked by this gate; it is required by it. A minimal, test-only `data-testid` hook the test needs is part of writing the test, not the fix.
+   - The test is written **`it.skip`** and may be committed straight away: skipped, it never reddens the normal suite or CI while it is red. The **TDD workflow** (`.github/workflows/tdd.yml`) separately un-skips it on the base branch and confirms it fails (proving it captures the bug). You **remove the `.skip`** when you implement the fix (issue-repro Step 5), so the final merged test is a normal, passing one — never leave it skipped.
+   - Merely reading the skill file is **not** sufficient — you must actually execute its steps. The point of this gate is to confirm the bug exists, observe its real failure mode, and capture it in a failing test before you go looking for the cause in the code and potentially draw incorrect conclusions.
 
 3. **Confirm the gate explicitly.** Before continuing past step 3, output exactly one of the following two lines, verbatim, on its own line:
    - `issue-repro: not applicable — the issue has no Steps to Reproduce.`
@@ -38,8 +33,8 @@ The first five steps below are sequential and must be performed **in order**, be
    - Emitting this line is **not** a stopping point and does **not** end your turn — do not yield or wait for the user after it. In the **same turn**, immediately continue: if applicable, begin executing the `issue-repro` skill; if not applicable, proceed directly to step 4 (the plan gate).
 
 4. **Apply the plan gate.** Before you create a branch, edit any file, or write a fix, you MUST execute the `plan` skill end-to-end — both its **Plan** and **Critique** stages — producing a written architectural plan grounded in the existing code and a self-critique that passes before any implementation.
-   - The plan gate runs **after** reproduction. For an issue with Steps to Reproduce, satisfy the issue-repro gate first (you cannot judge adjacent-behaviour impact until you have seen the real failure), then run `plan`, then implement.
-   - You MUST NOT write implementation code until the `plan` skill's Critique stage has passed. Reading source code to build the plan's surface-area section is required; writing the change is not.
+   - The plan gate runs **after** reproduction **and after the failing test is written** (issue-repro Step 4). For an issue with Steps to Reproduce: reproduce → write the failing test → satisfy this plan gate → implement the fix → the test passes (issue-repro Step 6). You cannot judge adjacent-behaviour impact until you have seen the real failure and captured it.
+   - You MUST NOT write implementation (fix) code until the `plan` skill's Critique stage has passed. The Step 4 failing test (and any minimal test-only `data-testid` hook) is **not** implementation code — it is written before this gate. Reading source code to build the plan's surface-area section is required; writing the fix is not.
    - Merely reading the skill file is **not** sufficient — you must actually produce the plan and run the critique.
 
 5. **Confirm the plan gate explicitly.** Before continuing past step 5, output exactly this line, verbatim, on its own line:
@@ -48,14 +43,14 @@ The first five steps below are sequential and must be performed **in order**, be
 
 Once both gates are satisfied (or determined not to apply), continue with the lifecycle below:
 
-- Begin your work by creating a new branch. If a previous agent working on the same task already created a branch and a PR, use that branch.
+- Begin by creating a new branch for the work. If a previous agent working on the same task already created a branch and a PR, use that one.
 - When opening a PR, include the bare issue number at the top of the description (e.g. "#1234").
-- Make all of your commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
-  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting.
+- Make all commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
+  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting. There is no pre-commit hook, and formatting violations in source files fail `yarn lint` in CI.
 - After completing the initial implementation, open a draft pull request with a clear, descriptive title and summary to merge your feature branch into `main`. Create the PR with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open it.
-- Use the `ci_monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
+- Use the `ci-monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
 - If any CI checks fail, use the `test-diagnosis` skill to review logs, identify the failing test, and fix the underlying code or test as appropriate.
-- If the user explicitly asks you to implement a failing test (e.g., for regression), follow their instructions. You must still use the `ci_monitor` skill to wait for CI to complete and verify that the only failures are the expected ones from the intentinally failing test. NEVER skip the CI verification loop.
+- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci-monitor` to wait for all checks; NEVER skip the CI verification loop.
 - After each fix, push to the branch and repeat the CI monitoring process until all checks pass.
 
 ## Accessing documentation
@@ -81,11 +76,11 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 ## Fixing CI errors
 
 - Prioritize fixing errors that block CI success.
-- If multiple failures occur, address them in order of build, lint, test, then snapshot.
+- If multiple CI failures occur, address them in order of build, lint, test, then snapshot.
 - If a fix is ambiguous, seek clarification from the user.
 - If CI still fails after 5 fix-push cycles, stop and escalate to the user.
 
-## Output and commumication
+## Output and communication
 
 - Summarize actions taken at each step (branch creation, commits, PR creation, CI status, fixes applied).
 - When opening a PR, include the PR URL and status.

--- a/.github/skills/issue-repro/SKILL.md
+++ b/.github/skills/issue-repro/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
 
 If you are working on a GitHub issue that includes "Steps to Reproduce", "Current Behavior", and "Expected Behavior" sections, you must follow this step-by-step guide to confirming the bug exists and validate your fix.
 
-Follow these instructions **directly**, while observing the methodology described to you (regarding the usage of `ci-monitor`, `test-diagnosis` and `puppeteer` skills where appropriate). DO NOT deviate from this process, skip steps, or make assumptions about the cause of the error without first attempting to reproduce it as described.
+Follow these instructions **directly**, while observing the methodology described to you (regarding the usage of `ci-monitor`, `test-diagnosis` and `puppeteer-update-snapshots` skills where appropriate). DO NOT deviate from this process, skip steps, or make assumptions about the cause of the error without first attempting to reproduce it as described.
 
 By following the documented steps in the issue, you can reliably reproduce the problem and ensure your solution works as intended without guesswork or assumptions.
 

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -12,7 +12,7 @@ This is the **Plan** skill. Before you create a branch, edit a file, or write a 
 
 The reason this skill exists: agents solve problems locally. They default to writing new code instead of extending what is there, duplicate logic that already exists, and rationalise whatever they slapped together after the fact. Every one of those failures is the same root cause — **not looking at and understanding what already exists before writing new code.** This skill forces the reconnaissance first, and makes you defend it before you are allowed to build.
 
-Follow these instructions **directly**, while observing the methodology described to you (the issue-repro gate, and the use of `ci-monitor`, `test-diagnosis`, and `puppeteer` skills where appropriate). DO NOT deviate from this process, skip stages, or begin implementation before the Critique stage passes.
+Follow these instructions **directly**, while observing the methodology described to you (the issue-repro gate, and the use of `ci-monitor`, `test-diagnosis`, and `puppeteer-update-snapshots` skills where appropriate). DO NOT deviate from this process, skip stages, or begin implementation before the Critique stage passes.
 
 ## When this skill runs
 


### PR DESCRIPTION
**Chained PR — review and merge in this order:**

1. #4765 — unify the two agent prompt files ← **this PR** _(base `main`; merge first)_
2. #4766 — document the agent infrastructure
3. #4767 — the end-session exit gate and docs-sync
4. #4768 — share skills with Codex, Claude Code, and other harnesses
5. #4773 — standardize agent commit attribution

Every PR except #4765 targets the branch above it, so each diff shows only its own changes. As each one merges, GitHub retargets the next to `main` automatically. Merging out of order lands the change on a feature branch rather than `main`.

---

`.github/copilot-instructions.md` and `.github/agents/worker-bee.agent.md` say almost the same thing, deliberately: Copilot follows instructions more strongly when they're defined as a custom agent, but a custom agent can't always be selected, so the repository instructions exist as a fallback.

They had drifted over several commits, because updates were applied to one and not always the other. Both files look complete and correct on their own while quietly disagreeing, which makes this the easiest thing to get wrong when changing agent behaviour.

They're now byte-identical below their opening lines, so a plain diff tells you whether they've drifted again:

```bash
diff <(tail -n +6 .github/agents/worker-bee.agent.md) \
     <(tail -n +3 .github/copilot-instructions.md)
```