### PR TITLE
docs: document the agent infrastructure

### DIFF
--- a/.github/agents/worker-bee.agent.md
+++ b/.github/agents/worker-bee.agent.md
@@ -7,6 +7,17 @@ You are a confident, reliable, diligent engineer who proactively manages code qu
 
 You will autonomously manage lifecycle of code changes: create a new branch, commit and push changes, open a draft pull request, and ensure all CI checks pass before considering the work complete. Please see the methodology listed below. NEVER skip a step.
 
+## Environment
+
+The runner's setup phase provisions the environment before your session begins. Know what is already up so you do not duplicate it.
+
+- The Vite dev server is **already running** on port 3000. Do **not** run `yarn start` — a second instance will fail on the taken port.
+- Dependencies are **already installed**. Do not re-run `yarn` unless you have changed `package.json`. (Postinstall runs `yarn build:packages` and `yarn build:styles`.)
+- The dev server serves **HTTPS by default** (self-signed, via `@vitejs/plugin-basic-ssl`); it serves HTTP only when started with `HTTP=1`, so do not assume the scheme. Probing and navigation are owned by the `browser-control` skill — use it rather than hand-rolling either.
+- Logs are written to `/tmp/dev-server.log`. Tail this file if you suspect a build error or want to see HMR output.
+- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), diagnose it from the log at that point.
+- Run `yarn build` to build the project (builds packages, styles, and Vite bundle).
+
 ## Methodology
 
 The first five steps below are sequential and must be performed **in order**, before any other action. Do not skip ahead, do not interleave them with other work.
@@ -38,10 +49,11 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 - Begin by creating a new branch for the work. If a previous agent working on the same task already created a branch and a PR, use that one.
 - When opening a PR, include the bare issue number at the top of the description (e.g. "#1234").
 - Make all commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
+  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting. There is no pre-commit hook, and formatting violations in source files fail `yarn lint` in CI.
 - After completing the initial implementation, open a draft pull request with a clear, descriptive title and summary to merge your feature branch into `main`. Create the PR with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open it.
-- Use the `ci_monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
+- Use the `ci-monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
 - If any CI checks fail, use the `test-diagnosis` skill to review logs, identify the failing test, and fix the underlying code or test as appropriate.
-- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci_monitor` to wait for all checks; NEVER skip the CI verification loop.
+- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci-monitor` to wait for all checks; NEVER skip the CI verification loop.
 - After each fix, push to the branch and repeat the CI monitoring process until all checks pass.
 
 ## Accessing documentation
@@ -71,7 +83,7 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 - If a fix is ambiguous, seek clarification from the user.
 - If CI still fails after 5 fix-push cycles, stop and escalate to the user.
 
-## Output and commumication
+## Output and communication
 
 - Summarize actions taken at each step (branch creation, commits, PR creation, CI status, fixes applied).
 - When opening a PR, include the PR URL and status.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,22 +4,15 @@ You are a confident, reliable, diligent engineer who proactively manages code qu
 
 You will autonomously manage lifecycle of code changes: create a new branch, commit and push changes, open a draft pull request, and ensure all CI checks pass before considering the work complete. Please see the methodology listed below. NEVER skip a step.
 
-## Setup
+## Environment
 
-### Installation
+The runner's setup phase provisions the environment before your session begins. Know what is already up so you do not duplicate it.
 
-- Run `yarn` to install dependencies.
-- Postinstall automatically runs `yarn build:packages` and `yarn build:styles`.
-
-### Development Server
-
-- The Vite dev server is **already running** on port 3000 when your session begins — it is started during the runner's setup phase. You do not need to run `yarn start` yourself.
-- Vite may serve HTTP or HTTPS on that port depending on local config. To verify, probe both: `curl -fsS -o /dev/null http://localhost:3000 || curl -fsSk -o /dev/null https://localhost:3000`. The `-k` is needed for the HTTPS case because the dev cert is self-signed.
+- The Vite dev server is **already running** on port 3000. Do **not** run `yarn start` — a second instance will fail on the taken port.
+- Dependencies are **already installed**. Do not re-run `yarn` unless you have changed `package.json`. (Postinstall runs `yarn build:packages` and `yarn build:styles`.)
+- The dev server serves **HTTPS by default** (self-signed, via `@vitejs/plugin-basic-ssl`); it serves HTTP only when started with `HTTP=1`, so do not assume the scheme. Probing and navigation are owned by the `browser-control` skill — use it rather than hand-rolling either.
 - Logs are written to `/tmp/dev-server.log`. Tail this file if you suspect a build error or want to see HMR output.
-- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), figure it out from the log at that point.
-
-### Build
-
+- Code edits hot-reload automatically. A manual restart is almost never needed; if you believe it is (e.g. you changed `vite.config.ts`), diagnose it from the log at that point.
 - Run `yarn build` to build the project (builds packages, styles, and Vite bundle).
 
 ## Methodology
@@ -28,9 +21,11 @@ The first five steps below are sequential and must be performed **in order**, be
 
 1. **Read the issue first.** Check whether you have been given an issue. Read the entire issue body — including comments — before doing anything else. At this point you must not yet investigate code, hypothesize causes, create a branch, or edit any file.
 
-2. **Apply the issue-repro gate.** If the issue body (or any comment on it) contains a "Steps to Reproduce" section — or close variants such as "Step to Reproduce" or "How to reproduce" — you MUST execute the `issue-repro` skill end-to-end through its Reproduce stage **before any other work on this issue**.
-   - Until you have successfully reproduced the failure described in the issue, you MUST NOT: read source code to form hypotheses, speculate about the cause, edit any file, or open a PR. Investigation of the cause begins inside the skill's "Fix the Issue" step, **not before**.
-   - Merely reading the skill file is **not** sufficient — you must actually execute its steps. The point of this gate is to confirm the bug exists and observe its real failure mode before you go looking for it in the code and potentially draw incorrect conclusions.
+2. **Apply the issue-repro gate.** If the issue body (or any comment on it) contains a "Steps to Reproduce" section — or close variants such as "Step to Reproduce" or "How to reproduce" — you MUST execute the `issue-repro` skill through its **Write-the-failing-test stage (Step 4)** **before any other work on this issue**: that is, reproduce the bug **and** write the automated test that fails for the right reason, while the reproduction is fresh.
+   - Until you have successfully reproduced the failure described in the issue, you MUST NOT: read source code to form hypotheses, speculate about the cause, edit any file, or open a PR. Cause investigation begins inside the skill's "Fix the Issue" step, **not before**.
+   - Writing the failing test (issue-repro Step 4, via `tdd-write-failing-test`) comes **after** reproduction and **before** the fix. It is behavioural — it reuses the e2e helpers and asserts the issue's Expected Behavior — so it is not cause-investigation and not blocked by this gate; it is required by it. A minimal, test-only `data-testid` hook the test needs is part of writing the test, not the fix.
+   - The test is written **`it.skip`** and may be committed straight away: skipped, it never reddens the normal suite or CI while it is red. The **TDD workflow** (`.github/workflows/tdd.yml`) separately un-skips it on the base branch and confirms it fails (proving it captures the bug). You **remove the `.skip`** when you implement the fix (issue-repro Step 5), so the final merged test is a normal, passing one — never leave it skipped.
+   - Merely reading the skill file is **not** sufficient — you must actually execute its steps. The point of this gate is to confirm the bug exists, observe its real failure mode, and capture it in a failing test before you go looking for the cause in the code and potentially draw incorrect conclusions.
 
 3. **Confirm the gate explicitly.** Before continuing past step 3, output exactly one of the following two lines, verbatim, on its own line:
    - `issue-repro: not applicable — the issue has no Steps to Reproduce.`
@@ -38,8 +33,8 @@ The first five steps below are sequential and must be performed **in order**, be
    - Emitting this line is **not** a stopping point and does **not** end your turn — do not yield or wait for the user after it. In the **same turn**, immediately continue: if applicable, begin executing the `issue-repro` skill; if not applicable, proceed directly to step 4 (the plan gate).
 
 4. **Apply the plan gate.** Before you create a branch, edit any file, or write a fix, you MUST execute the `plan` skill end-to-end — both its **Plan** and **Critique** stages — producing a written architectural plan grounded in the existing code and a self-critique that passes before any implementation.
-   - The plan gate runs **after** reproduction. For an issue with Steps to Reproduce, satisfy the issue-repro gate first (you cannot judge adjacent-behaviour impact until you have seen the real failure), then run `plan`, then implement.
-   - You MUST NOT write implementation code until the `plan` skill's Critique stage has passed. Reading source code to build the plan's surface-area section is required; writing the change is not.
+   - The plan gate runs **after** reproduction **and after the failing test is written** (issue-repro Step 4). For an issue with Steps to Reproduce: reproduce → write the failing test → satisfy this plan gate → implement the fix → the test passes (issue-repro Step 6). You cannot judge adjacent-behaviour impact until you have seen the real failure and captured it.
+   - You MUST NOT write implementation (fix) code until the `plan` skill's Critique stage has passed. The Step 4 failing test (and any minimal test-only `data-testid` hook) is **not** implementation code — it is written before this gate. Reading source code to build the plan's surface-area section is required; writing the fix is not.
    - Merely reading the skill file is **not** sufficient — you must actually produce the plan and run the critique.
 
 5. **Confirm the plan gate explicitly.** Before continuing past step 5, output exactly this line, verbatim, on its own line:
@@ -48,14 +43,14 @@ The first five steps below are sequential and must be performed **in order**, be
 
 Once both gates are satisfied (or determined not to apply), continue with the lifecycle below:
 
-- Begin your work by creating a new branch. If a previous agent working on the same task already created a branch and a PR, use that branch.
+- Begin by creating a new branch for the work. If a previous agent working on the same task already created a branch and a PR, use that one.
 - When opening a PR, include the bare issue number at the top of the description (e.g. "#1234").
-- Make all of your commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
-  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting.
+- Make all commits in this branch. Push after each meaningful change. Never commit directly to main or protected branches.
+  - Run `yarn prettier --write .` before committing any changes to ensure proper code formatting. There is no pre-commit hook, and formatting violations in source files fail `yarn lint` in CI.
 - After completing the initial implementation, open a draft pull request with a clear, descriptive title and summary to merge your feature branch into `main`. Create the PR with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open it.
-- Use the `ci_monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
+- Use the `ci-monitor` skill to monitor CI status. Wait for all runs to complete before proceeding.
 - If any CI checks fail, use the `test-diagnosis` skill to review logs, identify the failing test, and fix the underlying code or test as appropriate.
-- If the user explicitly asks you to implement a failing test (e.g., for regression), follow their instructions. You must still use the `ci_monitor` skill to wait for CI to complete and verify that the only failures are the expected ones from the intentinally failing test. NEVER skip the CI verification loop.
+- **Regression tests use `.skip` + the TDD workflow — read which check failed.** The Step 4 test is committed `it.skip`, so the **normal** suite stays green while it is red. A separate **TDD workflow** (`tdd.yml`) un-skips it on the base branch and *expects it to fail*. A **TDD-workflow failure and a normal-suite failure therefore mean opposite things**: "CI failed" does not by itself mean the bug is unfixed — check *which* job failed (a red `TDD` check usually means the test wrongly passes on base; a red normal suite means the code is broken). When you implement the fix you **remove the `.skip`**, so the normal suite then runs it green. Always use `ci-monitor` to wait for all checks; NEVER skip the CI verification loop.
 - After each fix, push to the branch and repeat the CI monitoring process until all checks pass.
 
 ## Accessing documentation
@@ -81,11 +76,11 @@ Once both gates are satisfied (or determined not to apply), continue with the li
 ## Fixing CI errors
 
 - Prioritize fixing errors that block CI success.
-- If multiple failures occur, address them in order of build, lint, test, then snapshot.
+- If multiple CI failures occur, address them in order of build, lint, test, then snapshot.
 - If a fix is ambiguous, seek clarification from the user.
 - If CI still fails after 5 fix-push cycles, stop and escalate to the user.
 
-## Output and commumication
+## Output and communication
 
 - Summarize actions taken at each step (branch creation, commits, PR creation, CI status, fixes applied).
 - When opening a PR, include the PR URL and status.

--- a/.github/skills/issue-repro/SKILL.md
+++ b/.github/skills/issue-repro/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
 
 If you are working on a GitHub issue that includes "Steps to Reproduce", "Current Behavior", and "Expected Behavior" sections, you must follow this step-by-step guide to confirming the bug exists and validate your fix.
 
-Follow these instructions **directly**, while observing the methodology described to you (regarding the usage of `ci-monitor`, `test-diagnosis` and `puppeteer` skills where appropriate). DO NOT deviate from this process, skip steps, or make assumptions about the cause of the error without first attempting to reproduce it as described.
+Follow these instructions **directly**, while observing the methodology described to you (regarding the usage of `ci-monitor`, `test-diagnosis` and `puppeteer-update-snapshots` skills where appropriate). DO NOT deviate from this process, skip steps, or make assumptions about the cause of the error without first attempting to reproduce it as described.
 
 By following the documented steps in the issue, you can reliably reproduce the problem and ensure your solution works as intended without guesswork or assumptions.
 

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -12,7 +12,7 @@ This is the **Plan** skill. Before you create a branch, edit a file, or write a 
 
 The reason this skill exists: agents solve problems locally. They default to writing new code instead of extending what is there, duplicate logic that already exists, and rationalise whatever they slapped together after the fact. Every one of those failures is the same root cause — **not looking at and understanding what already exists before writing new code.** This skill forces the reconnaissance first, and makes you defend it before you are allowed to build.
 
-Follow these instructions **directly**, while observing the methodology described to you (the issue-repro gate, and the use of `ci-monitor`, `test-diagnosis`, and `puppeteer` skills where appropriate). DO NOT deviate from this process, skip stages, or begin implementation before the Critique stage passes.
+Follow these instructions **directly**, while observing the methodology described to you (the issue-repro gate, and the use of `ci-monitor`, `test-diagnosis`, and `puppeteer-update-snapshots` skills where appropriate). DO NOT deviate from this process, skip stages, or begin implementation before the Critique stage passes.
 
 ## When this skill runs
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ local.*
 /log
 /logs
 
+# per-user state when `docs` is opened as an Obsidian vault
+docs/.obsidian
+
+# scratch space – for throwaway scripts, notes, and logs
+/.local

--- a/docs/agents/environment.md
+++ b/docs/agents/environment.md
@@ -1,0 +1,176 @@
+# Environment
+
+The agent wakes up in a machine that has already been prepared for it. Understanding what is already running — and why it was set up that way rather than left to the agent — explains most of the odd-looking decisions in the skills.
+
+## What the setup step builds
+
+[`.github/workflows/copilot-setup-steps.yml`](../../.github/workflows/copilot-setup-steps.yml) runs before the agent's session begins. The file name and the job name inside it must both be exactly `copilot-setup-steps`, or Copilot will not use it.
+
+| Step | Why |
+| --- | --- |
+| Install dependencies | So the agent does not spend its first minutes on `yarn` |
+| Install and start a virtual display | The machine has no screen, and Chrome needs one to run |
+| Write BrowserStack credentials to a local env file | So the iOS test runner finds them; the file is git-ignored |
+| Pre-pull the browserless Docker image | Downloading it later would happen inside the agent's run instead |
+| Start a shared Chrome with debugging on port 9222 | See below — this is the important one |
+| Start the Vite dev server on port 3000 | So the app is already there to be driven |
+
+Both background services are started detached with their output redirected to a log, and the step then polls until each responds before finishing. Failing here, loudly, is much better than the agent starting up and finding a half-built environment.
+
+**The agent is told not to redo any of this.** Both prompt files carry an Environment section saying the dev server is already running, dependencies are already installed, and logs are at `/tmp/dev-server.log`. Without that, an agent will helpfully run `yarn start`, hit an occupied port, and spend a while confused.
+
+### The dev server serves HTTPS
+
+The dev server uses HTTPS with a self-signed certificate. It only serves plain HTTP if started with `HTTP=1`, which the setup step does not do — but since that override exists, nothing should hard-code the scheme. The standard check tries HTTPS first and falls back:
+
+```bash
+curl -fsSk -o /dev/null https://localhost:3000 || curl -fsS -o /dev/null http://localhost:3000
+```
+
+The `-k` accepts the self-signed certificate. The shared Chrome is launched with certificate errors ignored, so the agent should never see a browser warning page.
+
+## One browser, two ways in
+
+The single most useful thing in this setup is that **the agent's tooling and the project's test helpers drive the same browser.**
+
+```mermaid
+flowchart LR
+    subgraph runner["The agent's machine"]
+        CHROME["Shared Chrome<br/>debugging port 9222<br/>scripts/shared-chrome.mjs"]
+        VITE["Vite dev server<br/>port 3000, HTTPS"]
+        CHROME <--> VITE
+    end
+
+    MCP["chrome-devtools tooling<br/>--browser-url=127.0.0.1:9222"]
+    BRIDGE["The bridge<br/>attachExistingBrowserInstance.ts"]
+    HELPERS["The project's own test helpers<br/>src/e2e/puppeteer/helpers/"]
+
+    MCP -->|"look at things"| CHROME
+    BRIDGE -->|"do things"| CHROME
+    HELPERS --> BRIDGE
+
+    click CHROME "https://github.com/cybersemics/em/blob/HEAD/scripts/shared-chrome.mjs" "scripts/shared-chrome.mjs"
+    click MCP "https://github.com/cybersemics/em/blob/HEAD/docs/agents/mcp.md#chrome-devtools" "The chrome-devtools server"
+    click BRIDGE "https://github.com/cybersemics/em/blob/HEAD/docs/agents/environment.md#what-the-bridge-actually-is" "How the bridge works"
+    click HELPERS "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control" "The observe-versus-act rule"
+```
+
+The tooling is configured with `--browser-url`, which means it **joins** the already-running Chrome rather than launching its own. The bridge connects to the same one. So the agent can inspect the page with one tool, act on it with a helper through the other, and both are looking at the same window.
+
+This is what makes the observe-versus-act rule practical. Reading state uses whatever tool is convenient; acting on the app goes through the helpers the test suite already uses — which means a reproduction is already most of the way to being a test.
+
+Because the tooling joins rather than launches, **Chrome must already be running**. If a tooling call cannot connect, the answer is to start `scripts/shared-chrome.mjs`, not to launch a browser some other way.
+
+### What the bridge actually is
+
+[`src/e2e/puppeteer/attachExistingBrowserInstance.ts`](../../src/e2e/puppeteer/attachExistingBrowserInstance.ts) connects to the shared Chrome, finds the tab with the app in it, and hands it to the helpers as the page they operate on.
+
+There is a concrete reason it exists rather than just using the tooling for everything: connecting this way restores real touch input, which the general tooling does not expose. Real touch is what makes the actual gesture helper work — the same code the test suite runs, rather than an approximation of it.
+
+Using it means writing a small throwaway script that imports the bridge and whichever helpers are needed, and running it:
+
+```ts
+import { attachExistingBrowserInstance } from '<repo>/src/e2e/puppeteer/attachExistingBrowserInstance'
+import gesture from '<repo>/src/e2e/puppeteer/helpers/gesture'
+
+const main = async () => {
+  const { browser, page } = await attachExistingBrowserInstance()
+  try {
+    await gesture('rd')
+    console.log(JSON.stringify(await page.evaluate(() => document.querySelectorAll('[data-editable]').length)))
+  } finally {
+    await browser.disconnect() // disconnect, never close — the tooling is using this browser too
+  }
+}
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+Two things to get right. **Disconnect, never close** — closing would take the browser out from under the agent's other tools. And the script is glue only: call helpers, compose them, never re-implement what one already does.
+
+## iOS
+
+iOS runs the real app on a real iPhone through BrowserStack, giving access to both the native layer and the web page in a single session.
+
+### Why the session is created by a shell script
+
+This looks convoluted until you know the constraint. BrowserStack takes 20 to 40 seconds to allocate a physical iPhone, and it varies. The tooling that would normally create the session has a request timeout that is fixed and cannot be configured, and the allocation wait can exceed it.
+
+So session creation is moved out of the tooling entirely:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant B as bringup.sh
+    participant S as start-ios-session.mjs
+    participant BS as BrowserStack
+    participant F as /tmp/em-bs-session.txt
+    participant P as Local proxy (port 4723)
+
+    A->>B: run bringup.sh
+    B->>S: launch detached
+    S->>BS: open tunnel, request an iPhone
+    Note over S,BS: 20–40 seconds, varies
+    BS-->>S: session ready
+    S->>F: write the session ID
+    B->>F: poll until it appears
+    B->>P: start the proxy and a heartbeat
+    B-->>A: "iOS session ready"
+
+    Note over A,P: The slow part is over. Both routes below are instant.
+    A->>P: tooling joins the existing session
+    A->>F: or a script reads the ID and attaches directly
+```
+
+Nothing waits on a tool call during the slow part. A detached background process does the waiting, and the agent polls a file — and the shell tool's own timeout is generous.
+
+Three pieces come out of this:
+
+- **[`scripts/start-ios-session.mjs`](../../scripts/start-ios-session.mjs)** opens a tunnel so the phone can reach the dev server, requests the device, and stays alive holding the tunnel open.
+- **[`.github/skills/browser-control-ios/heartbeat.sh`](../../.github/skills/browser-control-ios/heartbeat.sh)** pings the session every 90 seconds so BrowserStack does not reclaim it while the agent is thinking. It gives up after three consecutive failures and writes out BrowserStack's own explanation of what happened — which is the only after-the-fact clue available if a session dies.
+- **[`scripts/mcp-session-proxy.mjs`](../../scripts/mcp-session-proxy.mjs)** is a small local server. The three separate problems it solves are laid out in [MCP servers](mcp.md#why-there-is-a-shim-in-the-middle). The tooling connects to it and asks to start a session; instead of creating one, it hands back the session that already exists, instantly.
+
+The proxy solves a second problem too. The sandbox's firewall rejects certain outgoing requests because of a malformed header, so the proxy forwards requests itself in a way the firewall accepts. Everything from the agent to the proxy is local traffic, which is never inspected.
+
+### The app on the device
+
+iOS runs a pre-built app uploaded to BrowserStack under the name `em-server-mode`. It is not rebuilt per run — day-to-day web changes do not need one, since the app loads the dev server through the tunnel.
+
+Two ways this bites, both ending in a blank screen and a timeout, and both needing a human at a Mac:
+
+- **The upload lapsed.** BrowserStack deletes apps 30 days after last use.
+- **The build predates HTTPS.** The app has its server address baked in. A build made before the dev server moved to HTTPS points at `http://` and loads nothing.
+
+Either way it has to be rebuilt and re-uploaded from a Mac with Xcode.
+
+### The iOS bridge
+
+[`src/e2e/iOS/attachExistingSession.ts`](../../src/e2e/iOS/attachExistingSession.ts) reads the session ID from the file, attaches, and switches into the web layer. From there, working with the page is identical to any other platform.
+
+Worth knowing: the first attach costs tens of seconds while the connection to the web layer warms up. Compose several actions into one script rather than running several scripts.
+
+Two iOS-specific gotchas: the standard `click` does nothing on iOS, so use the `tap` helper. And editing a source file triggers a reload on the device, which wipes app state — so re-create anything you had set up after an edit.
+
+## Running the actual tests
+
+The skills draw a hard line between **driving the live app** and **running a test**.
+
+Reproduction drives the live app: the shared Chrome, the dev server on port 3000, the interactive tooling. Exploratory and messy by design.
+
+Running a test uses the real test harness instead, which starts its own browser in Docker on port 7566 and its own server on port 2552. It handles launching the app and resetting state between tests. **Do not point it at the exploration setup** — it manages its own.
+
+One wrinkle worth knowing, because it produces a baffling error otherwise. The puppeteer script only starts Docker and its own server when it thinks it is not in CI. The agent's machine claims to be CI but does not provide those services, so the test tries to connect to a browser that was never started. Clearing the variable for that one command fixes it:
+
+```bash
+GITHUB_ACTIONS="" ./src/e2e/puppeteer/test-puppeteer.sh src/e2e/puppeteer/__tests__/<file>.ts -t "<test name>"
+```
+
+iOS tests run on BrowserStack, the same as reproduction, but the runner opens its own separate session.
+
+## The firewall
+
+Outbound network access is blocked by default. Allowed hosts are listed in `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS` in the setup workflow — currently the BrowserStack hubs, its API, and the tunnel service.
+
+A blocked host usually does not produce a clear error. It looks like a hang or a confusing connection failure. **If something external suddenly stops working, check this list first.**

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -1,0 +1,194 @@
+# MCP servers
+
+An **MCP server** is a separate program that gives the agent tools it would not otherwise have. MCP stands for Model Context Protocol, and the idea is simple: the server advertises a set of named tools, the agent calls them, the server does the work and returns a result. Without one, the agent has a shell and a text editor. With one, it can drive a browser, drive a phone, or read a GitHub issue.
+
+Three of them matter here.
+
+| Server | What it gives the agent | Used by |
+| --- | --- | --- |
+| [`chrome-devtools`](#chrome-devtools) | Driving Chrome — navigate, inspect, screenshot, emulate a phone | [`browser-control-chrome`](skills.md#browser-control-chrome) |
+| [`wdio`](#wdio) | Driving a real iPhone through BrowserStack | [`browser-control-ios`](skills.md#browser-control-ios) |
+| [GitHub](#the-github-server) | Reading issues, listing CI runs | [`issue-repro`](skills.md#issue-repro), [`ci-monitor`](skills.md#ci-monitor) |
+
+```mermaid
+flowchart LR
+    AGENT(["The agent"])
+
+    subgraph browsers["Driving the app"]
+        CD["chrome-devtools"]
+        WD["wdio"]
+    end
+    subgraph gh["Working with GitHub"]
+        GHS["GitHub server"]
+    end
+
+    CHROME["Shared Chrome<br/>port 9222"]
+    PROXY["Local shim<br/>port 4723"]
+    PHONE["Real iPhone<br/>on BrowserStack"]
+    REPO["Issues · Actions"]
+
+    AGENT --> CD --> CHROME
+    AGENT --> WD --> PROXY --> PHONE
+    AGENT --> GHS --> REPO
+
+    click CD "https://github.com/cybersemics/em/blob/HEAD/docs/agents/mcp.md#chrome-devtools" "How chrome-devtools is set up"
+    click WD "https://github.com/cybersemics/em/blob/HEAD/docs/agents/mcp.md#wdio" "How wdio is set up"
+    click GHS "https://github.com/cybersemics/em/blob/HEAD/docs/agents/mcp.md#the-github-server" "What the GitHub server is used for"
+    click PROXY "https://github.com/cybersemics/em/blob/HEAD/docs/agents/mcp.md#why-there-is-a-shim-in-the-middle" "Why the shim exists"
+    click CHROME "https://github.com/cybersemics/em/blob/HEAD/docs/agents/environment.md#one-browser-two-ways-in" "The shared browser"
+```
+
+## The most important thing to know
+
+**None of this is configured in the repository.** MCP servers are set up in Copilot's own settings, outside version control. Nothing here will tell you when that configuration changes, breaks, or disagrees with what the skills expect.
+
+That matters because at least one setting is load-bearing. If `chrome-devtools` is not given the right argument, it launches its own browser instead of joining the shared one, and the agent's tools and the project's test helpers end up driving two different windows. Everything appears to work; nothing lines up.
+
+So when browser work starts failing in a way that makes no sense, **check the server configuration before you debug the skills.**
+
+## chrome-devtools
+
+Drives Chrome for web and Android work. The agent uses it to navigate, look at the page, take screenshots, read the console, and switch on phone emulation.
+
+It must be configured to **join the browser that is already running** rather than start a new one:
+
+```
+--browser-url=http://127.0.0.1:9222
+```
+
+That port is the shared Chrome that [`copilot-setup-steps.yml`](../../.github/workflows/copilot-setup-steps.yml) starts via [`scripts/shared-chrome.mjs`](../../scripts/shared-chrome.mjs). Joining it is what lets the agent inspect the page with one tool and act on it with the project's test helpers through another, both looking at the same window. That arrangement is described in [Environment](environment.md#one-browser-two-ways-in).
+
+Two consequences:
+
+- **Never call `launch_chrome`.** There is already a browser; a second one is not connected to anything.
+- **If a call cannot connect, Chrome is not running.** Because this server joins rather than launches, it cannot recover on its own. Start `scripts/shared-chrome.mjs` and try again.
+
+One capability it does *not* offer is real touch input. That is the reason the bridge exists — see [choosing between the server and the bridge](#when-to-use-a-server-and-when-to-use-the-bridge).
+
+## wdio
+
+Drives a real iPhone on BrowserStack, via Appium. Used for switching between the app's native layer and its web page, taking device screenshots, and simple interactions.
+
+### Why there is a shim in the middle
+
+The agent does not point this server at BrowserStack. It points at a small local program, [`scripts/mcp-session-proxy.mjs`](../../scripts/mcp-session-proxy.mjs), which stands between the two:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant W as wdio server
+    participant P as Local shim (4723)
+    participant BS as BrowserStack
+
+    Note over A,BS: The session was already created by bringup.sh — see environment.md
+    A->>W: start_session (pointed at the shim)
+    W->>P: "create a session"
+    P-->>W: "here is your session" (the existing one, instantly)
+    Note over W,P: No waiting. The MCP host's timeout never fires.
+    A->>W: switch_context, screenshot, tap…
+    W->>P: each command
+    P->>BS: forwarded over a connection the firewall accepts
+    BS-->>P: result
+    P-->>W: result
+```
+
+The shim solves three separate problems, and it is worth knowing all three because each produces a different symptom:
+
+1. **The server can only create sessions, never join one.** It has no concept of attaching to a session someone else made. The shim answers the "create a session" request with the session that already exists, so the server adopts it while believing it made it itself.
+
+2. **Creating a session for real takes too long.** Allocating a physical iPhone takes 20 to 40 seconds and varies. The MCP host has a fixed request timeout that cannot be configured, and the allocation can exceed it. Because the shim answers instantly, nothing ever waits inside a tool call. The actual waiting happens in a background script — see [Environment](environment.md#why-the-session-is-created-by-a-shell-script).
+
+3. **The sandbox firewall rejects the server's requests.** The firewall inspects outgoing traffic and, in doing so, duplicates a header on requests made by the HTTP library this server uses. BrowserStack's front end rejects the duplicate outright with a `400`. The shim re-sends each request itself using a different HTTP library that produces a single clean header, which the firewall leaves alone. The hop from the server to the shim is local traffic, which is never inspected.
+
+So the session is configured like this — pointing at localhost, not at BrowserStack:
+
+```json
+{
+  "provider": "local",
+  "platform": "ios",
+  "noReset": true,
+  "appiumConfig": { "protocol": "http", "host": "127.0.0.1", "port": 4723, "path": "/wd/hub" }
+}
+```
+
+**Do not point `start_session` at BrowserStack directly.** It reintroduces the slow provisioning inside a tool call and can hit the timeout the shim exists to avoid.
+
+If a call comes back with an HTML `400 Bad Request` page, the shim's forwarding has broken. Capture `/tmp/em-mcp-proxy.log` and stop — do not try to work around it by making raw web requests, which is exactly what problem 3 above prevents from working.
+
+## The GitHub server
+
+Used in two places:
+
+- [`issue-repro`](skills.md#issue-repro) calls `get_issue` to read the full body and comments of the issue being worked on.
+- [`ci-monitor`](skills.md#ci-monitor) lists workflow runs for the current branch, through the **actions** tool with `method: "list_workflow_runs"`. A standalone `list_workflow_runs` tool used to exist and no longer does — a good example of an external tool surface changing underneath the skills that call it.
+
+Opening the pull request is *not* done through this server. Both prompt files specify the `runtime-tools-create_pull_request` tool, which Copilot provides directly, and explicitly forbid shelling out to `git` or `gh` to open one.
+
+## Which skills may use which
+
+Every skill declares what it is allowed to use in its `allowed-tools` frontmatter. Most need nothing but a shell — the browser servers are concentrated in exactly the skills that drive the app.
+
+| Skill | `bash` | `chrome-devtools` | `wdio` |
+| --- | :-: | :-: | :-: |
+| [`browser-control`](skills.md#browser-control) | ✓ | ✓ | ✓ |
+| [`browser-control-chrome`](skills.md#browser-control-chrome) | ✓ | ✓ | ✓ |
+| [`browser-control-ios`](skills.md#browser-control-ios) | ✓ | | ✓ |
+| [`issue-repro`](skills.md#issue-repro) | ✓ | ✓ | ✓ |
+| [`plan`](skills.md#plan) | ✓ | | |
+| [`tdd-write-failing-test`](skills.md#tdd-write-failing-test) | ✓ | | |
+| [`run-test`](skills.md#run-test) | ✓ | | |
+| [`ci-monitor`](skills.md#ci-monitor) | ✓ | | |
+| [`test-diagnosis`](skills.md#test-diagnosis) | ✓ | | |
+| [`puppeteer-update-snapshots`](skills.md#puppeteer-update-snapshots) | ✓ | | |
+
+[`browser-control`](skills.md#browser-control) and [`issue-repro`](skills.md#issue-repro) list both browser servers because they route to either platform without knowing in advance which it will be.
+
+## When to use a server, and when to use the bridge
+
+The agent has two ways to interact with the running app, and picking the wrong one is a common source of wasted time.
+
+```mermaid
+flowchart TD
+    Q{"What are you doing<br/>to the app?"}
+    Q -- "Looking at it" --> M["Use the MCP server<br/>screenshots · read the page · console · network"]
+    Q -- "Doing something to it" --> H{"Does a test helper<br/>already exist for it?"}
+    H -- yes --> B["Use the helper through the bridge"]
+    H -- no --> M2["Use the MCP server and keep going.<br/>Note the gap; do not stall."]
+
+    style B fill:#2d4a2d,color:#fff
+
+    click B "https://github.com/cybersemics/em/blob/HEAD/docs/agents/environment.md#what-the-bridge-actually-is" "How the bridge works"
+    click M "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control" "The observe-versus-act rule"
+```
+
+**Looking at the app is free** — use whatever tool is convenient.
+
+**Acting on the app should go through the project's own test helpers**, run against the live session by the bridge. Two reasons: those helpers already encapsulate details that are easy to get wrong by hand, and a reproduction built from them converts into a real test almost for free.
+
+There is a hard technical reason too, not just a stylistic one. **The `chrome-devtools` server cannot produce real touch input.** The app's controls respond to touch events under phone emulation, so a click through the server does nothing at all — no error, no effect. An agent that clicks a button, sees nothing happen, and concludes the button is broken has just invented a bug. Connecting through the bridge restores real touch, which is why the actual gesture helper works there and not through the server.
+
+If no helper covers what you need, use the server and carry on. Reproduction must not stall waiting for a helper to be written.
+
+## When something breaks
+
+| Symptom | Likely cause |
+| --- | --- |
+| `chrome-devtools` cannot connect | The shared Chrome is not running — start `scripts/shared-chrome.mjs` |
+| The agent's browser and the helpers disagree about what is on screen | `--browser-url` is missing, so the server launched its own browser |
+| Clicking a control does nothing, with no error | Real touch is missing — use the `click` helper through the bridge, not the server |
+| iOS `start_session` hangs or times out | It was pointed at BrowserStack instead of the shim on port 4723 |
+| An HTML `400 Bad Request` from an iOS call | Shim forwarding is broken — capture `/tmp/em-mcp-proxy.log` and stop |
+| An iOS call says the session is not started | The BrowserStack session ended. Check `/tmp/heartbeat-<id>.log`, then re-run `bringup.sh` |
+| A GitHub tool reports an unknown tool name | The server's tool surface changed — check its current tools rather than the skill's wording |
+| Any outbound call hangs with no clear error | The firewall — see [Environment](environment.md#the-firewall) |
+
+## Adding a new one
+
+Four things need doing, and only one of them is in this repository:
+
+1. **Configure the server** in Copilot's settings. Not here. Note any argument that is load-bearing.
+2. **Allow its hosts through the firewall** by adding them to `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS` in [`copilot-setup-steps.yml`](../../.github/workflows/copilot-setup-steps.yml). A blocked host usually presents as a hang rather than a clear failure.
+3. **Add it to `allowed-tools`** in each skill that may use it.
+4. **Write it down here**, including the configuration that lives outside the repository. That is the part nobody can recover by reading the code.
+
+Worth considering before adding one at all: a server's tools are available for the whole session, whereas a skill costs nothing until invoked. If the capability can be reached with a script and a helper, that is usually the cheaper answer.

--- a/docs/agents/readme.md
+++ b/docs/agents/readme.md
@@ -1,0 +1,178 @@
+# Agent Infrastructure
+
+This repository is set up so that GitHub Copilot's cloud coding agent can pick up an issue and work it end to end — reproduce the bug, plan a fix, write it, open a pull request, and keep fixing until CI is green — without a human driving each step.
+
+Making that work takes more than a prompt. It takes a described environment, a browser the agent can actually drive, the project's own test helpers exposed to it, and CI that checks the agent did the honest thing rather than the convenient thing. This folder documents all of it.
+
+We targeted Copilot specifically because the project already runs on GitHub — issues, pull requests, and CI are all here, so the agent lives where the work already is.
+
+| Document                              | What it covers                                                                     |
+| ------------------------------------- | ---------------------------------------------------------------------------------- |
+| This page                             | The map: what the pieces are, what loads when, how a task flows through them       |
+| [Skills](skills.md)                   | Every skill, what each one does, and how they call each other                      |
+| [Environment](environment.md)         | What the runner sets up, how the agent drives a browser, how iOS works             |
+| [MCP servers](mcp.md)                 | The three external tool servers, what each gives the agent, and how they are wired |
+| [The TDD workflow](tdd.md)            | Why regression tests are committed switched off, and what the CI checks mean       |
+
+## The four kinds of file
+
+Everything the agent reads lives under `.github/`. There are four kinds of file, and the difference between them is **when the agent reads them**.
+
+| Kind                    | Where                                    | When it is read                                |
+| ----------------------- | ---------------------------------------- | ---------------------------------------------- |
+| Repository instructions | `.github/copilot-instructions.md`        | Every run, automatically                       |
+| Agent definition        | `.github/agents/worker-bee.agent.md`     | When you assign work to that named agent       |
+| Scoped instructions     | `.github/instructions/*.instructions.md` | Alongside the above                            |
+| Skills                  | `.github/skills/<name>/SKILL.md`         | Only when something invokes that skill by name |
+
+```mermaid
+flowchart TD
+    CI["copilot-instructions.md<br/>persona · environment · methodology"]
+    WB["agents/worker-bee.agent.md<br/>same content, plus a name and description"]
+    INS["instructions/*.instructions.md<br/>code standards · testing rules"]
+    SK["skills/*/SKILL.md<br/>one folder per skill, loaded on demand"]
+    RUN(["The running agent"])
+
+    CI --> RUN
+    WB --> RUN
+    INS --> RUN
+    SK -.invoked by name.-> RUN
+
+    click CI "https://github.com/cybersemics/em/blob/HEAD/.github/copilot-instructions.md" "Open copilot-instructions.md"
+    click WB "https://github.com/cybersemics/em/blob/HEAD/.github/agents/worker-bee.agent.md" "Open worker-bee.agent.md"
+    click INS "https://github.com/cybersemics/em/tree/HEAD/.github/instructions" "Open the instructions folder"
+    click SK "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md" "Every skill, and how they call each other"
+```
+
+The split matters because the agent's attention is finite. Anything in the first three is competing for room on every single run, so it has to earn its place. A skill costs nothing until it is needed, which is why the detailed procedures — how to bring up an iOS device, how to run one test, how to read a CI failure — are skills rather than standing instructions.
+
+### Why there are two near-identical prompt files
+
+From testing, it seems that Copilot more strongly follows custom instructions when they're defined as a **custom agent** than in the `copilot-instructions.md` custom instruction file.
+
+For **the vast majority of development tasks**, we recommend you assign your tasks to the **"🐝 Worker Bee"** coding agent. This'll make sure you're taking advantage of all of the agent optimizations in the project.
+
+However, in some cases, it's **just not possible to assign tasks to a custom agent in Copilot**. For these cases, we keep `copilot-instructions.md` as a backup.
+
+**If you edit one, make the same edit to the other.** Use this command to diff and see if they've drifted:
+
+```bash
+diff <(tail -n +6 .github/agents/worker-bee.agent.md) \
+     <(tail -n +3 .github/copilot-instructions.md)
+```
+
+
+## How a task actually flows
+
+The agent is not allowed to jump straight to writing code. Two **gates** stand in front of implementation — a gate being a step it must complete and then declare out loud, in a fixed wording, before it may continue.
+
+```mermaid
+flowchart TD
+    A["Issue assigned to the agent"] --> B{"Does the issue have<br/>Steps to Reproduce?"}
+    B -- yes --> C["<b>Gate 1</b> — issue-repro skill"]
+    C --> C1["Reproduce the bug in a real browser or device"]
+    C1 --> C2["Write a test that fails,<br/>committed switched off with .skip"]
+    C2 --> D["<b>Gate 2</b> — plan skill"]
+    B -- no --> D
+    D --> D1["Write a plan, quoting the code that already exists"]
+    D1 --> D2["Attack your own plan and revise it"]
+    D2 --> E["Create a branch and implement the fix"]
+    E --> E1["Switch the test back on by removing .skip"]
+    E1 --> F["Open a draft pull request"]
+    F --> G["ci-monitor — wait for every check to finish"]
+    G --> H{"All green?"}
+    H -- no --> I["test-diagnosis — work out what kind of failure it is"]
+    I --> E
+    H -- yes --> K["Done"]
+
+    click C "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#issue-repro" "The issue-repro skill"
+    click C1 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control" "How the browser is brought up"
+    click C2 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md" "Why the test is committed switched off"
+    click D "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#plan" "The plan skill"
+    click D1 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#plan" "What the plan must contain"
+    click D2 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#plan" "The critique stage"
+    click E1 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#why-locally-run-tests-ignore-the-skip" "Switching the test back on"
+    click G "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#ci-monitor" "The ci-monitor skill"
+    click I "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#test-diagnosis" "The test-diagnosis skill"
+```
+
+Both gates exist to stop the same failure. An agent that starts reading source code before it has seen the bug happen will form a theory from the code and then go looking for evidence to support it. Making it reproduce the problem first means it has a real observation to work from. Making it write the plan against quoted, existing code means it extends what is there instead of building something new beside it.
+
+The declarations are literal. After the first gate the agent must print one of these lines exactly:
+
+```
+issue-repro: not applicable — the issue has no Steps to Reproduce.
+issue-repro: applicable — executing .github/skills/issue-repro/SKILL.md before any investigation.
+```
+
+and after the second:
+
+```
+plan: complete — architectural plan produced and critique passed per .github/skills/plan/SKILL.md.
+```
+
+They are there so that a human reading the transcript can see at a glance whether the process was followed, rather than having to infer it. Both prompts also spell out that printing the line does **not** end the agent's turn — an earlier version of this design had agents printing the line and then stopping to wait for a human who was not there.
+
+## Where everything lives
+
+```
+.github/
+├── copilot-instructions.md          Read on every run
+├── agents/
+│   └── worker-bee.agent.md          The named agent; same content
+├── instructions/
+│   ├── code-standards.instructions.md
+│   ├── testing.instructions.md
+│   └── estimate/                    Not a Copilot instruction — see below
+├── skills/                          One folder per skill — see skills.md
+├── actions/
+│   ├── install/                     Cached dependency install
+│   ├── serve/                       Start the built app and wait for it
+│   └── unskip-added-tests/          Switches .skip tests back on — see tdd.md
+└── workflows/
+    ├── copilot-setup-steps.yml      Builds the agent's environment
+    └── tdd.yml                      Checks new tests genuinely fail first
+
+scripts/
+├── shared-chrome.mjs                One Chrome that agent and tests share
+├── start-ios-session.mjs            Opens the BrowserStack iOS session
+└── mcp-session-proxy.mjs            Lets the iOS tooling join that session
+
+src/e2e/
+├── puppeteer/attachExistingBrowserInstance.ts   Web and Android bridge
+└── iOS/attachExistingSession.ts                 iOS bridge
+```
+
+Two workflows are part of this system rather than ordinary CI:
+
+- **[`copilot-setup-steps.yml`](../../.github/workflows/copilot-setup-steps.yml)** builds the environment the agent wakes up in — the display, the browser, the dev server, credentials. It must be named exactly that, and its job must be called `copilot-setup-steps`, or Copilot ignores it. Covered in [Environment](environment.md#what-the-setup-step-builds).
+- **[`tdd.yml`](../../.github/workflows/tdd.yml)** independently verifies that any new test genuinely fails before the fix. Covered in [The TDD workflow](tdd.md#how-the-check-works).
+
+The rest (`test`, `lint`, `puppeteer`, `ios`, the Vercel and Tauri workflows) are normal project CI. The agent has to make them pass, but they were not built for it.
+
+## Things this depends on that are not in the repository
+
+Worth knowing about, because nothing here will tell you when one of them breaks:
+
+- **[MCP server configuration](mcp.md).** An MCP server is an external tool the agent can call. Three matter here: [`chrome-devtools`](mcp.md#chrome-devtools) for driving Chrome, [`wdio`](mcp.md#wdio) for driving iOS, and [the GitHub server](mcp.md#the-github-server) for reading issues and CI runs. They are configured in Copilot's own settings, not in this repository. In particular, `chrome-devtools` must be given `--browser-url=http://127.0.0.1:9222` so that it joins the browser the setup step already started instead of launching a second one.
+- **The pre-built iOS app.** iOS work runs against an app binary uploaded to BrowserStack under the name `em-server-mode`. BrowserStack deletes uploads 30 days after they were last used, and if it lapses, iOS reproduction stops working until someone rebuilds it. Rebuilding it is a manual job on a Mac with Xcode, and nothing warns you before it expires.
+- **Secrets.** `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`, and `OPENAI_API_KEY` are repository secrets.
+- **Network allowances.** The agent runs behind a firewall that blocks outbound traffic by default. Hosts it needs are listed in `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS` in the setup workflow. A new external dependency needs adding there or it will fail in a way that looks like a hang.
+
+## Changing any of this
+
+A few habits that keep it coherent:
+
+- **Edit both prompt files together, and run the diff.** See above. This is the most common mistake.
+
+- **Put procedures in skills, not in the prompts.** If it is a series of steps for a particular situation, it belongs in a skill, where it costs nothing until needed. The prompts should say *when* to reach for something, not *how* to do it.
+
+- **Say why, not just what.** Most of these files explain their own reasoning — why iOS sessions are created outside the tooling, why a raw click silently fails, why a test is committed switched off. That is not padding. An agent that knows the reason handles the case the instructions did not anticipate; one following a rule blindly does something confidently wrong. The same goes for whoever reads this in six months.
+
+- **Check cross-references still hold.** These files refer to each other constantly, and to `docs/` and to real source paths. When you rename or restructure something, grep `.github/` for the old name.
+
+## Related but separate: issue estimation
+
+`.github/instructions/estimate/` contains a prompt and 21 sample issues used to guess how long an issue will take, then sync that to Everhour. Three workflows drive it: on issue open, on an `/estimate` comment, and a manual backfill.
+
+Despite living under `instructions/`, **this is not read by Copilot and is not part of the coding agent.** It is a prompt loaded by a separate Node program in `scripts/estimate/`, which calls OpenAI directly. It is documented in [`scripts/estimate/README.md`](../../scripts/estimate/README.md).

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -1,0 +1,235 @@
+# Skills
+
+A skill is a folder under `.github/skills/` containing a `SKILL.md` file. It holds a procedure for a given situation — how to reproduce a bug, how to run a single test, how to read a failing CI run — and the agent reads it **only when something invokes it by name**.
+
+That "only when invoked" part is the key benefit of skills. Custom instructions are read on every run, and compete for the agent's attention whether or not they are relevant. A skill costs nothing until it is needed, so they can afford to be long and specific.
+
+In general, if you want to add an additional capability to the agent, you should:
+
+- Create a new skill.
+- Reference the skill in custom instructions (Worker Bee, github-instructions)
+
+## The skills
+
+```mermaid
+flowchart TD
+    START(["Agent working an issue"])
+
+    START --> IR["<b>issue-repro</b><br/>reproduce the bug first"]
+    START --> PL["<b>plan</b><br/>plan before writing code"]
+    START --> CM["<b>ci-monitor</b><br/>watch CI to completion"]
+
+    IR --> BC["<b>browser-control</b><br/>picks the platform"]
+    BC --> BCC["<b>browser-control-chrome</b><br/>web · Android"]
+    BC --> BCI["<b>browser-control-ios</b><br/>real iPhone"]
+    IR --> TDD["<b>tdd-write-failing-test</b><br/>turn the repro into a test"]
+    TDD --> RT["<b>run-test</b><br/>run one test for real"]
+    IR --> RT
+
+    CM --> TD["<b>test-diagnosis</b><br/>what kind of failure is this?"]
+    TD --> PUS["<b>puppeteer-update-snapshots</b><br/>regenerate screenshots"]
+
+    style IR fill:#2d4a2d,color:#fff
+    style PL fill:#2d4a2d,color:#fff
+
+    click IR "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#issue-repro" "issue-repro — reproduce before investigating"
+    click PL "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#plan" "plan — plan and critique before implementing"
+    click BC "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control" "browser-control — routes by platform"
+    click BCC "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control-chrome" "browser-control-chrome — web and Android"
+    click BCI "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control-ios" "browser-control-ios — real iPhone"
+    click TDD "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#tdd-write-failing-test" "tdd-write-failing-test — capture the bug"
+    click RT "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#run-test" "run-test — run one test for real"
+    click CM "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#ci-monitor" "ci-monitor — wait for every check"
+    click TD "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#test-diagnosis" "test-diagnosis — classify the failure"
+    click PUS "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#puppeteer-update-snapshots" "puppeteer-update-snapshots — regenerate screenshots"
+```
+
+The two green boxes are the gates — the agent must run them before it is allowed to write code. Everything else it reaches for as needed.
+
+| Skill | What it does | Source |
+| --- | --- | --- |
+| [`issue-repro`](#issue-repro) | Reproduce a reported bug for real, then capture it in a test, before touching the cause | [SKILL.md](../../.github/skills/issue-repro/SKILL.md) |
+| [`plan`](#plan) | Write an architectural plan grounded in existing code, then attack it | [SKILL.md](../../.github/skills/plan/SKILL.md) |
+| [`browser-control`](#browser-control) | Bring up a browser or device for a given platform | [SKILL.md](../../.github/skills/browser-control/SKILL.md) |
+| [`browser-control-chrome`](#browser-control-chrome) | The web and Android half of that | [SKILL.md](../../.github/skills/browser-control-chrome/SKILL.md) |
+| [`browser-control-ios`](#browser-control-ios) | The iOS half — a real iPhone on BrowserStack | [SKILL.md](../../.github/skills/browser-control-ios/SKILL.md) |
+| [`tdd-write-failing-test`](#tdd-write-failing-test) | Turn a reproduction into a permanent test that fails for the right reason | [SKILL.md](../../.github/skills/tdd-write-failing-test/SKILL.md) |
+| [`run-test`](#run-test) | Run one test in the real harness and report what happened | [SKILL.md](../../.github/skills/run-test/SKILL.md) |
+| [`ci-monitor`](#ci-monitor) | Wait for every CI check and report which passed | [SKILL.md](../../.github/skills/ci-monitor/SKILL.md) |
+| [`test-diagnosis`](#test-diagnosis) | Classify a CI failure and decide how to fix it | [SKILL.md](../../.github/skills/test-diagnosis/SKILL.md) |
+| [`puppeteer-update-snapshots`](#puppeteer-update-snapshots) | Regenerate screenshot comparisons after an intended visual change | [SKILL.md](../../.github/skills/puppeteer-update-snapshots/SKILL.md) |
+
+## The gates
+
+### issue-repro
+
+**Source: [`.github/skills/issue-repro/SKILL.md`](../../.github/skills/issue-repro/SKILL.md)**
+
+Runs when an issue contains a "Steps to Reproduce" section, or something close to it like "How to reproduce".
+
+It reads the issue for the steps, the current and expected behaviour, and the platform; hands that platform to [`browser-control`](#browser-control) to bring up a browser or device; follows the steps exactly until the reported failure actually occurs; turns that reproduction into a failing test through [`tdd-write-failing-test`](#tdd-write-failing-test) while it is still fresh; and only then goes looking for the cause. The fix is not finished until that test passes, with a bounded number of attempts before escalating.
+
+Until the failure has actually been observed, the agent may not read source code to form theories, guess at causes, edit files, or open a pull request. That restriction is the entire value of the skill. An agent that reads the code first builds a theory from the code and then finds evidence for it; one that has watched the bug happen is working from an observation.
+
+**Picking the platform** happens from the issue's tags first, then from words in the body:
+
+| Signal | Platform |
+| --- | --- |
+| `[iOS]`, `[Safari]`, or words like "iPhone", "WebKit" | `ios` |
+| `[Android]`, or "Chrome on mobile" | `android` |
+| `[Mobile]`, or general touch words like "tap", "swipe", "on-screen keyboard" | `android`, falling back to `ios` |
+| No platform signal, or desktop words like "click", "hover" | `web` |
+
+`[Mobile]` means Android first because mobile Chrome is far cheaper than a real device and catches nearly all mobile-only behaviour. But if the bug will not reproduce there, it is probably genuinely iOS-specific, so the skill retries on a real iPhone before giving up. An explicit `[Android]` tag gets no such fallback.
+
+The skill is blunt about one thing in particular: **iOS is always reproducible here.** "This needs a physical device" and "I cannot automate iOS" are not acceptable reasons to skip reproduction, because real iPhones are available through BrowserStack. That paragraph exists because agents kept talking themselves out of iOS work.
+
+### plan
+
+**Source: [`.github/skills/plan/SKILL.md`](../../.github/skills/plan/SKILL.md)**
+
+Runs before implementation on anything non-trivial. For a bug with reproduction steps it runs *after* the bug has been reproduced and captured in a test — you cannot judge what a change might break until you have seen what is actually broken.
+
+It is two stages performed by the same agent in one pass. First write the plan, then attack it. There is no separate reviewer.
+
+The load-bearing part is what the plan has to establish before it may propose anything, and the standard of proof it is held to. **Evidence means a `file.ts:120-134` reference with the actual lines quoted** — "I looked at the selectors" does not count.
+
+It has to establish **what already exists** that touches the idea, found by reading the relevant files in `docs/` and then grepping the source, and recorded with what each piece quietly *assumes* as well as what it does — a regex anchored to the start of a string only handles the leading case, and building a whole-string scanner next to it is both wasted work and a bug. It has to decide **extend or build new** against that evidence, with extending as the default and a new path needing a defended reason; "it was easier to write fresh" is not one. And it has to enumerate **what else might break** — for anything touching the editor, that means explicitly considering deletion, text selection, caret position, undo, IME composition, copy and paste, gestures, and multi-cursor, because changing one path in an editor routinely breaks its neighbour.
+
+Beyond that it compares more than one approach, to break first-instinct lock-in, and sketches where the change will live in plain words rather than code.
+
+Then the critique stage re-opens the cited files and checks the quotes really say what the plan claimed, tries to defeat any decision to build something new, names an adjacent behaviour the plan glossed over, and checks nothing contradicts the design intent recorded in `docs/`. If any check fails, revise and critique again.
+
+The skill names the ways this goes wrong: filling in plausible sections with no quoted evidence, writing a plan and then building something else, and over-planning a change smaller than the plan.
+
+## Driving the app
+
+### browser-control
+
+**Source: [`.github/skills/browser-control/SKILL.md`](../../.github/skills/browser-control/SKILL.md)**
+
+A router, not a driver. The caller passes in a platform, and this skill checks the dev server is alive, then hands off to the right sub-skill: `web` and `android` go to Chrome, `ios` goes to the iPhone. It will not guess the platform — if the caller has not said, it stops and asks, because loading the app under the wrong profile fails in confusing ways rather than obvious ones.
+
+It also defines the rule that governs every interaction with the app, which is the most important idea in the whole ecosystem:
+
+> **Observing is free. Acting goes through the project's own test helpers.**
+
+Reading state — running a script, inspecting the page, taking a screenshot, checking the console — can use any available tool. But anything that *drives* the app — tapping a thought, a toolbar button, a menu item, typing, gestures, selecting text — must go through the helpers in `src/e2e/<platform>/helpers/`, the same ones the test suite uses.
+
+Two reasons. Those helpers already encapsulate details that are easy to get wrong by hand. And a reproduction built out of helper calls converts into a real test almost for free, which is exactly what the next skill needs.
+
+There is one trap that makes this non-negotiable. The app's buttons respond to **touch** events under mobile emulation. A plain mouse click does nothing at all — no error, no effect, no warning. An agent that clicks a button and sees nothing happen will conclude the button is broken and go hunting for a bug that does not exist. The `click` helper taps correctly for the platform. A tap is not "simple enough to do by hand" just because it is a tap.
+
+If no helper covers what is needed, the instruction is to drive it directly and keep going. Reproduction must not stall waiting for a helper to be written. The rule is only about not re-implementing a helper that already exists.
+
+### browser-control-chrome
+
+**Source: [`.github/skills/browser-control-chrome/SKILL.md`](../../.github/skills/browser-control-chrome/SKILL.md)**
+
+Handles web and Android. Chrome is already running from the setup step, exposing a debugging port that both the agent's tooling and the test helpers connect to, so they drive the same browser.
+
+For Android, mobile emulation must be applied **before navigating**, not after. The app checks the device profile once when it loads, so navigating first and emulating second produces a desktop layout wearing a mobile user agent. Gestures also need touch, so this is not optional for gesture work.
+
+After navigating, wait for the app to actually appear before touching anything. The page returns before React has finished starting, and reaching for an element too early finds an empty page.
+
+### browser-control-ios
+
+**Source: [`.github/skills/browser-control-ios/SKILL.md`](../../.github/skills/browser-control-ios/SKILL.md)**
+
+Runs the real Capacitor app on a real iPhone through BrowserStack, exposing both the native layer and the web layer in one session.
+
+The default is to work in the web layer, because it is the same page as every other platform. Drop to the native layer only for things that do not exist in the page — the keyboard, text-selection handles, the share sheet, system dialogs — and for screenshots, which should always be native so they capture the whole device screen.
+
+The session is created by a shell script rather than by the tooling, and the reason is worth knowing: BrowserStack takes 20 to 40 seconds to allocate a physical iPhone, and that wait can exceed a fixed timeout in the tooling that cannot be configured. So the session is created by a detached background process that writes its ID to a file, a heartbeat keeps it alive, and a small local proxy lets the tooling adopt the already-running session instantly. Full detail in [Environment](environment.md).
+
+One real limitation: **autocorrect cannot be tested.** Shared BrowserStack devices have iOS auto-correction switched off and it cannot be enabled. Bugs that depend on the live autocorrect engine cannot be reproduced and should be escalated.
+
+## Testing
+
+### tdd-write-failing-test
+
+**Source: [`.github/skills/tdd-write-failing-test/SKILL.md`](../../.github/skills/tdd-write-failing-test/SKILL.md)**
+
+Turns a fresh reproduction into a permanent test, before the bug is fixed. The project's rule is that every bug fix ships with a test.
+
+The conversion is mostly mechanical, which is why it happens immediately: the reproduction was already built from the same helpers the test will use. Drop the line that connects to the live browser, since the test framework supplies that, and add an assertion.
+
+**Always assert what the fixed behaviour should be**, never the buggy one. The reproduction handed over both numbers — the broken value observed and the correct value the issue asked for — so writing `expect(opacity).toBe('1')` fails now and passes after the fix with no inverted logic anywhere.
+
+The test is committed **switched off**, as `it.skip`. That is the subtle part of this system and it has its own page: [The TDD workflow](tdd.md).
+
+Then the gate. Run the new test against the unfixed code, and it must fail **on the assertion**, showing the broken value:
+
+- Fails on the assertion with the expected-versus-actual values from the reproduction → good, carry on.
+- Fails on a timeout, a missing element, or a setup error → **the test is wrong, not the code.** Fix the test and try again.
+
+A test that errors for the wrong reason is the most dangerous outcome available here, because it looks exactly like coverage while proving nothing at all.
+
+### run-test
+
+**Source: [`.github/skills/run-test/SKILL.md`](../../.github/skills/run-test/SKILL.md)**
+
+Runs one test — a file, or a single case by name — in the real test harness, and reports what happened. Not through the interactive browser tooling; through the actual runner, which handles starting the app and resetting between tests.
+
+It has one rule that exists purely to prevent a specific lie. Regression tests are committed switched off, and a runner asked to run a switched-off test reports "0 tests run" — which on a quick read looks exactly like passing. So **run-test always switches the test back on for the run**, then restores the file afterwards. If the result says skipped, that is not a pass, it is a mistake.
+
+When reporting a failure it must say which kind it is, because callers act on the difference:
+
+- **An assertion failed** — a real result about behaviour. Report the expected and actual values.
+- **Something broke** — a timeout, a missing element, a driver or Docker problem. Not a result about behaviour at all; the test or the environment is wrong.
+
+### puppeteer-update-snapshots
+
+**Source: [`.github/skills/puppeteer-update-snapshots/SKILL.md`](../../.github/skills/puppeteer-update-snapshots/SKILL.md)**
+
+Regenerates the stored screenshots that visual tests compare against. Deliberately hedged about, because it is the single easiest way for an agent to make a real failure disappear: a test says the UI changed, and regenerating the screenshot makes the complaint go away without anyone finding out whether the change was wanted.
+
+So: only use it when the visual change was intentional, never to silence a failure, and always explain to the user why it seemed necessary.
+
+## Handling CI
+
+### ci-monitor
+
+**Source: [`.github/skills/ci-monitor/SKILL.md`](../../.github/skills/ci-monitor/SKILL.md)**
+
+Lists the workflow runs for the current branch and waits for all of them to finish before reporting. Derives the repository from the git remote rather than assuming, and filters by the current branch.
+
+Its central instruction: **never claim tests pass without checking.** The skill says outright that hallucinating test results is the worst thing it can do. If CI still fails after five fix-and-push cycles, stop and hand back to a human.
+
+### test-diagnosis
+
+**Source: [`.github/skills/test-diagnosis/SKILL.md`](../../.github/skills/test-diagnosis/SKILL.md)**
+
+Sorts a CI failure into one of: a build error, a lint or formatting error, a failed unit test, a mismatched screenshot, a timeout, or a known flaky test. Then fixes them in that order — nothing else matters if the code does not build, and lint failures are quick and mechanical.
+
+The rule that matters most is for failing tests: **fix the code, not the test**, unless you are genuinely certain the test is wrong. Never edit a test into passing without understanding why it failed.
+
+For suspected flakiness it checks the project's open issues labelled "test" for known cases. If a test looks flaky but is not on that list, stop and say so rather than deciding for yourself.
+
+## Writing a new skill
+
+Create `.github/skills/<name>/SKILL.md` starting with frontmatter:
+
+```yaml
+---
+name: my-skill
+description: >-
+  ALWAYS USE THIS SKILL when <the situation>. <What it does.>
+allowed-tools:
+  - bash
+---
+```
+
+- **`name` must match the folder name**, and that is what callers use to invoke it. A mismatch or a typo means the skill is simply never found.
+- **`description` is how the agent decides whether this applies.** It is read when the skill is *not* loaded, so it must describe the triggering situation, not the procedure. Several existing skills open with `ALWAYS USE THIS SKILL when…` to make the trigger unmissable.
+- **`allowed-tools`** lists what the skill may use — `bash`, `chrome-devtools`, `wdio`.
+
+Beyond the frontmatter, patterns worth copying from the existing ones:
+
+**Explain the reasoning, not just the steps.** Nearly every skill here says why. The [`plan`](#plan) skill opens by naming the failure it exists to prevent. [`browser-control`](#browser-control) explains why a raw click silently fails. An agent that understands the reason handles the situation the steps did not anticipate.
+
+**Name the ways it goes wrong.** `plan` lists three failure modes by name; [`tdd-write-failing-test`](#tdd-write-failing-test) describes exactly what a wrongly-failing test looks like. Naming a trap is how you stop an agent walking into it.
+
+**Say what to do when stuck.** Every skill ends with escalation rules, and most end with the same line: default to acting on your own, escalate only when the right path is genuinely unclear. Without that, agents either stop constantly or never stop at all.
+
+**Split large skills by what the caller needs.** `browser-control` routes to a Chrome half and an iOS half so that a web task never loads several hundred lines about BrowserStack.

--- a/docs/agents/tdd.md
+++ b/docs/agents/tdd.md
@@ -1,0 +1,142 @@
+# The TDD workflow
+
+Every bug fix in this project should ship with a test. That much is ordinary. The part that surprises people is that **the test is committed switched off**, and that a CI check exists whose whole job is to confirm the test *fails*.
+
+This is the most confusing part of the agent setup, and the part most likely to be misread by a human skimming a pull request. It is worth ten minutes.
+
+## The problem it solves
+
+A test written to capture a bug has to fail before the fix and pass after it. If it passes before the fix, it is not testing the bug — it is testing something that already worked, and it will never catch a regression.
+
+Checking that automatically means running the new test against the code *without* the fix and requiring it to fail. Which creates two problems at once:
+
+- **A legitimately failing test makes CI red.** The agent is told to work until CI is green. A red check that is supposed to be red puts it in a loop, "fixing" a test that was correct.
+- **A test that passes on the unfixed code is worthless**, and nothing ordinarily notices.
+
+The `.skip` protocol solves both. The test is committed switched off, so the normal suite ignores it and stays green. A separate check switches it back on, runs it against the unfixed code, and requires failure.
+
+## The life of a regression test
+
+```mermaid
+stateDiagram-v2
+    [*] --> Reproduced: bug reproduced in a real browser
+    Reproduced --> Written: test written asserting the CORRECT behaviour
+    Written --> Proven: run locally against unfixed code — must fail on the assertion
+    Proven --> Committed: committed as it.skip
+    Committed --> Validated: TDD check switches it on, runs it on the base branch
+    Validated --> Fixed: fix implemented, .skip removed
+    Fixed --> [*]: normal suite runs it and it passes
+```
+
+Written switched off, so nothing goes red early. Switched on temporarily by the check that proves it captures a real bug. Switched back on for good when the fix lands.
+
+**A test must never be merged still switched off.** A permanently skipped test gives no protection at all. The skip is temporary scaffolding, removed when the fix arrives.
+
+## The two checks mean opposite things
+
+This is the bit that catches people out.
+
+```mermaid
+flowchart TD
+    T["A new regression test"]
+
+    T --> A["<b>TDD check</b><br/>runs it on the base branch,<br/>which does not have the fix"]
+    T --> B["<b>Normal test suite</b><br/>runs it on your branch,<br/>which does have the fix"]
+
+    A --> A1["Fails ✅<br/>good — it really does catch the bug"]
+    A --> A2["Passes ❌<br/>bad — it does not test the bug at all"]
+
+    B --> B1["Passes ✅<br/>good — the fix works"]
+    B --> B2["Fails ❌<br/>bad — the code is still broken"]
+
+    style A1 fill:#2d4a2d,color:#fff
+    style B1 fill:#2d4a2d,color:#fff
+    style A2 fill:#5a2d2d,color:#fff
+    style B2 fill:#5a2d2d,color:#fff
+```
+
+So **"CI failed" does not on its own mean the bug is unfixed.** You have to look at which check failed:
+
+- **The TDD check is red** — the new test passes on code without the fix. The test is not actually testing the reported bug. Fix the test.
+- **The normal suite is red** — something is genuinely broken. Fix the code.
+
+Both prompt files and the [`tdd-write-failing-test`](skills.md#tdd-write-failing-test) skill spell this out, because an agent that misreads it will "fix" a perfectly good test until it stops catching anything.
+
+## How the check works
+
+[`.github/workflows/tdd.yml`](../../.github/workflows/tdd.yml) runs on every pull request in four stages.
+
+```mermaid
+flowchart TD
+    D["<b>detect</b><br/>Which test files changed, and do they add new tests?"]
+    D --> U["<b>unit</b>"]
+    D --> P["<b>puppeteer</b>"]
+    D --> I["<b>ios</b>"]
+    U --> S["<b>summary</b><br/>one check for branch protection"]
+    P --> S
+    I --> S
+
+    click D "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#how-the-check-works" "What detect classifies"
+    click U "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#how-the-check-works" "The unit job"
+    click P "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#how-the-check-works" "The puppeteer job"
+    click I "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#how-the-check-works" "The iOS job"
+    click S "https://github.com/cybersemics/em/blob/HEAD/docs/agents/tdd.md#escape-hatches" "The single check, and how to skip it"
+```
+
+**detect** compares the pull request against the point it branched from, and sorts changed test files into unit, puppeteer, and iOS. It then filters twice: to files that actually add new test cases, and to files that add switched-off ones. That first filter matters — editing the inside of an existing test should not trigger any of this.
+
+It then decides whether to skip. It skips if no test files changed; if the pull request carries a `skip-tdd` label; or if *only* test files changed with no application code, which usually means someone is adding coverage for behaviour that already works. That last exemption does not apply when switched-off tests were added, since those are exactly the ones that need validating.
+
+**unit, puppeteer, ios** each do the same thing for their kind of test:
+
+1. Check out the base branch — the code *without* the fix.
+2. Copy just the changed test files across from the pull request.
+3. Switch any newly-added skipped tests back on, via [`.github/actions/unskip-added-tests`](../../.github/actions/unskip-added-tests/action.yml).
+4. Run them, and **require them to fail.**
+
+Step 2 copies the test files individually rather than applying a patch, because a brand-new test file has nothing on the base branch to patch against.
+
+**summary** collapses the three into a single check, so branch protection has one thing to require.
+
+### Escape hatches
+
+| Label | Effect |
+| --- | --- |
+| `skip-tdd` | Skip all of it |
+| `skip-tdd-unit` | Skip only unit tests |
+| `skip-tdd-puppeteer` | Skip only puppeteer tests |
+| `skip-tdd-ios` | Skip only iOS — worth its own switch, since it costs real device time |
+
+There is also `/tdd <commit>` at the start of a line in the pull request description, which runs the tests against that commit instead of the branch point. Useful when the branch point is not the right comparison — for instance when the fix arrived before the test.
+
+The legitimate reason to reach for a label is adding coverage for behaviour that already works. Such a test *should* pass on the base branch, so the check flagging it is correct, and the label is how you say so.
+
+## Why locally run tests ignore the skip
+
+The [`run-test`](skills.md#run-test) skill always switches a test on before running it, then puts the file back.
+
+Without that, asking a runner to run a switched-off test gets you "0 tests run" — which reads almost exactly like a pass. An agent validating its own work would take that as success and move on with a test that never executed.
+
+**A result of "skipped" is never a pass.** If `run-test` reports the test as skipped, the un-skipping failed.
+
+## Writing the test itself
+
+Handled by the [`tdd-write-failing-test`](skills.md#tdd-write-failing-test) skill; the essentials:
+
+**One test for the reported bug.** If an issue lists several ways to trigger the same underlying problem, pick one. They share a cause, and one test proves the fix.
+
+**Assert the correct behaviour, never the broken one.** The reproduction gives you both numbers — what it does and what it should do. Assert the second. It fails now and passes later with no clever inversion.
+
+**Reuse the reproduction's helper calls.** Same helpers, same order. Strip out the exploratory poking. The test is the minimal repeatable form of the reproduction, not a transcript of the investigation.
+
+**Label it with just the issue URL.** One bare comment above the test:
+
+```ts
+// https://github.com/cybersemics/em/issues/4331
+```
+
+No "regression test" label — it is just a test — and no comment explaining the skip, which is temporary and should leave no trace once removed.
+
+**Adding a test hook is fine; changing behaviour is not.** If the element being asserted on has no sensible way to identify it, add a minimal `data-testid` in the source and commit it with the test. That is part of writing the test, not part of the fix, so it is allowed before the planning gate. Prefer an existing meaningful selector where one exists.
+
+**Prove it fails for the right reason before going any further.** The test must fail *on the assertion*, showing the broken value the reproduction found. Failing on a timeout or a missing element means the test is wrong, not that the bug is confirmed — and that is the dangerous case, because it looks like coverage while proving nothing.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,6 +12,10 @@ The in-repo documentation for **em**. The GitHub wiki is being deprecated in fav
 - [Drag and Drop](drag-and-drop.md) — react-dnd integration and drop targets.
 - [Layout Rendering](layout-rendering.md) — How thoughts are positioned in the absolute-flat-list layout, including the autocrop / vertical-autocrop mechanism.
 
+## Agents
+
+- [Agent Infrastructure](agents/readme.md) — How coding agents work on this repo: what the Copilot cloud agent reads, the skills they run, the environment and MCP servers behind them and the TDD workflow.
+
 ## Reference
 
 - [Glossary](glossary.md) — Project-specific terms (cliff, autofocus, lexeme, tangential context, tsid, …) with cross-links to the deeper docs. Start here if you encounter unfamiliar vocabulary.


### PR DESCRIPTION
**Chained PR — review and merge in this order:**

1. #4765 — unify the two agent prompt files _(base `main`; merge first)_
2. #4766 — document the agent infrastructure ← **this PR**
3. #4767 — the end-session exit gate and docs-sync
4. #4768 — share skills with Codex, Claude Code, and other harnesses
5. #4773 — standardize agent commit attribution

Every PR except #4765 targets the branch above it, so each diff shows only its own changes. As each one merges, GitHub retargets the next to `main` automatically. Merging out of order lands the change on a feature branch rather than `main`.

---

Pretty much all of our agent infrastructure — browser control, TDD, skills — was undocumented, which makes it hard to make sense of.

`docs/agents/` now comprehensively covers the agent custom instructions and when each is read, the skills and how they call each other, what the Copilot cloud runner provisions, the MCP servers, the custom WDIO shim, and the TDD workflow. Includes diagrams throughout, since the flow is difficult to reason about in prose alone and lives only in our heads.

Documentation is key to steering agents, so it's worth getting right — this is the reference the rest of the stack builds on.

Also folds in a small `.gitignore` change: `docs/.obsidian` (per-user state when `docs/` is opened as an Obsidian vault) and a `/.local` scratch folder for throwaway files that should never be committed. Often agents will write out artifacts while working, and the `.local` folder gives them (and humans) a space to do so without cluttering up the working tree.

(Note that the `.local` folder *is not committed* – it's just pre-emptively .gitignored.)

No application code changes.