### PR TITLE
feat: share skills with Codex, Claude Code, and other harnesses

### DIFF
--- a/.agents/skills/ci-monitor
+++ b/.agents/skills/ci-monitor
@@ -1,0 +1,1 @@
+../../.github/skills/ci-monitor

--- a/.agents/skills/docs-sync
+++ b/.agents/skills/docs-sync
@@ -1,0 +1,1 @@
+../../.github/skills/docs-sync

--- a/.agents/skills/end-session
+++ b/.agents/skills/end-session
@@ -1,0 +1,1 @@
+../../.github/skills/end-session

--- a/.agents/skills/plan
+++ b/.agents/skills/plan
@@ -1,0 +1,1 @@
+../../.github/skills/plan

--- a/.agents/skills/puppeteer-update-snapshots
+++ b/.agents/skills/puppeteer-update-snapshots
@@ -1,0 +1,1 @@
+../../.github/skills/puppeteer-update-snapshots

--- a/.agents/skills/tdd-write-failing-test
+++ b/.agents/skills/tdd-write-failing-test
@@ -1,0 +1,1 @@
+../../.github/skills/tdd-write-failing-test

--- a/.agents/skills/test-diagnosis
+++ b/.agents/skills/test-diagnosis
@@ -1,0 +1,1 @@
+../../.github/skills/test-diagnosis

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/skills/ci-monitor/SKILL.md
+++ b/.github/skills/ci-monitor/SKILL.md
@@ -19,6 +19,7 @@ allowed-tools:
   }
   ```
 
+- **In a local harness**, where that MCP server is not present, the `gh` CLI is the equivalent: `gh run list --branch "$(git rev-parse --abbrev-ref HEAD)"` to list, and `gh run view <id> --log-failed` to pull the failing log. Everything below applies unchanged — only the mechanism differs.
 - Wait for ALL in-progress runs to complete before reporting status. Never claim tests pass without actually checking.
 - For each workflow, report: passed, failed, or still running.
 - For failed workflows, pull the relevant log section showing the error.

--- a/.github/skills/docs-sync/SKILL.md
+++ b/.github/skills/docs-sync/SKILL.md
@@ -58,7 +58,7 @@ Noisy, and worth skimming rather than trusting wholesale — but it finds every 
 | [`commands.md`](../../docs/commands.md) | `src/commands/**`, `src/commands.ts` | You add, remove, or change a command, its shortcut, or the command system itself |
 | [`glossary.md`](../../docs/glossary.md) | The project's vocabulary, across all of `src/` | You introduce, rename, or retire a term of art — anything a newcomer would have to look up |
 | [`testing.md`](../../docs/testing.md) | `src/e2e/**`, `src/test-helpers/**`, `src/setupTests.js` | Helper contracts, test patterns, platforms, or runners change |
-| [`agents/*.md`](../../docs/agents/) | `.github/skills/**`, `.github/agents/**`, `.github/copilot-instructions.md`, `.github/workflows/copilot-setup-steps.yml`, `.github/workflows/tdd.yml`, the `scripts/` the agent depends on (`*.mjs`, `*.sh`) | Anything about how the agent works changes — a skill, the prompts, the environment, the MCP wiring |
+| [`agents/*.md`](../../docs/agents/) | `.github/skills/**`, `.github/agents/**`, `.github/copilot-instructions.md`, `AGENTS.md`, `.agents/**`, `.github/workflows/copilot-setup-steps.yml`, `.github/workflows/tdd.yml`, the `scripts/` the agent depends on (`*.mjs`, `*.sh`) | Anything about how any agent works changes — a skill, either entry point, which skills are shared, the environment, the MCP wiring |
 
 **A changed file that matches no row is a finding, not a pass.** Either the document that should describe that area does not exist — say so in your report, and do not invent one on the spot — or this table is missing a row, in which case add it here as part of your change.
 

--- a/.github/skills/end-session/SKILL.md
+++ b/.github/skills/end-session/SKILL.md
@@ -111,7 +111,7 @@ Use `ci-monitor`. Wait for every run on the branch to complete; do not report on
 
 ## Step 6: The pull request is in order
 
-- A draft PR exists for the branch, created with the `runtime-tools-create_pull_request` tool.
+- A draft PR exists for the branch. On Copilot, create it with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open one. In a local harness, where that tool does not exist, `gh pr create --draft` is the equivalent.
 - Its description starts with the bare issue number (e.g. `#1234`), with the architectural plan from the `plan` skill below it.
 - Its title and summary describe what actually landed — not what you set out to do three fixes ago.
 

--- a/.github/skills/test-diagnosis/SKILL.md
+++ b/.github/skills/test-diagnosis/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: test-diagnosis
-description: Use this skill when CI checks have failed. It analyzes the failure logs, identifies the specific failing test or build step, categorizes the failure type, and provides guidance on how to fix it. Use in combination with the CI Monitor skill.
+description: Use this skill when a test run has failed — a CI check, or a suite run locally. It analyzes the failure output, identifies the specific failing test or build step, categorizes the failure type, and provides guidance on how to fix it. In CI, use in combination with the CI Monitor skill.
 allowed-tools:
   - bash
 ---
 
 ## Diagnosing Failures
 
-When a CI run fails:
+When a run fails:
 
-1. Pull the logs for the failed step.
+1. Get the failure output. In CI, pull the logs for the failed step — `ci-monitor` reports which one. Running locally, read the runner output directly.
 2. Identify the specific failure: which test, what assertion, what error message.
 3. Categorize the failure as one of:
    - **Build error** — compilation or bundling failed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+**em** is a TypeScript/React/Redux web app that runs as a PWA or through Capacitor on mobile, and as a PWA or through Tauri on desktop.
+
+## Working in this repo
+
+**1. Reproduce before theorising.** If you are fixing reported behaviour, try observing the failure yourself before making assumptions. An agent that starts from the code builds a theory and then finds evidence for it; one that has watched the thing fail is working from an observation.
+
+**2. Suggest `end-session` when the work is wrapping up.** As the user starts to finish — pushing, opening a pull request, handing the change on — offer executing `end-session` to the user. It checks that documentation still describes reality, that nothing is uncommitted or unpushed, that no test was left switched off, and that anything claimed was actually observed.
+
+## Accessing documentation
+
+- `docs/` contains comprehensive documentation on the codebase. Start from [`docs/readme.md`](docs/readme.md), which indexes every subsystem doc.
+- `grep` across `docs/**/*.md` when investigating, and keep querying it — especially when you meet something you do not understand. [`docs/glossary.md`](docs/glossary.md) defines the project's vocabulary; if a term is unfamiliar, resolve it there first.
+- **Documentation is a two-way obligation: you read it, and you keep it true.** When a change makes something in `docs/` wrong, `docs-sync` will find and repair it — on its own if you invoke it, or as the first step of `end-session`. Landing the doc fix in the same commit as the change is what keeps the two from drifting apart.
+- This matters more here than in most projects, because `docs/` is the fastest way into an unfamiliar subsystem — for you, for the next person, and for the next agent, which may plan a change against whatever it says. Docs describe how the project works **now**, not how it changed, so a doc your change outdated is better rewritten than annotated with what it used to say.
+
+## Code standards
+
+See [`.github/instructions/code-standards.instructions.md`](.github/instructions/code-standards.instructions.md) and [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md). These describe the conventions the codebase follows. 
+
+Testing guidance lives in [`docs/testing.md`](docs/testing.md) — read it in full before writing tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agents/external-agents.md
+++ b/docs/agents/external-agents.md
@@ -1,0 +1,106 @@
+# External agents
+
+Everything else in this folder describes the GitHub Copilot cloud agent. This page describes the other half: **agents running on a developer's own machine** — Codex, Claude Code, or anything else that reads a repository-level instruction file.
+
+They are two environments that deliberately share their procedures. A cloud agent wakes up in a runner where the dev server is already listening, Chrome is already up on a debugging port, and BrowserStack credentials are already in the environment. None of that is true on a laptop. But *how to plan a change*, *how to write a test that fails for the right reason*, and *how to end a session honestly* do not depend on any of it.
+
+The environments are separate; the instruction files are not. The cloud agent reads the local entry point as well as its own, which constrains how that file can be written.
+
+## The two entry points
+
+| | Cloud agent | Local agent |
+| --- | --- | --- |
+| Reads | `.github/copilot-instructions.md`, `.github/agents/worker-bee.agent.md`, `.github/instructions/*` — **and `AGENTS.md` and `CLAUDE.md`** | `AGENTS.md` (Claude Code via `CLAUDE.md` → symlink) |
+| Skills in | `.github/skills/` | `.agents/skills/` → symlinks → `.github/skills/` |
+| Browser work | Yes — provisioned Chrome and real iPhones | No |
+
+The cloud agent's row is the surprising one, and it shapes everything below — see [Copilot reads AGENTS.md too](#copilot-reads-agentsmd-too).
+
+```mermaid
+flowchart TD
+    subgraph cloud["Copilot cloud agent"]
+        CI["copilot-instructions.md"]
+        WB["agents/worker-bee.agent.md"]
+    end
+    subgraph local["Local harness"]
+        AG["AGENTS.md"]
+        CL["CLAUDE.md"]
+        CL -.symlink.-> AG
+    end
+    SK[".github/skills/*/SKILL.md<br/>the actual procedures"]
+    AS[".agents/skills/"]
+    CS[".claude/skills"]
+
+    CS -.symlink.-> AS
+    AS -.symlinks.-> SK
+    CI --> SK
+    WB --> SK
+    AG --> AS
+    CI -.also reads,<br/>lowest precedence.-> AG
+
+    click SK "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md" "What each skill does"
+    click CI "https://github.com/cybersemics/em/blob/HEAD/.github/copilot-instructions.md" "Open copilot-instructions.md"
+    click AG "https://github.com/cybersemics/em/blob/HEAD/AGENTS.md" "Open AGENTS.md"
+```
+
+`AGENTS.md` is the canonical local entry point and `.agents/skills/` the canonical local skill directory. Claude Code's `CLAUDE.md` and `.claude/skills` are symlinks onto them, so a Claude Code session and a Codex session read byte-identical instructions. Both tools follow symlinks.
+
+The `CLAUDE.md` symlink is required, not decorative: Claude Code does **not** read `AGENTS.md` natively, and `ln -s AGENTS.md CLAUDE.md` is Anthropic's own documented workaround.
+
+## Copilot reads AGENTS.md too
+
+This was designed on the assumption that the two entry points were read by two different agents. That assumption was wrong, and it is worth stating plainly because it constrains how `AGENTS.md` can be written.
+
+Since August 2025 the Copilot coding agent reads `AGENTS.md` — and `CLAUDE.md`, and `GEMINI.md` — [alongside](https://github.blog/changelog/2025-08-28-copilot-coding-agent-now-supports-agents-md-custom-instructions/) its own files. They are **combined, not overridden**: "all sets of relevant instructions are provided to Copilot", in [this order of precedence](https://docs.github.com/en/copilot/concepts/response-customization):
+
+1. Path-specific — `.github/instructions/*.instructions.md`
+2. Repository-wide — `.github/copilot-instructions.md`
+3. Agent instructions — `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`
+
+There is no documented way to switch that off, so this cannot be solved by exclusion. Two consequences follow.
+
+**Every statement in `AGENTS.md` has to be true for the cloud agent as well.** An early draft opened by declaring that the Copilot agent does not read the file, and elsewhere stated that the browser and device skills were unavailable. Copilot would have read both as being about itself — and the second is precisely the belief [`issue-repro`](skills.md#issue-repro) exists to fight, since agents talk themselves out of iOS work given any excuse. Anything environment-specific belongs in the Copilot files, which the cloud agent reads at higher precedence anyway.
+
+**`AGENTS.md` is deliberately the softer document.** It describes rather than dictates, because a developer's own machine is their own workflow — branch naming, commit granularity, and when to run what are not this file's business. That register is safe *because* of the precedence order: the strict forms of the rules that protect shared state, like the exit gate and the documentation obligation, are stated independently in `.github/copilot-instructions.md`, which outranks this file. The rule to remember when editing: **do not soften something only `AGENTS.md` says**, or the cloud agent inherits the soft version by default.
+
+Because `CLAUDE.md` is a symlink, Copilot ingests the same content twice, once under each name. That is wasteful rather than harmful, and it is the price of Claude Code support.
+
+## Why the skills are symlinked rather than copied
+
+This repository has twice been bitten by the same defect: content duplicated across two files that then quietly disagreed. First the two Copilot prompt files, which drifted over several commits and had to be re-unified. Then `docs/agents/skills.md`, which restated each skill's steps and went stale the moment a step was added.
+
+A symlink makes that failure impossible rather than merely detectable. There is one file. Editing it from either side edits both, and there is no diff to remember to run.
+
+That is also why a skill needing slightly different behaviour per harness gets **one clause**, not a fork:
+
+> A draft PR exists for the branch. On Copilot, create it with the `runtime-tools-create_pull_request` tool — do not shell out to `git` or `gh` to open one. In a local harness, where that tool does not exist, `gh pr create --draft` is the equivalent.
+
+The skill states *what* must be true and lets a single clause carry *how* per environment. A forked hundred-and-fifty-line skill would drift; a two-clause sentence will not.
+
+## What is shared, and what is not
+
+**Shared** — [`plan`](skills.md#plan), [`tdd-write-failing-test`](skills.md#tdd-write-failing-test), [`test-diagnosis`](skills.md#test-diagnosis), [`puppeteer-update-snapshots`](skills.md#puppeteer-update-snapshots), [`ci-monitor`](skills.md#ci-monitor), [`docs-sync`](skills.md#docs-sync), [`end-session`](skills.md#end-session).
+
+Three of those needed a per-harness clause. `end-session` and `ci-monitor` name a Copilot tool that has no local equivalent — opening a pull request, listing workflow runs — and now name the `gh` command alongside it. `test-diagnosis` was written as though a failure could only arrive from CI; its trigger now covers a suite run locally, where the output is already on screen rather than in a log to be fetched.
+
+The rest of it was portable untouched. `puppeteer-update-snapshots` turned out to be the *most* local skill in the set — its command explicitly unsets `GITHUB_ACTIONS` so that the Docker and Vite setup runs, which is exactly the local path.
+
+**Not shared** — [`browser-control`](skills.md#browser-control) and its Chrome and iOS halves, [`issue-repro`](skills.md#issue-repro), and [`run-test`](skills.md#run-test).
+
+These depend on things the runner provides: Chrome already listening on a debugging port, a dev server already up, BrowserStack credentials, and MCP servers configured outside this repository. `issue-repro` and `run-test` are not conceptually cloud-only — reproduce before theorising, and never let a skipped test's "0 tests run" masquerade as a pass, are good rules anywhere — but both delegate to `browser-control`, so adapting them means solving the local browser story first. `AGENTS.md` states the reproduce-first principle in prose instead, so the discipline survives even though the skill does not.
+
+One idea inside `browser-control` is worth knowing wherever you drive this app, because it is a property of **em** rather than of any harness: *observing is free, but actuating goes through the project's own e2e helpers*, since em's controls use `fastClick` and a raw mouse click silently no-ops under touch emulation. It has not been extracted into a shared skill — do that if it starts causing trouble locally.
+
+## Changing any of this
+
+**Adding a skill to the shared set** is one symlink:
+
+```bash
+ln -s ../../.github/skills/<name> .agents/skills/<name>
+```
+
+Then add a row to the table in `AGENTS.md`, and update the shared list on this page. Check first that the skill names no cloud-only tool or provisioned resource — and if it names one in a single line, prefer the one-clause treatment above to leaving it out.
+
+**The two prompt files are not symlinked to each other, and should not be.** `AGENTS.md` and `.github/copilot-instructions.md` genuinely differ: one describes an environment that is already running, the other an environment you have to start, and one dictates where the other suggests. Their overlap is the parts already delegated to skills. Do not try to unify them — unify the procedures they both call instead. Remember that the cloud agent reads *both*, so they must not contradict each other, only differ in what they cover.
+
+**`allowed-tools` is an open question.** Every skill declares it with Copilot's vocabulary — `bash`, and the MCP *server* names `chrome-devtools` and `wdio`. Claude Code expects its own tool names, and none of the skills installed locally on any developer machine here use the field at all. Whether an unrecognised value is ignored or is treated as a restriction granting nothing has not been tested. If a shared skill behaves as though it has no tools, this is the first thing to check.

--- a/docs/agents/readme.md
+++ b/docs/agents/readme.md
@@ -6,6 +6,8 @@ Making that work takes more than a prompt. It takes a described environment, a b
 
 We targeted Copilot specifically because the project already runs on GitHub — issues, pull requests, and CI are all here, so the agent lives where the work already is.
 
+> Agents running on a developer's own machine — Codex, Claude Code — share a subset of these skills through symlinks. See [External agents](external-agents.md).
+
 | Document                              | What it covers                                                                     |
 | ------------------------------------- | ---------------------------------------------------------------------------------- |
 | This page                             | The map: what the pieces are, what loads when, how a task flows through them       |
@@ -13,10 +15,11 @@ We targeted Copilot specifically because the project already runs on GitHub — 
 | [Environment](environment.md)         | What the runner sets up, how the agent drives a browser, how iOS works             |
 | [MCP servers](mcp.md)                 | The three external tool servers, what each gives the agent, and how they are wired |
 | [The TDD workflow](tdd.md)            | Why regression tests are committed switched off, and what the CI checks mean       |
+| [External agents](external-agents.md) | Codex and Claude Code — what they share with the cloud agent, and what they cannot |
 
 ## The four kinds of file
 
-Everything the agent reads lives under `.github/`. There are four kinds of file, and the difference between them is **when the agent reads them**.
+Everything the **cloud agent** reads lives under `.github/`. (A local agent reads `AGENTS.md` and `.agents/skills/` instead — see [External agents](external-agents.md).) There are four kinds of file, and the difference between them is **when the agent reads them**.
 
 | Kind                    | Where                                    | When it is read                                |
 | ----------------------- | ---------------------------------------- | ---------------------------------------------- |
@@ -155,6 +158,16 @@ scripts/
 src/e2e/
 ├── puppeteer/attachExistingBrowserInstance.ts   Web and Android bridge
 └── iOS/attachExistingSession.ts                 iOS bridge
+```
+
+And the local half, which is almost entirely symlinks into the above — see [External agents](external-agents.md):
+
+```
+AGENTS.md                            Read by Codex and Claude Code
+CLAUDE.md            → AGENTS.md
+.agents/skills/                      The shared subset, one symlink each
+└── <name>           → .github/skills/<name>
+.claude/skills       → .agents/skills
 ```
 
 Two workflows are part of this system rather than ordinary CI:

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -7,7 +7,9 @@ That "only when invoked" part is the key benefit of skills. Custom instructions 
 In general, if you want to add an additional capability to the agent, you should:
 
 - Create a new skill.
-- Reference the skill in custom instructions (Worker Bee, github-instructions)
+- Reference the skill in custom instructions (Worker Bee, github-instructions, AGENTS.md)
+
+> A subset of skills is shared with agents running on a developer's own machine, through symlinks from `.agents/skills/`. This is covered in [External agents](external-agents.md).
 
 ## The skills
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -14,7 +14,7 @@ The in-repo documentation for **em**. The GitHub wiki is being deprecated in fav
 
 ## Agents
 
-- [Agent Infrastructure](agents/readme.md) — How coding agents work on this repo: what the Copilot cloud agent reads, the skills they run, the environment and MCP servers behind them and the TDD workflow.
+- [Agent Infrastructure](agents/readme.md) — How coding agents work on this repo: what the Copilot cloud agent reads, the skills they run, the environment and MCP servers behind them, the TDD workflow, and how Codex and Claude Code share the same suite.
 
 ## Reference
 


### PR DESCRIPTION
**Chained PR — review and merge in this order:**

1. #4765 — unify the two agent prompt files _(base `main`; merge first)_
2. #4766 — document the agent infrastructure
3. #4767 — the end-session exit gate and docs-sync
4. #4768 — share skills with Codex, Claude Code, and other harnesses ← **this PR**
5. #4773 — standardize agent commit attribution

Every PR except #4765 targets the branch above it, so each diff shows only its own changes. As each one merges, GitHub retargets the next to `main` automatically. Merging out of order lands the change on a feature branch rather than `main`.

---

Many members of the team use external coding agents like Claude Code or Codex, and so far had no way to leverage any of the skills written for Copilot — despite several being compatible and useful to those developers.

A subset of skills — those compatible out of the box — are symlinked into `.agents/skills`, with `AGENTS.md` as the local entry point. This enables support for other harnesses that follow the open `.agents` standard, such as OpenCode, Pi, Codex, Cursor and Copilot CLI.

For Claude Code, which does *not* support the standard, `.agents/skills` is symlinked into `.claude/skills` and `CLAUDE.md` onto `AGENTS.md`. This works just fine.

Symlinks make capability differences between harnesses impossible.

`AGENTS.md` is deliberately lightweight compared with the Worker Bee and repository instructions: basic project principles and guidance on reading the documentation, leaving the developer agency to drive their local agent as they prefer.

**Worth knowing when reviewing:** the Copilot agent reads `AGENTS.md` too, and there's no documented way to disable that. To ensure Copilot's behaviour is unaffected: every statement in `AGENTS.md` has to hold for the cloud agent as well, and `AGENTS.md` may stay the softer, more suggestive document only because the strict forms of the rules that protect shared state are stated independently in the higher-precedence file.