### PR TITLE
Vercel Preview: report preview URL via GitHub Deployments API

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  deployments: write
 
 env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -48,6 +48,40 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/install
 
+      # Create a GitHub deployment so the preview URL appears in the PR's deployment
+      # box (and under repo Environments) rather than as a bot comment. Superseded
+      # deployments are automatically marked inactive, so stale preview URLs on older
+      # commits are visibly greyed out.
+      - name: Create deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const { data } = await github.rest.repos.createDeployment({
+              owner,
+              repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: 'Preview',
+              // Defaults to true, which makes GitHub merge the base branch into ref and
+              // return a merge result *instead of* creating a deployment.
+              auto_merge: false,
+              // Defaults to all existing commit statuses, which would fail creation while
+              // the other CI checks on this commit are still pending.
+              required_contexts: [],
+              // Marks the environment as temporary so GitHub deactivates it on merge/close.
+              transient_environment: true,
+              description: `PR #${context.payload.pull_request.number}`,
+            })
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: data.id,
+              state: 'in_progress',
+              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            })
+            return data.id
+
       - name: Pull Vercel environment
         run: yarn dlx vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
@@ -61,19 +95,20 @@ jobs:
           test -n "$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
-      - name: Comment preview URL
+      # always() so a failed build/deploy is reported as a failed deployment rather than
+      # leaving the PR showing "in_progress" forever.
+      - name: Update deployment status
+        if: always() && steps.deployment.outputs.result
         uses: actions/github-script@v7
         with:
           script: |
             const url = '${{ steps.deploy.outputs.url }}'
-            const marker = '<!-- vercel-preview -->'
-            const body = `${marker}\n<sub><img src="https://avatars.githubusercontent.com/in/8329?s=20&v=4" width="14" /></sub> Vercel preview: ${url}`
             const { owner, repo } = context.repo
-            const issue_number = context.payload.pull_request.number
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number })
-            const existing = comments.find(c => c.body && c.body.includes(marker))
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body })
-            }
+            await github.rest.repos.createDeploymentStatus({
+              owner,
+              repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: url ? 'success' : 'failure',
+              environment_url: url || undefined,
+              log_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            })


### PR DESCRIPTION
## What

Replaces the ad hoc `<!-- vercel-preview -->` bot comment in `.github/workflows/vercel-preview.yml` with GitHub's first-class [Deployments API](https://docs.github.com/en/rest/deployments/deployments).

- **New "Create deployment" step** runs before the Vercel pull/build, creating a deployment for the PR head SHA in the `Preview` environment and immediately marking it `in_progress`.
- **"Comment preview URL" → "Update deployment status"**, which sets `success` with `environment_url` pointing at the Vercel URL, or `failure` if the deploy produced no URL.
- **Permissions**: `pull-requests: write` → `deployments: write`. The comment was the only thing that needed PR write access.

## Why

The preview URL now shows up in the PR's deployment box and under repo → Environments instead of as a bot comment:

- The deployment box updates in place and GitHub automatically marks superseded deployments **inactive**, so a stale preview URL on an older commit is visibly greyed out — something the comment could not express.
- Creating the deployment before the build means the PR shows progress while Vercel runs, rather than nothing until it finishes.

## Notes for reviewers

The three non-default `createDeployment` params are all load-bearing (each is commented in the workflow):

- `auto_merge: false` — the default `true` makes GitHub merge base into `ref` and return a merge result *instead of* creating a deployment.
- `required_contexts: []` — the default requires all existing commit statuses to be green, which would fail creation while the other CI checks on the commit are still pending.
- `transient_environment: true` — marks the environment temporary so GitHub deactivates it on merge/close.

`Update deployment status` is guarded by `if: always() && steps.deployment.outputs.result` so a failed build reports a failed deployment rather than leaving the PR stuck at `in_progress`.

This works for fork PRs because `pull_request_target` runs with the base repo's token.

Two known tradeoffs:

1. **Open PRs keep their now-stale bot comment.** No cleanup step was added, since that would mean retaining `pull-requests: write` and a `listComments` call on every run forever for a one-time migration. Easy to add if preferred.
2. **All PRs share the `Preview` environment**, so a new deploy on any PR marks earlier ones inactive — the older PR's box goes grey, though the link still works. The alternative is a per-PR environment name (`Preview – PR 123`) plus a PR-close workflow to delete it, at the cost of clutter in the Environments list.

Also worth noting: the deployment box is less prominent than a comment and does not generate a notification. If anyone relies on the comment to ping reviewers with the URL, that goes away here.

## Testing

Cannot be verified locally — `pull_request_target` workflows only run once merged to the default branch. The YAML parses and passes Prettier. First real exercise will be the next PR opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)