### PR TITLE
Load Radio Canada Big at parse time instead of preloading it

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,34 +17,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#333333" />
     <link href="/fonts/lora.css" rel="stylesheet" />
-    <link
-      rel="preload"
-      href="/fonts/RadioCanadaBig/RadioCanadaBig-Regular.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/fonts/RadioCanadaBig/RadioCanadaBig-Medium.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/fonts/RadioCanadaBig/RadioCanadaBig-SemiBold.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/fonts/RadioCanadaBig/RadioCanadaBig-Bold.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin
-    />
     <link href="/fonts/RadioCanadaBig/radio-canada-big.css" rel="stylesheet" />
     <!-- Web manifest is injected via vite-plugin-pwa. See: vite.config.ts-->
     <meta name="msapplication-TileColor" content="#000000" />
@@ -73,14 +45,18 @@
       document.body.setAttribute('data-env', navigator.webdriver ? 'test' : '%MODE%')
 
       // Proactively load Radio Canada Big at startup so it is ready before the gesture menu opens.
-      // Preload only warms the HTTP cache; it does not load the @font-face. Without this the font
-      // loads lazily on first menu render, triggering font-display's block/swap window (font blip).
-      // Run on window load so the @font-face rules are registered; calling load() earlier matches
-      // zero faces (the stylesheet has not been parsed yet) and silently does nothing.
+      // Without this the font loads lazily on first menu render, triggering font-display's
+      // block/swap window (font blip).
+      // This replaces <link rel="preload"> of the woff2 files, which only warmed the HTTP cache
+      // without ever loading the @font-face. Since nothing renders with the font at startup, the
+      // fonts were not used until well after the preloads completed, and Chrome logged them as
+      // unused preloads.
+      // Parser-inserted scripts wait for pending stylesheets, so the @font-face rules above are
+      // already registered here and load() matches them. Running this earlier in <head>, before
+      // the stylesheet link, would match zero faces and silently do nothing.
       if (document.fonts && document.fonts.load) {
-        window.addEventListener('load', () =>
-          ['400', '500', '600', '700'].forEach(weight => document.fonts.load(weight + ' 1em "Radio Canada Big"')),
-        )
+        const weights = ['400', '500', '600', '700']
+        weights.forEach(weight => document.fonts.load(weight + ' 1em "Radio Canada Big"'))
       }
     </script>
     <script type="module" src="/src/index.tsx"></script>


### PR DESCRIPTION
Fixes the console warning:

> The resource https://localhost:3000/fonts/RadioCanadaBig/RadioCanadaBig-Medium.woff2 was preloaded using link preload but not used within a few seconds from the window's load event.

## Why

The preloading was added in [#4205](https://github.com/cybersemics/em/pull/4205) (`[Liminal UI] implement new design for Gesturemenu Commands`), along with the `document.fonts.load()` warm-up.

`Radio Canada Big` is only used by `GestureMenu`, which does not render at startup. The four woff2 files were preloaded with `<link rel="preload">`, but preload only warms the HTTP cache — it never loads the `@font-face`. The compensating `document.fonts.load()` warm-up was deferred to `window.load`, which fires very late in this app.

Measured against the dev server under network throttling: the preloads completed at **440ms**, but `loadEventStart` was at **30.6s**. Chrome only counts a preload as used if a matching request arrives around the load event, so by the time the fonts were actually requested the preloads had long been abandoned — hence the warning.

## What changed

- Removed the four `<link rel="preload">` tags for the Radio Canada Big weights.
- Moved the `document.fonts.load()` warm-up out of the `load` listener; it now runs inline in the existing startup script.

Parser-inserted scripts wait for pending stylesheets, so the `@font-face` rules are already registered when the script runs. That was the concern behind the original "matches zero faces" comment — but it only required the script to come *after* the stylesheet link in document order, not to wait for the load event.

## Result

Same dev server, throttled, headless Brave 150:

| | font request starts | `@font-face` loaded by |
|---|---|---|
| before | 176ms (preload, cache only) | ~30.6s (at `load`) |
| after | 279ms | ~660ms |

All four weights match exactly one face and reach `loaded`, so the gesture menu still gets the font without a blip — and considerably sooner than before. No preload tags remain for Chrome to flag.

## Note for reviewers

My headless harness never captured the warning text itself in either direction — browser-generated preload warnings did not surface through `console` or CDP `Log.entryAdded`, even on a control page where the preload was definitely unused. The timing numbers above are what I verified directly; the warning going away follows from there being no preload tags at all. Worth a quick confirmation in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
