### PR TITLE
Run stripTags on email value before testing

### DIFF
--- a/src/components/ThoughtAnnotation.tsx
+++ b/src/components/ThoughtAnnotation.tsx
@@ -87,7 +87,13 @@ UrlIconLink.displayName = 'UrlIconLink'
 
 /** Renders an email icon and adds mailto: to email addresses. */
 const EmailIconLink = React.memo(({ email }: { email: string }) => (
-  <a href={`mailto:${email}`} target='_blank' rel='noopener noreferrer' className={urlLinkStyle}>
+  <a
+    aria-label='email-link'
+    href={`mailto:${email}`}
+    target='_blank'
+    rel='noopener noreferrer'
+    className={urlLinkStyle}
+  >
     {' '}
     <EmailIcon />
   </a>
@@ -268,7 +274,9 @@ const ThoughtAnnotationContainer = React.memo(
       return urlValue ? stripTags(urlValue) : urlValue
     })
 
-    const email = isEmail(value) ? value : undefined
+    // Strip formatting tags (e.g. the font/span tags added by foreColor and backColor) before testing for an email address, otherwise the annotation disappears as soon as the thought is colored.
+    const emailValue = stripTags(value)
+    const email = isEmail(emailValue) ? emailValue : undefined
 
     // if a thought has the same value as editValue, re-render its ThoughtAnnotation in order to get the correct number of contexts
     editingValueStore.useSelector((editingValue: string | null) => value === editingValue)

--- a/src/components/__tests__/ThoughtAnnotation.ts
+++ b/src/components/__tests__/ThoughtAnnotation.ts
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/dom'
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('renders the email annotation on a plain email address', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - foo@bar.com
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(screen.getByLabelText('email-link')).toHaveAttribute('href', 'mailto:foo@bar.com')
+})
+
+it('renders the email annotation when a foreColor is applied', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - <font color="#ff573d">foo@bar.com</font>
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(screen.getByLabelText('email-link')).toHaveAttribute('href', 'mailto:foo@bar.com')
+})
+
+it('renders the email annotation when a backColor is applied', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - <span style="background-color: rgb(223, 122, 1);">foo@bar.com</span>
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(screen.getByLabelText('email-link')).toHaveAttribute('href', 'mailto:foo@bar.com')
+})
+
+it('does not render the email annotation on a non-email thought', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - <font color="#ff573d">b</font>
+      `,
+    }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(screen.queryByLabelText('email-link')).toBeNull()
+})


### PR DESCRIPTION
Fixes #4215

The email was not being stripped of tags before or during the [isEmail](https://github.com/ethan-james/em/blob/e18b2734ce4786c710d32f8d1f174e7a683e56bd/src/components/ThoughtAnnotation.tsx#L279) check, so a formatted email address did not match. The stripped value also needs to be passed to `EmailIconLink` to form the mailto URL, so I stripped the value outside of the `isEmail` test rather than inside.

There is a more complex [selector](https://github.com/ethan-james/em/blob/e18b2734ce4786c710d32f8d1f174e7a683e56bd/src/components/ThoughtAnnotation.tsx#L266) for URLs that also finds them within the thought's children. I did not copy that for email, so an email annotation will only appear on the thought that has the email address.