### PR TITLE
chore: ignore .claude/worktrees in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,6 +95,7 @@ export default [
   {
     ignores: [
       'node_modules/**',
+      '.claude/worktrees/**',
       'packages/**/dist/**/*',
       'packages/**/.build/**/*',
       '**/styled-system/*',


### PR DESCRIPTION
## What

Adds `.claude/worktrees/**` to the `ignores` list in `eslint.config.js`.

## Why

`lint:src` runs `eslint .`, and ESLint flat config does not skip dot-directories by default (only `node_modules` and `.git`). Git worktrees created under `.claude/worktrees` are therefore linted as part of the parent repo — duplicating every source file, slowing the run, and surfacing errors from unrelated branches.

## Notes for reviewers

Verified by dropping a deliberately non-conforming `bad.ts` into `.claude/worktrees/tmptest/` and running `eslint --no-cache` on it: ESLint reported it as ignored by a matching pattern instead of linting it. The temp file was removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)