### PR TITLE
Move HTML-trimming into onBlur handler

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -770,10 +770,10 @@ const Editable = ({
       // the editable, so anything that forces a re-render from Redux (e.g. formatSelection) deletes whitespace the user
       // is still typing (#4657).
       dispatch((dispatch, getState) => {
+        // the thought may have been deleted while it was focused, in which case there is nothing to trim
         if (transient || !getThoughtById(getState(), head(simplePath))) return
         const untrimmedValue = oldValueRef.current
         const trimmedValue = trimHtml(untrimmedValue)
-        // the thought may have been deleted while it was focused, in which case there is nothing to trim
         if (trimmedValue === untrimmedValue) return
         oldValueRef.current = trimmedValue
         dispatch(editThought({ oldValue: untrimmedValue, newValue: trimmedValue, path: simplePath }))

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -591,10 +591,9 @@ const Editable = ({
         // That style should be re-applied once they type something. (#3673)
 
         const wrappedValue = state.cursorCleared ? applyOuterTag(e.target.value, oldValue) : e.target.value
-        const trimmedWrappedValue = trimHtml(wrappedValue)
-        const valueWithEmojiSpace = addEmojiSpace(trimmedWrappedValue)
+        const valueWithEmojiSpace = addEmojiSpace(wrappedValue)
         const newValue = stripEmptyFormattingTags(valueWithEmojiSpace)
-        const emojiSpaceAdded = valueWithEmojiSpace !== trimmedWrappedValue
+        const emojiSpaceAdded = valueWithEmojiSpace !== wrappedValue
         const emojiSpaceInsertionIndex = emojiSpaceAdded ? valueWithEmojiSpace.indexOf(' ') : null
 
         /* The realtime editingValue must always be updated (and not short-circuited) since oldValueRef is throttled. Otherwise, editingValueStore becomes stale and heights are not recalculated in VirtualThought.
@@ -766,6 +765,19 @@ const Editable = ({
   const onBlur: FocusEventHandler<HTMLElement> = useCallback(
     e => {
       throttledChangeRef.current.flush()
+
+      // Trim whitespace on blur rather than on every keystroke (#2159). Trimming mid-edit desyncs the Redux value from
+      // the editable, so anything that forces a re-render from Redux (e.g. formatSelection) deletes whitespace the user
+      // is still typing (#4657).
+      dispatch((dispatch, getState) => {
+        if (transient || !getThoughtById(getState(), head(simplePath))) return
+        const untrimmedValue = oldValueRef.current
+        const trimmedValue = trimHtml(untrimmedValue)
+        // the thought may have been deleted while it was focused, in which case there is nothing to trim
+        if (trimmedValue === untrimmedValue) return
+        oldValueRef.current = trimmedValue
+        dispatch(editThought({ oldValue: untrimmedValue, newValue: trimmedValue, path: simplePath }))
+      })
 
       // update the ContentEditable if the new scrubbed value is different (i.e. stripped, space after emoji added, etc)
       // they may intentionally become out of sync during editing if the value is modified programmatically (such as trim) in order to avoid reseting the caret while the user is still editing

--- a/src/components/__tests__/Editable.ts
+++ b/src/components/__tests__/Editable.ts
@@ -4,11 +4,16 @@ import userEvent from '@testing-library/user-event'
 import { act, createElement } from 'react'
 import { Provider } from 'react-redux'
 import SimplePath from '../../@types/SimplePath'
+import { formatSelectionActionCreator as formatSelection } from '../../actions/formatSelection'
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { executeCommand } from '../../commands'
+import clearThoughtCommand from '../../commands/clearThought'
 import { HOME_TOKEN } from '../../constants'
+import getTextContentFromHTML from '../../device/getTextContentFromHTML'
 import * as selection from '../../device/selection'
 import contextToPath from '../../selectors/contextToPath'
 import exportContext from '../../selectors/exportContext'
+import getThoughtById from '../../selectors/getThoughtById'
 import store from '../../stores/app'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import dispatch from '../../test-helpers/dispatch'
@@ -16,6 +21,7 @@ import { moveThoughtAtFirstMatchActionCreator as moveThought } from '../../test-
 import findThoughtByText from '../../test-helpers/queries/findThoughtByText'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import windowEvent from '../../test-helpers/windowEvent'
+import head from '../../util/head'
 import Editable from '../Editable'
 
 beforeEach(createTestApp)
@@ -149,4 +155,91 @@ it('inserts emoji spacing immediately before colored text', async () => {
 
   expect(editable.textContent).toBe('👋 Hello')
   expect(editable.innerHTML).toBe('👋 <font color="#ff0000">Hello</font>')
+})
+
+it('re-applies the outer formatting tag after clearThought (#3673)', async () => {
+  act(() => {
+    windowEvent('keydown', { key: 'Enter' })
+  })
+
+  const editable = (await findThoughtByText(''))!
+  expect(editable).toBeVisible()
+
+  const user = userEvent.setup({ delay: null })
+  await user.type(editable, 'hello')
+  await act(vi.runAllTimersAsync)
+  await dispatch(formatSelection('bold'))
+  await act(vi.runAllTimersAsync)
+  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b>hello</b>')
+
+  await act(async () => {
+    executeCommand(clearThoughtCommand)
+  })
+  await act(vi.runAllTimersAsync)
+  expect(editable.innerHTML).toBe('')
+
+  await user.type(editable, 'a')
+  await act(vi.runAllTimersAsync)
+
+  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b>a</b>')
+  expect(editable.innerHTML).toBe('<b>a</b>')
+})
+
+it('preserves a trailing space while typing', async () => {
+  act(() => {
+    windowEvent('keydown', { key: 'Enter' })
+  })
+
+  const editable = (await findThoughtByText(''))!
+  expect(editable).toBeVisible()
+
+  const user = userEvent.setup({ delay: null })
+  await user.type(editable, 'North Star ')
+  await act(vi.runAllTimersAsync)
+
+  expect(editable.textContent).toBe('North Star ')
+  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('North Star ')
+})
+
+it('preserves a trailing space when applying a background color (#4657)', async () => {
+  act(() => {
+    windowEvent('keydown', { key: 'Enter' })
+  })
+
+  const editable = (await findThoughtByText(''))!
+  expect(editable).toBeVisible()
+
+  const user = userEvent.setup({ delay: null })
+  await user.type(editable, 'North Star ')
+  await act(vi.runAllTimersAsync)
+  await dispatch(formatSelection('backColor', 'red'))
+  await act(vi.runAllTimersAsync)
+
+  expect(editable.textContent).toBe('North Star ')
+  const value = getThoughtById(store.getState(), head(store.getState().cursor!))!.value
+  expect(getTextContentFromHTML(value)).toBe('North Star ')
+})
+
+it('trims whitespace on blur (#2159)', async () => {
+  act(() => {
+    windowEvent('keydown', { key: 'Enter' })
+  })
+
+  const editable = (await findThoughtByText(''))!
+  expect(editable).toBeVisible()
+
+  const user = userEvent.setup({ delay: null })
+  await user.type(editable, 'North Star ')
+  await act(vi.runAllTimersAsync)
+  await dispatch(formatSelection('bold'))
+  await act(vi.runAllTimersAsync)
+  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b>North Star </b>')
+
+  act(() => {
+    editable.blur()
+  })
+  await act(vi.runAllTimersAsync)
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/html')
+  expect(exported).toContain('<b>North Star</b>')
 })

--- a/src/components/__tests__/Editable.ts
+++ b/src/components/__tests__/Editable.ts
@@ -4,12 +4,11 @@ import userEvent from '@testing-library/user-event'
 import { act, createElement } from 'react'
 import { Provider } from 'react-redux'
 import SimplePath from '../../@types/SimplePath'
-import { formatSelectionActionCreator as formatSelection } from '../../actions/formatSelection'
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { newThoughtActionCreator as newThought } from '../../actions/newThought'
 import { executeCommand } from '../../commands'
 import clearThoughtCommand from '../../commands/clearThought'
 import { HOME_TOKEN } from '../../constants'
-import getTextContentFromHTML from '../../device/getTextContentFromHTML'
 import * as selection from '../../device/selection'
 import contextToPath from '../../selectors/contextToPath'
 import exportContext from '../../selectors/exportContext'
@@ -158,19 +157,14 @@ it('inserts emoji spacing immediately before colored text', async () => {
 })
 
 it('re-applies the outer formatting tag after clearThought (#3673)', async () => {
-  act(() => {
-    windowEvent('keydown', { key: 'Enter' })
-  })
+  // formatSelection cannot be used to create the formatted value, as it applies formatting with document.execCommand,
+  // which is stubbed out as a noop in JSDOM. See: /setupTests.js. This will change as soon as #4657 is merged.
+  await dispatch([newThought({ value: '<b>hello</b>' }), setCursor(['<b>hello</b>'])])
+  await act(vi.runAllTimersAsync)
 
-  const editable = (await findThoughtByText(''))!
+  // findThoughtByText cannot be used here, as it only matches direct text children, not the nested <b>
+  const editable = document.querySelector<HTMLElement>(`[aria-label="editable-${head(store.getState().cursor!)}"]`)!
   expect(editable).toBeVisible()
-
-  const user = userEvent.setup({ delay: null })
-  await user.type(editable, 'hello')
-  await act(vi.runAllTimersAsync)
-  await dispatch(formatSelection('bold'))
-  await act(vi.runAllTimersAsync)
-  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b>hello</b>')
 
   await act(async () => {
     executeCommand(clearThoughtCommand)
@@ -178,6 +172,7 @@ it('re-applies the outer formatting tag after clearThought (#3673)', async () =>
   await act(vi.runAllTimersAsync)
   expect(editable.innerHTML).toBe('')
 
+  const user = userEvent.setup({ delay: null })
   await user.type(editable, 'a')
   await act(vi.runAllTimersAsync)
 
@@ -201,45 +196,30 @@ it('preserves a trailing space while typing', async () => {
   expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('North Star ')
 })
 
-it('preserves a trailing space when applying a background color (#4657)', async () => {
-  act(() => {
-    windowEvent('keydown', { key: 'Enter' })
-  })
-
-  const editable = (await findThoughtByText(''))!
-  expect(editable).toBeVisible()
-
-  const user = userEvent.setup({ delay: null })
-  await user.type(editable, 'North Star ')
-  await act(vi.runAllTimersAsync)
-  await dispatch(formatSelection('backColor', 'red'))
-  await act(vi.runAllTimersAsync)
-
-  expect(editable.textContent).toBe('North Star ')
-  const value = getThoughtById(store.getState(), head(store.getState().cursor!))!.value
-  expect(getTextContentFromHTML(value)).toBe('North Star ')
-})
-
 it('trims whitespace on blur (#2159)', async () => {
-  act(() => {
-    windowEvent('keydown', { key: 'Enter' })
-  })
+  // formatSelection cannot be used to create the formatted value, as it applies formatting with document.execCommand,
+  // which is stubbed out as a noop in JSDOM. See: /setupTests.js. This will change as soon as #4657 is merged.
+  await dispatch([newThought({ value: '<b>a b</b>' }), setCursor(['<b>a b</b>'])])
+  await act(vi.runAllTimersAsync)
 
-  const editable = (await findThoughtByText(''))!
+  // findThoughtByText cannot be used here, as it only matches direct text children, not the nested <b>
+  const editable = document.querySelector<HTMLElement>(`[aria-label="editable-${head(store.getState().cursor!)}"]`)!
   expect(editable).toBeVisible()
 
-  const user = userEvent.setup({ delay: null })
-  await user.type(editable, 'North Star ')
+  // delete the "a", leaving a leading space inside the bold tag
+  editable.innerHTML = '<b> b</b>'
+  act(() => {
+    fireEvent.input(editable, { bubbles: true })
+  })
   await act(vi.runAllTimersAsync)
-  await dispatch(formatSelection('bold'))
-  await act(vi.runAllTimersAsync)
-  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b>North Star </b>')
+  expect(getThoughtById(store.getState(), head(store.getState().cursor!))!.value).toBe('<b> b</b>')
 
   act(() => {
+    editable.focus()
     editable.blur()
   })
   await act(vi.runAllTimersAsync)
 
   const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/html')
-  expect(exported).toContain('<b>North Star</b>')
+  expect(exported).toContain('<b>b</b>')
 })


### PR DESCRIPTION
Related to #2666, #3955 and #4657

In #2159 (closed by #2666) the expected behavior was "White space should be trimmed on blur." but the call to `trimHtml` ended up in `onChangeHandler`. The situation has evolved in the last 2 years, and now `onChangeHandler` gets called more frequently than just `onBlur`.

This PR moves the trimming logic into the blur handler so that other use cases such as applying formatting do not trigger the trim.

---

## Implications for #3955

By itself, this PR does not fix #3955. I separated it out from #4657 because I think it needs its own review.

Shaking the device is guaranteed to blur the editable when the native undo dialog appears. According to https://github.com/cybersemics/em/issues/2159, blur should result in the text being trimmed. This means that the first shake will result in `editThought` being dispatched, trimming the editable. Combined with #4657, accepting the undo will put the space back instead of removing it as it does on `main`. This is perhaps not a huge UX improvement, but it is logical based on the actions that are occurring. Then the second undo will remove the background color.