### PR TITLE
ci: skip Test, Puppeteer, BrowserStack, and Vercel Preview for changes that cannot affect them

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,11 +1,38 @@
 name: BrowserStack
 
+# Documentation, agent instructions, and editor config cannot change app behavior, so a change set
+# confined to them has nothing for a real device to test. Skipping is worth more here than in a
+# cheap workflow: every run occupies the repo-wide `browserstack` concurrency group below and a
+# slot in the shared BrowserStack session pool, so a docs-only run delays every other PR's tests.
+#
+# paths-ignore skips the workflow outright, which means NO check is reported — not a "skipped"
+# check, and not a synthetic pass from a job-level `if`. That is only correct because BrowserStack
+# is no longer a required status check on main. If it is ever made required again, filtered PRs
+# will sit at "Expected — Waiting for status to be reported" and block; use a job-level guard then.
+#
+# A run is skipped only when EVERY changed file matches, so any PR that also touches app or test
+# code still runs in full. `**/*.md` is safe because nothing under src/ imports markdown.
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
   pull_request_target:
     types: [opened, synchronize, reopened]
+    # GitHub Actions does not support YAML anchors, so this list is duplicated from `push` above.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
   workflow_dispatch:
     inputs:
       rerun_id:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,28 +1,43 @@
 name: BrowserStack
 
-# Documentation, agent instructions, and editor config cannot change app behavior, so a change set
-# confined to them has nothing for a real device to test. Skipping is worth more here than in a
-# cheap workflow: every run occupies the repo-wide `browserstack` concurrency group below and a
-# slot in the shared BrowserStack session pool, so a docs-only run delays every other PR's tests.
+# Documentation, agent/editor configuration, and the native platform projects cannot change what
+# this workflow tests, so a change set confined to them has nothing for a real device to exercise.
+# Skipping is worth more here than in a cheap workflow: every run occupies the repo-wide
+# `browserstack` concurrency group below and a slot in the shared BrowserStack session pool, so one
+# pointless run delays every other PR's iOS tests behind it.
 #
 # paths-ignore skips the workflow outright, which means NO check is reported — not a "skipped"
 # check, and not a synthetic pass from a job-level `if`. That is only correct because BrowserStack
 # is no longer a required status check on main. If it is ever made required again, filtered PRs
 # will sit at "Expected — Waiting for status to be reported" and block; use a job-level guard then.
+# (Lint is deliberately left unfiltered and required, so every PR still reports one check.)
 #
 # A run is skipped only when EVERY changed file matches, so any PR that also touches app or test
 # code still runs in full. `**/*.md` is safe because nothing under src/ imports markdown.
+#
+# The native entries below rest on `yarn build` staying web-only (build:packages, build:styles,
+# vite build) and on this workflow testing mobile Safari over a tunnel rather than the Capacitor
+# app. None of those directories contains a JS or TS file today. If a Capacitor asset is ever wired
+# into the Vite build, remove them — otherwise a real change would ship untested.
 on:
   push:
     branches:
       - main
     paths-ignore:
+      # Documentation and agent/editor configuration.
       - '**/*.md'
       - 'docs/**'
       - '.github/instructions/**'
+      - '.github/skills/**'
       - '.claude/**'
       - '.agents/**'
       - '.vscode/**'
+      - '.hooks/**'
+      # Native platform projects, and the icon/splash sources generated into them.
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   pull_request_target:
     types: [opened, synchronize, reopened]
     # GitHub Actions does not support YAML anchors, so this list is duplicated from `push` above.
@@ -30,9 +45,15 @@ on:
       - '**/*.md'
       - 'docs/**'
       - '.github/instructions/**'
+      - '.github/skills/**'
       - '.claude/**'
       - '.agents/**'
       - '.vscode/**'
+      - '.hooks/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   workflow_dispatch:
     inputs:
       rerun_id:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -1,12 +1,37 @@
 name: Puppeteer
 
+# Documentation, agent instructions, and editor config cannot change app behavior, so a change set
+# confined to them has nothing for a browser to test.
+#
+# paths-ignore skips the workflow outright, which means NO check is reported — not a "skipped"
+# check, and not a synthetic pass from a job-level `if`. That is only correct because Puppeteer is
+# no longer a required status check on main. If it is ever made required again, filtered PRs will
+# sit at "Expected — Waiting for status to be reported" and block; use a job-level guard then.
+#
+# A run is skipped only when EVERY changed file matches, so any PR that also touches app or test
+# code still runs in full. `**/*.md` is safe because nothing under src/ imports markdown.
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
   pull_request:
     branches:
       - '**'
+    # GitHub Actions does not support YAML anchors, so this list is duplicated from `push` above.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
   workflow_dispatch:
     inputs:
       rerun_id:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -1,26 +1,39 @@
 name: Puppeteer
 
-# Documentation, agent instructions, and editor config cannot change app behavior, so a change set
-# confined to them has nothing for a browser to test.
+# Documentation, agent/editor configuration, and the native platform projects cannot change what
+# this workflow tests, so a change set confined to them has nothing for a browser to exercise.
 #
 # paths-ignore skips the workflow outright, which means NO check is reported — not a "skipped"
 # check, and not a synthetic pass from a job-level `if`. That is only correct because Puppeteer is
 # no longer a required status check on main. If it is ever made required again, filtered PRs will
 # sit at "Expected — Waiting for status to be reported" and block; use a job-level guard then.
+# (Lint is deliberately left unfiltered and required, so every PR still reports one check.)
 #
 # A run is skipped only when EVERY changed file matches, so any PR that also touches app or test
 # code still runs in full. `**/*.md` is safe because nothing under src/ imports markdown.
+#
+# The native entries below rest on `yarn build` staying web-only (build:packages, build:styles,
+# vite build). None of those directories contains a JS or TS file today, and the web favicons come
+# from public/, not assets/. If a Capacitor asset is ever wired into the Vite build, remove them.
 on:
   push:
     branches:
       - main
     paths-ignore:
+      # Documentation and agent/editor configuration.
       - '**/*.md'
       - 'docs/**'
       - '.github/instructions/**'
+      - '.github/skills/**'
       - '.claude/**'
       - '.agents/**'
       - '.vscode/**'
+      - '.hooks/**'
+      # Native platform projects, and the icon/splash sources generated into them.
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   pull_request:
     branches:
       - '**'
@@ -29,9 +42,15 @@ on:
       - '**/*.md'
       - 'docs/**'
       - '.github/instructions/**'
+      - '.github/skills/**'
       - '.claude/**'
       - '.agents/**'
       - '.vscode/**'
+      - '.hooks/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   workflow_dispatch:
     inputs:
       rerun_id:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,54 @@
 name: Test
 
+# `yarn test` is `vitest --project unit`, which only ever reads src/. Documentation, agent/editor
+# configuration, and the native platform projects are invisible to it, so a change set confined to
+# them has nothing to test.
+#
+# paths-ignore skips the workflow outright, which means NO check is reported — not a "skipped"
+# check, and not a synthetic pass from a job-level `if`. That is only correct because Test is no
+# longer a required status check on main. If it is ever made required again, filtered PRs will sit
+# at "Expected — Waiting for status to be reported" and block; use a job-level guard then.
+# (Lint is deliberately left unfiltered and required, so every PR still reports one check.)
+#
+# A run is skipped only when EVERY changed file matches, so any PR that also touches app or test
+# code still runs in full. `**/*.md` is safe because nothing under src/ imports markdown, and none
+# of the native directories contains a JS or TS file.
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      # Documentation and agent/editor configuration.
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.github/skills/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
+      - '.hooks/**'
+      # Native platform projects, and the icon/splash sources generated into them.
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   pull_request:
     branches:
       - '**'
+    # GitHub Actions does not support YAML anchors, so this list is duplicated from `push` above.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.github/skills/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
+      - '.hooks/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
   workflow_dispatch:
     inputs:
       rerun_id:

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -3,9 +3,36 @@ name: Vercel Preview
 # pull_request_target runs in the base repo's context, so repo secrets are
 # available even for fork PRs. Untrusted fork code is gated by GitHub's
 # "require approval for outside collaborators" setting before it runs.
+#
+# The Vercel build is the web app, so documentation, agent/editor configuration, and the native
+# platform projects cannot change the preview. A PR confined to them gets no deployment and no
+# preview comment, which is the intended outcome — there is nothing to look at.
+#
+# paths-ignore skips the workflow outright, which means NO check is reported. That is only correct
+# because Vercel Preview is no longer a required status check on main. If it is ever made required
+# again, filtered PRs will sit at "Expected — Waiting for status to be reported" and block.
+# (Lint is deliberately left unfiltered and required, so every PR still reports one check.)
+#
+# A run is skipped only when EVERY changed file matches, so a PR that also touches app code still
+# deploys a preview as usual.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      # Documentation and agent/editor configuration.
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/instructions/**'
+      - '.github/skills/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.vscode/**'
+      - '.hooks/**'
+      # Native platform projects, and the icon/splash sources generated into them.
+      - 'android/**'
+      - 'ios/**'
+      - 'desktop/**'
+      - 'assets/**'
 
 permissions:
   contents: read

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -613,11 +613,22 @@ When the failure is wrong, fix the test—not the application—and rerun it aga
 
 The primary Test, Puppeteer, and BrowserStack workflows run on pushes to `main` and on pull requests (BrowserStack uses `pull_request_target`). The TDD workflow runs on pull requests that add tests. All four accept `workflow_dispatch` with an optional `rerun_id` so the `ghworkflow` shell function (see [Tips](#triggering-github-actions-workflows-manually)) can fan out manually triggered runs for flake hunting.
 
-Puppeteer and BrowserStack additionally carry a `paths-ignore` filter covering markdown, `docs/`, `.github/instructions/`, `.claude/`, `.agents/`, and `.vscode/`. A change set confined to those paths cannot affect app behavior, so neither workflow runs — and because `paths-ignore` skips the workflow outright, **no check is reported at all** rather than a skipped or passing one. That is only viable because neither is a required status check on `main`; making either required again would leave filtered pull requests waiting on a check that never arrives.
+#### Path filtering
+
+Test, Puppeteer, BrowserStack, and Vercel Preview each carry the same `paths-ignore` filter, covering two groups:
+
+- **Documentation and agent/editor configuration** — `**/*.md`, `docs/`, `.github/instructions/`, `.github/skills/`, `.claude/`, `.agents/`, `.vscode/`, `.hooks/`.
+- **Native platform projects** — `android/`, `ios/`, `desktop/`, and `assets/` (the icon and splash sources generated into the first two).
+
+A change set confined to those paths cannot affect what any of the four workflows tests: `yarn build` is web-only (`build:packages`, `build:styles`, `vite build`), `yarn test` reads only `src/`, and BrowserStack exercises mobile Safari over a tunnel rather than the Capacitor app. None of the native directories contains a JS or TS file, and the web favicons come from `public/`, not `assets/`. **If a Capacitor asset is ever wired into the Vite build, the native entries must be removed** — otherwise a real change would ship untested.
+
+Because `paths-ignore` skips a workflow outright, **no check is reported at all** rather than a skipped or passing one. That is only viable while these are not required status checks on `main`; making any of them required again would leave filtered pull requests waiting on a check that never arrives. **Lint is deliberately left unfiltered and required**, so every pull request — including a documentation-only one — still reports exactly one check.
+
+TDD needs no filter: its `detect` job already finds no changed tests in such a pull request and skips on its own. A run is skipped only when *every* changed file matches, so any pull request that also touches app or test code runs everything in full.
 
 | Workflow | File | What it runs | Notes |
 |---|---|---|---|
-| **Test** | [`.github/workflows/test.yml`](../.github/workflows/test.yml) | `yarn test` (Vitest unit + jsdom) | The fast tier. Should always pass. |
+| **Test** | [`.github/workflows/test.yml`](../.github/workflows/test.yml) | `yarn test` (Vitest unit + jsdom) | The fast tier. Should always pass. Filtered by `paths-ignore` (see above). |
 | **Puppeteer** | [`.github/workflows/puppeteer.yml`](../.github/workflows/puppeteer.yml) | `yarn test:puppeteer` against a `browserless/chrome:latest` service container on port 7566. | On failure, image-snapshot diffs are uploaded in the `__diff_output__` artifact. |
 | **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`, and serialized to avoid exhausting the shared device pool. |
 | **TDD** | [`.github/workflows/tdd.yml`](../.github/workflows/tdd.yml) | Runs newly added unit, Puppeteer, and iOS tests against the selected pre-fix commit. | Expects the new regression test to fail before the fix. Pull requests only. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -613,11 +613,13 @@ When the failure is wrong, fix the test—not the application—and rerun it aga
 
 The primary Test, Puppeteer, and BrowserStack workflows run on pushes to `main` and on pull requests (BrowserStack uses `pull_request_target`). The TDD workflow runs on pull requests that add tests. All four accept `workflow_dispatch` with an optional `rerun_id` so the `ghworkflow` shell function (see [Tips](#triggering-github-actions-workflows-manually)) can fan out manually triggered runs for flake hunting.
 
+Puppeteer and BrowserStack additionally carry a `paths-ignore` filter covering markdown, `docs/`, `.github/instructions/`, `.claude/`, `.agents/`, and `.vscode/`. A change set confined to those paths cannot affect app behavior, so neither workflow runs — and because `paths-ignore` skips the workflow outright, **no check is reported at all** rather than a skipped or passing one. That is only viable because neither is a required status check on `main`; making either required again would leave filtered pull requests waiting on a check that never arrives.
+
 | Workflow | File | What it runs | Notes |
 |---|---|---|---|
 | **Test** | [`.github/workflows/test.yml`](../.github/workflows/test.yml) | `yarn test` (Vitest unit + jsdom) | The fast tier. Should always pass. |
 | **Puppeteer** | [`.github/workflows/puppeteer.yml`](../.github/workflows/puppeteer.yml) | `yarn test:puppeteer` against a `browserless/chrome:latest` service container on port 7566. | On failure, image-snapshot diffs are uploaded in the `__diff_output__` artifact. |
-| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0`, and serialized to avoid exhausting the shared device pool. |
+| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`, and serialized to avoid exhausting the shared device pool. |
 | **TDD** | [`.github/workflows/tdd.yml`](../.github/workflows/tdd.yml) | Runs newly added unit, Puppeteer, and iOS tests against the selected pre-fix commit. | Expects the new regression test to fail before the fix. Pull requests only. |
 
 When a Puppeteer snapshot test fails on a pull request, the [`Puppeteer Diff Comment`](../.github/workflows/puppeteer-diff-comment.yml) workflow safely publishes the diff images to the `snapshot-diffs` branch and upserts a PR comment with the affected files and targeted `yarn test:puppeteer -u ...` command. The raw `__diff_output__` artifact is also available from the workflow run. Locally, the diff path is printed in the test runner output. See [Visual snapshot tests](#visual-snapshot-tests).


### PR DESCRIPTION
Replaces #4598. Skips four CI workflows when a pull request changes nothing that could affect what they test.

## Approach

`paths-ignore` on the triggers, rather than #4598's `dorny/paths-filter` gate job plus a job-level `if`. #4598 needed that machinery because the checks were **required** — a workflow that never ran would leave the check unreported and block the PR forever, so the run had to happen and the heavy job had to be skipped from inside it.

With the required-check requirement lifted, the trigger filter does the same work with none of the machinery: no gate jobs, no `needs:` wiring, and no third-party action executing inside `ios.yml`'s privileged `pull_request_target` context.

## Filtered paths

The same list on all seven trigger blocks, in two groups:

```yaml
paths-ignore:
  # Documentation and agent/editor configuration.
  - '**/*.md'
  - 'docs/**'
  - '.github/instructions/**'
  - '.github/skills/**'
  - '.claude/**'
  - '.agents/**'
  - '.vscode/**'
  - '.hooks/**'
  # Native platform projects, and the icon/splash sources generated into them.
  - 'android/**'
  - 'ios/**'
  - 'desktop/**'
  - 'assets/**'
```

## Workflows

| Workflow | Filtered | Why |
|---|---|---|
| **Test** | ✅ | `yarn test` is `vitest --project unit`; reads only `src/`. |
| **Puppeteer** | ✅ | Tests the web build in Chrome. |
| **BrowserStack** | ✅ | Tests mobile Safari over a tunnel — not the Capacitor app. |
| **Vercel Preview** | ✅ | Builds the web app; a filtered PR gets no deployment and no preview comment, which is the intended outcome. |
| **Lint** | ❌ deliberately | See below. |
| **TDD** | ❌ not needed | Its `detect` job already finds no changed tests in such a PR and skips on its own. |

## Lint stays required and unfiltered

`Lint` is the one remaining required status check on `main` (verified against the branch protection API). Leaving it unfiltered means every PR — including a documentation-only one — still reports exactly one check rather than presenting a reviewer with an empty check list. It is also the cheapest workflow in the set: `eslint . --cache` plus `tsc`, no browser, no device, no external service.

This matters because `paths-ignore` skips a workflow outright, so **no check is reported at all** — not a "skipped" check, and not the synthetic pass a job-level `if` produces. Each filtered workflow carries a comment saying so, and what to do if it is ever made required again.

## Evidence for the native entries

- `yarn build` is `build:packages && build:styles && vite build` — web only.
- Nothing in `vite.config.ts`, `capacitor.config.ts`, or `vitest.config.ts` references `android/`, `ios/`, `desktop/`, or `assets/`. The only `src/` match for those strings is a test *name* in `emojiRegex.ts`.
- **None of those directories contains a single JS or TS file.** `android/` is png/xml/gradle/java, `ios/` is png/json/swift/storyboard/plist, `desktop/` is png/rs/toml, `assets/` is png only. So `eslint .` and `tsc` cannot see them either.
- The web favicons come from `public/` via root-relative paths in `index.html`; `assets/favicon.png` is a Capacitor source, unused by the web build.
- `desktop/` keeps its own coverage in `tauri-release-main.yml` (push to `main`) and `tauri-release-prod.yml` (`v*` tags), both untouched here. `android/` and `ios/` have no build workflow at all, so these suites were never covering them.

**The caveat, recorded in the workflow comments:** unlike markdown, which cannot execute by nature, the native entries depend on the build graph *staying* web-only. If a Capacitor asset is ever wired into the Vite build, they must be removed.

## Notes for reviewers

- A run is skipped only when **every** changed file matches, so any PR that also touches app or test code runs everything in full. The existing `changed_files > 0` guards are left in place; they cover the empty-change-set case, a different condition.
- `.github/skills/` contributes only 2 new files — its 12 `SKILL.md` files were already covered by `**/*.md`. The two shell scripts are agent session tooling, referenced only by `docs/agents/` and by comment lines in `copilot-setup-steps.yml`.
- Nothing gitignored is listed. `.idea/` was the only candidate that is (`.gitignore:28`) and was excluded.
- **Not** filtered, deliberately: `packages/` (`build:packages` runs as part of `yarn build`), `public/`, `scripts/`, `.yarn/`, `.github/workflows/`, `.github/actions/`. `server/` was left alone pending a check of the client connection path.
- GitHub Actions does not support YAML anchors, so the list is duplicated per trigger. Each file notes this inline.
- This PR edits `.github/workflows/*.yml`, which is not in the ignore list, so its own checks run — as they should for a CI change. It does not self-demonstrate the skip; a docs-only PR is needed for that.
- Validated by parsing the YAML rather than reading it: all seven trigger blocks carry byte-identical 12-entry lists, `workflow_dispatch` correctly carries none, and all five changed files are prettier-clean.
- `docs/testing.md` gains a "Path filtering" subsection in the same commit, covering both groups, the Lint exception, and the Capacitor caveat.
