### PR TITLE
Keep the trailing space that commits an iOS autocorrect (#4828)

### DIFF
--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { isTouch } from '../browser'
+import globals from '../globals'
 
 interface ContentEditableProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   style?: React.CSSProperties
@@ -90,7 +91,12 @@ const ContentEditable = React.memo(
           const innerHTML = contentRef!.current!.innerHTML
 
           // allow innerHTML updates after blur
-          allowInnerHTMLChange.current = true
+          // The momentary blur of the iOS autocomplete focus retarget does not end editing — focus returns to the
+          // editable immediately — so keep innerHTML updates suppressed there, or a re-render can overwrite what the
+          // user is typing with the trimmed value from Redux (#4828).
+          if (!globals.suppressBlurSync) {
+            allowInnerHTMLChange.current = true
+          }
 
           const event = Object.assign({}, originalEvent, {
             target: {

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -441,7 +441,12 @@ const Editable = ({
         // that stopped returning (the last 'retarget' entry before the log goes silent is the culprit). `deferred`
         // distinguishes these entries from pre-#4607-fix logs, where the retarget ran synchronously in the input event.
         debugLog.log('retarget', { step: 'asyncFocus', savedOffset: savedCharOffset, deferred: true })
+        // asyncFocus dispatches blur synchronously, and focus returns to the editable a few lines below, so the user
+        // is still typing. Suppress the blur handlers that resync the editable to the value in Redux, which by now
+        // has been trimmed by onChangeHandler: they would swallow the space that committed the autocomplete (#4828).
+        globals.suppressBlurSync = true
         asyncFocus({ force: true })
+        globals.suppressBlurSync = false
 
         debugLog.log('retarget', { step: 'preventAutoscroll', savedOffset: savedCharOffset })
         preventAutoscroll(editable)
@@ -749,7 +754,8 @@ const Editable = ({
       // update the ContentEditable if the new scrubbed value is different (i.e. stripped, space after emoji added, etc)
       // they may intentionally become out of sync during editing if the value is modified programmatically (such as trim) in order to avoid reseting the caret while the user is still editing
       // oldValueRef.current is the latest value since throttledChangeRef was just flushed
-      if (contentRef.current?.innerHTML !== oldValueRef.current) {
+      // Skipped during the iOS autocomplete focus retarget, whose momentary blur does not end editing (#4828).
+      if (!globals.suppressBlurSync && contentRef.current?.innerHTML !== oldValueRef.current) {
         // remove the invalid state error, remove invalid-option class, and reset editable html
         dispatch((dispatch, getState) => {
           const state = getState()

--- a/src/components/__tests__/EditableAutocomplete.ts
+++ b/src/components/__tests__/EditableAutocomplete.ts
@@ -1,0 +1,69 @@
+import { fireEvent } from '@testing-library/dom'
+import { render } from '@testing-library/react'
+import { act, createElement } from 'react'
+import { Provider } from 'react-redux'
+import SimplePath from '../../@types/SimplePath'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { HOME_TOKEN } from '../../constants'
+import * as selection from '../../device/selection'
+import contextToPath from '../../selectors/contextToPath'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import dispatch from '../../test-helpers/dispatch'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import Editable from '../Editable'
+
+// The focus retarget that follows iOS autocomplete (#4467) is only installed on Mobile Safari.
+vi.mock('../../browser', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../browser')>()
+  return { ...actual, isTouch: true, isSafari: () => true }
+})
+
+beforeEach(initStore)
+
+// Only the DOM half of the scenario can be emulated here: typing the next word depends on the caret that
+// selection.set restores, and jsdom does not move focus with the selection. The space surviving in the editable is
+// what the next keystroke lands after, so it is the observable that regressed.
+it('keeps the space that commits an iOS autocorrect in the editable (#4828)', async () => {
+  await dispatch([importText({ text: '- Adf' }), setCursor(['Adf'])])
+
+  const simplePath = contextToPath(store.getState(), ['Adf']) as SimplePath
+  const { container } = render(
+    createElement(Provider, {
+      store,
+      children: createElement(Editable, {
+        isEditing: true,
+        isVisible: true,
+        path: simplePath,
+        rank: 0,
+        simplePath,
+      }),
+    }),
+  )
+  const editable = container.querySelector('[data-editable]') as HTMLElement
+  editable.focus()
+
+  // Pressing space on a misspelled word makes iOS replace the word...
+  editable.innerHTML = 'All'
+  selection.set(editable, { offset: 'All'.length })
+  fireEvent.input(editable, { inputType: 'insertReplacementText' })
+
+  // ...and then insert the space that committed the correction.
+  editable.innerHTML = 'All '
+  selection.set(editable, { offset: 'All '.length })
+  fireEvent.input(editable, { inputType: 'insertText', data: ' ' })
+
+  // the focus retarget blurs and refocuses the editable on the next animation frame
+  await act(vi.runAllTimersAsync)
+
+  // The editable the user is typing into must keep the space, otherwise the next word they type is appended
+  // directly to the corrected word ("Allthings").
+  expect(editable.textContent).toBe('All ')
+
+  // The value committed to Redux is trimmed. It is the divergence between the two that regressed: the retarget's
+  // blur used to resync the editable to this trimmed value.
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+  expect(exported).toEqual(`- ${HOME_TOKEN}
+  - All`)
+})

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -35,6 +35,10 @@ let abandonImport = false
 /** Used to suppress the Editable change handler to ignore execCommand in registerNativeUndoStep. */
 let suppressChange = false
 
+/** Used to suppress the blur handlers that resync the editable's innerHTML to the value in Redux. Set while the
+ * editable is momentarily blurred and refocused to retarget focus after iOS autocomplete, which does not end editing. */
+let suppressBlurSync = false
+
 // check duplicate ranks within the same context for debugging
 const globals = {
   abandonImport,
@@ -44,6 +48,7 @@ const globals = {
   rendered,
   suppressExpansion,
   suppressChange,
+  suppressBlurSync,
   arrowKeyBoundaryCross: arrowKeyBoundaryCross as string | null,
   touching,
 }


### PR DESCRIPTION
#4828

Regression from #4821. Reproduced from the two production debug-log traces captured right before the failure.

## Diagnosis

The traces pin the exact frame:

```
#286076 input  branch=retarget   value="Giving it the space " sel=20   ← iOS commits the autocorrect with a space
#286078 action editThought       newValue="Giving it the space "       ← retarget flush (untrimmed)
#286079 change branch=immediate  oldValue="…space " newValue="…space"  ← trimHtml strips the trailing space
#286081 action editThought       newValue="Giving it the space"        ← Redux is now trimmed
#286082 retarget asyncFocus deferred=true                              ← the rAF from #4821 fires
#286083 blur                                                            ← onBlur resyncs innerHTML to the trimmed value
#286086 retarget selection.set savedOffset=20                          ← offset 20 clamps to 19
#286091 input  value="Giving it the spacei"                            ← the space is gone
```

Before #4821 the retarget blurred synchronously **inside** the input event, i.e. before React's `onChange` ran. `oldValueRef` still held the untrimmed `"…space "`, so `onBlur`'s `innerHTML !== oldValueRef` comparison matched and nothing was resynced. Deferring the retarget to `requestAnimationFrame` moved the blur to *after* the trim, so `onBlur` now sees a legitimate-looking mismatch and overwrites the live contenteditable with the trimmed value from Redux.

Only trailing whitespace is trimmed, which is why the issue does not occur when typing in the middle of a thought, and only Mobile Safari installs the retarget effect.

## Fix

Prevents the trim rather than re-inserting the space, per the issue. `globals.suppressBlurSync` marks the retarget's blur as not the end of editing:

- `Editable.tsx` — set around `asyncFocus({ force: true })`, which dispatches blur synchronously, so the flag cannot leak into a real blur.
- `Editable.tsx` `onBlur` — skips the innerHTML resync while set.
- `ContentEditable.tsx` — keeps `allowInnerHTMLChange` false for the same window. This half is **defensive and not exercised by the test**: the `html` prop happens not to change between the blur and the next keystroke, but without it the fix rests on that incidental fact rather than on the invariant.

## Validation

- New JSDOM regression test `src/components/__tests__/EditableAutocomplete.ts` fires the real `insertReplacementText` → `insertText " "` pair on a Mobile-Safari-mocked `Editable`. It fails without the fix with `expected 'All' to be 'All '` — the bug's exact signature — and passes with it.
- `yarn test` ✅ 1560 passed / 75 skipped, 0 failures
- `yarn lint` (incl. tsc) ✅ · `yarn prettier --check` ✅
- **Not verified on device.** iOS autocorrect cannot be driven on shared BrowserStack devices (`docs/agents/skills.md`). Field check: type a misspelled word, press space to accept the correction, then type another word.

## Notes

- The test does not emulate typing the next word: that depends on the caret `selection.set` restores, and jsdom does not move focus with the selection. The space surviving in the editable is what the next keystroke lands after, so it is the observable that regressed.
- Unrelated and untouched: the retarget's flush commits the untrimmed value to Redux for one dispatch (`Missing Lexeme: "All "`) before the trim lands. Pre-existing and self-correcting.
- `docs:` unaffected — no document describes the blur-time resync or the autocomplete retarget path. `cursor-and-caret.md` covers `asyncFocus` and `selection.set`, both unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)