### PR TITLE
ci: cancel superseded CI runs on pull requests

### DIFF
--- a/.github/skills/ci-monitor/SKILL.md
+++ b/.github/skills/ci-monitor/SKILL.md
@@ -21,6 +21,7 @@ allowed-tools:
 
 - **In a local harness**, where that MCP server is not present, the `gh` CLI is the equivalent: `gh run list --branch "$(git rev-parse --abbrev-ref HEAD)"` to list, and `gh run view <id> --log-failed` to pull the failing log. Everything below applies unchanged — only the mechanism differs.
 - Wait for ALL in-progress runs to complete before reporting status. Never claim tests pass without actually checking.
+- **A `cancelled` run is not a failure.** Test, Puppeteer, Lint, and Vercel Preview cancel a run as soon as a newer push supersedes it (`docs/testing.md` § Superseded runs), so a branch that was pushed to twice in quick succession normally carries cancelled runs on the older commits. Judge each workflow by its run on the current head sha (`git rev-parse HEAD`), and never enter the iteration loop below for a run that was merely superseded.
 - For each workflow, report: passed, failed, or still running.
 - For failed workflows, pull the relevant log section showing the error.
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,24 @@ on:
     branches:
       - '**'
 
+# Supersede the in-progress run when a pull request is pushed again; its result is about to be
+# replaced anyway. Only pull_request runs are grouped: `github.ref` is `refs/pull/<n>/merge` there,
+# so it is already per-PR. (vercel-preview.yml must key on the PR number instead because
+# pull_request_target sets github.ref to the base branch.)
+#
+# Pushes to main fall back to github.run_id, which is unique per run and therefore never collides.
+# That is deliberate, and not the same as cancel-in-progress: false — a shared group with
+# cancellation off *queues* runs, and GitHub cancels a pending run when a newer one queues behind
+# it. Each push to main needs its own result to identify the commit that broke the build.
+#
+# Lint is the one required status check on main (see § Path filtering in docs/testing.md), and a
+# cancelled run reports `cancelled`, not `success`. That does not block anything: branch protection
+# evaluates the checks on the pull request's *head* commit, and only a superseded commit's run is
+# ever cancelled. The head commit's run always finishes, because nothing supersedes it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -57,6 +57,26 @@ on:
         description: 'Optional ID for tracking repeated runs'
         required: false
 
+# Supersede the in-progress run when a pull request is pushed again; its result is about to be
+# replaced anyway. Only pull_request runs are grouped: `github.ref` is `refs/pull/<n>/merge` there,
+# so it is already per-PR. (vercel-preview.yml must key on the PR number instead because
+# pull_request_target sets github.ref to the base branch.)
+#
+# Every other event falls back to github.run_id, which is unique per run and therefore never
+# collides. That is deliberate, and not the same as cancel-in-progress: false — a shared group with
+# cancellation off *queues* runs, and GitHub cancels a pending run when a newer one queues behind
+# it. Pushes to main each need their own result to identify the commit that broke the build, and the
+# `ghworkflow` flake hunt (docs/testing.md § Triggering GitHub Actions workflows manually) fans out
+# many workflow_dispatch runs on one ref that must all run.
+#
+# Cancelling is safe for the downstream pair: puppeteer-diff-comment.yml acts only on a `success`
+# or `failure` conclusion, so a cancelled run posts nothing from its partial artifacts. The
+# browserless service container lives inside the job and dies with it — nothing is shared across
+# runs the way ios.yml's BrowserStack session pool is, which is why that one queues instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -10,6 +10,23 @@ on:
         description: 'Optional ID for tracking repeated runs'
         required: false
 
+# Supersede the in-progress run when a pull request is pushed again; its result is about to be
+# replaced anyway. Only pull_request runs are grouped: `github.ref` is `refs/pull/<n>/merge` there,
+# so it is already per-PR. (vercel-preview.yml must key on the PR number instead because
+# pull_request_target sets github.ref to the base branch.)
+#
+# workflow_dispatch falls back to github.run_id, which is unique per run and therefore never
+# collides. That is deliberate, and not the same as cancel-in-progress: false — a shared group with
+# cancellation off *queues* runs, and GitHub cancels a pending run when a newer one queues behind
+# it, which would break the `ghworkflow` flake hunt (docs/testing.md § Triggering GitHub Actions
+# workflows manually) that fans out many runs on one ref.
+#
+# This group is separate from ios.yml's `browserstack` one, so the contention noted on the ios job
+# below is unchanged; cancelling a superseded run only ever reduces the draw on that shared pool.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,21 @@ on:
         description: 'Optional ID for tracking repeated runs'
         required: false
 
+# Supersede the in-progress run when a pull request is pushed again; its result is about to be
+# replaced anyway. Only pull_request runs are grouped: `github.ref` is `refs/pull/<n>/merge` there,
+# so it is already per-PR. (vercel-preview.yml must key on the PR number instead because
+# pull_request_target sets github.ref to the base branch.)
+#
+# Every other event falls back to github.run_id, which is unique per run and therefore never
+# collides. That is deliberate, and not the same as cancel-in-progress: false — a shared group with
+# cancellation off *queues* runs, and GitHub cancels a pending run when a newer one queues behind
+# it. Pushes to main each need their own result to identify the commit that broke the build, and the
+# `ghworkflow` flake hunt (docs/testing.md § Triggering GitHub Actions workflows manually) fans out
+# many workflow_dispatch runs on one ref that must all run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -202,7 +202,7 @@ So: only use it when the visual change was intentional, never to silence a failu
 
 **Source: [`.github/skills/ci-monitor/SKILL.md`](../../.github/skills/ci-monitor/SKILL.md)**
 
-Lists the workflow runs for the current branch and waits for all of them to finish before reporting. Derives the repository from the git remote rather than assuming, and filters by the current branch.
+Lists the workflow runs for the current branch and waits for all of them to finish before reporting. Derives the repository from the git remote rather than assuming, and filters by the current branch. Because the main workflows cancel a run the moment a newer push supersedes it (see [Superseded runs](../testing.md#superseded-runs)), it judges each workflow by its run on the current head sha — a `cancelled` run on an older commit is not a failure to chase.
 
 Its central instruction: **never claim tests pass without checking.** The skill says outright that hallucinating test results is the worst thing it can do. If CI still fails after five fix-and-push cycles, stop and hand back to a human.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -637,7 +637,7 @@ TDD needs no filter: its `detect` job already finds no changed tests in such a p
 
 #### Superseded runs
 
-Path filtering decides which runs start; concurrency decides which of them are worth finishing. When a pull request is pushed to twice in quick succession only the newer run's result is ever read, so Test, Puppeteer, Lint, and Vercel Preview each cancel the run they supersede. The first three carry this block:
+Path filtering decides which runs start; concurrency decides which of them are worth finishing. When a pull request is pushed to twice in quick succession only the newer run's result is ever read, so Test, Puppeteer, Lint, TDD, and Vercel Preview each cancel the run they supersede. The first four carry this block:
 
 ```yml
 concurrency:
@@ -653,7 +653,7 @@ concurrency:
 
 Downstream workflows already tolerate it: [`Puppeteer Diff Comment`](../.github/workflows/puppeteer-diff-comment.yml) acts only on a `success` or `failure` conclusion, so a cancelled run posts nothing from its partial artifacts.
 
-Two workflows sit outside this. BrowserStack queues rather than supersedes, for the reason in its table note below. TDD carries no concurrency group, so its runs are never cancelled.
+BrowserStack is the one exception: it queues rather than supersedes, for the reason in its table note below. TDD's iOS job runs against the same BrowserStack account from a *different* group, so it contends for that shared session cap either way — cancelling a superseded TDD run only reduces the draw on it.
 
 | Workflow | File | What it runs | Notes |
 |---|---|---|---|

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -635,11 +635,31 @@ Because `paths-ignore` skips a workflow outright, **no check is reported at all*
 
 TDD needs no filter: its `detect` job already finds no changed tests in such a pull request and skips on its own. A run is skipped only when *every* changed file matches, so any pull request that also touches app or test code runs everything in full.
 
+#### Superseded runs
+
+Path filtering decides which runs start; concurrency decides which of them are worth finishing. When a pull request is pushed to twice in quick succession only the newer run's result is ever read, so Test, Puppeteer, Lint, and Vercel Preview each cancel the run they supersede. The first three carry this block:
+
+```yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+```
+
+**The group key is per-trigger, not copyable between workflows.** For a `pull_request` workflow, `github.ref` is `refs/pull/<n>/merge` and is already per-pull-request. Vercel Preview cannot use it: `pull_request_target` sets `github.ref` to the base branch, which would put every open pull request in one group, so it keys on `github.event.pull_request.number` instead. Check the trigger before reusing either form.
+
+**Only pull-request runs are grouped.** Every other event falls back to `github.run_id`, which is unique per run and so never collides. This is not the same as `cancel-in-progress: false`: a *shared* group with cancellation off queues runs instead, and GitHub cancels a pending run when a newer one queues behind it — the reason BrowserStack also sets `queue: max`. Two things depend on non-pull-request runs neither cancelling nor queueing: each push to `main` needs its own result to identify the commit that broke the build, and the `ghworkflow` flake hunt ([Tips](#triggering-github-actions-workflows-manually)) fans out many `workflow_dispatch` runs on a single ref that must all actually run.
+
+**Cancelling does not strand the required check.** A cancelled run reports `cancelled`, not `success`, and Lint is the one required status check on `main`. It still cannot block a merge, because branch protection evaluates the checks on the pull request's *head* commit and only a superseded commit's run is ever cancelled — the head commit's run always finishes, since nothing supersedes it. This is the opposite of the `paths-ignore` hazard above, where the check that would gate the merge is never reported at all.
+
+Downstream workflows already tolerate it: [`Puppeteer Diff Comment`](../.github/workflows/puppeteer-diff-comment.yml) acts only on a `success` or `failure` conclusion, so a cancelled run posts nothing from its partial artifacts.
+
+Two workflows sit outside this. BrowserStack queues rather than supersedes, for the reason in its table note below. TDD carries no concurrency group, so its runs are never cancelled.
+
 | Workflow | File | What it runs | Notes |
 |---|---|---|---|
 | **Test** | [`.github/workflows/test.yml`](../.github/workflows/test.yml) | `yarn test` (Vitest unit + jsdom) | The fast tier. Should always pass. Filtered by `paths-ignore` (see above). |
 | **Puppeteer** | [`.github/workflows/puppeteer.yml`](../.github/workflows/puppeteer.yml) | `yarn test:puppeteer` against a `browserless/chrome:latest` service container on port 7566. | On failure, image-snapshot diffs are uploaded in the `__diff_output__` artifact. |
-| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`, and serialized to avoid exhausting the shared device pool. |
+| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`. Serialized repo-wide by a `browserstack` group with `cancel-in-progress: false` and `queue: max`: because the BrowserStack parallel-session cap is shared across every run, these queue rather than supersede each other, and no run is dropped. |
 | **TDD** | [`.github/workflows/tdd.yml`](../.github/workflows/tdd.yml) | Runs newly added unit, Puppeteer, and iOS tests against the selected pre-fix commit. | Expects the new regression test to fail before the fix. Pull requests only. |
 
 When a Puppeteer snapshot test fails on a pull request, the [`Puppeteer Diff Comment`](../.github/workflows/puppeteer-diff-comment.yml) workflow safely publishes the diff images to the `snapshot-diffs` branch and upserts a PR comment with the affected files and targeted `yarn test:puppeteer -u ...` command. The raw `__diff_output__` artifact is also available from the workflow run. Locally, the diff path is printed in the test runner output. See [Visual snapshot tests](#visual-snapshot-tests).


### PR DESCRIPTION
Follows #4834, which gave `vercel-preview.yml` a concurrency group. `test.yml`, `puppeteer.yml`, `lint.yml`, and `tdd.yml` had none, so rapid pushes to a branch ran every build to completion.

Observed on #4834: a second push started Puppeteer run [30833354088](https://github.com/cybersemics/em/actions/runs/30833354088) while the first push's [30833017185](https://github.com/cybersemics/em/actions/runs/30833017185) was still in progress, and both ran to completion.

All four now carry:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
  cancel-in-progress: true
```

## Group key

These are `pull_request` workflows, so `github.ref` is `refs/pull/<n>/merge` and is already per-PR. `vercel-preview.yml` could not use that form — `pull_request_target` sets `github.ref` to the base branch — which is why #4834 keyed it on the PR number. Verified per workflow rather than copied.

## Why non-PR events get a unique group, not `cancel-in-progress: false`

`cancel-in-progress: false` on a *shared* group does not mean "run freely" — it **queues**, and GitHub cancels a pending run when a newer one queues behind it (default queue depth 1, which is why `ios.yml` needs `queue: max`). Under that form:

- pushes to `main` would serialize instead of each reporting their own result, and
- the `ghworkflow` flake hunt (`docs/testing.md` § Triggering GitHub Actions workflows manually) fans out many `workflow_dispatch` runs **on a single ref** — most would be silently cancelled while pending.

Falling back to `github.run_id` gives each non-PR run its own group. This branch demonstrates it: a `workflow_dispatch` Test run and a `pull_request` Test run were in progress simultaneously without either cancelling the other.

## Required checks

`gh api repos/cybersemics/em/branches/main/protection` confirms `Lint` is the only required status check. A cancelled run reports `cancelled`, not `success`, but it cannot block a merge: branch protection evaluates the checks on the PR's **head** commit, and only a *superseded* commit's run is ever cancelled — the head commit's run always finishes, since nothing supersedes it. This is the inverse of the `paths-ignore` hazard already documented, where the gating check is never reported at all.

## Left alone

`ios.yml`'s `browserstack` group keeps `cancel-in-progress: false` + `queue: max` — the BrowserStack parallel-session cap is shared repo-wide, so those runs must queue rather than supersede. TDD's iOS job stays outside that group, so the contention documented there is unchanged; cancelling a superseded TDD run only reduces the draw on the shared cap.

## Found while checking

- `puppeteer-diff-comment.yml` already gates on a `success` or `failure` conclusion, so a cancelled run posts nothing from partial artifacts. No change needed.
- **`ci-monitor` would have misreported.** It said "report: passed, failed, or still running" — a trichotomy cancellation makes incomplete, so an agent would have entered the fix-push loop chasing superseded runs. It now judges each workflow by its run on the current head sha.

## Docs

- `docs/testing.md` gains § Superseded runs under § CI workflows; the BrowserStack table note now names `cancel-in-progress: false` + `queue: max` explicitly as the contrasting case.
- `docs/agents/skills.md` § ci-monitor updated to match.
- The `docs-sync` routing table needs no change — #4834 already routed `.github/workflows/` to `testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)