### PR TITLE
Fix BrowserStack PR runs failing at checkout; layer concurrency groups

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -60,19 +60,32 @@ on:
         description: 'Optional ID for tracking repeated runs'
         required: false
 
-# Serialize BrowserStack runs repo-wide. Every run draws from the same shared parallel-session pool, so
-# overlapping runs (a main push + PR syncs + reruns) can over-subscribe it and fail with session-creation
-# timeouts. Allowing one active run at a time keeps total live sessions within maxInstances.
-# (The Cloudflare tunnel pool tolerates concurrent connectors on its own — see
-# cloudflareTunnelPool.ts's self-verifying claim — so this serialization is purely about the
-# BrowserStack session cap now, not the tunnel.)
-# cancel-in-progress: false queues runs instead of cancelling them, so no run is dropped.
-# queue: max extends the queue from the default 1 to the maximum of 100, ensuring runs don't get silently
-# dropped if lots of jobs queue up.
+# Concurrency is layered across two groups because two requirements pull in opposite directions:
+# BrowserStack usage must be serialized repo-wide (queue, never cancel), while commits to the same
+# PR must supersede each other (cancel, never queue). One group cannot do both, but GitHub allows a
+# workflow-level group and a job-level group in the same workflow, and they are independent.
+#
+# This workflow-level group handles per-PR superseding. Each PR gets its own group with
+# cancel-in-progress, so a new commit cancels the PR's previous run whether it is still waiting for
+# the BrowserStack gate or already mid-suite — only the newest head is worth a device session, and
+# the repo-wide queue below routinely holds runs for 30-50 minutes, long enough for several pushes.
+# Non-PR runs (push to main, workflow_dispatch) get a unique group per run: superseding is only
+# wanted within a PR, every main commit should be tested, and workflow_dispatch runs are fanned out
+# deliberately for flake hunting (see ghworkflow in docs/testing.md), so none of these may cancel
+# each other. Serialization for them is enforced by the job-level gate, not here.
+#
+# The repo-wide `browserstack` gate lives on the `run` job (see below). It queues because every run
+# draws from the same shared parallel-session pool, so overlapping runs (a main push + PR syncs +
+# reruns) can over-subscribe it and fail with session-creation timeouts. (The Cloudflare tunnel pool
+# tolerates concurrent connectors on its own — see cloudflareTunnelPool.ts's self-verifying claim —
+# so that serialization is purely about the BrowserStack session cap, not the tunnel.)
+#
+# Tradeoff, accepted: a suite cancelled mid-run leaves its BrowserStack session to expire on the
+# provider's idle timeout instead of closing cleanly, briefly counting against the pool. That costs
+# less than what it replaces — running entire suites against superseded commits.
 concurrency:
-  group: browserstack
-  cancel-in-progress: false
-  queue: max
+  group: ${{ github.event_name == 'pull_request_target' && format('browserstack-pr-{0}', github.event.pull_request.number) || format('browserstack-run-{0}', github.run_id) }}
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -91,12 +104,71 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request_target' || github.event.pull_request.changed_files > 0
 
+    # The repo-wide gate — see the concurrency comment at the top of the file for why it sits at the
+    # job level (it must coexist with the per-PR workflow-level group; a workflow gets only one
+    # group per level). A run waiting here holds no runner. cancel-in-progress: false queues runs
+    # instead of cancelling them, and queue: max extends the pending queue from the default single
+    # slot to the maximum of 100 so queued runs are not silently dropped.
+    concurrency:
+      group: browserstack
+      cancel-in-progress: false
+      queue: max
+
+    # The cancel step below needs actions: write, and declaring any permission zeroes the rest, so
+    # everything the job uses is listed. contents: read is for checkout; nothing else uses the token.
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+
     steps:
+      # A run can wait 30-50 minutes at the `browserstack` gate above, and its PR may merge or close
+      # in the meantime. A merge triggers this workflow's own `push` run on main, so testing the
+      # merged code again here proves nothing while holding a device session for the whole suite and
+      # delaying every PR queued behind it. The job-level `if:` cannot catch this — it is evaluated
+      # when the run is created, while the PR is still open — so the state is re-read here, as the
+      # first step after the gate admits the job. Cancelling (rather than exiting green) is honest:
+      # no test ran, so nothing may report as passed. `state` is "closed" for merged and abandoned
+      # PRs alike, and neither is worth a device session. Same-PR staleness needs no check here —
+      # the workflow-level group already cancelled superseded runs of an open PR.
+      - name: Cancel if PR is no longer open
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{github.token}}
+          REPO: ${{github.repository}}
+          PR_NUMBER: ${{github.event.pull_request.number}}
+          RUN_ID: ${{github.run_id}}
+        run: |
+          STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .state)
+          if [ "$STATE" = 'open' ]; then
+            echo "PR #$PR_NUMBER is open — proceeding."
+            exit 0
+          fi
+          echo "PR #$PR_NUMBER is $STATE — cancelling this run. Merged code is covered by the push run on main."
+          gh api --method POST "repos/$REPO/actions/runs/$RUN_ID/cancel"
+          # Cancellation is asynchronous — the runner kills this step when it lands, normally within
+          # seconds. If it has not landed after a minute, fail loudly rather than build a dead PR.
+          sleep 60
+          echo "Cancellation did not land within 60s."
+          exit 1
+
+      # Check out the PR by head SHA, not by branch name. A bare branch name makes actions/checkout
+      # build a wildcard refspec (`+refs/heads/<name>*:refs/remotes/origin/<name>*`), and a wildcard
+      # that matches nothing makes `git fetch` exit 1 with an *empty* stderr — so a branch deleted on
+      # merge killed this step with a bare "The process '/usr/bin/git' failed with exit code 1" and
+      # no iOS test ran. The cancel step above turns away already-merged runs, but a PR can still
+      # merge in the window between that check and this one, so the checkout has to be robust on its
+      # own rather than relying on the guard.
+      #
+      # A SHA is fetched exactly, and GitHub keeps a PR's head commit reachable in the base repo (via
+      # refs/pull/<n>/head) even after the branch is gone — for fork PRs too, which is why
+      # `repository:` is not needed here. It also pins the run to the commit the event actually fired
+      # for, rather than whatever the branch tip has become. On push and workflow_dispatch the
+      # expression is empty and checkout falls back to the triggering ref.
       - name: Clone repository
         uses: actions/checkout@v6
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{github.event.pull_request.head.sha}}
           # v6 (upgraded from v4 in #3981) refuses to check out fork PR code from a
           # pull_request_target workflow unless this is set. Untrusted fork code is
           # gated by GitHub's "require approval for outside collaborators" setting.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -457,7 +457,7 @@ Only then does the run attach its connector, and it requires a burst of consecut
 
 If every tunnel is occupied the run waits, rescanning the pool every 10s for up to 45 minutes, rather than failing immediately. The starting index is derived from `GITHUB_RUN_ID` (or the PID locally) so concurrent runs spread across the pool instead of all racing for the first entry.
 
-This means `ios.yml`, `tdd.yml`, and local/agent runs can safely run concurrently against the same pool without a shared cross-workflow lock — each just claims whichever tunnel is free. (The `browserstack` concurrency group in `ios.yml` still exists, but purely because of BrowserStack's own shared parallel-session cap, not the tunnel.)
+This means `ios.yml`, `tdd.yml`, and local/agent runs can safely run concurrently against the same pool without a shared cross-workflow lock — each just claims whichever tunnel is free. (The job-level `browserstack` concurrency group in `ios.yml` still exists, but purely because of BrowserStack's own shared parallel-session cap, not the tunnel — see [Layered BrowserStack concurrency](#layered-browserstack-concurrency).)
 
 ##### One-time setup: provisioning the pool
 
@@ -639,10 +639,24 @@ TDD needs no filter: its `detect` job already finds no changed tests in such a p
 |---|---|---|---|
 | **Test** | [`.github/workflows/test.yml`](../.github/workflows/test.yml) | `yarn test` (Vitest unit + jsdom) | The fast tier. Should always pass. Filtered by `paths-ignore` (see above). |
 | **Puppeteer** | [`.github/workflows/puppeteer.yml`](../.github/workflows/puppeteer.yml) | `yarn test:puppeteer` against a `browserless/chrome:latest` service container on port 7566. | On failure, image-snapshot diffs are uploaded in the `__diff_output__` artifact. |
-| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`, and serialized to avoid exhausting the shared device pool. |
+| **BrowserStack** | [`.github/workflows/ios.yml`](../.github/workflows/ios.yml) | `yarn test:ios` (an alias of `test:ios:browserstack`) against real iOS devices via BrowserStack. | Uses `pull_request_target` so credentials are available, guarded by `changed_files > 0` and `paths-ignore`, serialized repo-wide, and deduplicated per PR (see [Layered BrowserStack concurrency](#layered-browserstack-concurrency)). |
 | **TDD** | [`.github/workflows/tdd.yml`](../.github/workflows/tdd.yml) | Runs newly added unit, Puppeteer, and iOS tests against the selected pre-fix commit. | Expects the new regression test to fail before the fix. Pull requests only. |
 
 When a Puppeteer snapshot test fails on a pull request, the [`Puppeteer Diff Comment`](../.github/workflows/puppeteer-diff-comment.yml) workflow safely publishes the diff images to the `snapshot-diffs` branch and upserts a PR comment with the affected files and targeted `yarn test:puppeteer -u ...` command. The raw `__diff_output__` artifact is also available from the workflow run. Locally, the diff path is printed in the test runner output. See [Visual snapshot tests](#visual-snapshot-tests).
+
+#### Layered BrowserStack concurrency
+
+BrowserStack has two concurrency requirements that no single group can satisfy: usage must be serialized repo-wide (queue, never cancel — the shared parallel-session pool over-subscribes otherwise), while commits to the same pull request must supersede each other (cancel, never queue — only the newest head is worth a device session). GitHub allows an independent concurrency group at the workflow level and the job level, so [`ios.yml`](../.github/workflows/ios.yml) uses one of each:
+
+- **Workflow level — per-PR superseding.** Each pull request gets its own group with `cancel-in-progress: true`, so a new commit cancels the PR's previous run whether it is still queued or already mid-suite. Non-PR runs (pushes to `main`, `workflow_dispatch`) get a unique group per run: every `main` commit should be tested, and `ghworkflow` fans out dispatch runs deliberately for flake hunting, so none of these may cancel each other.
+- **Job level — the repo-wide `browserstack` gate** on the `run` job, with `cancel-in-progress: false` and `queue: max`, so runs from different sources queue without being dropped. A run waiting at this gate holds no runner. A queued run routinely waits 30–50 minutes here.
+
+Two consequences of that wait are handled inside the `run` job, after the gate admits it — a job-level `if:` cannot handle either, because it is evaluated when the run is *created*, while the pull request is still open:
+
+- **Merged or closed PRs cancel themselves.** The first step re-reads the pull request state and cancels its own run via the API if the PR is no longer open — a merge triggers the workflow's own `push` run on `main`, so re-testing the merged code would prove nothing while occupying the gate for a full suite. Cancelling rather than exiting green is deliberate: no test ran, so nothing may report as passed.
+- **Checkout pins `github.event.pull_request.head.sha`, not the head branch name.** A branch name makes `actions/checkout` build a wildcard refspec, and a wildcard matching nothing makes `git fetch` exit non-zero with an **empty stderr** — so a branch deleted on merge used to fail the clone with a bare `The process '/usr/bin/git' failed with exit code 1`. A SHA is fetched exactly and stays reachable in the base repository via `refs/pull/<n>/head` after the branch is deleted (including for fork pull requests, which is why no `repository:` input is needed), keeping the checkout robust in the window between the cancel step's check and the fetch.
+
+Accepted tradeoff: a suite cancelled mid-run leaves its BrowserStack session to expire on the provider's idle timeout instead of closing cleanly, briefly counting against the pool — cheaper than running entire suites against superseded commits.
 
 Other workflows live in [`.github/workflows/`](../.github/workflows), including `lint.yml`, `docs.yml`, `update-browserslist.yml`, and `copilot-setup-steps.yml`.
 


### PR DESCRIPTION
Partially addresses #4798

## The clone failure

Every `pull_request_target` run of BrowserStack failed at **Clone repository** with a bare `The process '/usr/bin/git' failed with exit code 1`, so no iOS test ran on a PR. Runs on `main` succeeded.

The step checked out `head.ref` — a bare branch name — which makes `actions/checkout` build a **wildcard** refspec (`+refs/heads/<name>*:refs/remotes/origin/<name>*`). A wildcard matching nothing makes `git fetch` exit 1 with an **empty stderr**, which is why the logs carried no diagnosis. Reproduced against this repo:

```
=== ref: main ===                          * [new branch] main -> origin/main   EXIT=0
=== ref: nonexistent-no-slash-xyz ===                                           EXIT=1
=== ref: claude/issue-4828-debug-83e64d ===                                     EXIT=1
```

Runs queue repo-wide and routinely started 30–50 minutes after being triggered — by which time the PR had merged and its branch was auto-deleted, leaving nothing for the wildcard to match. PR #4832: opened 03:07:27, run queued 03:08:48, **merged 03:19:43**, fetch ran 03:55:29. Every failing branch is deleted; branches whose PRs stayed open succeeded. `main` never gets deleted, which is why push runs were unaffected.

Checkout now pins `head.sha`. A SHA is fetched exactly, and GitHub keeps a PR's head reachable in the base repo via `refs/pull/<n>/head` after the branch is gone — verified for fork PRs too, which is why the `repository:` input is no longer needed.

## The concurrency rework

The same queue delay meant full suites ran against merged or superseded commits. Two requirements no single group can meet — repo-wide serialization must queue and never cancel, while commits to one PR must cancel and never queue — so both available levels are used:

- **Workflow level:** a per-PR group with `cancel-in-progress`, so a new commit supersedes that PR's earlier run whether queued or mid-suite. Non-PR runs get a unique group per run, so `main` pushes and the deliberate `workflow_dispatch` fan-out never cancel each other.
- **Job level:** the existing repo-wide `browserstack` queue (`cancel-in-progress: false`, `queue: max`), unchanged.

A merged or closed PR now cancels its own run in the first step after the gate admits it, rather than reporting green — no test ran, so nothing may report as passed. This cannot live in the job `if:`, which is evaluated when the run is created, while the PR is still open.

## Verification

- Failing fetch reproduced locally against this repo, and the fix verified — including fork PR head SHAs fetched from the base repo after their branches were deleted.
- The cancel step's three branches executed against live PR data (open / merged / closed-unmerged) with the cancel API stubbed.
- `queue: max` confirmed valid at job level: workflow-level and job-level `concurrency` `$ref` the same schema definition, which includes `queue`.
- actionlint reports the same three pre-existing findings before and after.

## Notes for review

- `pull_request_target` runs the workflow file from `main`, so **this PR's own BrowserStack run still uses the old workflow.** The change only takes effect for PRs opened after it merges.
- Partially addresses #4798: it removes superseded and already-merged runs from the queue, which is where much of the wasted wait comes from. It does not raise the session cap itself (#4816).
- Accepted tradeoff: a suite cancelled mid-run leaves its BrowserStack session to expire on the provider's idle timeout rather than closing cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
