### PR TITLE
fix: await Puppeteer executable path in Copilot setup

### DIFF
--- a/scripts/shared-chrome.mjs
+++ b/scripts/shared-chrome.mjs
@@ -14,7 +14,7 @@ import { spawn } from 'node:child_process'
 import puppeteer from 'puppeteer'
 
 const port = process.env.EM_CHROME_PORT || '9222'
-const executablePath = puppeteer.executablePath()
+const executablePath = await puppeteer.executablePath()
 const args = [
   `--remote-debugging-port=${port}`,
   '--user-data-dir=/tmp/em-chrome-shared',


### PR DESCRIPTION
In commit 7c7715f91ae19c731b051daafd26710ed3f0ec8e (July 31), the project upgraded from Puppeteer 24.42.0 too Puppeteer 25.4.0.

This changed `executablePath()` from returning a string to returning a `Promise<string>`. The shared-Chrome launcher passed that Promise directly to `child_process.spawn`, causing the Copilot setup step to fail with `ERR_INVALID_ARG_TYPE`.

Failed run: https://github.com/cybersemics/em/actions/runs/30908932099/job/91990555291

## Verification

- Reproduced the pre-fix `[object Promise]` / `ERR_INVALID_ARG_TYPE` failure locally.
- Confirmed the fixed launcher starts Chrome and exposes the DevTools endpoint on port 9222.
- `yarn lint`
- `yarn test --run` — 182 files and 1,646 tests passed.
