### PR TITLE
test: add unit coverage for scripts/shared-chrome.mjs

### DIFF
--- a/scripts/__tests__/shared-chrome.ts
+++ b/scripts/__tests__/shared-chrome.ts
@@ -1,0 +1,91 @@
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import sharedChromeConfig from '../shared-chrome.mjs'
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+/** Overrides process.platform for a single test so the platform-dependent sandbox flags can be exercised on any host. */
+const stubPlatform = (platform: NodeJS.Platform) =>
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  Object.defineProperty(process, 'platform', platformDescriptor)
+})
+
+describe('sharedChromeConfig', () => {
+  // Regression test for #4848: puppeteer.executablePath() became async in puppeteer 24+, and the
+  // un-awaited Promise was passed to spawn as the executable — so the shared Chrome never launched.
+  it('resolves the Chrome executable to an absolute path, not a Promise', async () => {
+    const { executablePath } = await sharedChromeConfig()
+
+    expect(typeof executablePath).toBe('string')
+    expect(path.isAbsolute(executablePath)).toBe(true)
+  })
+
+  it('serves the CDP endpoint on port 9222 by default', async () => {
+    const { args, port } = await sharedChromeConfig()
+
+    expect(port).toBe('9222')
+    expect(args).toContain('--remote-debugging-port=9222')
+  })
+
+  it('serves the CDP endpoint on EM_CHROME_PORT when set', async () => {
+    vi.stubEnv('EM_CHROME_PORT', '9333')
+
+    const { args, port } = await sharedChromeConfig()
+
+    expect(port).toBe('9333')
+    expect(args).toContain('--remote-debugging-port=9333')
+    expect(args).not.toContain('--remote-debugging-port=9222')
+  })
+
+  it('launches headless by default', async () => {
+    const { args } = await sharedChromeConfig()
+
+    expect(args).toContain('--headless=new')
+  })
+
+  it('launches headed when EM_CHROME_HEADLESS=0', async () => {
+    vi.stubEnv('EM_CHROME_HEADLESS', '0')
+
+    const { args } = await sharedChromeConfig()
+
+    expect(args).not.toContain('--headless=new')
+  })
+
+  it('auto-accepts the dev server’s self-signed certificate', async () => {
+    const { args } = await sharedChromeConfig()
+
+    expect(args).toContain('--ignore-certificate-errors')
+  })
+
+  it('disables the Chrome sandbox on Linux, where CI runners block unprivileged user namespaces', async () => {
+    stubPlatform('linux')
+
+    const { args } = await sharedChromeConfig()
+
+    expect(args).toContain('--no-sandbox')
+    expect(args).toContain('--disable-setuid-sandbox')
+    expect(args).toContain('--disable-dev-shm-usage')
+  })
+
+  it('keeps the Chrome sandbox on Linux when EM_CHROME_NO_SANDBOX=0', async () => {
+    stubPlatform('linux')
+    vi.stubEnv('EM_CHROME_NO_SANDBOX', '0')
+
+    const { args } = await sharedChromeConfig()
+
+    expect(args).not.toContain('--no-sandbox')
+    expect(args).not.toContain('--disable-setuid-sandbox')
+    expect(args).not.toContain('--disable-dev-shm-usage')
+  })
+
+  it('keeps the Chrome sandbox on macOS', async () => {
+    stubPlatform('darwin')
+
+    const { args } = await sharedChromeConfig()
+
+    expect(args).not.toContain('--no-sandbox')
+  })
+})

--- a/scripts/shared-chrome.mjs
+++ b/scripts/shared-chrome.mjs
@@ -11,32 +11,43 @@
  *   EM_CHROME_HEADLESS=0 node scripts/shared-chrome.mjs   # headed, for watching locally
  */
 import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import puppeteer from 'puppeteer'
 
-const port = process.env.EM_CHROME_PORT || '9222'
-const executablePath = await puppeteer.executablePath()
-const args = [
-  `--remote-debugging-port=${port}`,
-  '--user-data-dir=/tmp/em-chrome-shared',
-  '--no-first-run',
-  '--no-default-browser-check',
-  // The dev server now serves HTTPS with a self-signed cert (@vitejs/plugin-basic-ssl). Auto-accept it
-  // so navigation never hits the interstitial — this shared Chrome only ever loads our own dev server,
-  // so blanket-ignoring cert errors is safe here and removes the need for the `thisisunsafe` bypass.
-  '--ignore-certificate-errors',
-  ...(process.env.EM_CHROME_HEADLESS === '0' ? [] : ['--headless=new']),
-  // Chrome's sandbox needs unprivileged user namespaces, which CI runners (Ubuntu 23.10+ / current
-  // GitHub Actions images) disable via an AppArmor policy — Chrome then aborts on launch with
-  // "No usable sandbox". Disable the sandbox on Linux only: the runner is an ephemeral, single-tenant
-  // VM loading only our own dev server. This is independent of headless/Xvfb (the crash happens headed
-  // too). `--disable-dev-shm-usage` avoids separate crashes from the small /dev/shm in CI containers.
-  // macOS keeps its sandbox. Override with EM_CHROME_NO_SANDBOX=0.
-  ...(process.platform === 'linux' && process.env.EM_CHROME_NO_SANDBOX !== '0'
-    ? ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
-    : []),
-]
+/** Resolves the Chrome executable and command-line args for the shared Chrome. Reads EM_CHROME_* configuration from the environment at call time. */
+const sharedChromeConfig = async () => {
+  const port = process.env.EM_CHROME_PORT || '9222'
+  const executablePath = await puppeteer.executablePath()
+  const args = [
+    `--remote-debugging-port=${port}`,
+    '--user-data-dir=/tmp/em-chrome-shared',
+    '--no-first-run',
+    '--no-default-browser-check',
+    // The dev server now serves HTTPS with a self-signed cert (@vitejs/plugin-basic-ssl). Auto-accept it
+    // so navigation never hits the interstitial — this shared Chrome only ever loads our own dev server,
+    // so blanket-ignoring cert errors is safe here and removes the need for the `thisisunsafe` bypass.
+    '--ignore-certificate-errors',
+    ...(process.env.EM_CHROME_HEADLESS === '0' ? [] : ['--headless=new']),
+    // Chrome's sandbox needs unprivileged user namespaces, which CI runners (Ubuntu 23.10+ / current
+    // GitHub Actions images) disable via an AppArmor policy — Chrome then aborts on launch with
+    // "No usable sandbox". Disable the sandbox on Linux only: the runner is an ephemeral, single-tenant
+    // VM loading only our own dev server. This is independent of headless/Xvfb (the crash happens headed
+    // too). `--disable-dev-shm-usage` avoids separate crashes from the small /dev/shm in CI containers.
+    // macOS keeps its sandbox. Override with EM_CHROME_NO_SANDBOX=0.
+    ...(process.platform === 'linux' && process.env.EM_CHROME_NO_SANDBOX !== '0'
+      ? ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
+      : []),
+  ]
+  return { executablePath, args, port }
+}
 
-console.info(`Launching shared Chrome on :${port}\n  ${executablePath} ${args.join(' ')}`)
+export default sharedChromeConfig
 
-const chrome = spawn(executablePath, args, { stdio: 'inherit' })
-chrome.on('exit', code => process.exit(code ?? 0))
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { executablePath, args, port } = await sharedChromeConfig()
+
+  console.info(`Launching shared Chrome on :${port}\n  ${executablePath} ${args.join(' ')}`)
+
+  const chrome = spawn(executablePath, args, { stdio: 'inherit' })
+  chrome.on('exit', code => process.exit(code ?? 0))
+}


### PR DESCRIPTION
Adds regression coverage for the failure fixed in #4848, where the un-awaited `puppeteer.executablePath()` Promise (async in puppeteer 24+) was passed to `spawn` as the executable, so the shared Chrome never launched in the Copilot setup.

## Approach

- Refactor `scripts/shared-chrome.mjs` following the `scripts/estimate` pattern: the launch configuration (executable resolution + Chrome args) moves into an exported `sharedChromeConfig()`, and the `spawn` is guarded behind a main-module check, so `node scripts/shared-chrome.mjs` behaves exactly as before.
- New unit tests in `scripts/__tests__/shared-chrome.ts` (collected by the root `unit` vitest project) assert the executable resolves to an absolute path **string** — the #4848 regression — and cover the `EM_CHROME_PORT`, `EM_CHROME_HEADLESS`, and platform-dependent `EM_CHROME_NO_SANDBOX` arg logic.

## Verification

- Temporarily removing the `await` makes the regression test fail with `expected 'object' to be 'string'` — it fails for the right reason.
- The script still launches Chrome for real: ran it on port 9223 and the CDP endpoint answered `/json/version`.
- Tests pass with an empty puppeteer cache, so they work in unit CI where `PUPPETEER_SKIP_DOWNLOAD` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)