### PR TITLE
fix: pre-resolve vitest-localstorage-mock setup file so unit tests run in agent worktrees

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
+import { createRequire } from 'node:module'
 import Terminal from 'vite-plugin-terminal'
 import { defineConfig } from 'vitest/config'
+
+const require = createRequire(import.meta.url)
 
 export default defineConfig({
   test: {
@@ -19,7 +22,10 @@ export default defineConfig({
           // vitest-localstorage-mock provides an in-test localStorage/sessionStorage mock. Note it does NOT
           // by itself prevent the intermittent `ReferenceError: localStorage is not defined` (#3345), which is
           // a teardown race handled by the persistent global-prototype fallback installed in src/setupTests.js.
-          setupFiles: ['vitest-localstorage-mock', 'src/setupTests.js'],
+          // Pre-resolve the bare specifier: vitest resolves setupFiles against the project root's *parent*
+          // directory chain, so inside an agent worktree (.claude/worktrees/*) it finds the outer checkout's
+          // copy first, which then fails vite's outside-root import check and breaks every unit test.
+          setupFiles: [require.resolve('vitest-localstorage-mock'), 'src/setupTests.js'],
         },
       },
       {


### PR DESCRIPTION
Every `yarn test` run from inside an agent worktree (`.claude/worktrees/*`) currently fails during setup with:

```
Error: Cannot find module '/@fs/Users/…/em/node_modules/vitest-localstorage-mock/dist/index.mjs'
```

## Cause

Vitest resolves bare-specifier `setupFiles` with `resolveModule(file, { paths: [root] })`, and the underlying resolver treats the extensionless root as a file URL — so resolution starts from the root's **parent** directory chain. Inside `.claude/worktrees/<name>`, that walk reaches the outer checkout's `node_modules/vitest-localstorage-mock` before ever considering the worktree's own copy, and importing that outside-root file then fails, breaking every unit test in the worktree.

## Fix

Pre-resolve the specifier in `vitest.config.ts` with `createRequire(import.meta.url).resolve(…)`, which pins the project's own install. In a normal checkout this resolves to the same file as before — verified by running the full unit suite (1655 tests passing) — and inside a worktree it makes `yarn test` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)