### PR TITLE
test: run scripts/shared-chrome.mjs for real in its own CI workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,9 @@ on: workflow_dispatch
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -91,8 +91,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
   # Activates the console proxy (src/util/consoleProxy.ts), which we need because BrowserStack
   # can't access iOS console logs.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -81,8 +81,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:

--- a/.github/workflows/shared-chrome.yml
+++ b/.github/workflows/shared-chrome.yml
@@ -1,0 +1,78 @@
+name: Shared Chrome
+
+# Integration test for scripts/shared-chrome.mjs, the shared Chrome CDP launcher that Copilot agent
+# sessions depend on. copilot-setup-steps.yml launches the script in every agent session but only
+# triggers on changes to itself, and every other workflow sets PUPPETEER_SKIP_DOWNLOAD — so without
+# this workflow, no CI ever runs the script or puppeteer's managed Chrome, and a break like #4848
+# (un-awaited executablePath() Promise passed to spawn) ships silently and takes down agent
+# sessions. scripts/shared-chrome.test.mjs launches the real script and asserts the CDP endpoint
+# answers with Chrome's actual handshake.
+#
+# `paths` means a non-matching PR reports no check at all — not a skipped one — so this workflow
+# must never be made a required status check on main (see § Path filtering in docs/testing.md).
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - scripts/shared-chrome.mjs
+      - scripts/shared-chrome.test.mjs
+      - .github/workflows/shared-chrome.yml
+      # A puppeteer bump is exactly the #4848 vector: executablePath() went async with a version
+      # change. Any dependency change materializes here, and the job is cheap.
+      - yarn.lock
+  pull_request:
+    branches:
+      - '**'
+    # GitHub Actions does not support YAML anchors, so this list is duplicated from `push` above.
+    paths:
+      - scripts/shared-chrome.mjs
+      - scripts/shared-chrome.test.mjs
+      - .github/workflows/shared-chrome.yml
+      - yarn.lock
+  workflow_dispatch:
+
+# Supersede the in-progress run when a pull request is pushed again; its result is about to be
+# replaced anyway. Only pull_request runs are grouped: `github.ref` is `refs/pull/<n>/merge` there,
+# so it is already per-PR. Every other event falls back to github.run_id, which is unique per run
+# and therefore never collides. (See the identical block in lint.yml for the full rationale.)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CI: true
+  # Chrome-for-Testing download hosts, needed because this job — unlike every other workflow, which
+  # sets PUPPETEER_SKIP_DOWNLOAD — deliberately lets puppeteer's postinstall download its managed
+  # Chrome: launching that browser is the behavior under test.
+  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
+
+jobs:
+  run:
+    name: Shared Chrome
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      # Plain `yarn` rather than ./.github/actions/install: the composite action restores
+      # node_modules from cache, and on a hit yarn skips dependency postinstalls — including
+      # puppeteer's Chrome download — leaving no browser for the script to launch. Plain `yarn` is
+      # also exactly how copilot-setup-steps.yml installs, so this job exercises the same
+      # environment the script actually runs in.
+      - name: Install npm dependencies
+        run: yarn
+
+      - name: Run shared Chrome integration test
+        run: node scripts/shared-chrome.test.mjs

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -34,8 +34,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI: true
   COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: googlechromelabs.github.io,storage.googleapis.com
-  # Skip Puppeteer's Chrome download on install — no CI job uses the bundled browser (Puppeteer
-  # tests attach to the browserless/chrome service via CDP), saving ~20s per install.
+  # Skip Puppeteer's Chrome download on install — none of this workflow's jobs uses the bundled
+  # browser (Puppeteer tests attach to the browserless/chrome service via CDP; only
+  # shared-chrome.yml launches the bundled browser), saving ~20s per install.
   PUPPETEER_SKIP_DOWNLOAD: true
 
 jobs:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -678,7 +678,7 @@ Two consequences of that wait are handled inside the `run` job, after the gate a
 
 Accepted tradeoff: a suite cancelled mid-run leaves its BrowserStack session to expire on the provider's idle timeout instead of closing cleanly, briefly counting against the pool — cheaper than running entire suites against superseded commits.
 
-Other workflows live in [`.github/workflows/`](../.github/workflows), including `lint.yml`, `docs.yml`, `update-browserslist.yml`, and `copilot-setup-steps.yml`.
+Other workflows live in [`.github/workflows/`](../.github/workflows), including `lint.yml`, `docs.yml`, `update-browserslist.yml`, and `copilot-setup-steps.yml`. One of them is itself a test: `shared-chrome.yml` runs [`scripts/shared-chrome.test.mjs`](../scripts/shared-chrome.test.mjs), which launches the real [`scripts/shared-chrome.mjs`](../scripts/shared-chrome.mjs) and asserts its Chrome CDP endpoint answers — the script otherwise runs only inside Copilot agent sessions, where a break like #4848 would ship unnoticed. It is the one CI job that uses puppeteer's downloaded Chrome (every other workflow sets `PUPPETEER_SKIP_DOWNLOAD`), and it triggers on the script, its test, its workflow, and `yarn.lock` (a puppeteer bump is how #4848 arrived).
 
 ### TDD regression validation
 

--- a/scripts/shared-chrome.test.mjs
+++ b/scripts/shared-chrome.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Integration test for shared-chrome.mjs: launch the real script and assert that the Chrome CDP
+ * endpoint it promises actually comes up. Guards against regressions like #4848, where the
+ * un-awaited (async since puppeteer 22) `puppeteer.executablePath()` Promise was passed to `spawn`,
+ * so Chrome never launched — a failure only observable by actually running the script, which no CI
+ * workflow did. Run by .github/workflows/shared-chrome.yml.
+ *
+ *   node scripts/shared-chrome.test.mjs
+ *
+ * Respects EM_CHROME_PORT like the script itself (CI uses the default :9222, the same port the
+ * chrome-devtools MCP and the web executor bridge are configured for). When running locally, note
+ * that the script's fixed --user-data-dir means an already-running shared Chrome will prevent this
+ * test's instance from launching — stop it first.
+ */
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const port = process.env.EM_CHROME_PORT || '9222'
+const timeoutMs = 60_000
+const pollMs = 250
+
+let output = ''
+/** Set by the exit handler so the poll loop can fail fast instead of sleeping out the timeout. */
+let exited = null
+
+// detached: the script does not forward signals to the Chrome it spawns, so kill the whole process
+// group on cleanup rather than orphaning a headless Chrome.
+const child = spawn(process.execPath, [fileURLToPath(new URL('shared-chrome.mjs', import.meta.url))], {
+  detached: true,
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+child.stdout.on('data', data => (output += data))
+child.stderr.on('data', data => (output += data))
+child.on('exit', (code, signal) => {
+  exited = { code, signal }
+})
+
+const cleanup = () => {
+  if (child.pid && !exited) {
+    try {
+      process.kill(-child.pid, 'SIGTERM')
+    } catch {
+      // process group already gone
+    }
+  }
+}
+
+/** Print the failure and the script's captured output, then exit nonzero. */
+const fail = message => {
+  console.error(`FAIL: ${message}\n\n--- shared-chrome.mjs output ---\n${output || '(none)'}`)
+  cleanup()
+  process.exit(1)
+}
+
+// Poll the CDP endpoint until it answers, the script dies, or the deadline passes. Each outcome
+// fails distinguishably: a crash reports the exit code and log immediately (the #4848 failure
+// mode — spawn threw synchronously), a timeout reports the log after 60s.
+const deadline = Date.now() + timeoutMs
+let version
+for (;;) {
+  if (exited)
+    fail(`script exited (code ${exited.code}, signal ${exited.signal}) before the CDP endpoint answered on :${port}`)
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/version`)
+    if (res.ok) {
+      version = await res.json()
+      break
+    }
+  } catch {
+    // endpoint not up yet
+  }
+  if (Date.now() > deadline) fail(`CDP endpoint did not answer on :${port} within ${timeoutMs / 1000}s`)
+  await new Promise(resolve => setTimeout(resolve, pollMs))
+}
+
+// Assert the responder is really Chrome's CDP handshake — the contract both consumers bootstrap
+// from (the chrome-devtools MCP via --browser-url and the web executor bridge via
+// puppeteer.connect) — not merely that something answered on the port.
+if (!/^(Headless)?Chrome\//.test(version.Browser ?? ''))
+  fail(`/json/version Browser is ${JSON.stringify(version.Browser)}, expected (Headless)Chrome/<version>`)
+if (!(version.webSocketDebuggerUrl ?? '').startsWith(`ws://127.0.0.1:${port}/`))
+  fail(
+    `/json/version webSocketDebuggerUrl is ${JSON.stringify(version.webSocketDebuggerUrl)}, expected ws://127.0.0.1:${port}/...`,
+  )
+
+console.info(`PASS: shared Chrome (${version.Browser}) answered CDP on :${port}`)
+cleanup()
+process.exit(0)


### PR DESCRIPTION
Adds regression coverage for #4848, where the un-awaited `puppeteer.executablePath()` Promise (async in current puppeteer) was passed to `spawn` as the executable, so the shared Chrome that Copilot agent sessions depend on never launched.

Unlike the abandoned unit-test approach in #4851, this does not refactor the script or assert on config values. The script is untouched; the test runs it for real.

## Approach

- **`scripts/shared-chrome.test.mjs`** — integration test. Spawns the real `scripts/shared-chrome.mjs` in its own process group, streams its output, and:
  - fails **immediately** with the captured log if the script process exits before the CDP endpoint answers (the exact #4848 failure mode — `spawn` throws synchronously on the Promise), rather than sleeping out a timeout;
  - polls `http://127.0.0.1:9222/json/version` (respecting `EM_CHROME_PORT` like the script) up to 60s;
  - asserts the response is Chrome's actual CDP handshake — `Browser` matches `(Headless)Chrome/…` and `webSocketDebuggerUrl` is `ws://127.0.0.1:<port>/…` — the contract both real consumers (the chrome-devtools MCP via `--browser-url`, the web executor bridge via `puppeteer.connect`) bootstrap from;
  - kills the whole process group on exit, since the script does not forward signals to the Chrome it spawns.
- **`.github/workflows/shared-chrome.yml`** — dedicated workflow, triggered on changes to the script, the test, the workflow itself, and `yarn.lock` (a puppeteer bump is exactly how #4848 arrived). It installs with plain `yarn` — deliberately not the composite install action, whose `node_modules` cache-hit skips puppeteer's postinstall Chrome download — and does **not** set `PUPPETEER_SKIP_DOWNLOAD`. This makes it the only CI job that exercises puppeteer's managed Chrome, matching the Copilot environment where the script actually runs. Being `paths`-filtered, it must never become a required status check (see § Path filtering in docs/testing.md).
- Rewords the now-stale "no CI job uses the bundled browser" comment in the six workflows that set `PUPPETEER_SKIP_DOWNLOAD`, and documents the new workflow in docs/testing.md § CI workflows.

## Why this gap existed

`copilot-setup-steps.yml` launches the script in every Copilot agent session, but its `on.paths` watch only the workflow file itself — a change to `scripts/shared-chrome.mjs` ran in no workflow at all. And every other workflow skips the puppeteer browser download, so the managed Chrome the script launches didn't even exist in CI.

## Verification

- `node scripts/shared-chrome.test.mjs` passes locally: `PASS: shared Chrome (Chrome/151.0.7922.47) answered CDP on :9222`, and no Chrome process is left behind.
- Reintroducing the #4848 bug (removing the `await`) makes it fail for the right reason, immediately: `FAIL: script exited (code 1, signal null) before the CDP endpoint answered on :9222` with the script's `[object Promise]` / `ERR_INVALID_ARG_TYPE` output captured in the failure message.
- `yarn lint` clean.
- The new workflow triggers on this PR (its own paths match), so the green side runs below.

## Architectural plan (per .github/skills/plan/SKILL.md)

**Surface area.** The regression site is `scripts/shared-chrome.mjs:17` (`await puppeteer.executablePath()`) feeding `spawn` at line 41. The only CI consumer is the launch step in `copilot-setup-steps.yml:104-117`, whose triggers (lines 6-13) watch only that file. `test.yml`/`lint.yml`/`puppeteer.yml`/`tdd.yml`/`docs.yml`/`ios.yml` all set `PUPPETEER_SKIP_DOWNLOAD: true` with a comment claiming "no CI job uses the bundled browser". The vitest `unit` project collects only `**/__tests__/**/*.ts` under jsdom, so it can neither host a real launch nor accidentally collect the new `.mjs` file. The composite `.github/actions/install` documents that a `node_modules` cache hit skips workspace postinstalls — which would skip the Chrome download.

**Build vs extend.** New workflow + new test file (user-mandated shape); no existing workflow can host it (skip-download env, wrong tier, or bootstrap-only). The script under test is not modified — an exported-config refactor would change the very thing being guarded.

**Adjacent behaviour.** `yarn test` collection unchanged (`.mjs` outside `__tests__/` matches neither vitest project); `copilot-setup-steps.yml` untouched; the six-workflow comment reworded to stay true; the `paths`-filter/required-check hazard called out in the workflow header; locally, an already-running shared Chrome collides on the fixed `--user-data-dir` — documented in the test header, and CI runners are always clean.

**Approaches considered.** (a) inline shell in the workflow — assertion logic in YAML, not runnable locally, and like the existing copilot step it cannot distinguish "crashed instantly" from "slow start" (docs/testing.md Principle 7: a validating CI step must distinguish *ran and failed* from *never ran*); (b) standalone node test script + thin workflow — **chosen**; (c) a new vitest project — config surface for one test, jsdom machinery in a process-spawning test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)