### PR TITLE
test: make swapParent Created-sort test deterministic across machine speeds

### DIFF
--- a/src/actions/__tests__/swapParent.ts
+++ b/src/actions/__tests__/swapParent.ts
@@ -283,23 +283,34 @@ describe('sort', () => {
 
   it('root children are re-sorted after swapParent with active sort', () => {
     // Reproduce the issue: cursor on A, set Created sort, create subthought B, swap B with A.
-    // B must be created as a separate step so its creation order is after A, C, D.
-    const steps = [
-      importText({
-        text: `
+    // B must be created in a later millisecond than A, C, and D: Created sort falls back to alphabetical order on
+    // thoughts created in the same millisecond, which would put b first regardless of the swap. The reducers run
+    // synchronously, so the clock has to be advanced explicitly between the two creation steps.
+    vi.useFakeTimers()
+    let stateNew
+    try {
+      const stateBefore = reducerFlow([
+        importText({
+          text: `
         - a
         - c
         - d
       `,
-      }),
-      setCursor(['a']),
-      setSortPreference({ simplePath: HOME_PATH, sortPreference: { type: 'Created', direction: 'Asc' } }),
-      newThought({ value: 'b', insertNewSubthought: true }),
-      setCursor(['a', 'b']),
-      swapParent,
-    ]
+        }),
+        setCursor(['a']),
+        setSortPreference({ simplePath: HOME_PATH, sortPreference: { type: 'Created', direction: 'Asc' } }),
+      ])(initialState())
 
-    const stateNew = reducerFlow(steps)(initialState())
+      vi.advanceTimersByTime(1000)
+
+      stateNew = reducerFlow([
+        newThought({ value: 'b', insertNewSubthought: true }),
+        setCursor(['a', 'b']),
+        swapParent,
+      ])(stateBefore)
+    } finally {
+      vi.useRealTimers()
+    }
 
     // Use excludeMeta to focus on regular thoughts only.
     // b was created last (separate newThought step), so it always sorts after c and d in Created Asc order.


### PR DESCRIPTION
## Problem

`root children are re-sorted after swapParent with active sort` (added in #4033) is a latent flake. It requires `b` to be created in a later millisecond than `a`, `c`, and `d`, but the reducers run synchronously in a single `reducerFlow`, so whether that happens depends on whether the runner crosses a millisecond boundary mid-flow. On a tie, `compareThoughtByCreated` falls back to `compareReasonable` (alphabetical), which puts `b` first regardless of the swap:

```
AssertionError: expected '- __ROOT__\n  - b\n    - a\n  - c\n  …' to be '- __ROOT__\n  - c\n  - d\n  - b\n    …'
```

It fails deterministically on a fast machine (Apple Silicon, warm cache) and failed on a Test workflow run on #4520 with the identical alphabetical received value, while typically passing on CI runners that are slow enough to cross the boundary.

## Fix

Freeze the clock with fake timers, build `a`/`c`/`d`, advance time explicitly, then create `b` and swap — making the intended creation order a guarantee instead of a race. Timers are restored in a `finally` so a failing assertion cannot leak fake timers into sibling tests.

Test-only change; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)