### PR TITLE
test: emulate gestures before navigation

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -338,13 +338,15 @@ The Puppeteer tests are run via Vitest using the `puppeteer-e2e` project defined
 
 High level helper functions are available for executing common user interactions: [/src/e2e/puppeteer/helpers](../src/e2e/puppeteer/helpers)
 
-Mobile devices can be emulated in puppeteer. This is good for testing non-platform specific mobile functionality, such as gestures. If you can test it with the Chrome Device Toolbar, you can emulate it in puppeteer.
+Mobile devices can be emulated in puppeteer. This is good for testing non-platform specific mobile functionality, such as gestures. If you can test it with the Chrome Device Toolbar, you can emulate it in puppeteer. Select the device at suite scope so that shared setup applies it before navigation; changing mobile or touch emulation after navigation may reload the page and restart app initialization.
 
 ```ts
-await emulate(KnownDevices['iPhone 15 Pro'])
+deviceEmulation.useForSuite(KnownDevices['iPhone 15 Pro'])
 
-await gesture(newThoughtCommand)
-await keyboard.type('a')
+it('creates a thought with a gesture', async () => {
+  await gesture(newThoughtCommand)
+  await keyboard.type('a')
+})
 ```
 
 While we prefer to avoid backdoor access to state in integration tests, it is recommended that you use the [exportThoughts](../src/e2e/puppeteer/helpers/exportThoughts.ts) helper for asserting the overall thought structure. Parsing the DOM, activating the Export modal, or taking a snapshot are either too slow or too tightly coupled to other functionality. `exportThoughts` is fast, direct, and makes for readable tests.
@@ -506,7 +508,7 @@ Integration tests are blackbox, but named helpers may take shortcuts during arra
 | Incidental app setup | Arrange | [`command`](../src/e2e/puppeteer/helpers/command.ts), [`openModal`](../src/e2e/puppeteer/helpers/openModal.ts), [`setTheme`](../src/e2e/puppeteer/helpers/setTheme.ts) | Use only when the command, modal entry point, or Settings navigation is not under test. |
 | Browser/driver limitation | Arrange | Puppeteer [`setSelection`](../src/e2e/puppeteer/helpers/setSelection.ts) and [`closeKeyboard`](../src/e2e/puppeteer/helpers/closeKeyboard.ts); iOS [`setSelection`](../src/e2e/iOS/helpers/setSelection.ts) | Simulate browser state the driver cannot reliably produce. The subsequent behavior under test must still use a real user entry point. |
 | Visual snapshot stabilization | Arrange | [`hide`](../src/e2e/puppeteer/helpers/hide.ts), [`hideVisibility`](../src/e2e/puppeteer/helpers/hideVisibility.ts), [`hideHUD`](../src/e2e/puppeteer/helpers/hideHUD.ts), [`showMousePointer`](../src/e2e/puppeteer/helpers/showMousePointer.ts), [`screenshot`](../src/e2e/puppeteer/helpers/screenshot.ts) | DOM/style mutation is allowed only to remove irrelevant nondeterminism or expose input position in a visual test. Do not hide the subject of the snapshot. |
-| Test environment controls | Arrange | [`simulateDragAndDrop`](../src/e2e/puppeteer/helpers/simulateDragAndDrop.ts), [`scrollTo`](../src/e2e/puppeteer/helpers/scrollTo.ts), and reviewed helpers that set [`testFlags`](../src/e2e/testFlags.ts) | Use only for a condition that cannot be created reliably through normal input, explain why, and restore mutable flags in `afterEach`. The control must not change the semantic outcome under test. |
+| Test environment controls | Arrange | [`deviceEmulation`](../src/e2e/puppeteer/helpers/deviceEmulation.ts), [`setConnectionStatus`](../src/e2e/puppeteer/helpers/setConnectionStatus.ts), [`simulateDragAndDrop`](../src/e2e/puppeteer/helpers/simulateDragAndDrop.ts), [`scrollTo`](../src/e2e/puppeteer/helpers/scrollTo.ts), and reviewed helpers that set [`testFlags`](../src/e2e/testFlags.ts) | Use only for a condition that cannot be created reliably through normal input, explain why, and restore mutable controls in the corresponding `afterEach` or `afterAll` hook unless per-test page isolation resets them. The control must not change the semantic outcome under test. |
 | Structural assertion | Assert | [`exportThoughts`](../src/e2e/puppeteer/helpers/exportThoughts.ts) | Export the thought tree as plaintext. Do not make additional assertions on Redux state. |
 | Non-visual synchronization | Wait | [`waitForContextHasChildWithValue`](../src/e2e/puppeteer/helpers/waitForContextHasChildWithValue.ts), [`waitForThoughtExistInDb`](../src/e2e/puppeteer/helpers/waitForThoughtExistInDb.ts), [`waitForState`](../src/e2e/puppeteer/helpers/waitForState.ts) | Use only when persistence or another prerequisite has no immediate visual signal. This is synchronization, not the test's assertion; assert the final user-visible result separately. |
 | Timing/environment spoofing | Arrange | [`reloadWithProductionTiming`](../src/e2e/puppeteer/helpers/reloadWithProductionTiming.ts) (spoofs `navigator.webdriver` to restore production animation timing) | Use only for a state that cannot exist under test timing (such as the loading phase). Justify in the helper's doc comment and state how the spoof is undone (per-test page isolation counts, but say so). Subsequent waits must still name conditions rather than replay production durations. |

--- a/src/e2e/puppeteer/__tests__/gestures.ts
+++ b/src/e2e/puppeteer/__tests__/gestures.ts
@@ -2,6 +2,7 @@ import { type ConsoleMessage, KnownDevices } from 'puppeteer'
 import newSubthoughtCommand from '../../../commands/newSubthought'
 import newThoughtCommand from '../../../commands/newThought'
 import $ from '../helpers/$'
+import deviceEmulation from '../helpers/deviceEmulation'
 import exportThoughts from '../helpers/exportThoughts'
 import gesture, { startGesture } from '../helpers/gesture'
 import keyboard from '../helpers/keyboard'
@@ -12,6 +13,8 @@ import waitForSelector from '../helpers/waitForSelector'
 import { page } from '../session'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
+deviceEmulation.useForSuite(KnownDevices['iPhone 15 Pro'])
 
 /**
  * Test suite for gesture alert behavior.
@@ -24,10 +27,6 @@ vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
  * with ongoing gesture interactions.
  */
 describe('alerts', () => {
-  beforeEach(async () => {
-    await page.emulate(KnownDevices['iPhone 15 Pro'])
-  })
-
   /**
    * Test that verifies no alert appears during gesture progress.
    *
@@ -66,10 +65,6 @@ describe('alerts', () => {
 })
 
 describe('gestures', () => {
-  beforeEach(async () => {
-    await page.emulate(KnownDevices['iPhone 15 Pro'])
-  })
-
   // https://github.com/cybersemics/em/issues/3887
   it('releases a gesture whose touch target unmounts mid-gesture', async () => {
     // The loading indicator is the element that unmounts under the user's finger in the reported
@@ -176,10 +171,6 @@ describe('gestures', () => {
 })
 
 describe('chaining commands', () => {
-  beforeEach(async () => {
-    await page.emulate(KnownDevices['iPhone 15 Pro'])
-  })
-
   it('chained command', async () => {
     const warnings: string[] = []
     /** Collect browser warnings emitted during the chained gesture. */

--- a/src/e2e/puppeteer/helpers/deviceEmulation.ts
+++ b/src/e2e/puppeteer/helpers/deviceEmulation.ts
@@ -1,0 +1,26 @@
+import { Device } from 'puppeteer'
+
+let activeDevice: Device | undefined
+
+const deviceEmulation = {
+  /** Returns the device selected for the next page setup. */
+  get device(): Device | undefined {
+    return activeDevice
+  },
+
+  /**
+   * Selects a device before navigation for every test in the current suite.
+   * Changing mobile or touch emulation after navigation may reload the page and restart app initialization.
+   */
+  useForSuite(device: Device): void {
+    beforeAll(() => {
+      activeDevice = device
+    })
+
+    afterAll(() => {
+      activeDevice = undefined
+    })
+  },
+}
+
+export default deviceEmulation

--- a/src/e2e/puppeteer/setup.ts
+++ b/src/e2e/puppeteer/setup.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import { Browser, BrowserContext, ConsoleMessage, Device } from 'puppeteer'
+import deviceEmulation from './helpers/deviceEmulation'
 import { page, setPage } from './session'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/prefer-namespace-keyword
@@ -15,7 +16,7 @@ const setup = async ({
   // Use host.docker.internal to connect to the host machine from inside the container. On Github actions, host.docker.internal is not available, so use 172.17.0.1 instead.
   url = process.env.CI ? 'https://172.17.0.1:3000' : 'https://host.docker.internal:2552',
   // url = 'https://google.com',
-  emulatedDevice,
+  emulatedDevice = deviceEmulation.device,
   skipTutorial = true,
 }: {
   puppeteerBrowser?: Browser


### PR DESCRIPTION
The gesture suite currently calls `page.emulate` after shared setup has already loaded em with `page.goto`. Puppeteer documents that `page.emulate` applies a viewport through `setViewport`, and that changing `isMobile` or `hasTouch` may reload the page. The iPhone profile changes both.

That reload can start application initialization a second time after setup has finished. Its queued connection-status transition can then overwrite the state arranged by the #3887 guard test, so the test flakes (in TreeCRDT integration PR #4325  ) even though its own steps are deterministic.
 
This selects the iPhone profile once for the gesture suite and applies it in shared setup before navigation. `setConnectionStatus` remains a direct test control. No production code changes.

Puppeteer references: [page.emulate](https://pptr.dev/api/puppeteer.page.emulate), [page.setViewport](https://pptr.dev/api/puppeteer.page.setviewport)

Fixes #4868 