### PR TITLE
Revert accidental direct pushes to main

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -93,8 +93,6 @@ There's a special case in `beforeInput` for `newThought` and `indent` to handle 
 
 A gesture is a string of swipe directions, where each character is one of `'l'`, `'r'`, `'u'`, `'d'` (left/right/up/down). For example, `'rdru'` is right → down → right → up. Multiple sequences can map to the same command — the first one is the canonical gesture shown in the UI.
 
-A gesture can only *start* inside the gesture zone ([`isInGestureZone`](../src/util/isInGestureZone.ts), enforced by [`MultiGesture`](../src/components/MultiGesture.tsx)): the screen minus the scroll zone (a strip on the right, or on the left for left-handed users), the toolbar at the top, and — on devices with a home indicator (nonzero `safe-area-inset-bottom`) — a strip at the bottom where the OS recognizes system gestures. Without the bottom exclusion, the upward app switcher swipe is committed as the Open Command Center gesture right before the app suspends. Touches that start outside the zone scroll the page as usual.
-
 `handleGestureSegment` is called incrementally as the user swipes; it triggers a haptic for each new segment and, after `COMMAND_PALETTE_TIMEOUT`, opens the gesture menu so the user can see all commands reachable from the current sequence.
 
 `handleGestureEnd` runs when the gesture finishes. It looks up the final sequence in `commandGestureIndex`, with two special cases:

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -5,7 +5,6 @@ import Gesture from '../@types/Gesture'
 import { noop } from '../constants'
 import testFlags from '../e2e/testFlags'
 import { clearGesture, updateGesture } from '../stores/gesture'
-import debugLog from '../util/debugLog'
 import isInGestureZone from '../util/isInGestureZone'
 import ScrollZone from './ScrollZone'
 import TraceGesture from './TraceGesture'
@@ -189,11 +188,6 @@ class MultiGesture extends React.Component<MultiGestureProps> {
       if (testFlags.logMultigesture) {
         console.info('touchcancel')
       }
-      debugLog.log('gestureCancel', {
-        sequence: this.sequence,
-        x: this.clientStart && Math.round(this.clientStart.x),
-        y: this.clientStart && Math.round(this.clientStart.y),
-      })
       this.props.onCancel?.({ clientStart: this.clientStart, e })
       this.reset()
     })
@@ -276,12 +270,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
           // Check if we're in the gesture zone before deciding whether to disable scrolling
           // This ensures we only prevent scrolling in the gesture zone, but allow it elsewhere
           const touchLocation = e.nativeEvent.touches[0] || e.nativeEvent
-          // isInGestureZone takes viewport coordinates, so convert from page coordinates. Otherwise the zone's viewport-relative bounds are compared against scroll-offset coordinates and the check breaks when the page is scrolled.
-          const inGestureZone = isInGestureZone(
-            touchLocation.pageX - window.scrollX,
-            touchLocation.pageY - window.scrollY,
-            this.leftHanded,
-          )
+          const inGestureZone = isInGestureZone(touchLocation.pageX, touchLocation.pageY, this.leftHanded)
 
           // Only keep disableScroll=true if we're actually in the gesture zone
           // This addresses both issues: prevents scrolling in gesture zone during gestures,
@@ -340,15 +329,6 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             abandon: this.abandon,
           })
         }
-        // Log the start and end coordinates so that a false gesture, such as an OS app switcher swipe misread as a command gesture, can be diagnosed from the debug log.
-        debugLog.log('gesture', {
-          sequence: this.sequence,
-          x: this.clientStart && Math.round(this.clientStart.x),
-          y: this.clientStart && Math.round(this.clientStart.y),
-          endX: Math.round(gestureState.moveX),
-          endY: Math.round(gestureState.moveY),
-          abandon: this.abandon,
-        })
         if (!this.abandon) {
           const clientEnd = {
             x: gestureState.moveX,

--- a/src/e2e/puppeteer/__tests__/commandCenter.ts
+++ b/src/e2e/puppeteer/__tests__/commandCenter.ts
@@ -70,40 +70,4 @@ describe('command center', () => {
     )
     expect(showCommandCenter).toBeFalsy()
   })
-
-  // The iOS app switcher swipe can also be delivered to the page as a complete touch sequence
-  // (touchstart → touchmove → touchend), which the gesture engine recognizes as the Open Command
-  // Center gesture (swipe up) and commits right before the app suspends. Touches that begin in the
-  // bottom system-gesture strip — present exactly on devices with a home indicator, i.e. a nonzero
-  // safe-area-inset-bottom — must not start a gesture.
-  it('does not open when a swipe starts at the bottom edge of the screen (iOS app switcher gesture)', async () => {
-    await paste(`
-        - a
-        - b
-        `)
-
-    // the Open Command Center command requires a cursor
-    await clickThought('a')
-
-    // emulate a home-indicator device: the app reads the inset from the --safe-area-inset-bottom
-    // custom property, which env(safe-area-inset-bottom) initializes on real devices
-    await page.evaluate(() => document.documentElement.style.setProperty('--safe-area-inset-bottom', '34px'))
-
-    const { innerWidth, innerHeight } = await page.evaluate(() => ({
-      innerWidth: window.innerWidth,
-      innerHeight: window.innerHeight,
-    }))
-
-    // swipe up starting at the very bottom of the viewport, as the app switcher swipe does
-    await gesture('u', { xStart: innerWidth / 4, yStart: innerHeight - 5 })
-
-    const showCommandCenter = await page.evaluate(
-      () => (window.em as WindowEm).testHelpers.getState().showCommandCenter,
-    )
-    expect(showCommandCenter).toBeFalsy()
-
-    // control: the same swipe starting above the system-gesture strip must still open the Command Center
-    await gesture('u', { xStart: innerWidth / 4, yStart: innerHeight - 200 })
-    await waitUntil(() => (window.em as WindowEm).testHelpers.getState().showCommandCenter)
-  })
 })

--- a/src/util/isInGestureZone.ts
+++ b/src/util/isInGestureZone.ts
@@ -1,16 +1,12 @@
 import { TOOLBAR_HEIGHT } from '../constants'
-import getSafeAreaBottom from '../device/virtual-keyboard/getSafeAreaBottom'
 import viewportStore from '../stores/viewport'
 
-/** Returns true if the pointer is in the gesture zone. To the right for righties, to the left for lefties. Coordinates are viewport (client) coordinates. Excludes the toolbar at the top and, on devices with a home indicator (nonzero safe-area-inset-bottom), a strip at the bottom of the screen where the OS recognizes system gestures — otherwise the upward app switcher swipe is committed as the Open Command Center gesture right before the app suspends. The strip is twice the safe area inset to allow for the touchstart registering slightly above the bezel. */
+/** Returns true if the pointer is in the gesture zone. To the right for righties, to the left for lefties. */
 const isInGestureZone = (x: number, y: number, leftHanded: boolean) => {
   const viewport = viewportStore.getState()
   const scrollZoneWidth = viewport.scrollZoneWidth
-  const bottomSystemGestureZoneHeight = getSafeAreaBottom() * 2
   const isInGestureZone =
-    (leftHanded ? x > scrollZoneWidth : x < viewport.innerWidth - scrollZoneWidth) &&
-    y > TOOLBAR_HEIGHT &&
-    y < viewport.innerHeight - bottomSystemGestureZoneHeight
+    (leftHanded ? x > scrollZoneWidth : x < viewport.innerWidth - scrollZoneWidth) && y > TOOLBAR_HEIGHT
   return isInGestureZone
 }
 


### PR DESCRIPTION
Reverts f209afc089 and 9e18a89824, which I (Claude, via Raine's session) pushed directly to main by mistake instead of to a feature branch — the branch had been created from origin/main and the repo's push.default=upstream config resolved the push to main.

History is not rewritten since the commits have been public for over an hour; this restores the tree to 3366e2dbbf (verified: `git diff 3366e2dbbf` on this branch is empty). The change itself — excluding the bottom system-gesture strip from starting gestures so the iOS app switcher swipe does not open the Command Center — will be resubmitted properly via a feature-branch PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)