### PR TITLE
Do not commit a gesture that starts in the bottom system-gesture strip

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -93,6 +93,8 @@ There's a special case in `beforeInput` for `newThought` and `indent` to handle 
 
 A gesture is a string of swipe directions, where each character is one of `'l'`, `'r'`, `'u'`, `'d'` (left/right/up/down). For example, `'rdru'` is right → down → right → up. Multiple sequences can map to the same command — the first one is the canonical gesture shown in the UI.
 
+A gesture can only *start* inside the gesture zone ([`isInGestureZone`](../src/util/isInGestureZone.ts), enforced by [`MultiGesture`](../src/components/MultiGesture.tsx)): the screen minus the scroll zone (a strip on the right, or on the left for left-handed users), the toolbar at the top, and — on devices with a home indicator (nonzero `safe-area-inset-bottom`) — a strip at the bottom where the OS recognizes system gestures. Without the bottom exclusion, the upward app switcher swipe is committed as the Open Command Center gesture right before the app suspends. Touches that start outside the zone scroll the page as usual.
+
 `handleGestureSegment` is called incrementally as the user swipes; it triggers a haptic for each new segment and, after `COMMAND_PALETTE_TIMEOUT`, opens the gesture menu so the user can see all commands reachable from the current sequence.
 
 `handleGestureEnd` runs when the gesture finishes. It looks up the final sequence in `commandGestureIndex`, with two special cases:

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -3,8 +3,10 @@ import { GestureResponderEvent, PanResponder, PanResponderInstance, View } from 
 import Direction from '../@types/Direction'
 import Gesture from '../@types/Gesture'
 import { noop } from '../constants'
+import getSafeAreaBottom from '../device/virtual-keyboard/getSafeAreaBottom'
 import testFlags from '../e2e/testFlags'
 import { clearGesture, updateGesture } from '../stores/gesture'
+import viewportStore from '../stores/viewport'
 import debugLog from '../util/debugLog'
 import isInGestureZone from '../util/isInGestureZone'
 import ScrollZone from './ScrollZone'
@@ -193,6 +195,8 @@ class MultiGesture extends React.Component<MultiGestureProps> {
         sequence: this.sequence,
         x: this.clientStart && Math.round(this.clientStart.x),
         y: this.clientStart && Math.round(this.clientStart.y),
+        innerHeight: viewportStore.getState().innerHeight,
+        safeAreaBottom: getSafeAreaBottom(),
       })
       this.props.onCancel?.({ clientStart: this.clientStart, e })
       this.reset()
@@ -340,7 +344,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             abandon: this.abandon,
           })
         }
-        // Log the start and end coordinates so that a false gesture, such as an OS app switcher swipe misread as a command gesture, can be diagnosed from the debug log.
+        // Log the start and end coordinates so that a false gesture, such as an OS app switcher swipe misread as a command gesture, can be diagnosed from the debug log. innerHeight and safeAreaBottom determine the bottom system-gesture exclusion that was in effect (see isInGestureZone), so the log also reveals if the exclusion was inert because the safe area inset read as zero.
         debugLog.log('gesture', {
           sequence: this.sequence,
           x: this.clientStart && Math.round(this.clientStart.x),
@@ -348,6 +352,8 @@ class MultiGesture extends React.Component<MultiGestureProps> {
           endX: Math.round(gestureState.moveX),
           endY: Math.round(gestureState.moveY),
           abandon: this.abandon,
+          innerHeight: viewportStore.getState().innerHeight,
+          safeAreaBottom: getSafeAreaBottom(),
         })
         if (!this.abandon) {
           const clientEnd = {

--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -5,6 +5,7 @@ import Gesture from '../@types/Gesture'
 import { noop } from '../constants'
 import testFlags from '../e2e/testFlags'
 import { clearGesture, updateGesture } from '../stores/gesture'
+import debugLog from '../util/debugLog'
 import isInGestureZone from '../util/isInGestureZone'
 import ScrollZone from './ScrollZone'
 import TraceGesture from './TraceGesture'
@@ -188,6 +189,11 @@ class MultiGesture extends React.Component<MultiGestureProps> {
       if (testFlags.logMultigesture) {
         console.info('touchcancel')
       }
+      debugLog.log('gestureCancel', {
+        sequence: this.sequence,
+        x: this.clientStart && Math.round(this.clientStart.x),
+        y: this.clientStart && Math.round(this.clientStart.y),
+      })
       this.props.onCancel?.({ clientStart: this.clientStart, e })
       this.reset()
     })
@@ -270,7 +276,12 @@ class MultiGesture extends React.Component<MultiGestureProps> {
           // Check if we're in the gesture zone before deciding whether to disable scrolling
           // This ensures we only prevent scrolling in the gesture zone, but allow it elsewhere
           const touchLocation = e.nativeEvent.touches[0] || e.nativeEvent
-          const inGestureZone = isInGestureZone(touchLocation.pageX, touchLocation.pageY, this.leftHanded)
+          // isInGestureZone takes viewport coordinates, so convert from page coordinates. Otherwise the zone's viewport-relative bounds are compared against scroll-offset coordinates and the check breaks when the page is scrolled.
+          const inGestureZone = isInGestureZone(
+            touchLocation.pageX - window.scrollX,
+            touchLocation.pageY - window.scrollY,
+            this.leftHanded,
+          )
 
           // Only keep disableScroll=true if we're actually in the gesture zone
           // This addresses both issues: prevents scrolling in gesture zone during gestures,
@@ -329,6 +340,15 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             abandon: this.abandon,
           })
         }
+        // Log the start and end coordinates so that a false gesture, such as an OS app switcher swipe misread as a command gesture, can be diagnosed from the debug log.
+        debugLog.log('gesture', {
+          sequence: this.sequence,
+          x: this.clientStart && Math.round(this.clientStart.x),
+          y: this.clientStart && Math.round(this.clientStart.y),
+          endX: Math.round(gestureState.moveX),
+          endY: Math.round(gestureState.moveY),
+          abandon: this.abandon,
+        })
         if (!this.abandon) {
           const clientEnd = {
             x: gestureState.moveX,

--- a/src/e2e/puppeteer/__tests__/commandCenter.ts
+++ b/src/e2e/puppeteer/__tests__/commandCenter.ts
@@ -76,7 +76,7 @@ describe('command center', () => {
   // Center gesture (swipe up) and commits right before the app suspends. Touches that begin in the
   // bottom system-gesture strip — present exactly on devices with a home indicator, i.e. a nonzero
   // safe-area-inset-bottom — must not start a gesture.
-  it.skip('does not open when a swipe starts at the bottom edge of the screen (iOS app switcher gesture)', async () => {
+  it('does not open when a swipe starts at the bottom edge of the screen (iOS app switcher gesture)', async () => {
     await paste(`
         - a
         - b

--- a/src/e2e/puppeteer/__tests__/commandCenter.ts
+++ b/src/e2e/puppeteer/__tests__/commandCenter.ts
@@ -70,4 +70,40 @@ describe('command center', () => {
     )
     expect(showCommandCenter).toBeFalsy()
   })
+
+  // The iOS app switcher swipe can also be delivered to the page as a complete touch sequence
+  // (touchstart → touchmove → touchend), which the gesture engine recognizes as the Open Command
+  // Center gesture (swipe up) and commits right before the app suspends. Touches that begin in the
+  // bottom system-gesture strip — present exactly on devices with a home indicator, i.e. a nonzero
+  // safe-area-inset-bottom — must not start a gesture.
+  it.skip('does not open when a swipe starts at the bottom edge of the screen (iOS app switcher gesture)', async () => {
+    await paste(`
+        - a
+        - b
+        `)
+
+    // the Open Command Center command requires a cursor
+    await clickThought('a')
+
+    // emulate a home-indicator device: the app reads the inset from the --safe-area-inset-bottom
+    // custom property, which env(safe-area-inset-bottom) initializes on real devices
+    await page.evaluate(() => document.documentElement.style.setProperty('--safe-area-inset-bottom', '34px'))
+
+    const { innerWidth, innerHeight } = await page.evaluate(() => ({
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+    }))
+
+    // swipe up starting at the very bottom of the viewport, as the app switcher swipe does
+    await gesture('u', { xStart: innerWidth / 4, yStart: innerHeight - 5 })
+
+    const showCommandCenter = await page.evaluate(
+      () => (window.em as WindowEm).testHelpers.getState().showCommandCenter,
+    )
+    expect(showCommandCenter).toBeFalsy()
+
+    // control: the same swipe starting above the system-gesture strip must still open the Command Center
+    await gesture('u', { xStart: innerWidth / 4, yStart: innerHeight - 200 })
+    await waitUntil(() => (window.em as WindowEm).testHelpers.getState().showCommandCenter)
+  })
 })

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -8,6 +8,7 @@ import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/
 import { isMac } from '../browser'
 import { AlertType, LongPressState } from '../constants'
 import hasMulticursor from '../selectors/hasMulticursor'
+import debugLog from '../util/debugLog'
 import useLongPress from './useLongPress'
 
 /** Adds event handlers to detect long press and set state.longPress while the user is long pressing a thought in preparation for a drag. */
@@ -50,6 +51,12 @@ const useDragHold = ({
 
       dispatch((dispatch, getState) => {
         const state = getState()
+
+        // Log how the press ended so that a false multiselect, e.g. an OS app switcher swipe misread as a long press, can be diagnosed from the debug log. eventType distinguishes a deliberate release (touchend) from a system-claimed touch (touchcancel).
+        debugLog.log('longPressEnd', {
+          eventType: e?.type ?? null,
+          dragHold: state.longPress === LongPressState.DragHold,
+        })
 
         if (state.longPress === LongPressState.DragHold) {
           if (!hasMulticursor(state)) dispatch(alert(null))

--- a/src/util/initEvents.ts
+++ b/src/util/initEvents.ts
@@ -27,6 +27,7 @@ import syncStatusStore from '../stores/syncStatus'
 import { updateSize } from '../stores/viewport'
 import isRoot from '../util/isRoot'
 import pathToContext from '../util/pathToContext'
+import debugLog from './debugLog'
 import durations from './durations'
 import equalPath from './equalPath'
 
@@ -304,6 +305,9 @@ const initEvents = (store: Store<State, any>) => {
   /** Handle a page lifecycle state change, i.e. switching apps. */
   const onStateChange = ({ oldState, newState }: { oldState: LifecycleState; newState: LifecycleState }) => {
     clearTimeout(passiveTimeout)
+
+    // Log lifecycle transitions so that events can be correlated with the app being backgrounded or foregrounded, e.g. a false Command Center open right before an app switch. More direct than inferring suspension from gaps in the log timeline.
+    debugLog.log('lifecycle', { oldState, newState })
 
     // dismiss the gesture alert on hide
     if (newState === 'hidden' || oldState === 'hidden') {

--- a/src/util/isInGestureZone.ts
+++ b/src/util/isInGestureZone.ts
@@ -1,12 +1,16 @@
 import { TOOLBAR_HEIGHT } from '../constants'
+import getSafeAreaBottom from '../device/virtual-keyboard/getSafeAreaBottom'
 import viewportStore from '../stores/viewport'
 
-/** Returns true if the pointer is in the gesture zone. To the right for righties, to the left for lefties. */
+/** Returns true if the pointer is in the gesture zone. To the right for righties, to the left for lefties. Coordinates are viewport (client) coordinates. Excludes the toolbar at the top and, on devices with a home indicator (nonzero safe-area-inset-bottom), a strip at the bottom of the screen where the OS recognizes system gestures — otherwise the upward app switcher swipe is committed as the Open Command Center gesture right before the app suspends. The strip is twice the safe area inset to allow for the touchstart registering slightly above the bezel. */
 const isInGestureZone = (x: number, y: number, leftHanded: boolean) => {
   const viewport = viewportStore.getState()
   const scrollZoneWidth = viewport.scrollZoneWidth
+  const bottomSystemGestureZoneHeight = getSafeAreaBottom() * 2
   const isInGestureZone =
-    (leftHanded ? x > scrollZoneWidth : x < viewport.innerWidth - scrollZoneWidth) && y > TOOLBAR_HEIGHT
+    (leftHanded ? x > scrollZoneWidth : x < viewport.innerWidth - scrollZoneWidth) &&
+    y > TOOLBAR_HEIGHT &&
+    y < viewport.innerHeight - bottomSystemGestureZoneHeight
   return isInGestureZone
 }
 


### PR DESCRIPTION
## Problem

The Command Center sometimes opens right as the user swipes up from the bottom edge to switch apps on iPhone, so it is sitting open when they return (first reported and partially fixed in #4871; recurrence diagnosed from a new debug log with command logging).

The new log shows `command {"id":"openCommandCenter","commandType":"gesture"}` executing ~1s before the rAF heartbeat stops: the app switcher swipe was delivered to the page as a **complete** touch sequence (touchstart → touchmove → touchend), which `MultiGesture` recognized as the swipe-up gesture and committed in `onPanResponderRelease`. This is the dominant delivery mode — six of the seven original incident logs carry `openCommandCenter.exec`'s dispatch signature (`addMulticursor` with no `longPress` entry). #4871 fixed the rarer `touchcancel` delivery mode of the same swipe.

The gesture zone (`isInGestureZone`) already excluded the toolbar at the top and the scroll zone at the side, but extended all the way to the bottom bezel where iOS system swipes begin.

## Fix

- `isInGestureZone` excludes a strip at the bottom of the viewport, sized at twice `safe-area-inset-bottom` (≈68px on home-indicator iPhones, exactly 0 on devices without one — the exclusion self-disables where no system swipe exists). Touches starting there scroll the page as usual. Reuses the existing `getSafeAreaBottom()` reader.
- `MultiGesture`'s first-move gesture-zone re-check now converts page coordinates to viewport coordinates before calling `isInGestureZone` — a latent inconsistency that the new upper y-bound would otherwise turn into a scroll bug on scrolled pages.
- Gesture end/cancel coordinates are now written to the debug log, so any future false gesture can be diagnosed (and the threshold tuned) from a user-captured log.
- `docs/commands.md` now documents the gesture zone's exclusions.

## Testing

- New e2e test: with `--safe-area-inset-bottom` set, a swipe-up starting 5px from the bottom must not open the Command Center; an in-test control swipe from normal height must still open it. Verified **red on unfixed code** (`expected true to be falsy` — the bottom-edge swipe opened it) and **green with the fix**. Committed skipped first per the TDD workflow, un-skipped with the fix.
- Adjacent suites green locally: gestures 6/6 (incl. scroll-zone rejection and mid-gesture unmount), multiselect 6/6, drag-and-drop multiselect 6/6, scroll, commandCenter 3/3 (incl. the #4871 touchcancel test), typecheck/lint/prettier clean.

## Notes for reviewers

- These are the same two commits accidentally pushed to main and reverted in #4889, cherry-picked onto post-revert main — resubmitted here for proper review.
- Complementary to #4871 (touchcancel variant), not a replacement: the two fixes cover the two delivery modes of the same OS swipe.
- Threshold (2× inset) is a judgment call pending real-world coordinates; the new debug logging records gesture start positions so it can be tuned on evidence if a false open ever recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)