### PR TITLE
Fix FadeTransition fallback node ref

### DIFF
--- a/src/components/FadeTransition.tsx
+++ b/src/components/FadeTransition.tsx
@@ -16,6 +16,7 @@ const FadeTransition = ({
   type,
   id = 0,
   children,
+  nodeRef,
   ...props
 }: PropsWithChildren<
   {
@@ -40,15 +41,8 @@ const FadeTransition = ({
   const ref = useRef<HTMLDivElement>(null)
 
   return (
-    <CSSTransition
-      key={id}
-      classNames={fadeClasses}
-      timeout={durations.get(type)}
-      // This would get overridden by {...props} anyway, but make it explicit for clarity.
-      nodeRef={props.nodeRef ?? ref}
-      {...props}
-    >
-      {props.nodeRef ? (
+    <CSSTransition key={id} classNames={fadeClasses} timeout={durations.get(type)} {...props} nodeRef={nodeRef ?? ref}>
+      {nodeRef ? (
         // If a nodeRef was provided, render children directly. Some components like ContextBreadcrumbs rely on the DOM hierarchy and will break if wrapped in a span. This can be removed if we refactor those components to not rely on the DOM hierarchy.
         children
       ) : (

--- a/src/components/__tests__/FadeTransition.ts
+++ b/src/components/__tests__/FadeTransition.ts
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react'
+import { createElement } from 'react'
+import ReactDOM from 'react-dom'
+import FadeTransition from '../FadeTransition'
+
+const findDOMNode = vi.fn(() => document.createElement('span'))
+const legacyReactDOM = ReactDOM as typeof ReactDOM & { findDOMNode?: typeof findDOMNode }
+
+beforeAll(() => {
+  legacyReactDOM.findDOMNode = findDOMNode
+})
+
+afterAll(() => {
+  delete legacyReactDOM.findDOMNode
+})
+
+it('renders an appearing transition without falling back to findDOMNode', () => {
+  const view = render(
+    createElement(
+      FadeTransition,
+      { type: 'fast', in: true, appear: true, nodeRef: undefined },
+      createElement('span', null, 'transition content'),
+    ),
+  )
+
+  expect(view.getByText('transition content')).toBeInTheDocument()
+  expect(findDOMNode).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Problem

A breadcrumb overflow entry can pass an explicitly undefined `nodeRef` to `FadeTransition`. The component selected its internal fallback ref before spreading the remaining props, so the undefined prop overwrote the fallback. `react-transition-group` then called `ReactDOM.findDOMNode`, which was removed in React 19.

TreeCRDT hydration exposed the timing, but the crashing transition is reproducible on current `main` when an already-mounted favorite path grows beyond the breadcrumb overflow threshold.

## Fix

- Destructure `nodeRef` so it cannot overwrite the fallback through the props spread.
- Pass the resolved node ref after the remaining transition props.
- Add a focused regression test for an appearing transition with an explicitly undefined ref.


Addresses https://github.com/cybersemics/em/pull/4325#issuecomment-5247909935
