### PR TITLE
Fix Swap Parent undo with root cursor

### DIFF
--- a/src/components/TreeNodePositioner.tsx
+++ b/src/components/TreeNodePositioner.tsx
@@ -48,8 +48,9 @@ const TreeNodePositioner = ({
   const isSwap = useSelector(
     state =>
       state.lastUndoableActionType === 'swapParent' &&
+      !!state.cursor &&
       // path is involved in the swap if it is the cursor or the parent of the cursor
-      (equalPath(state.cursor, path) || equalPath(parentOf(state.cursor!), path)),
+      (equalPath(state.cursor, path) || equalPath(parentOf(state.cursor), path)),
   )
 
   /** The direction of the curved animation in swapParent. If the child (cursor) thought value is greater than the parent thought value, rotate clockwise, otherwise rotate counterclockwise. This ensures that the parent and child curve in opposite directions, and activating swapParent twice will appear as a reversal instead of another rotation in the same direction. Returns null if the last action is not swapParent. */


### PR DESCRIPTION
#4870

## Summary

- Guard the Swap Parent animation selector when the cursor is at the root.
- Remove the unsafe non-null assertion before calling `parentOf`.
- Add a JSDOM regression test for undo state with `cursor: null`.

## Root cause

Undo can restore `cursor: null` while `lastUndoableActionType` remains
`swapParent`. `TreeNodePositioner` asserted that the cursor was non-null and
passed it to `parentOf`, which called `.slice` on `null`.

## Implementation

The existing Swap Parent animation predicate now checks that the cursor exists
before calling `parentOf`. This preserves the current behavior for valid
cursors while safely handling the root cursor state.

The regression test renders `TreeNodePositioner` with `cursor: null` and
`lastUndoableActionType: 'swapParent'`, then verifies that rendering does not
throw and that the child remains visible.

## Scope

This does not change:

- Swap Parent behavior for valid cursors
- command execution
- multicursor handling
- undo/redo state management
- the `parentOf` contract

