### PR TITLE
Harden the BrowserStack tunnel pool, and document how to get access

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -468,9 +468,13 @@ This means `ios.yml`, `tdd.yml`, and local/agent runs can safely run concurrentl
 Requires an **Account**-scoped Cloudflare permission grant including `Cloudflare One Connector: cloudflared Write` (Tunnel management is an account resource, not zone-scoped — a zone-scoped grant like the one used for `emthought.cc`'s bot/firewall settings does not cover it).
 
 1. `cloudflared tunnel login`, authorizing the `emthought.cc` zone.
-2. Run `provision-cloudflare-tunnel-pool.sh` (defaults to 20 tunnels named `browserstack-01.emthought.cc` … `browserstack-20.emthought.cc`). It creates each tunnel, routes its DNS CNAME, and fetches its connector token via the CLI — no dashboard steps, no timing-sensitive "catch the connector while it's live" dance.
+2. Run `provision-cloudflare-tunnel-pool.sh [POOL_SIZE] [NAME_PREFIX] [DOMAIN]`. It creates each tunnel, routes its DNS CNAME, and fetches its connector token via the CLI — no dashboard steps, no timing-sensitive "catch the connector while it's live" dance.
 3. The script writes `cloudflare-tunnel-pool.json` (gitignored — it contains live tokens). Set its contents as the GitHub Actions secret `CLOUDFLARE_TUNNEL_POOL`: `gh secret set CLOUDFLARE_TUNNEL_POOL < cloudflare-tunnel-pool.json`.
 4. Re-run the script (same or a larger `POOL_SIZE`) any time to top up the pool — it reuses tunnels that already exist rather than recreating them.
+
+##### If you're a developer who needs tunnel access
+
+If you're a developer or agent making changes to BrowserStack CI, you'll need access to a **separate tunnel pool used for the development environment**. Ask the project maintainer, who will be able to give you access to the values needed for the `CLOUDFLARE_TUNNEL_POOL` secret.
 
 Related tests: [/src/e2e/iOS](../src/e2e/iOS)
 

--- a/src/e2e/iOS/config/cloudflareTunnelPool.ts
+++ b/src/e2e/iOS/config/cloudflareTunnelPool.ts
@@ -162,6 +162,16 @@ async function claim(
   const logStream = fs.createWriteStream(CONNECTOR_LOG_PATH, { flags: 'a' })
   logStream.write(`\n--- claiming ${candidate.name} (${candidate.hostname}) ---\n`)
 
+  // Child-scoped TUNNEL_TOKEN carries this candidate's connector token; it shadows the parent's
+  // TUNNEL_TOKEN (the Vite app-gate token) for this process only, same seam PR #4622 established.
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, TUNNEL_TOKEN: candidate.token }
+  // cloudflared logs its entire environment at startup. It masks TUNNEL_TOKEN, because it knows
+  // that one is a credential, but it has no reason to treat CLOUDFLARE_TUNNEL_POOL as anything
+  // special — so inheriting the pool writes every connector token in it, in plaintext, into the
+  // connector log this function is about to pipe to. The connector only ever needs its own token,
+  // handed to it above, so the pool has no business being in this process at all.
+  delete childEnv.CLOUDFLARE_TUNNEL_POOL
+
   // http:// here matches the origin the CI "Serve" step starts with HTTP=1 — Cloudflare's tunnel already
   // terminates HTTPS at its edge for Safari (a real CA-signed cert on the public hostname), so this local
   // connector-to-origin hop never needs its own TLS. (Also: these are remotely-managed tunnels, so this
@@ -172,10 +182,7 @@ async function claim(
     ['tunnel', '--no-autoupdate', '--protocol', 'http2', 'run', '--url', 'http://localhost:3000'],
     {
       stdio: ['ignore', 'pipe', 'pipe'],
-      // Child-scoped TUNNEL_TOKEN carries this candidate's connector token; it shadows the
-      // parent's TUNNEL_TOKEN (the Vite app-gate token) for this process only, same seam PR
-      // #4622 established.
-      env: { ...process.env, TUNNEL_TOKEN: candidate.token },
+      env: childEnv,
     },
   )
   proc.stdout?.pipe(logStream)


### PR DESCRIPTION
1. **Keep the tunnel pool out of the connector's environment:** `cloudflared` logs every environment variable it was started with, masking only the ones it recognises as credentials. It knows about `TUNNEL_TOKEN` and prints `TUNNEL_TOKEN:*****`; it has no reason to treat `CLOUDFLARE_TUNNEL_POOL` as anything but ordinary configuration, so under certain circumstances the whole pool could land in `cloudflared-browserstack.log` verbatim.
    - **Fixed.** Also checked the repo for any potential exposure; none found.

2. **Update testing.md to inform developer/agents to contact project maintainer if they need access to the `CLOUDFLARE_TUNNEL_POOL` secret for development purposes.** Maintain two different values for `CLOUDFLARE_TUNNEL_POOL`: one for `cybersemics/em`, the other for developer forks.

🤖 Generated by Claude Code
