### PR TITLE
Fix drag-and-drop being completely broken in the Tauri desktop build

### DIFF
--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -18,7 +18,8 @@
         "minWidth": 360,
         "minHeight": 480,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -23,6 +23,14 @@ Both backends are configured with:
 
 The values come from [`constants.ts`](../src/constants.ts).
 
+#### Tauri desktop shell
+
+The desktop app runs the same web build inside a Tauri (wry) webview, so it selects `HTML5Backend` like any other desktop browser. That only works because [`desktop/tauri.conf.json`](../desktop/tauri.conf.json) sets `dragDropEnabled: false` on the window.
+
+Left at its default of `true`, Tauri installs a native drag-and-drop handler on the webview so it can surface OS file drops as `tauri://drag-*` events. On macOS that handler overrides the webview's `NSDraggingDestination` methods (`draggingEntered:`, `draggingUpdated:`, `performDragOperation:`, `draggingExited:`) and unconditionally reports every drag as consumed, so the `WKWebView` superclass implementation never runs and WebKit never dispatches the corresponding DOM `dragenter` / `dragover` / `drop` events. Only the destination side is intercepted — `dragstart` still fires, so `beginDrag` runs and the drag appears to start, but nothing can ever be hovered or dropped. Windows (WebView2) and Linux (WebKitGTK) intercept drops the same way.
+
+Disabling it removes that handler, so drag events reach the page normally. Nothing is lost: em never listened for the `tauri://drag-*` events, and OS file drops go back to arriving as react-dnd's `NativeTypes.FILE`, which is what the app already handles.
+
 ### State machine: `state.longPress`
 
 The whole subsystem is orchestrated by a single Redux state field, [`state.longPress`](../src/@types/State.ts), which is a `LongPressState` enum with these values (see [`constants.ts`](../src/constants.ts)):


### PR DESCRIPTION
## Problem

Drag-and-drop did not work at all in the Tauri desktop build. A drag would appear to start, then nothing could be hovered or dropped.

## Cause

`desktop/tauri.conf.json` never set `dragDropEnabled`, so it defaulted to `true`. With it enabled, `tauri-runtime-wry` installs a native drag-and-drop handler on the webview so OS file drops can be surfaced as `tauri://drag-*` events — and that handler's callback [unconditionally returns `true`](https://docs.rs/tauri-runtime-wry).

In wry, that return value is the "I consumed this event" signal. Every `false` branch is what calls through to the `WKWebView` superclass:

```rust
if !listener(DragDropEvent::Over { position }) {
    let os_operation = objc2::msg_send![super(this), draggingUpdated: drag_info];
    ...
} else { NSDragOperation::Copy }
```

Since the listener always returned `true`, `draggingEntered:`, `draggingUpdated:`, `performDragOperation:` and `draggingExited:` never reached WebKit, so WebKit never dispatched the corresponding DOM `dragenter` / `dragover` / `drop` events.

Only the *destination* side is intercepted — `dragstart` still fired, so `beginDrag` ran and `state.longPress` went to `DragInProgress`, which is why the drag looked like it started. Windows (WebView2) and Linux (WebKitGTK) intercept drops the same way.

## Fix

One line in `desktop/tauri.conf.json`. Tauri's own config docs say *"Disabling it is required to use HTML5 drag and drop on the frontend."*

```json
"dragDropEnabled": false
```

Nothing is lost by disabling it: em never listened for the `tauri://drag-*` events those drops were being converted into. With the handler gone, OS file drops go back to arriving as react-dnd's `NativeTypes.FILE`, which the app already handles — so this also restores file-drop import in the desktop build.

## Scope

Confined to the Tauri window config. It is not read by the web build or by Capacitor (iOS/Android), and no file under `src/` changed, so the carefully tuned touch-backend and browser drag-and-drop behavior is untouched.

## Verification

- Confirmed working in the running Tauri app — drag-and-drop functions after the change.
- Confirmed the config value reaches the runtime: a temporary `setup` probe printing `app.config().app.windows[].drag_drop_enabled` reported `drag_drop_enabled=false`. The probe was removed and the rebuild verified clean. (`WindowConfig` uses `deny_unknown_fields`, so a misspelled key fails the build outright.)
- Ruled out the yarn patches as a cause. The `react-dnd-html5-backend` patch only removes a `preventDefault()` in the native-item `dragenter` path and is unrelated.

## Docs

`docs/drag-and-drop.md` gains a "Tauri desktop shell" subsection under Backend selection, recording why the flag is load-bearing so a future config cleanup doesn't silently undo it.