### PR TITLE
Fix stable sorting for emoji-only thoughts

### DIFF
--- a/src/actions/__tests__/editThought.ts
+++ b/src/actions/__tests__/editThought.ts
@@ -415,6 +415,44 @@ describe('sort', () => {
     - C`)
   })
 
+  it('keep a thought with an empty HTML tag at its insertion point until text is added', () => {
+    const stateBefore = reducerFlow([
+      importText({
+        text: `
+          - X
+            - =sort
+              - Alphabetical
+            - A
+            - B
+            - C
+        `,
+      }),
+      setCursor(['X']),
+      newThought({ insertNewSubthought: true, value: '' }),
+      editThought(['X', ''], '<b></b>'),
+    ])(initialState())
+
+    expect(exportContext(stateBefore, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - X
+    - =sort
+      - Alphabetical
+    - A
+    - B
+    - C
+    - ****`)
+
+    const stateAfter = editThought(['X', '<b></b>'], '<b></b>a')(stateBefore)
+
+    expect(exportContext(stateAfter, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - X
+    - ****a
+    - =sort
+      - Alphabetical
+    - A
+    - B
+    - C`)
+  })
+
   it('rank should not change when editing a thought to empty', () => {
     const text = `
     - =sort

--- a/src/actions/__tests__/editThought.ts
+++ b/src/actions/__tests__/editThought.ts
@@ -376,6 +376,45 @@ describe('sort', () => {
   - D`)
   })
 
+  // https://github.com/cybersemics/em/issues/4847
+  it('keep an emoji-only thought at its insertion point until text is added', () => {
+    const stateEmoji = reducerFlow([
+      importText({
+        text: `
+          - X
+            - =sort
+              - Alphabetical
+            - A
+            - B
+            - C
+        `,
+      }),
+      setCursor(['X']),
+      newThought({ insertNewSubthought: true, value: '' }),
+      editThought(['X', ''], '🙂'),
+    ])(initialState())
+
+    expect(exportContext(stateEmoji, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - X
+    - =sort
+      - Alphabetical
+    - A
+    - B
+    - C
+    - 🙂`)
+
+    const stateEmojiWithText = editThought(['X', '🙂'], '🙂a')(stateEmoji)
+
+    expect(exportContext(stateEmojiWithText, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - X
+    - =sort
+      - Alphabetical
+    - 🙂a
+    - A
+    - B
+    - C`)
+  })
+
   it('rank should not change when editing a thought to empty', () => {
     const text = `
     - =sort

--- a/src/actions/__tests__/editThought.ts
+++ b/src/actions/__tests__/editThought.ts
@@ -386,7 +386,7 @@ describe('sort', () => {
               - Alphabetical
             - A
             - B
-            - C
+            - D
         `,
       }),
       setCursor(['X']),
@@ -400,19 +400,19 @@ describe('sort', () => {
       - Alphabetical
     - A
     - B
-    - C
+    - D
     - 🙂`)
 
-    const stateEmojiWithText = editThought(['X', '🙂'], '🙂a')(stateEmoji)
+    const stateEmojiWithText = editThought(['X', '🙂'], '🙂C')(stateEmoji)
 
     expect(exportContext(stateEmojiWithText, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
   - X
     - =sort
       - Alphabetical
-    - 🙂a
+    - 🙂C
     - A
     - B
-    - C`)
+    - D`)
   })
 
   it('keep a thought with an empty HTML tag at its insertion point until text is added', () => {
@@ -424,7 +424,7 @@ describe('sort', () => {
               - Alphabetical
             - A
             - B
-            - C
+            - D
         `,
       }),
       setCursor(['X']),
@@ -438,19 +438,19 @@ describe('sort', () => {
       - Alphabetical
     - A
     - B
-    - C
+    - D
     - ****`)
 
-    const stateAfter = editThought(['X', '<b></b>'], '<b></b>a')(stateBefore)
+    const stateAfter = editThought(['X', '<b></b>'], '<b></b>C')(stateBefore)
 
     expect(exportContext(stateAfter, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
   - X
-    - ****a
+    - ****C
     - =sort
       - Alphabetical
     - A
     - B
-    - C`)
+    - D`)
   })
 
   it('rank should not change when editing a thought to empty', () => {

--- a/src/actions/editThought.ts
+++ b/src/actions/editThought.ts
@@ -21,6 +21,7 @@ import hashThought from '../util/hashThought'
 import head from '../util/head'
 import isAttribute from '../util/isAttribute'
 import isDivider from '../util/isDivider'
+import isEmptyOrEmojiOnly from '../util/isEmptyOrEmojiOnly'
 import parentOf from '../util/parentOf'
 import reducerFlow from '../util/reducerFlow'
 import removeContext from '../util/removeContext'
@@ -137,12 +138,13 @@ const editThought = (state: State, { cursorOffset, force, oldValue, newValue, pa
   const isNote = parentOfEditedThought.value === '=note'
   const sortPreference = getSortPreference(state, editedThought.parentId)
   const sortType = sortPreference.type
+  const isValueEmptyOrEmojiOnly = isEmptyOrEmojiOnly(newValue)
 
   const thoughtNew: Thought = {
     ...editedThought,
     ...(editedThought.generating ? { generating: false } : null),
     rank:
-      newValue !== '' && (sortType === 'Alphabetical' || sortType === 'Created' || sortType === 'Updated')
+      !isValueEmptyOrEmojiOnly && (sortType === 'Alphabetical' || sortType === 'Created' || sortType === 'Updated')
         ? getSortedRank(state, editedThought.parentId, newValue, {
             created: editedThought.created,
             staleId: editedThought.id,

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -46,6 +46,7 @@ import appendToPath from '../util/appendToPath'
 import createId from '../util/createId'
 import head from '../util/head'
 import headValue from '../util/headValue'
+import isEmptyOrEmojiOnly from '../util/isEmptyOrEmojiOnly'
 import isRoot from '../util/isRoot'
 import once from '../util/once'
 import parentOf from '../util/parentOf'
@@ -138,21 +139,22 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
   // if the sort preference is Created, then the current timestamp will be used to sort the new thought into place (#3782)
   const created = Date.now()
   const sortPreference = getSortPreference(state, insertId)
+  const isValueEmptyOrEmojiOnly = isEmptyOrEmojiOnly(value)
 
   // if meta key is pressed, add a child instead of a sibling of the current thought
   // if shift key is pressed, insert the child before the current thought
   const newRank = insertContext
     ? getNextRank(state, ABSOLUTE_TOKEN)
-    : sortPreference.type === 'Created' || (value !== '' && sortPreference.type === 'Alphabetical')
+    : sortPreference.type === 'Created' || (!isValueEmptyOrEmojiOnly && sortPreference.type === 'Alphabetical')
       ? getSortedRank(state, insertId, value, { created })
       : insertBefore
         ? insertNewSubthought || !simplePath || isRoot(simplePath)
           ? getPrevRank(state, insertId, { aboveMeta })
           : getRankBefore(state, simplePath)
         : insertNewSubthought || !simplePath
-          ? // if inserting an empty thought into a sorted context via insertNewSubthought, get the rank after the last sorted child rather than incrementing the highest rank
-            // otherwise the empty thought will not be correctly sorted by resortEmptyInPlace
-            value === '' && sortPreference.type === 'Alphabetical' && getLastSortedChildPath()
+          ? // if inserting an empty or emoji-only thought into a sorted context via insertNewSubthought, get the rank after the last sorted child rather than incrementing the highest rank
+            // otherwise it will not retain its point of creation
+            isValueEmptyOrEmojiOnly && sortPreference.type === 'Alphabetical' && getLastSortedChildPath()
             ? getRankAfter(state, getLastSortedChildPath()!)
             : getNextRank(state, insertId)
           : getRankAfter(state, simplePath)

--- a/src/commands/toggleSortPicker.ts
+++ b/src/commands/toggleSortPicker.ts
@@ -6,6 +6,7 @@ import getSortPreference from '../selectors/getSortPreference'
 import rootedParentOf from '../selectors/rootedParentOf'
 import simplifyPath from '../selectors/simplifyPath'
 import head from '../util/head'
+import isEmptyOrEmojiOnly from '../util/isEmptyOrEmojiOnly'
 import isRoot from '../util/isRoot'
 
 const toggleSortCommand: Command = {
@@ -44,8 +45,8 @@ const toggleSortCommand: Command = {
     const comparator = getSortComparator(state, id)
     if (!comparator) return null
 
-    // ignore empty thoughts since they are sorted to their point of creation rather than by the sort condition
-    const childrenRanked = getChildrenRanked(state, id).filter(child => child.value)
+    // ignore empty and emoji-only thoughts since they are sorted to their point of creation rather than by the sort condition
+    const childrenRanked = getChildrenRanked(state, id).filter(child => !isEmptyOrEmojiOnly(child.value))
 
     // The ranks match the sort condition as long as the rank order contains no strict inversion, i.e. no adjacent
     // pair where the earlier-ranked thought sorts after the later-ranked one. Ties (equal sort keys, e.g. duplicate

--- a/src/util/isEmptyOrEmojiOnly.ts
+++ b/src/util/isEmptyOrEmojiOnly.ts
@@ -4,10 +4,7 @@ import stripTags from './stripTags'
 /** Returns true when a thought is empty or its visible content consists only of emoji and whitespace. */
 const isEmptyOrEmojiOnly = (value: string): boolean => {
   const visibleValue = stripTags(value)
-  return (
-    value === '' ||
-    (!!visibleValue.match(REGEX_EMOJI_GLOBAL) && visibleValue.replace(REGEX_EMOJI_GLOBAL, '').trim() === '')
-  )
+  return visibleValue.replace(REGEX_EMOJI_GLOBAL, '').trim() === ''
 }
 
 export default isEmptyOrEmojiOnly

--- a/src/util/isEmptyOrEmojiOnly.ts
+++ b/src/util/isEmptyOrEmojiOnly.ts
@@ -1,0 +1,13 @@
+import { REGEX_EMOJI_GLOBAL } from '../constants'
+import stripTags from './stripTags'
+
+/** Returns true when a thought is empty or its visible content consists only of emoji and whitespace. */
+const isEmptyOrEmojiOnly = (value: string): boolean => {
+  const visibleValue = stripTags(value)
+  return (
+    value === '' ||
+    (!!visibleValue.match(REGEX_EMOJI_GLOBAL) && visibleValue.replace(REGEX_EMOJI_GLOBAL, '').trim() === '')
+  )
+}
+
+export default isEmptyOrEmojiOnly


### PR DESCRIPTION
Issue #4847

## Summary

- Treat thoughts containing only emoji as empty thoughts for stable sorting.
- Preserve their insertion position until non-emoji text is entered.
- Apply the same behavior when creating thoughts, editing thoughts, and validating sort order.
- Preserve the existing emoji-first ordering once a thought contains additional text.

## Implementation

A shared `isEmptyOrEmojiOnly` predicate expands the existing empty-thought condition without changing the alphabetical comparator itself.

Regression coverage verifies that:

1. An empty thought is created at the end of an alphabetically sorted context.
2. Typing `🙂` does not move it.
3. Typing `🙂a` moves it to its normal alphabetical position.