### PR TITLE
Reset ministores in test setup instead of per-file teardown

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -500,7 +500,7 @@ beforeEach(createTestApp)
 afterEach(cleanupTestApp)
 ```
 
-`initStore` clears the shared store and enables fake timers. `createTestApp` additionally mounts the React tree, initializes persistence and event handlers, and enables the test drag-and-drop backend. `cleanupTestApp` clears storage, the local YJS database, the store, and event handlers, and flushes pending timers. Do not share fixture state between tests or rely on test execution order.
+`initStore` clears the shared store, resets every [ministore](glossary.md#m) to its initial state, and enables fake timers. Ministores are module-level singletons that vitest isolates per test *file*, not per test, so resetting them in setup is what keeps one test's ephemeral UI state out of the next; a test that needs a ministore reset on its own can call `store.reset()` on it directly. `initStore({ persist: true })` skips both resets. `createTestApp` resets ministores the same way, before `initialize()` runs, and additionally mounts the React tree, initializes persistence and event handlers, and enables the test drag-and-drop backend. `cleanupTestApp` clears storage, the local YJS database, the store, and event handlers, and flushes pending timers. Do not share fixture state between tests or rely on test execution order.
 
 ## Sanctioned Backdoors
 
@@ -557,7 +557,7 @@ There are three helper directories. Use them before reaching for raw Redux dispa
 
 The helpers in [`../src/test-helpers/`](../src/test-helpers) cover store setup and operations that are otherwise verbose to write by hand:
 
-- [`createTestApp`](../src/test-helpers/createTestApp.tsx) — mounts `<App />` into the JSDOM environment via `@testing-library/react`, runs `initialize()`, swaps in `react-dnd-test-backend`, opts into fake timers, and closes the welcome modal. Use this when a test touches the rendered app. Pair every call with `cleanupTestApp` (it clears `localStorage`, the local YJS db, the store, and event handlers).
+- [`createTestApp`](../src/test-helpers/createTestApp.tsx) — mounts `<App />` into the JSDOM environment via `@testing-library/react`, resets all ministores, runs `initialize()`, swaps in `react-dnd-test-backend`, opts into fake timers, and closes the welcome modal. Use this when a test touches the rendered app. Pair every call with `cleanupTestApp` (it clears `localStorage`, the local YJS db, the store, and event handlers).
 - [`initStore`](../src/test-helpers/initStore.ts) — initializes the store without mounting the React tree, for store-level tests that don't need a DOM.
 - [`importToContext`](../src/test-helpers/importToContext.ts) — seeds the store with a tree from a multi-line plaintext outline (the same format the `Import` modal accepts). Most fixture setup goes through this.
 - [`dispatch`](../src/test-helpers/dispatch.ts) — a thin wrapper that lets a test dispatch synchronously without re-typing `store.dispatch(...)` plumbing.

--- a/src/stores/ministore.ts
+++ b/src/stores/ministore.ts
@@ -16,6 +16,23 @@ export interface Ministore<T> {
   ) => () => void
   /** Updates the state. If the state is an object, accepts a partial update. Accepts an updater function that passes the old state. */
   update: (updatesOrUpdater: Partial<T> | ((oldState: T) => Partial<T>)) => void
+  /** Restores the state to the initial state that the store was created with. */
+  reset: () => void
+}
+
+/** All ministores created by the factory, so that global state can be restored between tests. Derived stores are excluded, as they recompute from their sources. Ministores are module-level singletons, so the set does not grow at runtime. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stores = new Set<Ministore<any>>()
+
+/** Resets all ministores to their initial state. Called by the initStore test helper so that module-level store state does not leak from one test to the next. */
+export const resetStores = () => {
+  stores.forEach(store => store.reset())
+}
+
+/** Removes a store from the reset registry. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const unregister = (store: Ministore<any>) => {
+  stores.delete(store)
 }
 
 /** Creates a mini store that tracks state and can update consumers. */
@@ -88,13 +105,21 @@ const ministore = <T>(initialState: T): Ministore<T> => {
     return cancellable<T>(promise, unsubscribe)
   }
 
-  return {
+  /** Restores the initial state, notifying subscribers if it changed. */
+  const reset = () => update(initialState)
+
+  const store = {
     getState: () => state,
     once,
+    reset,
     subscribe,
     subscribeSelector,
     update,
   }
+
+  stores.add(store)
+
+  return store
 }
 
 /** Create a read-only computed ministore that derives its state from one or more ministores. */
@@ -109,6 +134,9 @@ function compose<T, S extends any[]>(
 
   const store = ministore(computeFromStores())
 
+  // A derived store is never written to directly, so exclude it from the reset registry. It recomputes when its sources are reset.
+  unregister(store)
+
   /** Update the composite store with the computed state. */
   const updateCompositeState = () => {
     store.update(computeFromStores())
@@ -117,7 +145,7 @@ function compose<T, S extends any[]>(
   const unsubscribes = stores.map(store => store.subscribe(updateCompositeState))
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { update, ...readonlyStore } = store
+  const { update, reset, ...readonlyStore } = store
 
   return {
     ...readonlyStore,

--- a/src/test-helpers/createTestApp.tsx
+++ b/src/test-helpers/createTestApp.tsx
@@ -8,6 +8,7 @@ import App from '../components/App'
 import * as db from '../data-providers/yjs/thoughtspace'
 import { initialize } from '../initialize'
 import store from '../stores/app'
+import { resetStores } from '../stores/ministore'
 import storage from '../util/storage'
 
 let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
@@ -16,6 +17,12 @@ let cleanup: Await<ReturnType<typeof initialize>>['cleanup']
 const createTestApp = async ({ tutorial }: { tutorial?: boolean } = {}) => {
   await act(async () => {
     vi.useFakeTimers({ loopLimit: 100000 })
+
+    // Ministores are module-level singletons that vitest only isolates per test file, so reset them
+    // before initialize so that each test mounts against a clean slate. Must come before initialize,
+    // which populates some ministores (e.g. offlineStatusStore).
+    resetStores()
+
     // calls initEvents, which must be manually cleaned up
     const init = await initialize()
     cleanup = init.cleanup

--- a/src/test-helpers/initStore.ts
+++ b/src/test-helpers/initStore.ts
@@ -1,5 +1,6 @@
 import { clearActionCreator as clear } from '../actions/clear'
 import store from '../stores/app'
+import { resetStores } from '../stores/ministore'
 
 interface Params {
   /**
@@ -22,7 +23,13 @@ const initStore = ({ persist, allowTutorial }: Params = {}) => {
   // This makes tests deterministic and prevents post-teardown access to window/localStorage.
   vi.useFakeTimers()
 
-  if (!persist) store.dispatch(clear())
+  if (!persist) {
+    store.dispatch(clear())
+
+    // Ministores are module-level singletons that vitest only isolates per test file, so reset them
+    // alongside the Redux store to give each test the same clean slate.
+    resetStores()
+  }
 
   if (!allowTutorial) {
     store.dispatch([

--- a/src/util/__tests__/ministore.ts
+++ b/src/util/__tests__/ministore.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import ministore from '../../stores/ministore'
+import ministore, { resetStores } from '../../stores/ministore'
 
 it('getState', () => {
   const store = ministore(1)
@@ -16,6 +16,59 @@ it('update partial', () => {
   const store = ministore({ a: 1, b: 2 })
   store.update({ a: 3 })
   expect(store.getState()).toEqual({ a: 3, b: 2 })
+})
+
+describe('reset', () => {
+  it('restore the initial state', () => {
+    const store = ministore({ a: 1, b: 2 })
+    store.update({ a: 3 })
+    store.reset()
+    expect(store.getState()).toEqual({ a: 1, b: 2 })
+  })
+
+  it('trigger subscribers', () => {
+    let counter = 0
+    const store = ministore(0)
+    store.update(1)
+    store.subscribe(() => counter++)
+    store.reset()
+    expect(counter).toBe(1)
+    expect(store.getState()).toBe(0)
+  })
+
+  it('only trigger if state has changed', () => {
+    let counter = 0
+    const store = ministore(0)
+    store.subscribe(() => counter++)
+    store.reset()
+    expect(counter).toBe(0)
+  })
+})
+
+describe('resetStores', () => {
+  it('reset every store', () => {
+    const storeA = ministore(1)
+    const storeB = ministore({ a: 1, b: 2 })
+    storeA.update(2)
+    storeB.update({ a: 3 })
+
+    resetStores()
+
+    expect(storeA.getState()).toBe(1)
+    expect(storeB.getState()).toEqual({ a: 1, b: 2 })
+  })
+
+  it('recompute a composed store when its sources are reset', () => {
+    const storeA = ministore(1)
+    const storeB = ministore(2)
+    const composite = ministore.compose((state1: number, state2: number) => 10 * state1 + state2, [storeA, storeB])
+    storeA.update(3)
+    expect(composite.getState()).toBe(32)
+
+    resetStores()
+
+    expect(composite.getState()).toBe(12)
+  })
 })
 
 describe('subscribe', () => {


### PR DESCRIPTION
## What

- `reset()` on the `Ministore` interface, restoring the initial state the store was created with.
- A registry of every store created by the factory, plus `resetStores()`.
- Both test setup helpers — `initStore` (gated on `!persist`) and `createTestApp` — reset all ministores.

## Why

Ministores are module-level singletons, and vitest isolates modules per test *file*, not per test. A store written by one test stays dirty for the next one in the same file. Tests worked around this by resetting individual stores by hand:

```ts
beforeEach(() => {
  initStore()
  // someStore is a module-level store that is not reset by initStore
  someStore.update({ ... })
})
```

That requires every test author to know which module-level stores exist, and it encodes a store's clean state at the call site rather than in the store — knowledge that goes stale as soon as a store is added or its initial state changes.

**Setup, not teardown.** With `afterEach` cleanup, a file that omits the hook (or a test that throws past it) leaks into the *next* test, so the failure surfaces one test later than its cause, in a test that did nothing wrong. Resetting in setup makes each test's preconditions its own responsibility.

## Notes for review

- `reset()` is implemented via `update(initialState)`, so it inherits the existing change-detection and emitter semantics: subscribers fire on reset, and a store already at its initial state short-circuits without notifying.
- The registry is populated inside the `ministore()` factory, so stores added in future are covered with no test-setup change. All production ministores are module-level singletons (nothing constructs one per render or per call), so the set does not grow at runtime.
- `ministore.compose` unregisters its internal store and strips `reset` from the returned readonly API, matching how it already strips `update`. Derived stores are never written directly — they recompute when their sources reset, which is covered by a test.
- In `createTestApp` the reset must run **before** `initialize()`, since `initialize()` itself populates some ministores (`offlineStatusStore` among them); resetting afterward would wipe legitimate init state rather than stale state.
- `initStore({ persist: true })` skips the ministore reset along with the Redux `clear()`.
- [docs/testing.md](docs/testing.md) described `initStore` as clearing only the store and enabling fake timers; updated in both places it describes the setup helpers.

## Testing

- New unit tests for `reset` (restores state, triggers subscribers, short-circuits when unchanged) and `resetStores` (resets all stores; a composed store re-derives).
- Full unit suite passes locally: 184 files, 1676 tests, 0 failures. Typecheck, eslint, and prettier clean.
