### PR TITLE
Repeat: restore the keyboardIndex of the repeated command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,7 +56,7 @@ const pinCommand: Command = {
 
 `exec` receives the Redux `dispatch`, a `getState` thunk, the event that triggered the command, and a `{ type }` field that is `'keyboard'`, `'gesture'`, `'toolbar'`, or `'chainedGesture'` so the command can adapt its behavior (e.g. `pin` shows an alert only when triggered via keyboard, since the toolbar already gives visual feedback).
 
-A command bound to an array of keyboard shortcuts also receives `keyboardIndex`, the index within that array of the shortcut that was pressed (`undefined` for every other activation type). This lets one command cover a family of related shortcuts: `applyColor` maps Command/Ctrl + Option/Alt + *n* and Option/Alt + *n* to the *n*th text and background swatch of the [`ColorPicker`](../src/components/ColorPicker.tsx). Since only the first shortcut of an array is displayed, such a command can set `keyboardDisplay` to a single `Key` representing the whole range (`applyColor` displays `Cmd + Option + 0-8`).
+A command bound to an array of keyboard shortcuts also receives `keyboardIndex`, the index within that array of the shortcut that was pressed (`undefined` when the command was not activated by one of its own keyboard shortcuts). This lets one command cover a family of related shortcuts: `applyColor` maps Command/Ctrl + Option/Alt + *n* and Option/Alt + *n* to the *n*th text and background swatch of the [`ColorPicker`](../src/components/ColorPicker.tsx). Since only the first shortcut of an array is displayed, such a command can set `keyboardDisplay` to a single `Key` representing the whole range (`applyColor` displays `Cmd + Option + 0-8`).
 
 ### Discovery and indexing
 
@@ -155,7 +155,9 @@ Three fields shape what happens when the command might not be runnable:
 
 ### Repeat
 
-`repeat` (Command/Ctrl + .) has no behavior of its own — its `exec` is a noop. `executeCommand` records the last command it executed in a module-level `lastCommand` variable, and both `executeCommand` and `executeCommandWithMulticursor` resolve `repeat` to it before executing, so the repeated command runs through the normal path with its own `canExecute`, multicursor, and `keyboardIndex` handling. Resolving before execution (rather than executing from within `repeat.exec`) also keeps `repeat.ts` free of an import of `commands.ts`, which would be circular.
+`repeat` (Command/Ctrl + .) has no behavior of its own — its `exec` is a noop. `executeCommand` records the last command it executed in a module-level `lastCommand` variable, and both `executeCommand` and `executeCommandWithMulticursor` resolve `repeat` to it before executing, so the repeated command runs through the normal path with its own `canExecute` and multicursor handling. Resolving before execution (rather than executing from within `repeat.exec`) also keeps `repeat.ts` free of an import of `commands.ts`, which would be circular.
+
+`keyboardIndex` is recorded alongside the command and restored when it is repeated, since it cannot be derived from the Command/Ctrl + . keypress — that keypress matches none of the repeated command's own shortcuts. Without it, repeating `applyColor` would have no swatch to apply and would silently do nothing. `executeCommandWithMulticursor` resolves `repeat` itself and then delegates an already-resolved command, so it forwards the recorded index through executeCommand's `keyboardIndex` option.
 
 Only commands that make an *undoable, non-navigational* change are recorded, so that Repeat repeats the last edit no matter how many navigation or non-undoable commands intervened. `executeCommand` detects this by comparing the last non-navigation undo patch (the patch that Undo would revert, as classified by [`actionMetadata.registry`](../src/util/actionMetadata.registry.ts)) before and after `exec`. Consequently:
 

--- a/src/@types/Command.ts
+++ b/src/@types/Command.ts
@@ -19,7 +19,7 @@ interface Command {
   /** A readable, internal unique id. */
   id: CommandId
 
-  /** Executes the command. When activated by a keyboard shortcut and the command defines an array of keyboard shortcuts, `keyboardIndex` is the index of the shortcut that was pressed within that array. */
+  /** Executes the command. When activated by a keyboard shortcut and the command defines an array of keyboard shortcuts, `keyboardIndex` is the index of the shortcut that was pressed within that array. When the command is executed again by repeat, it is the index that was recorded with it. */
   exec: (
     dispatch: Dispatch,
     getState: () => State,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -389,13 +389,31 @@ const nearestNonAttributeAncestor = (state: State, path: Path): Path | null => {
 /**
  * The last command that was executed, tracked so that it can be executed again by the repeat command. Not reactive — nothing subscribes to it — so it is a plain module variable rather than a ministore.
  *
- * Repeat has no behavior of its own. Both executeCommand and executeCommandWithMulticursor swap it out for lastCommand before executing, rather than executing from within its exec, so that the repeated command runs through the same path as any other command and gets its own canExecute, multicursor, and keyboardIndex handling. Since repeat is repeatable: false, it is never recorded here, so the swap never resolves to repeat itself and cannot recurse.
+ * Repeat has no behavior of its own. Both executeCommand and executeCommandWithMulticursor swap it out for lastCommand before executing, rather than executing from within its exec, so that the repeated command runs through the same path as any other command and gets its own canExecute and multicursor handling. Since repeat is repeatable: false, it is never recorded here, so the swap never resolves to repeat itself and cannot recurse.
+ *
+ * The keyboardIndex that triggered the command is recorded alongside it, since it cannot be recovered from the repeat keypress. Without it, a command bound to an array of shortcuts (applyColor) would have no shortcut to repeat.
  */
-let lastCommand: Command | null = null
+let lastCommand: { command: Command; keyboardIndex?: number } | null = null
 
 /** Resets the last command. For testing only, since lastCommand persists across tests within a file. */
 export const resetLastCommand = () => {
   lastCommand = null
+}
+
+/** Resolves the repeat command to the last command that was executed and the keyboardIndex it was triggered with. Returns null if there is nothing to repeat. Any other command resolves to itself with no keyboardIndex, leaving it to be derived from the event. */
+const resolveRepeat = (command: Command): { command: Command; keyboardIndex?: number } | null =>
+  command.id === 'repeat' ? lastCommand : { command }
+
+/** Returns the index of the command's keyboard shortcut that was pressed, so that it can be read in exec (e.g. to select a color based on the pressed shortcut). Returns undefined if the command was not activated by one of its own keyboard shortcuts. */
+const keyboardIndexOf = (
+  command: Command,
+  type: CommandType,
+  event: Event | GestureResponderEvent | KeyboardEvent | React.MouseEvent | React.TouchEvent,
+): number | undefined => {
+  if (type !== 'keyboard' || !(event instanceof KeyboardEvent) || !command.keyboard) return undefined
+  const keyboardShortcuts = Array.isArray(command.keyboard) ? command.keyboard : [command.keyboard]
+  const index = keyboardShortcuts.findIndex(keyboard => hashCommand(keyboard) === hashKeyDown(event))
+  return index === -1 ? undefined : index
 }
 
 /** Returns the last undo patch that is not a navigation action, i.e. the patch that Undo would revert. Mirrors getLatestActionType, but returns the patch itself so that patches can be compared by identity. */
@@ -413,11 +431,14 @@ export const executeCommand = (
     store: storeArg,
     type,
     event,
+    keyboardIndex: keyboardIndexArg,
   }: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     store?: Store<State, any>
     type?: CommandType
     event?: Event | GestureResponderEvent | KeyboardEvent | React.MouseEvent | React.TouchEvent
+    /** The index of the keyboard shortcut that triggered the command, when it cannot be derived from the event. Set by executeCommandWithMulticursor, which resolves repeat before delegating here and so must carry the recorded index with it. */
+    keyboardIndex?: number
   } = {},
 ) => {
   const commandStore = storeArg ?? store
@@ -425,23 +446,16 @@ export const executeCommand = (
   event = event ?? eventNoop
 
   // resolve repeat to the last command that was executed, and exit early if there is none
-  const command = commandArg.id !== 'repeat' ? commandArg : lastCommand
-  if (!command) return
+  const resolved = resolveRepeat(commandArg)
+  if (!resolved) return
+  const command = resolved.command
 
   const canExecute = !command.canExecute || command.canExecute(commandStore.getState())
   // Exit early if the command cannot execute
   if (!canExecute) return
 
-  // When activated by a keyboard shortcut, determine which of the command's keyboard shortcuts was pressed so it can be read in exec (e.g. to select a color based on the pressed shortcut).
-  const keyboardShortcuts = command.keyboard
-    ? Array.isArray(command.keyboard)
-      ? command.keyboard
-      : [command.keyboard]
-    : []
-  const keyboardIndex =
-    type === 'keyboard' && event instanceof KeyboardEvent && keyboardShortcuts.length > 0
-      ? keyboardShortcuts.findIndex(keyboard => hashCommand(keyboard) === hashKeyDown(event))
-      : undefined
+  // A repeated command takes the keyboardIndex that was recorded with it, since the repeat keypress matches none of its own keyboard shortcuts. Otherwise it is derived from the event.
+  const keyboardIndex = keyboardIndexArg ?? resolved.keyboardIndex ?? keyboardIndexOf(command, type, event)
 
   debugLog.log('command', { id: command.id, commandType: type })
 
@@ -453,7 +467,7 @@ export const executeCommand = (
   // Record the last command so that it can be executed again by the repeat command, but only if it made an undoable, non-navigational change to the thoughtspace. Otherwise repeat would repeat cursor movements and commands that dispatch no undoable actions (e.g. Cursor Down, Export) rather than the last edit, no matter how many of them occurred since.
   // Patches are compared by identity rather than by action type, since the same command may be executed repeatedly (e.g. Bold twice in a row). A command that only dispatches asynchronously (e.g. Generate Thought) is not recorded, as its patch does not exist yet.
   if (command.repeatable !== false && lastUndoablePatch(commandStore.getState()) !== undoablePatchPrev) {
-    lastCommand = command
+    lastCommand = { command, keyboardIndex }
   }
 }
 
@@ -476,14 +490,17 @@ export const executeCommandWithMulticursor = (
   event = event ?? eventNoop
 
   // resolve repeat to the last command that was executed, and exit early if there is none
-  const command = commandArg.id !== 'repeat' ? commandArg : lastCommand
-  if (!command) return
+  const resolved = resolveRepeat(commandArg)
+  if (!resolved) return
+  const command = resolved.command
+  // Every executeCommand call below is given the already resolved command, so it cannot resolve repeat itself. Forward the recorded keyboardIndex explicitly, otherwise it would be derived from the repeat keypress and lost.
+  const keyboardIndex = resolved.keyboardIndex
 
   const state = commandStore.getState()
 
   // If we don't have active multicursors or the command ignores multicursors, execute the command normally.
   if (!command.multicursor || !hasMulticursor(state)) {
-    return executeCommand(command, { store: commandStore, type, event })
+    return executeCommand(command, { store: commandStore, type, event, keyboardIndex })
   }
 
   /** The value of Command['multicursor'] resolved to an object. That is, bare false has already short circuited, and bare true resolves to an empty object so that we don't need to make existential checks everywhere. */
@@ -513,7 +530,7 @@ export const executeCommandWithMulticursor = (
     if (!state.cursor || !isMulticursorPath(state, state.cursor)) {
       commandStore.dispatch(setCursor({ path: paths[0] }))
     }
-    return executeCommand(command, { store: commandStore, type, event })
+    return executeCommand(command, { store: commandStore, type, event, keyboardIndex })
   }
 
   // For each multicursor, place the cursor on the path and execute the command by calling executeCommand.
@@ -548,7 +565,7 @@ export const executeCommandWithMulticursor = (
       if (!recomputedPath) continue
 
       commandStore.dispatch(setCursor({ path: recomputedPath }))
-      executeCommand(command, { store: commandStore, type, event })
+      executeCommand(command, { store: commandStore, type, event, keyboardIndex })
     }
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -400,10 +400,6 @@ export const resetLastCommand = () => {
   lastCommand = null
 }
 
-/** Resolves the repeat command to the last command that was executed and the keyboardIndex it was triggered with. Returns null if there is nothing to repeat. Any other command resolves to itself with no keyboardIndex, leaving it to be derived from the event. */
-const resolveRepeat = (command: Command): { command: Command; keyboardIndex?: number } | null =>
-  command.id === 'repeat' ? lastCommand : { command }
-
 /** Returns the index of the command's keyboard shortcut that was pressed, so that it can be read in exec (e.g. to select a color based on the pressed shortcut). Returns undefined if the command was not activated by one of its own keyboard shortcuts. */
 const keyboardIndexOf = (
   command: Command,
@@ -445,8 +441,8 @@ export const executeCommand = (
   type = type ?? 'keyboard'
   event = event ?? eventNoop
 
-  // resolve repeat to the last command that was executed, and exit early if there is none
-  const resolved = resolveRepeat(commandArg)
+  // resolve repeat to the last command that was executed and the keyboardIndex it was triggered with, and exit early if there is none
+  const resolved = commandArg.id === 'repeat' ? lastCommand : { command: commandArg }
   if (!resolved) return
   const command = resolved.command
 
@@ -489,8 +485,8 @@ export const executeCommandWithMulticursor = (
   type = type ?? 'keyboard'
   event = event ?? eventNoop
 
-  // resolve repeat to the last command that was executed, and exit early if there is none
-  const resolved = resolveRepeat(commandArg)
+  // resolve repeat to the last command that was executed and the keyboardIndex it was triggered with, and exit early if there is none
+  const resolved = commandArg.id === 'repeat' ? lastCommand : { command: commandArg }
   if (!resolved) return
   const command = resolved.command
   // Every executeCommand call below is given the already resolved command, so it cannot resolve repeat itself. Forward the recorded keyboardIndex explicitly, otherwise it would be derived from the repeat keypress and lost.

--- a/src/commands/__tests__/applyColor.ts
+++ b/src/commands/__tests__/applyColor.ts
@@ -1,0 +1,103 @@
+import { act } from 'react'
+import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { resetLastCommand } from '../../commands'
+import getThoughtById from '../../selectors/getThoughtById'
+import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
+
+beforeEach(async () => {
+  await createTestApp()
+  resetLastCommand()
+})
+afterEach(cleanupTestApp)
+
+/** Presses a keyboard shortcut on the window, where the global keyDown handler picks it up and executes the matching command. */
+const keyDown = async (key: string, { alt, meta }: { alt?: boolean; meta?: boolean } = {}) => {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key, altKey: alt, metaKey: meta, bubbles: true }))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+}
+
+/** Returns the value of the cursor thought. */
+const cursorValue = (): string => {
+  const state = store.getState()
+  return getThoughtById(state, head(state.cursor!))!.value
+}
+
+it('applies the text color of the pressed shortcut', async () => {
+  act(() => {
+    store.dispatch(newThought({ value: 'Golden Retriever' }))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // Command + Option + 5 is the sixth swatch, blue
+  await keyDown('5', { meta: true, alt: true })
+
+  expect(cursorValue()).toBe('<font color="#00c7e6">Golden Retriever</font>')
+})
+
+it('applies the background color of the pressed shortcut', async () => {
+  act(() => {
+    store.dispatch(newThought({ value: 'Golden Retriever' }))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // Option + 4 is the fifth swatch of the background color row, green
+  await keyDown('4', { alt: true })
+
+  expect(cursorValue()).toBe(
+    '<font color="#000000" style="background-color: rgb(0, 214, 136);">Golden Retriever</font>',
+  )
+})
+
+it('repeat applies the same color as the shortcut that was pressed', async () => {
+  act(() => {
+    store.dispatch([newThought({ value: 'Golden Retriever' }), newThought({ value: 'Labrador' })])
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  act(() => {
+    store.dispatch(setCursor(['Golden Retriever']))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await keyDown('5', { meta: true, alt: true })
+
+  act(() => {
+    store.dispatch(setCursor(['Labrador']))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // Command + . repeats Apply Color with the same swatch
+  await keyDown('.', { meta: true })
+
+  expect(cursorValue()).toBe('<font color="#00c7e6">Labrador</font>')
+})
+
+it('repeat applies the same color to a single selected thought', async () => {
+  act(() => {
+    store.dispatch([newThought({ value: 'Golden Retriever' }), newThought({ value: 'Labrador' })])
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  act(() => {
+    store.dispatch(setCursor(['Golden Retriever']))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await keyDown('5', { meta: true, alt: true })
+
+  // Apply Color disallows multiple thoughts, so a single selected thought takes the multicursor path that resolves repeat before delegating to executeCommand.
+  act(() => {
+    store.dispatch(addMulticursor(['Labrador']))
+  })
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await keyDown('.', { meta: true })
+
+  expect(cursorValue()).toBe('<font color="#00c7e6">Labrador</font>')
+})


### PR DESCRIPTION
Follow-up to #4894, which left this out:

> applyColor is bound to a range of shortcuts and picks its color from keyboardIndex, which is derived from the keypress that triggered execution. Since the recorded command carries no keyboardIndex, repeating a color shortcut is a no-op rather than re-applying the color.

## The bug

`executeCommand` derived `keyboardIndex` by matching the *current* keypress against the resolved command's shortcuts. For a repeat that means matching Command + . against `applyColor`'s digit shortcuts, so `findIndex` returned `-1`, `colorShortcuts[-1]` was `undefined`, and `exec` bailed. Pressing Cmd + Option + 5 and then Cmd + . on another thought left that thought uncolored.

## The fix

- `lastCommand` records `{ command, keyboardIndex }` instead of a bare `Command`, and `resolveRepeat` returns both. A repeated command takes the recorded index; anything else derives it from the event as before.
- `executeCommandWithMulticursor` resolves `repeat` itself and then hands `executeCommand` an already-resolved command, so it can't re-resolve — it forwards the recorded index through a new `keyboardIndex` option. This is the path `applyColor` actually takes when a thought is selected, since it is `multicursor: { disallow: true }`.
- Extracted the derivation into `keyboardIndexOf`, which returns `undefined` rather than `-1` when the event matches none of the command's shortcuts. That is what `exec`'s `keyboardIndex == null` guard was already written to expect, and what `docs/commands.md` already claimed.

## Notes for the reviewer

- This adds one option to `executeCommand`'s signature, which #4894 deliberately deferred. It is needed because `executeCommandWithMulticursor` resolves `repeat` before delegating, so the callee has no way to recover the index on its own.
- The `-1` → `undefined` change is only observable in `applyColor`, the sole consumer of `keyboardIndex`, where `-1` was already being treated as "no shortcut" by way of a failed array lookup.

## Testing

New `src/commands/__tests__/applyColor.ts` drives real `keydown` events through the global handler: text color, background color, repeat, and repeat with a single selected thought. The last one was verified to fail when the multicursor forwarding is removed, so it guards that branch specifically. The repeat test was written first and observed failing against the old behavior.

Full unit suite passes (1681 passed, 75 pre-existing skips), along with typecheck and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)