### PR TITLE
Extend thin-wrapper rule to single-expression functions

### DIFF
--- a/.github/instructions/code-standards.instructions.md
+++ b/.github/instructions/code-standards.instructions.md
@@ -14,10 +14,20 @@
 
 - Do not create new files for constants, hooks, components, selectors, or helper functions that are only used in a single file. Instead, define them in the same file where they are used.
   - Prefer co-located functions over unnecessary abstraction. If a function is only used in one module, define it there instead of abstracting it out into a separate file.
-- Avoid thin wrappers that give the appearance of abstraction. Before extracting a function, confirm it earns its place by answering yes to at least one of the questions below; if the answer is no to all three, inline it at the call site. A thin wrapper enlarges the internal API and hides the significant call it wraps (e.g. a lifecycle hook such as `evaluateOnNewDocument`, or a subscription), making the control flow harder to follow than the code it replaced.
-  - Does it reduce duplication? A helper called once does not.
+- Avoid thin functions that give the appearance of abstraction. Before extracting a function, confirm it earns its place by answering yes to at least one of the questions below; if the answer is no to all three, inline it at the call site. A thin function enlarges the internal API while hiding the code that mattered — the significant call it wraps (e.g. a lifecycle hook such as `evaluateOnNewDocument`, or a subscription), or the condition it evaluates — making the control flow harder to follow than the code it replaced.
+  - Does it reduce duplication? A helper called once does not. Neither does a single expression called twice — repeating it at both call sites is cheaper to read than a jump.
   - Does it establish an encapsulation boundary? A helper whose only consumers live in the same module does not.
-  - Does it hide meaningful complexity? A one- or two-line body that just forwards its arguments does not.
+  - Does it hide meaningful complexity? A one- or two-line body that just forwards its arguments does not. Neither does a body that is a single boolean expression, ternary, or lookup — inline the expression, and put any explanation in a comment above it rather than a JSDoc on a helper:
+    ```ts
+    // ✗ too thin: the whole function is one ternary
+    /** Resolves the repeat command to the last command that was executed. */
+    const resolveRepeat = (command: Command): Command | null => (command.id === 'repeat' ? lastCommand : command)
+
+    // ✓ inline at the call site
+    // the repeat command resolves to the last command that was executed
+    const resolved = command.id === 'repeat' ? lastCommand : command
+    ```
+    Multi-line logic with branches or early returns is fine to extract.
 - Only a single, default export is allowed. Named exports are not allowed.
   - Exception: action-creators are co-located with reducers in `src/actions` and exported as named exports.
   - Filenames should exactly match the default export name.


### PR DESCRIPTION
## What

Extends the existing "avoid thin wrappers" guideline in [`.github/instructions/code-standards.instructions.md`](.github/instructions/code-standards.instructions.md) to cover functions whose entire body is a single boolean expression, ternary, or lookup.

## Why

The rule as written was framed around wrappers — functions that forward their arguments to a significant call (a lifecycle hook, a subscription). A function like this escaped it, since it wraps nothing:

```ts
/** Resolves the repeat command to the last command that was executed. */
const resolveRepeat = (command: Command): Command | null => (command.id === 'repeat' ? lastCommand : command)
```

It is still a named indirection that costs a jump to read and buys nothing.

## Changes

- Re-framed from "thin wrappers" to "thin functions", so the lead sentence covers both the hidden call and the hidden condition.
- Duplication bullet: a single expression used at two call sites still does not earn extraction — repeating it reads cheaper than the jump.
- Complexity bullet: names the single-expression case explicitly, with a ✗/✓ example, and directs the explanation into a comment above the inlined expression rather than a JSDoc on a helper.
- Kept the carve-out that multi-line logic with branches or early returns is fine to extract.

## Notes for reviewers

Guideline text only — no code changes. Prettier passes on the file.