### PR TITLE
Allow Clear Thought to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/clearThought.ts
+++ b/src/commands/__tests__/clearThought.ts
@@ -1,11 +1,17 @@
 import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import { setCursorActionCreator as setCursor } from '../../actions/setCursor'
-import { executeCommand } from '../../commands'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommand, executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import childIdsToThoughts from '../../selectors/childIdsToThoughts'
+import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator } from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
 import headValue from '../../util/headValue'
 import clearThoughtCommand from '../clearThought'
 import cursorBackCommand from '../cursorBack'
@@ -87,5 +93,199 @@ describe('clearThought', () => {
     const state = store.getState()
     expect(state.cursorCleared).toBe(false)
     expect(state.cursor && headValue(state, state.cursor)).toBe('hello')
+  })
+})
+
+describe('multicursor', () => {
+  it('clears the text of every selected thought while preserving descendants', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - x
+          - b
+            - y
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - ${''}
+    - x
+  - ${''}
+    - y`)
+  })
+
+  it('clears selected thoughts at different depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+              - c
+          - d
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['d']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - ${''}
+      - c
+  - ${''}`)
+  })
+
+  it('does not clear a selected divider', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - ---
+          - b
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['---']),
+      addMulticursor(['b']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - ${''}
+  - ---
+  - ${''}`)
+  })
+
+  it('enters the transient clear mode instead of editing when a single thought is selected', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const state = store.getState()
+
+    // the transient mode is active and the persisted value is untouched
+    expect(state.cursorCleared).toBe(true)
+    expect(state.cursor && headValue(state, state.cursor)).toBe('a')
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b`)
+  })
+
+  it('toggles the transient clear mode off when executed again with a single selected thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    // Precondition: the first execution entered the transient clear mode, otherwise the second execution would enter it rather than toggle it off.
+    expect(store.getState().cursorCleared).toBe(true)
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const state = store.getState()
+
+    expect(state.cursorCleared).toBe(false)
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a`)
+  })
+
+  it('keeps the cursor and multiselection on the cleared thoughts without entering the transient clear mode', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - x
+          - b
+            - y
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+    ])
+
+    // both cleared thoughts end up with the empty value, so compare the cursor by thought id rather than by value
+    const cursorIdBefore = head(store.getState().cursor!)
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    const state = store.getState()
+
+    expect(state.cursor && head(state.cursor)).toBe(cursorIdBefore)
+    expect(
+      Object.values(state.multicursors).map(path => childIdsToThoughts(state, path).map(thought => thought.value)),
+    ).toEqual([[''], ['']])
+    // the transient clear mode applies to a single cursor thought only and must not be activated by a multi-thought clear
+    expect(state.cursorCleared).toBe(false)
+  })
+
+  it('restores the text of every cleared thought on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+            - x
+          - c
+        `,
+      }),
+      setCursorFirstMatchActionCreator(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+      addMulticursor(['c']),
+    ])
+
+    executeCommandWithMulticursor(clearThoughtCommand, { store })
+
+    // Precondition: all three thoughts were cleared, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - ${''}
+  - ${''}
+    - x
+  - ${''}`)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b
+    - x
+  - c`)
   })
 })

--- a/src/commands/clearThought.ts
+++ b/src/commands/clearThought.ts
@@ -1,9 +1,28 @@
 import Command from '../@types/Command'
+import Dispatch from '../@types/Dispatch'
+import State from '../@types/State'
 import { cursorClearedActionCreator as cursorCleared } from '../actions/cursorCleared'
+import { editThoughtActionCreator as editThought } from '../actions/editThought'
+import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import ClearThoughtIcon from '../components/icons/ClearThoughtIcon'
 import * as selection from '../device/selection'
 import hasMulticursor from '../selectors/hasMulticursor'
+import isMulticursorPath from '../selectors/isMulticursorPath'
+import simplifyPath from '../selectors/simplifyPath'
+import headValue from '../util/headValue'
 import isDocumentEditable from '../util/isDocumentEditable'
+
+/** Toggles the transient clear thought mode on the cursor thought. The editable renders empty and typing replaces the old text, but the persisted value is untouched; navigating away restores it. */
+const toggleClearThought = (dispatch: Dispatch, getState: () => State) => {
+  const { cursorCleared: isCursorCleared } = getState()
+
+  dispatch(cursorCleared({ value: !isCursorCleared }))
+
+  // if toggling off, remove the browser selection
+  if (isCursorCleared) {
+    selection.clear()
+  }
+}
 
 const clearThoughtCommand: Command = {
   id: 'clearThought',
@@ -12,23 +31,42 @@ const clearThoughtCommand: Command = {
   gesture: 'rl',
   keyboard: { key: 'c', alt: true, shift: true, meta: true },
   multicursor: {
-    disallow: true,
-    error: 'Cannot clear multiple thoughts.',
+    // The cursor restore at the end of the multicursor loop dispatches setCursor, which resets cursorCleared and would immediately cancel the transient mode entered by the single-thought branch below. execMulticursor never moves the cursor, so there is nothing to restore in the multi-thought branch either.
+    preventSetCursor: true,
+    execMulticursor: (cursors, dispatch, getState) => {
+      // A single selected thought enters the same transient clear mode as a plain cursor. On mobile, opening the Command Center selects the cursor thought, so this is the normal way the command is invoked there.
+      if (cursors.length === 1) {
+        const state = getState()
+        if (!state.cursor || !isMulticursorPath(state, state.cursor)) {
+          dispatch(setCursor({ path: cursors[0] }))
+        }
+        toggleClearThought(dispatch, getState)
+        return
+      }
+
+      // The transient cursorCleared mode is a single global flag on the cursor thought, so it cannot represent multiple selected thoughts. Clear their persisted text instead. isMulticursorExecuting collapses the edits into a single undo step.
+      cursors.forEach(path => {
+        const state = getState()
+        const oldValue = headValue(state, path)
+        // nothing to clear on a missing or already-empty thought; editThought bails on a divider on its own
+        if (!oldValue) return
+        dispatch(
+          editThought({
+            oldValue,
+            newValue: '',
+            path: simplifyPath(state, path),
+            // ContentEditable does not re-render while editing, so force the Editable to re-render when the cursor thought is cleared while in edit mode
+            force: true,
+          }),
+        )
+      })
+    },
   },
   svg: ClearThoughtIcon,
   canExecute: state => {
     return isDocumentEditable() && (!!state.cursor || hasMulticursor(state))
   },
-  exec: (dispatch, getState) => {
-    const { cursorCleared: isCursorCleared } = getState()
-
-    dispatch(cursorCleared({ value: !isCursorCleared }))
-
-    // if toggling off, remove the browser selection
-    if (isCursorCleared) {
-      selection.clear()
-    }
-  },
+  exec: toggleClearThought,
 }
 
 export default clearThoughtCommand


### PR DESCRIPTION
## What

Clear Thought declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot clear multiple thoughts." This replaces the declaration with a custom `execMulticursor` that clears the persisted text of every selected thought, and adds a store test suite for the resulting behavior.

## Why

Unlike most per-cursor commands, Clear Thought's `exec` does not edit the thoughtspace — it toggles the global `state.cursorCleared` flag, a transient editing mode on the single cursor thought (the editable renders empty, typing replaces the old text, navigating away restores it). That flag cannot represent multiple selected thoughts, and running `exec` once per cursor through the standard loop would just toggle the global flag back and forth. So the multiselect semantics had to be designed rather than inherited:

- **Multiple selected thoughts**: the natural reading of "Clear Thought" applied to a multiselect is "empty these thoughts", so `execMulticursor` dispatches `editThought` with an empty `newValue` for each selected thought (`force: true`, mirroring `formatLetterCase`'s bulk edits, since ContentEditable does not re-render while editing). This is a persistent edit where single-cursor mode is a recoverable UI state — a deliberate difference, weighed as follows: the transient mode's recovery path (navigate away / escape) is inherently single-thought, while the multi-thought clear gets an equivalent recovery path from `isMulticursorExecuting`, which collapses all the edits into a single undo step. Descendants are preserved; a selected divider is left intact (`editThought` bails on dividers); an already-empty thought is skipped.
- **A single selected thought** (the common case — on mobile, opening the Command Center selects the cursor thought): still enters the exact same transient clear mode the old `disallow` carve-out produced, including the toggle-off on second invocation. `preventSetCursor` is required for this: the loop's final cursor restore dispatches `setCursor`, which unconditionally resets `cursorCleared` and would cancel the mode the moment it was entered. `execMulticursor` never moves the cursor, so there is nothing to restore in the multi-thought branch either.

## Tests

New store tests in `src/commands/__tests__/clearThought.ts` (`multicursor` describe block):

- clears the text of every selected thought while preserving descendants
- clears selected thoughts at different depths
- does not clear a selected divider
- enters the transient clear mode instead of editing when a single thought is selected
- toggles the transient clear mode off when executed again with a single selected thought
- keeps the cursor and multiselection on the cleared thoughts without entering the transient clear mode
- restores the text of every cleared thought on a single undo

The five multi-thought tests fail against the previous `disallow: true` declaration (the alert blocks execution, so the outline is unchanged) and pass with this change. The two single-selection tests pass on both — deliberately, since they pin the single-selection behavior that the old `disallow` path already produced and this change preserves. The undo test asserts the post-clear outline as a precondition, since without it that test would pass vacuously when nothing was cleared.

## Notes for reviewers

- With the multiselect preserved after the run, the cleared thoughts stay selected (compared by thought id in the tests, since their values are now all empty), and `cursorCleared` stays false — the transient mode must not be activated by a multi-thought clear.
- `exec` and the single-selection branch share the mode toggle via a module-level `toggleClearThought`, so single-cursor behavior cannot drift from single-selection behavior.
- `docs/commands.md` documents Clear Thought's behavior but not its multicursor declaration, so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
