### PR TITLE
Allow Bump Thought Down to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/bumpThoughtDown.ts
+++ b/src/commands/__tests__/bumpThoughtDown.ts
@@ -1,33 +1,258 @@
 import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
-import { executeCommand } from '../../commands'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommand, executeCommandWithMulticursor } from '../../commands'
 import bumpThoughtDown from '../../commands/bumpThoughtDown'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import hasMulticursor from '../../selectors/hasMulticursor'
+import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import dispatch from '../../test-helpers/dispatch'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 
-beforeEach(createTestApp)
-afterEach(cleanupTestApp)
+beforeEach(initStore)
 
-it('reset content editable inner html on bumpThoughtDown', async () => {
-  await dispatch([
-    importText({
-      text: `
+describe('DOM', () => {
+  beforeEach(createTestApp)
+  afterEach(cleanupTestApp)
+
+  it('reset content editable inner html on bumpThoughtDown', async () => {
+    await dispatch([
+      importText({
+        text: `
         - a
           - b`,
-    }),
-    setCursor(['a']),
-  ])
+      }),
+      setCursor(['a']),
+    ])
 
-  await act(vi.runOnlyPendingTimersAsync)
+    await act(vi.runOnlyPendingTimersAsync)
 
-  expect(document.querySelector(`div[data-editable]`)?.textContent).toBe('a')
+    expect(document.querySelector(`div[data-editable]`)?.textContent).toBe('a')
 
-  await act(async () => {
-    executeCommand(bumpThoughtDown)
+    await act(async () => {
+      executeCommand(bumpThoughtDown)
+    })
+
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(document.querySelector(`div[data-editable]`)?.textContent).toBe('')
+  })
+})
+
+describe('multicursor', () => {
+  it('bumps each selected thought down into a new empty thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - 
+    - a
+    - b
+  - 
+    - c
+    - d`)
   })
 
-  await act(vi.runOnlyPendingTimersAsync)
+  it('bumps selected thoughts at different depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+              - e
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['c', 'd']),
+    ])
 
-  expect(document.querySelector(`div[data-editable]`)?.textContent).toBe('')
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - 
+      - b
+  - c
+    - 
+      - d
+      - e`)
+  })
+
+  it('bumps each selected sibling down into its own empty thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - p
+            - a
+            - b
+        `,
+      }),
+      setCursor(['p', 'a']),
+      addMulticursor(['p', 'a']),
+      addMulticursor(['p', 'b']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    // A childless thought is bumped via the categorize path, which creates a new empty parent for it.
+    // Each sibling must get its own empty parent rather than being grouped under a single one.
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - p
+    - 
+      - a
+    - 
+      - b`)
+  })
+
+  it('bumps a selected parent and its selected child', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+              - c
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['a', 'b']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    // a is bumped first, moving its value into a new first child. b's path is recomputed through the
+    // now-empty parent before b is bumped in turn.
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - 
+    - a
+    - 
+      - b
+      - c`)
+  })
+
+  it('sets the cursor on the new empty thought when a single selected thought is bumped', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - p
+            - a
+        `,
+      }),
+      setCursor(['p', 'a']),
+      addMulticursor(['p', 'a']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    const state = store.getState()
+
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - p
+    - 
+      - a`)
+
+    // The caret belongs on the new empty thought, ready to type the bumped thought's replacement,
+    // just as when the command is executed without a multiselect.
+    expectPathToEqual(state, state.cursor, ['p', ''])
+    expect(hasMulticursor(state)).toBeFalse()
+  })
+
+  it('sets the cursor on the last bumped empty thought and clears the multicursor', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+              - e
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['c', 'd']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    const state = store.getState()
+
+    // d is the last selected thought in document order, so the caret ends on its empty replacement.
+    expectPathToEqual(state, state.cursor, ['c', ''])
+    expect(hasMulticursor(state)).toBeFalse()
+  })
+
+  it('reverts every bump on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+          - e
+            - f
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c']),
+      addMulticursor(['e']),
+    ])
+
+    executeCommandWithMulticursor(bumpThoughtDown, { store })
+
+    // Precondition: all three bumps occurred, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - 
+    - a
+    - b
+  - 
+    - c
+    - d
+  - 
+    - e
+    - f`)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - c
+    - d
+  - e
+    - f`)
+  })
 })

--- a/src/commands/bumpThoughtDown.ts
+++ b/src/commands/bumpThoughtDown.ts
@@ -12,9 +12,13 @@ const bumpThoughtDownCommand: Command = {
   description: 'Bump the current thought down one level and replace it with a new, empty thought.',
   gesture: 'drd',
   keyboard: { key: 'd', meta: true, alt: true },
+  // The command ends with the caret in a new empty thought ready for typing, so keep the cursor where
+  // the last execution put it and clear the selection, as newThought does. Restoring the original
+  // cursor would move the caret off the empty thought whenever the bumped thought had no children,
+  // since the recomputed path then leads to the moved value rather than its empty replacement.
   multicursor: {
-    disallow: true,
-    error: 'Cannot bump down multiple thoughts.',
+    preventSetCursor: true,
+    clearMulticursor: true,
   },
   svg: BumpThoughtDownIcon,
   canExecute: state => {


### PR DESCRIPTION
## What

Bump Thought Down declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot bump down multiple thoughts." This changes the declaration to `multicursor: { preventSetCursor: true, clearMulticursor: true }` so the standard multicursor loop executes it once per selected thought, and adds a store test suite for the resulting behavior.

## Why

`bumpThoughtDown` is a per-cursor action, and the multicursor loop already recomputes each path between iterations, so bumps compose — including a selected parent and its selected child, where the child's path is recomputed through the now-empty parent before its own bump. The childless case (which the action delegates to the `categorize` reducer) also composes: the loop's per-iteration `setCursor` clears `state.multicursors`, so `categorize`'s own multicursor handling (which would group all selected thoughts under a single empty thought, or reject selections spanning parents) never engages, and each thought gets its own empty replacement.

```
- a
  - b
- c
  - d
```

Selecting `a` and `c` and invoking Bump Thought Down now yields two empty thoughts at the root, each holding its old value and children as subthoughts.

The two options are load-bearing rather than cosmetic:

- **`preventSetCursor`** — the command's postcondition is a caret in the new empty thought, ready to type (the action sets that cursor itself, with `offset: 0` and the keyboard open). The default restore would override it, and whenever a bumped thought had no children the recomputed original path lands on the *moved value thought* rather than its empty replacement — including the common mobile flow where opening the Command Center selects the single cursor thought, which the old `disallow` declaration handled correctly by executing directly without a restore. With `preventSetCursor` the caret stays on the last bumped thought's empty replacement, matching single-cursor semantics.
- **`clearMulticursor`** — after the run the old selection no longer identifies a coherent set (a thought with children keeps its id as the emptied replacement; a childless thought's id follows the moved value), and the user's next act is typing into the empty thought. Clearing matches `newThought`/`newSubthought` — the other commands that end with the caret in a new empty thought — and the pre-change behavior for a single selected thought, whose own `setCursor` also cleared the selection.

## Tests

New store tests in `src/commands/__tests__/bumpThoughtDown.ts` (`multicursor` describe block); the existing JSDOM test moved unchanged into a `describe('DOM')` block per the `deleteEmptyThoughtOrOutdent.ts` convention:

- each selected thought is bumped down into a new empty thought (the fixture above)
- selections at different depths are bumped independently
- selected childless siblings each get their *own* empty parent (the `categorize` path), not grouped under a single one
- a selected parent and its selected child compose through path recomputation
- a single selected thought (the Command Center flow) leaves the caret on the new empty thought, with the multicursor cleared
- with multiple selections, the caret ends on the last bumped thought's empty replacement, with the multicursor cleared
- a single undo reverts every bump; the post-bump outline is asserted as a precondition so the test cannot pass vacuously

Red-side proof, run locally against both wrong declarations:

- Against the previous `disallow: true` declaration, 6 of the 7 fail (alert instead of execution). The single-selection cursor test passes there by design — `disallow` executes a lone selection directly — so it documents behavior this PR preserves rather than adds.
- Against a naive `multicursor: true` declaration, both cursor tests fail (the restore moves the caret onto the moved value thought), which is the evidence for the two options above.

`yarn vitest run --project unit src/commands/__tests__/bumpThoughtDown.ts`: 8 passed. `yarn lint`: clean.

## Notes for reviewers

- The multicursor loop's per-iteration `setCursor` clearing `state.multicursors` is what neutralizes `categorize`'s built-in multicursor handling. If that loop ever switches to `preserveMulticursor: true`, the childless-siblings test here will catch the regression (the thoughts would collapse under one shared empty parent).
- `src/__tests__/commands.ts` contains no `bumpThoughtDown` disallow test, so nothing needed removing there, and `docs/commands.md` documents the command's behavior but not its multicursor declaration, so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
