### PR TITLE
Allow Apply Color to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/applyColor.ts
+++ b/src/commands/__tests__/applyColor.ts
@@ -1,6 +1,10 @@
 import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { undoActionCreator as undo } from '../../actions/undo'
 import { resetLastCommand } from '../../commands'
+import { EMPTY_SPACE, HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
 import getThoughtById from '../../selectors/getThoughtById'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
@@ -91,13 +95,192 @@ it('repeat applies the same color to a single selected thought', async () => {
 
   await keyDown('5', { meta: true, alt: true })
 
-  // Apply Color disallows multiple thoughts, so a single selected thought takes the multicursor path that resolves repeat before delegating to executeCommand.
+  // Select the cursor thought, as opening the Command Center does. Apply Color declares multicursor: false, so the
+  // selection takes the multicursor path that resolves repeat and forwards its recorded keyboardIndex before
+  // short-circuiting to executeCommand.
   act(() => {
-    store.dispatch(addMulticursor(['Labrador']))
+    store.dispatch([setCursor(['Labrador']), addMulticursor(['Labrador'])])
   })
   await act(vi.runOnlyPendingTimersAsync)
 
   await keyDown('.', { meta: true })
 
+  // formatSelectionColor applies the color to the selected thought via formatSelection's multicursor branch.
   expect(cursorValue()).toBe('<font color="#00c7e6">Labrador</font>')
+})
+
+describe('multicursor', () => {
+  it('applies the text color of the pressed shortcut to every selected thought', async () => {
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    // Command + Option + 5 is the sixth swatch, blue
+    await keyDown('5', { meta: true, alt: true })
+
+    // The exact match on the whole tree also proves the color is applied exactly once per thought: a repeated
+    // application would either toggle the color back off or nest additional font tags.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/html')).toBe(`<ul>
+  <li>${HOME_TOKEN}${EMPTY_SPACE}
+    <ul>
+      <li><font color="#00c7e6">a</font></li>
+      <li><font color="#00c7e6">b</font></li>
+      <li><font color="#00c7e6">c</font></li>
+    </ul>
+  </li>
+</ul>`)
+  })
+
+  it('applies the background color of the pressed shortcut to every selected thought', async () => {
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    // Option + 4 is the fifth swatch of the background color row, green
+    await keyDown('4', { alt: true })
+
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/html')).toBe(`<ul>
+  <li>${HOME_TOKEN}${EMPTY_SPACE}
+    <ul>
+      <li><font color="#000000" style="background-color: rgb(0, 214, 136);">a</font></li>
+      <li><font color="#000000" style="background-color: rgb(0, 214, 136);">b</font></li>
+      <li><font color="#000000" style="background-color: rgb(0, 214, 136);">c</font></li>
+    </ul>
+  </li>
+</ul>`)
+  })
+
+  it('applies the color when there is a multiselect but no cursor', async () => {
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+          `,
+        }),
+        setCursor(null),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+      ])
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    await keyDown('5', { meta: true, alt: true })
+
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/html')).toBe(`<ul>
+  <li>${HOME_TOKEN}${EMPTY_SPACE}
+    <ul>
+      <li><font color="#00c7e6">a</font></li>
+      <li><font color="#00c7e6">b</font></li>
+    </ul>
+  </li>
+</ul>`)
+  })
+
+  it('keeps the cursor and the multicursor selection after applying a color', async () => {
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const { cursor: cursorBefore, multicursors: multicursorsBefore } = store.getState()
+
+    await keyDown('5', { meta: true, alt: true })
+
+    const state = store.getState()
+
+    // Precondition: the color was applied, otherwise the unchanged cursor and selection would be vacuous.
+    expect(exportContext(state, [HOME_TOKEN], 'text/html')).toContain('<font color="#00c7e6">a</font>')
+
+    // The single formatSelectionColor dispatch edits the selected thoughts in place (thought ids are stable across
+    // edits), so the cursor and the multicursor selection are untouched.
+    expect(state.cursor).toEqual(cursorBefore)
+    expect(state.multicursors).toEqual(multicursorsBefore)
+  })
+
+  it('reverts the color of every selected thought on a single undo', async () => {
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    await keyDown('5', { meta: true, alt: true })
+
+    // Precondition: every selected thought was colored, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/html')).toBe(`<ul>
+  <li>${HOME_TOKEN}${EMPTY_SPACE}
+    <ul>
+      <li><font color="#00c7e6">a</font></li>
+      <li><font color="#00c7e6">b</font></li>
+      <li><font color="#00c7e6">c</font></li>
+    </ul>
+  </li>
+</ul>`)
+
+    act(() => {
+      store.dispatch(undo())
+    })
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/html')).toBe(`<ul>
+  <li>${HOME_TOKEN}${EMPTY_SPACE}
+    <ul>
+      <li>a</li>
+      <li>b</li>
+      <li>c</li>
+    </ul>
+  </li>
+</ul>`)
+  })
 })

--- a/src/commands/applyColor.ts
+++ b/src/commands/applyColor.ts
@@ -2,6 +2,7 @@ import Command from '../@types/Command'
 import Key from '../@types/Key'
 import { formatSelectionColorActionCreator as formatSelectionColor } from '../actions/formatSelectionColor'
 import { ColorToken } from '../colors.config'
+import hasMulticursor from '../selectors/hasMulticursor'
 import isDocumentEditable from '../util/isDocumentEditable'
 
 /** The swatch colors, in the order they appear in the ColorPicker. Applies to both the text color and background color rows. */
@@ -19,7 +20,7 @@ const colorShortcuts: ColorShortcut[] = [
   })),
 ]
 
-/** Applies a text color or background color to the cursor thought via a keyboard shortcut, equivalent to tapping the corresponding swatch in the color picker. */
+/** Applies a text color or background color to the cursor thought or all selected thoughts via a keyboard shortcut, equivalent to tapping the corresponding swatch in the color picker. */
 const applyColor: Command = {
   id: 'applyColor',
   label: 'Apply Color',
@@ -29,12 +30,14 @@ const applyColor: Command = {
   keyboard: colorShortcuts.map(shortcut => shortcut.keyboard),
   // The command is bound to a shortcut per color, so display the range of digits rather than a single shortcut.
   keyboardDisplay: { key: `0-${swatchColors.length - 1}`, meta: true, alt: true },
-  multicursor: {
-    disallow: true,
-    error: 'Cannot change text color with multiple thoughts.',
-  },
+  // formatSelectionColor already applies the color to every selected thought itself, through formatSelection's
+  // multicursor branch, which brackets the edits with setIsMulticursorExecuting so they collapse into a single undo
+  // step — the same path as tapping a swatch in the ColorPicker on a multiselect. A single dispatch therefore covers
+  // the whole multiselect. The per-cursor loop of multicursor: true would re-enter that branch once per selected
+  // thought and prematurely end its undo bracket after the first iteration.
+  multicursor: false,
   hideFromGestureMenu: true,
-  canExecute: state => isDocumentEditable() && !!state.cursor,
+  canExecute: state => isDocumentEditable() && (!!state.cursor || hasMulticursor(state)),
   exec: (dispatch, _getState, _e, { keyboardIndex }) => {
     if (keyboardIndex == null) return
     const shortcut = colorShortcuts[keyboardIndex]


### PR DESCRIPTION
## What

Apply Color declared `multicursor: { disallow: true }`, so selecting several thoughts and pressing a color shortcut (Command/Ctrl + Option/Alt + *n* for text, Option/Alt + *n* for background) only produced the error alert "Cannot change text color with multiple thoughts." This changes the declaration to `multicursor: false` and extends `canExecute` to allow a multiselect without a cursor, so a single dispatch colors every selected thought.

## Why

`multicursor: false` — not `multicursor: true` — is the correct declaration here, because the action the command dispatches already handles the multiselect itself:

- `formatSelectionColor` dispatches `formatSelection('foreColor' | 'backColor', ...)`, and `formatSelection` has a dedicated multicursor branch: when `state.multicursors` is non-empty it applies the color to **every selected thought in one dispatch**, bracketing the edits with `setIsMulticursorExecuting` so they collapse into a single undo step (#4841). This is exactly the path the ColorPicker takes when a swatch is tapped on a multiselect (its `textColor` toolbar command likewise declares `multicursor: false`), so the keyboard shortcut now matches the swatch tap precisely.
- `multicursor: true` would be actively wrong: the per-cursor loop keeps `state.multicursors` populated while it iterates, so every iteration would re-enter the internal multicursor branch and re-apply the color to **all** selected thoughts (N×N), and the branch's own `setIsMulticursorExecuting({ value: false })` would end the loop's undo bracket after the first iteration, splitting the run into multiple undo steps. `execMulticursor` dispatching once would work but merely re-implements the short-circuit that `multicursor: false` already provides.

`canExecute` changes from `!!state.cursor` to `!!state.cursor || hasMulticursor(state)`, mirroring `textColor`, since with `multicursor: false` it is evaluated against the real state and a multiselect can exist without a cursor.

One observable behavior change to the previous single-selection path: `disallow` moved the cursor onto the single selected thought before executing; now the color is applied to the selected thought through the multicursor branch and the cursor stays where it was, consistent with `multicursor: false` semantics ("selection stays").

## Tests

Extended `src/commands/__tests__/applyColor.ts` with a `multicursor` describe block, driven through the real keyboard entry point (`window` keydown → `executeCommandWithMulticursor`), which also exercises `keyboardIndex` resolution from the pressed shortcut:

- the text color of the pressed shortcut applies to every selected thought
- the background color of the pressed shortcut applies to every selected thought
- the color applies when there is a multiselect but no cursor (covers the `canExecute` change)
- the cursor and the multicursor selection are unchanged after applying a color (with a colored-output precondition so it cannot pass vacuously)
- a single undo reverts the color of every selected thought (with a colored-output precondition, since under `disallow` the undo would have had nothing to revert)

All 5 fail against the previous `disallow: true` declaration (verified by temporarily restoring it: the alert fires and no color is applied) and pass with this change. The exact whole-tree `text/html` assertions also guard the double-application risk: a second application per thought would toggle the color back off or nest additional font tags.

The existing test "repeat applies the same color to a single selected thought" relied on the `disallow` path moving the cursor to the selected thought, which also reset the command state via the cursor-change middleware. It now selects the cursor thought the way the Command Center does (cursor and multicursor on the same thought) and asserts the same colored value.

## Notes for reviewers

- `formatSelectionColor`'s toggle semantics are unchanged and apply here as they do to the ColorPicker: if the command state (derived from the cursor thought) already shows the pressed color as active, the shortcut resets the selection to the default color rather than re-applying — the same as tapping a highlighted swatch.
- `docs/commands.md` mentions `applyColor` only in connection with `keyboardIndex` and the ColorPicker/`formatSelection` bracketing (both still accurate), so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
