### PR TITLE
Allow Note to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/note.ts
+++ b/src/commands/__tests__/note.ts
@@ -1,0 +1,227 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import headValue from '../../util/headValue'
+import noteCommand from '../note'
+
+beforeEach(initStore)
+
+/** Returns the sorted values of the current multicursor set. */
+const multicursorValues = (): (string | undefined)[] => {
+  const state = store.getState()
+  return Object.values(state.multicursors)
+    .map(path => headValue(state, path))
+    .sort()
+}
+
+describe('note', () => {
+  it('creates an empty note on the cursor thought and focuses it', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+        `,
+      }),
+      setCursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(noteCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - =note
+      - `)
+
+    expect(store.getState().noteFocus).toBe(true)
+  })
+
+  it('removes an empty note when the note is focused', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+        `,
+      }),
+      setCursor(['a']),
+    ])
+
+    // the first execution creates an empty note and focuses it; the second deletes the still-empty note
+    executeCommandWithMulticursor(noteCommand, { store })
+    executeCommandWithMulticursor(noteCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a`)
+
+    expect(store.getState().noteFocus).toBe(false)
+  })
+
+  describe('multicursor', () => {
+    it('creates a note on each selected thought', () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+
+      executeCommandWithMulticursor(noteCommand, { store })
+
+      const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - =note
+      - 
+  - b
+    - =note
+      - 
+  - c
+    - =note
+      - `)
+    })
+
+    it('creates notes only on the thoughts without notes on a mixed selection', () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+              - =note
+                - hello
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+
+      executeCommandWithMulticursor(noteCommand, { store })
+
+      // a and c gain empty notes, while b keeps its existing note untouched
+      const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - =note
+      - 
+  - b
+    - =note
+      - hello
+  - c
+    - =note
+      - `)
+    })
+
+    it('places the caret in the note of the last selected thought in document order', () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        // select c before a to ensure the final cursor follows document order rather than selection order
+        setCursor(['c']),
+        addMulticursor(['c']),
+        addMulticursor(['a']),
+      ])
+
+      executeCommandWithMulticursor(noteCommand, { store })
+
+      const state = store.getState()
+
+      expectPathToEqual(state, state.cursor, ['c'])
+      expect(state.noteFocus).toBe(true)
+      expect(multicursorValues()).toEqual(['a', 'c'])
+    })
+
+    it('creates and focuses a note on a single selected thought like direct execution', () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+      ])
+
+      executeCommandWithMulticursor(noteCommand, { store })
+
+      const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - =note
+      - 
+  - b`)
+
+      const state = store.getState()
+
+      expectPathToEqual(state, state.cursor, ['a'])
+      expect(state.noteFocus).toBe(true)
+      expect(multicursorValues()).toEqual(['a'])
+    })
+
+    it('reverts every created note on a single undo', () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        addMulticursor(['a']),
+        addMulticursor(['b']),
+        addMulticursor(['c']),
+      ])
+
+      executeCommandWithMulticursor(noteCommand, { store })
+
+      // Precondition: all three notes were created, otherwise the undo below would have nothing to revert.
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - =note
+      - 
+  - b
+    - =note
+      - 
+  - c
+    - =note
+      - `)
+
+      store.dispatch(undo())
+
+      const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b
+  - c`)
+    })
+  })
+})

--- a/src/commands/note.ts
+++ b/src/commands/note.ts
@@ -3,6 +3,7 @@ import { toggleNoteActionCreator as toggleNote } from '../actions/toggleNote'
 import PencilIcon from '../components/icons/PencilIcon'
 import { HOME_PATH } from '../constants'
 import asyncFocus from '../device/asyncFocus'
+import hasMulticursor from '../selectors/hasMulticursor'
 import noteValue from '../selectors/noteValue'
 import simplifyPath from '../selectors/simplifyPath'
 import isDocumentEditable from '../util/isDocumentEditable'
@@ -14,11 +15,11 @@ const noteCommand: Command = {
   keyboard: { key: 'n', alt: true, meta: true },
   gesture: 'rdlr',
   multicursor: {
-    disallow: true,
-    error: 'Cannot create a note with multiple thoughts.',
+    // The end-of-run cursor restore dispatches setCursor, which resets noteFocus and would yank the caret out of the note that was just created. Instead, leave the cursor on the last selected thought with its note focused, ready to type.
+    preventSetCursor: true,
   },
   svg: PencilIcon,
-  canExecute: state => isDocumentEditable() && !!state.cursor,
+  canExecute: state => isDocumentEditable() && (!!state.cursor || hasMulticursor(state)),
   exec: (dispatch, getState) => {
     const state = getState()
     const { cursor } = state


### PR DESCRIPTION
## What

Note declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot create a note with multiple thoughts." This declares `multicursor: { preventSetCursor: true }` so the standard multicursor loop toggles a note on each selected thought, and extends `canExecute` with `hasMulticursor` (the `bold`/`swapNote`/`archive` pattern) so the command fires when a multiselect is active without a cursor.

> Process note: this is a resubmission-through-review of commit 9876de580a, which briefly landed directly on `main` via a push misfire and is removed by the base PR #4922. Stacked on #4922 — merge that first and this PR retargets to `main` automatically. The content is identical to the reverted commit.

## Why

`toggleNote` is per-cursor and composes in the loop. Plain `multicursor: true` would be wrong: the end-of-run cursor restore dispatches `setCursor`, which resets `noteFocus` (src/actions/setCursor.ts) and would yank the caret out of the note that was just created — the very problem the old `disallow` single-selection special case existed to avoid. With `preventSetCursor: true` the cursor stays on the document-order-last selected thought with its note focused, ready to type; a single selected thought reproduces the old direct-execution result exactly.

Semantics on a mixed selection: thoughts without notes gain an empty focused `=note`; existing notes are untouched (their toggle is caret-only — note deletion requires `noteFocus` to already be true on an empty note, which is unreachable inside the loop, matching single-cursor behavior).

## Tests

7 store tests in `src/commands/__tests__/note.ts` (new file):

- creates an empty note on the cursor thought and focuses it (no multicursor)
- removes an empty note when the note is focused (toggle-off)
- creates a note on each selected thought
- creates notes only on the thoughts without notes on a mixed selection
- places the caret in the note of the last selected thought in document order
- creates and focuses a note on a single selected thought like direct execution
- reverts every created note on a single undo (with precondition assert)

With the old `disallow` declaration temporarily restored, the four multiselect tests fail (error alert instead of execution); the other three pass on both by design — they pin the preserved single-cursor and single-selection behavior. `yarn lint` clean.

## Notes for reviewers

- Corner case: with a multicursor active, invoking Note while the caret is inside an empty note re-focuses the note instead of deleting it (the loop's per-iteration `setCursor` resets `noteFocus` first). Barely reachable in practice.
- `docs/commands.md` describes Note but not its multicursor declaration, so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
