### PR TITLE
Allow New Subthought (next) to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/newUncle.ts
+++ b/src/commands/__tests__/newUncle.ts
@@ -1,0 +1,202 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import hasMulticursor from '../../selectors/hasMulticursor'
+import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import getChildrenRankedByContext from '../../test-helpers/getChildrenRankedByContext'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
+import newUncleCommand from '../newUncle'
+
+beforeEach(initStore)
+
+describe('multicursor', () => {
+  it('creates an empty uncle for each selected sibling', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+            - c
+          - x
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['a', 'c']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+    - c
+  - 
+  - 
+  - x`)
+  })
+
+  it('creates an empty uncle for each selected thought across different parents and depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+              - e
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['c', 'd', 'e']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - 
+  - c
+    - d
+      - e
+    - `)
+  })
+
+  it('skips a selected root thought instead of blocking the rest of the run', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+            - c
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b', 'c']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    // a is at the root, so it has no parent to insert at and is skipped; c still gets its uncle
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b
+    - c
+  - `)
+  })
+
+  it('leaves the caret on the empty uncle of the last selected thought and clears the multicursor', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['c', 'd']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    const state = store.getState()
+    const rootChildren = getChildrenRankedByContext(state, [HOME_TOKEN])
+
+    // one empty uncle after each selected thought's parent
+    expect(rootChildren.map(thought => thought.value)).toEqual(['a', '', 'c', ''])
+
+    // the caret ends on the empty uncle created for the last selected thought, ready to type
+    expect(state.cursor && head(state.cursor)).toBe(rootChildren[3].id)
+
+    expect(hasMulticursor(state)).toBe(false)
+  })
+
+  it('creates a single empty uncle with the caret on it when one thought is selected', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    const state = store.getState()
+    const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - `)
+
+    const rootChildren = getChildrenRankedByContext(state, [HOME_TOKEN])
+    expect(state.cursor && head(state.cursor)).toBe(rootChildren[1].id)
+    expect(hasMulticursor(state)).toBe(false)
+  })
+
+  it('reverts every created thought on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+          - e
+            - f
+        `,
+      }),
+      setCursor(['a', 'b']),
+      addMulticursor(['a', 'b']),
+      addMulticursor(['c', 'd']),
+      addMulticursor(['e', 'f']),
+    ])
+
+    executeCommandWithMulticursor(newUncleCommand, { store })
+
+    // Precondition: all three uncles were created, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - 
+  - c
+    - d
+  - 
+  - e
+    - f
+  - `)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - c
+    - d
+  - e
+    - f`)
+  })
+})

--- a/src/commands/newUncle.ts
+++ b/src/commands/newUncle.ts
@@ -2,6 +2,7 @@ import { Key } from 'ts-key-enum'
 import Command from '../@types/Command'
 import { newThoughtActionCreator as newThought } from '../actions/newThought'
 import NewSubthoughtNextIcon from '../components/icons/NewSubthoughtNextIcon'
+import hasMulticursor from '../selectors/hasMulticursor'
 import isDocumentEditable from '../util/isDocumentEditable'
 import parentOf from '../util/parentOf'
 
@@ -13,13 +14,16 @@ const newUncleCommand: Command = {
   gesture: 'dl',
   keyboard: { key: Key.Enter, meta: true, alt: true },
   multicursor: {
-    disallow: true,
-    error: 'Cannot create a new subthought with multiple thoughts.',
+    // The cursor restore at the end of the multicursor loop would pull the caret off the empty thought created for the last selected thought. The newThought action places the cursor on each thought it creates, so preventing the restore leaves the caret there, ready to type — the same postcondition as a single-cursor invocation.
+    preventSetCursor: true,
+    // After execution the selection is stale — the user's next act is typing into the new empty thought. Clearing matches the single-cursor behavior, where the newThought action's own setCursor clears the selection.
+    clearMulticursor: true,
   },
   svg: NewSubthoughtNextIcon,
   canExecute: state => {
     const { cursor } = state
-    return isDocumentEditable() && !!cursor && cursor.length > 1
+    // hasMulticursor allows the command to execute when thoughts are selected but the cursor is missing or on a root thought. Selected root thoughts (which have no parent to insert at) do not block the multicursor run: the loop's per-iteration setCursor clears the selection, so the per-iteration canExecute check fails for them and they are skipped.
+    return isDocumentEditable() && ((!!cursor && cursor.length > 1) || hasMulticursor(state))
   },
   exec: (dispatch, getState) => {
     const { cursor } = getState()


### PR DESCRIPTION
## What

New Subthought (next) declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot create a new subthought with multiple thoughts." This changes the declaration to `multicursor: { preventSetCursor: true, clearMulticursor: true }` so the standard multicursor loop executes it once per selected thought, and adds a store test suite for the resulting behavior.

`canExecute` additionally accepts `hasMulticursor(state)`, so the command is enabled when thoughts are selected but the cursor is missing or on a root thought.

## Why

`newUncle` dispatches `newThought({ at: parentOf(cursor) })` — a new empty thought inserted after the cursor's *parent*. That is a per-cursor action, so it composes under the multicursor loop: each selected thought yields one new empty uncle. Two selected siblings under the same parent yield two new uncles, matching the direction that a creation command creates a thought **for each** selected thought rather than collapsing the selection to one insertion per sibling group. (Deliberately no `filter: 'last-sibling'`/`'first-sibling'` here — the old filtered declarations on `newThought`/`newSubthought`/`newThoughtAbove` are being migrated away from in parallel.)

```
- a
  - b
- c
  - d
```

Selecting `b` and `d` and invoking New Subthought (next) now yields two new empty thoughts at the root, one after `a` and one after `c`.

Each option is load-bearing rather than cosmetic — each was verified by running the suite against the alternative:

- **`preventSetCursor`** — the command's postcondition is a caret in the new empty thought, ready to type (the `newThought` action sets that cursor itself). The default restore at the end of the loop would pull the caret back to the *original* cursor thought. Against a naive `multicursor: true`, both cursor tests fail on exactly this.
- **`clearMulticursor`** — after the run the old selection no longer describes what the user is working on; their next act is typing into the new empty thought. Clearing matches the single-cursor behavior, where `newThought`'s own `setCursor` clears the selection. Against `{ preventSetCursor: true }` alone, both cursor tests fail on the `hasMulticursor` assertion.
- **`hasMulticursor` in `canExecute`** — without it, a selection containing a root-level thought disables the command outright at the top level (`executeCommand`'s check runs against the real `state.cursor`), so nothing executes at all. Against the unchanged strict `canExecute`, the root-thought test fails.

**Root thoughts in the selection are skipped, not blocking.** A root-level thought has no parent to insert at, so `cursor.length > 1` is false for it. Note this does *not* trip the loop's up-front all-or-nothing `filteredPaths.every(...)` gate: that gate evaluates `canExecute({ ...state, cursor: path })` on a state where `state.multicursors` is still populated, so the new `hasMulticursor` disjunct is true for every path and the run proceeds. Inside the loop, the per-iteration `setCursor` clears `state.multicursors`, so `canExecute` then falls back to the `cursor.length > 1` test and the root thought is skipped individually while the rest of the selection still executes. That is the behavior I chose (partial execution over blocking the whole run), and it is pinned by a test either way.

## Tests

New store test suite in `src/commands/__tests__/newUncle.ts` (`multicursor` describe block), modeled on `swapParent.ts`:

- one new empty uncle per selected sibling under a single parent (two selected siblings → two uncles)
- selections spanning different parents *and* different depths each get their own uncle
- a selected root thought is skipped without blocking the rest of the run
- the caret ends on the empty uncle created for the last selected thought, with the multicursor cleared
- a single selected thought (the mobile Command Center flow) creates one uncle with the caret on it, multicursor cleared
- a single undo reverts every created thought; the post-run outline is asserted as a precondition so the test cannot pass vacuously

Red-side proof, run locally against each wrong declaration:

- Against the previous `disallow: true` declaration, **5 of the 6 fail** (alert instead of execution). The single-selection test passes there by design — `disallow` executes a lone selection directly — so it documents behavior this PR preserves rather than adds.
- Against a naive `multicursor: true`, the 2 cursor tests fail (the restore moves the caret off the new empty thought) — evidence for `preventSetCursor`.
- Against `{ preventSetCursor: true }` alone, the 2 cursor tests fail on the multicursor-cleared assertion — evidence for `clearMulticursor`.
- Against the unchanged strict `canExecute`, the root-thought test fails — evidence for the `hasMulticursor` disjunct.

`yarn vitest run --project unit src/commands/__tests__/newUncle.ts`: 6 passed. `yarn lint`: clean. Both re-run after rebasing onto current `main` (3d788ae).

## Notes for reviewers

- `src/__tests__/commands.ts` contains no `newUncle` disallow test, so nothing needed removing there. `src/@types/Command.ts` and `src/commands.ts` are untouched — a separate follow-up PR removes the `disallow` option itself.
- `docs/commands.md` describes this command's behavior ("New Subthought (next)") but not its multicursor declaration, so no doc change was needed.
- The empty-thought lines in the expected outlines carry a trailing space, which is what `exportContext` emits for an empty thought. Worth knowing before "tidying" them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
