### PR TITLE
Allow New Grandchild to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/newGrandChild.ts
+++ b/src/commands/__tests__/newGrandChild.ts
@@ -1,0 +1,236 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import newGrandChildCommand from '../newGrandChild'
+
+beforeEach(initStore)
+
+describe('multicursor', () => {
+  it('creates a new empty grandchild in each selected thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+          - e
+            - f
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c']),
+      addMulticursor(['e']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+      - ${''}
+  - c
+    - d
+      - ${''}
+  - e
+    - f
+      - ${''}`)
+  })
+
+  it('appends the new grandchild to the existing children of the first subthought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+              - x
+            - c
+          - d
+            - e
+              - y
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['d']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+      - x
+      - ${''}
+    - c
+  - d
+    - e
+      - y
+      - ${''}`)
+  })
+
+  it('creates new grandchildren in selected thoughts at different depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+              - e
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c', 'd']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+      - ${''}
+  - c
+    - d
+      - e
+        - ${''}`)
+  })
+
+  it('skips a selected thought with no children while the rest of the selection proceeds', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+            - c
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    // a has no subthought to create a grandchild in, so the action is a no-op for it. b still gets its new grandchild.
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b
+    - c
+      - ${''}`)
+  })
+
+  it('places the caret in the last created empty grandchild and clears the multicursor', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const state = store.getState()
+
+    // the cursor must end in the new empty grandchild of the last selected thought, ready to type
+    expectPathToEqual(state, state.cursor, ['c', 'd', ''])
+
+    // the selection of parent thoughts is stale once the caret is in a new empty thought
+    expect(state.multicursors).toEqual({})
+  })
+
+  it('places the caret in the new empty grandchild when a single thought is selected', () => {
+    // on mobile, opening the Command Center selects the cursor thought, so a single selected thought is the common case
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const state = store.getState()
+
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+      - ${''}`)
+
+    expectPathToEqual(state, state.cursor, ['a', 'b', ''])
+    expect(state.multicursors).toEqual({})
+  })
+
+  it('reverts every created grandchild on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+          - c
+            - d
+          - e
+            - f
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['c']),
+      addMulticursor(['e']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    // Precondition: all three grandchildren were created, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+      - ${''}
+  - c
+    - d
+      - ${''}
+  - e
+    - f
+      - ${''}`)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b
+  - c
+    - d
+  - e
+    - f`)
+  })
+})

--- a/src/commands/newGrandChild.ts
+++ b/src/commands/newGrandChild.ts
@@ -9,8 +9,10 @@ const newGrandChildCommand: Command = {
   description: 'Create a thought within the first subthought.',
   gesture: 'rdrd',
   multicursor: {
-    disallow: true,
-    error: 'Cannot create a new grandchild with multiple thoughts.',
+    // The action sets the cursor to the new empty grandchild with the keyboard open, ready to type. The default restore would move the caret back to the originally selected thought.
+    preventSetCursor: true,
+    // The selection of parent thoughts is stale once the caret is in a new empty grandchild; keeping it would aim the next multicursor command at the parents while the user is typing elsewhere.
+    clearMulticursor: true,
   },
   // TODO: Create unique icon
   svg: SettingsIcon,


### PR DESCRIPTION
## What

New Grandchild declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot create a new grandchild with multiple thoughts." This changes the declaration to `multicursor: { preventSetCursor: true, clearMulticursor: true }` so the standard multicursor loop executes it once per selected thought, and adds a store test suite for the resulting behavior.

## Why

`newGrandChild` is a per-cursor action — it appends a new empty thought inside the *first visible subthought* of the cursor — and it composes when executed once per selected thought. There is no filter: each selected thought gets its own new empty grandchild, rather than the selection collapsing to a single insertion.

```
- a
  - b
- c
  - d
```

Selecting `a` and `c` and invoking New Grandchild now yields an empty thought under `b` and another under `d`.

The two options are load-bearing rather than cosmetic:

- **`preventSetCursor`** — the command's postcondition is a caret in the new empty grandchild, ready to type (the action delegates to `newThought`, which sets that cursor itself with the keyboard open). The loop's default restore would move the caret back to the originally selected *parent* thought, leaving the user typing nowhere near what was just created. This includes the common mobile flow where opening the Command Center selects the single cursor thought, which the old `disallow` declaration handled correctly by executing directly without a restore.
- **`clearMulticursor`** — after the run the selection still points at the original parent thoughts, which is stale once the caret has moved down two levels into a new empty thought; keeping it would aim the next multicursor command at the parents while the user is typing elsewhere. Clearing matches the other commands that end with the caret in a new empty thought, and matches the pre-change behavior for a single selected thought, whose own `setCursor` also cleared the selection.

**Childless selected thoughts.** `newGrandChild` returns state unchanged when the cursor thought has no visible children, and `canExecute` is only `isDocumentEditable()`, so the loop still runs for such a path — it simply contributes nothing while the rest of the selection proceeds. That mixed outcome is the right one here: the alternative (`filteredPaths.every(...)` failing) would block the entire run because one selected thought happened to be a leaf. It is pinned by a test.

## Tests

New store tests in `src/commands/__tests__/newGrandChild.ts` (`multicursor` describe block):

- creates a new empty grandchild in each selected thought (the fixture above)
- appends the new grandchild after the first subthought's existing children, leaving later siblings alone
- creates new grandchildren in selected thoughts at different depths
- skips a selected childless thought while the rest of the selection proceeds
- with multiple selections, the caret ends in the last created empty grandchild, with the multicursor cleared
- a single selected thought (the Command Center flow) leaves the caret in the new empty grandchild, with the multicursor cleared
- a single undo reverts every created grandchild; the post-run outline is asserted as a precondition so the test cannot pass vacuously

Red-side proof, run locally against all three wrong declarations:

- Against the previous `disallow: true` declaration, 6 of the 7 fail (the alert blocks execution, so the outline is unchanged). The single-selection test passes there by design — `disallow` executes a lone selection directly — so it documents behavior this PR preserves rather than adds.
- Against a naive `multicursor: true`, both cursor tests fail with the caret restored to the originally selected parent (`expected [ 'a' ] to deeply equal [ 'c', 'd', '' ]`), which is the evidence for `preventSetCursor`.
- Against `{ preventSetCursor: true }` alone, both cursor tests fail on the surviving multicursors (`expected { …(2) } to deeply equal {}`), which is the evidence for `clearMulticursor`.

`yarn vitest run --project unit src/commands/__tests__/newGrandChild.ts`: 7 passed. `yarn lint`: clean.

## Notes for reviewers

- The action inserts into the first *visible* child (`firstVisibleChild`), so a leading meta attribute such as `=pin` is skipped rather than receiving the new grandchild. That is existing single-cursor behavior, unchanged here.
- `src/__tests__/commands.ts` contains no `newGrandChild` disallow test, so nothing needed removing there. `docs/commands.md` documents the command's description but not its multicursor declaration, so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
