### PR TITLE
Create a new thought for each selected thought

### DIFF
--- a/src/commands/__tests__/newThought.ts
+++ b/src/commands/__tests__/newThought.ts
@@ -1,19 +1,46 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommandWithMulticursor } from '../../commands'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
+import { getChildrenRanked } from '../../selectors/getChildren'
 import hasMulticursor from '../../selectors/hasMulticursor'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
 import newThoughtCommand from '../newThought'
 
 beforeEach(initStore)
 
+it('create an empty thought after the cursor thought', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+        - b
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  executeCommandWithMulticursor(newThoughtCommand, { store })
+
+  const state = store.getState()
+  const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+  - ${''}
+  - b`)
+
+  // expect cursor to be on the new thought
+  expectPathToEqual(state, state.cursor, [''])
+})
+
 describe('multicursor', () => {
-  it('create a new thought after the last multicursor', () => {
+  it('create a new empty thought after each selected thought', () => {
     store.dispatch([
       importText({
         text: `
@@ -33,10 +60,11 @@ describe('multicursor', () => {
 
     const state = store.getState()
     const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
-    expect(exported).toBe(`- __ROOT__
+    expect(exported).toBe(`- ${HOME_TOKEN}
   - a
   - b
   - c
+  - ${''}
   - d
   - ${''}
   - e`)
@@ -44,7 +72,111 @@ describe('multicursor', () => {
     // expect multicursor to be cleared
     expect(hasMulticursor(state)).toBeFalse()
 
+    // expect cursor to be on the last created thought (the empty thought after d), ready for typing
+    const children = getChildrenRanked(state, HOME_TOKEN)
+    expect(head(state.cursor!)).toBe(children[5].id)
+  })
+
+  it('create each new thought as a sibling of its own selected thought across parents and depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+            - a
+              - a1
+              - a2
+            - b
+              - b1
+          `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['a', 'a1']),
+      addMulticursor(['b', 'b1']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtCommand, { store })
+
+    const state = store.getState()
+    const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - a1
+    - ${''}
+    - a2
+  - ${''}
+  - b
+    - b1
+    - ${''}`)
+
+    // expect multicursor to be cleared
+    expect(hasMulticursor(state)).toBeFalse()
+
+    // expect cursor to be on the last created thought (the empty thought after b1)
+    const bChildren = getChildrenRanked(state, head(state.cursor!.slice(0, -1)))
+    expectPathToEqual(state, state.cursor, ['b', ''])
+    expect(head(state.cursor!)).toBe(bChildren[1].id)
+  })
+
+  it('create a single empty thought after a single selected thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+            - a
+            - b
+          `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtCommand, { store })
+
+    const state = store.getState()
+    const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+  - ${''}
+  - b`)
+
+    // expect multicursor to be cleared
+    expect(hasMulticursor(state)).toBeFalse()
+
     // expect cursor to be on the new thought
     expectPathToEqual(state, state.cursor, [''])
+  })
+
+  it('revert every created thought on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+            - a
+            - b
+            - c
+          `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+      addMulticursor(['c']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtCommand, { store })
+
+    // Precondition: all three thoughts were created, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a
+  - ${''}
+  - b
+  - ${''}
+  - c
+  - ${''}`)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+  - b
+  - c`)
   })
 })

--- a/src/commands/newThought.ts
+++ b/src/commands/newThought.ts
@@ -60,8 +60,8 @@ const exec: Command['exec'] = (dispatch, getState, e, { type }: { type: string }
   }
 }
 
+// Create a new empty thought after each selected thought. Each newThought in the multicursor loop sets the cursor to the thought it creates, so preventSetCursor keeps the cursor on the last created thought instead of restoring the pre-command cursor, and clearMulticursor drops the stale selection — leaving the user ready to type into the new thought.
 const multicursor: Command['multicursor'] = {
-  filter: 'last-sibling',
   clearMulticursor: true,
   preventSetCursor: true,
 }


### PR DESCRIPTION
## What

New Thought declared `multicursor: { filter: 'last-sibling', clearMulticursor: true, preventSetCursor: true }`. On a multiselect the filter collapsed the selection down to the last selected thought within each parent, so selecting several siblings and pressing Enter created exactly **one** new thought.

This removes the `filter`, letting the standard multicursor loop run `newThought` once per selected thought, so a new empty sibling is created after **each** selected thought. `clearMulticursor` and `preventSetCursor` are retained — both are load-bearing for the new semantics (see Notes).

## Why

This is an explicit product decision by the user to migrate New Thought away from the last-sibling filter. Unlike the sibling PRs in this effort, which unblock commands that declared `multicursor: { disallow: true }`, New Thought already supported multicursor — but with semantics that were decided to be the wrong ones. "New Thought" applied to a multiselect should mean "give each of these a new sibling", not "give this group one new thought": the old filter silently discarded most of the selection, and the number of thoughts created did not correspond to the number selected.

The `filter` is the entire behavioral difference. Everything else in the declaration is retained because it serves the new semantics as well as the old.

## Tests

`src/commands/__tests__/newThought.ts`:

- **create an empty thought after the cursor thought** — single-cursor behavior, unchanged by this PR
- **create a new empty thought after each selected thought** — the converted last-sibling test; two selected siblings now yield two new thoughts, each directly after its own selected thought, with the cursor on the last created one and the multicursor cleared
- **create each new thought as a sibling of its own selected thought across parents and depths** — a selection spanning a parent, one of its children, and a child of a different parent; verifies each new thought lands next to *its* selected thought as the loop mutates ranks between iterations
- **create a single empty thought after a single selected thought** — the common mobile case (opening the Command Center selects the cursor thought)
- **revert every created thought on a single undo** — three creations collapse into one undo entry

All 5 pass. Proof the changed behavior is actually pinned:

- Against the previous `filter: 'last-sibling'` declaration, the three multi-thought tests **fail** (the collapse produces a single new thought, so the expected outlines do not match); the single-cursor and single-selection tests pass on both, deliberately, since they pin behavior this change preserves.
- Against a naive `multicursor: true`, the three tests asserting the cleared selection **fail** (`hasMulticursor` is restored to true), and with `{ clearMulticursor: true }` alone the cursor assertions **fail** (the cursor is restored to the pre-command thought, e.g. `['a']` instead of `['']`). Both options were verified individually rather than assumed.

`yarn lint` is clean.

## Notes for reviewers

- **Why both options are kept.** Each `newThought` in the loop sets the cursor to the thought it just created. `preventSetCursor` suppresses the loop's final cursor restore so the caret stays in the last created empty thought, ready to type — restoring the pre-command cursor would drop the user back on an existing thought with several new empty ones left behind. `clearMulticursor` drops the selection, which is stale once every selected thought has a new sibling after it.
- **The split path is untouched.** `exec` splits the thought at the text caret for keyboard invocations, gated on `editingValueStore.getState()` and a real `selection.split(e.target)`. In the multicursor loop the event is `executeCommandWithMulticursor`'s `eventNoop` (whose `target` is not an `HTMLElement`, so `selection.split` returns null), so it falls through to plain `newThought({ value: '' })` for every iteration. Single-cursor split behavior is unchanged.
- **Insertion positions under mutation.** Creating a sibling after one selected thought changes ranks before the next iteration runs. The loop's `recomputePath` tracks each path by thought id, so every new thought still lands directly after its own selected thought; the cross-parent/cross-depth test asserts the full resulting outline rather than a count.
- **Chaining is unaffected.** `isChainable` (Outdent) and Select All's `isChainable` predicate both key off `!!command.multicursor`, which is still a truthy object. Removing the `filter` changes only which paths the loop iterates.
- **Docs.** `docs/commands.md` documents the `filter` option generically and describes New Thought's behavior without mentioning its multicursor declaration, so no doc change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
