### PR TITLE
Create a new thought above each selected thought

### DIFF
--- a/src/commands/__tests__/newThoughtAbove.ts
+++ b/src/commands/__tests__/newThoughtAbove.ts
@@ -1,4 +1,5 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommandWithMulticursor } from '../../commands'
 import { HOME_TOKEN } from '../../constants'
 import exportContext from '../../selectors/exportContext'
@@ -8,43 +9,154 @@ import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../..
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import initStore from '../../test-helpers/initStore'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
-import newThoughtCommand from '../newThoughtAbove'
+import newThoughtAboveCommand from '../newThoughtAbove'
 
 beforeEach(initStore)
 
 describe('multicursor', () => {
-  it('create a new thought before the first multicursor', () => {
+  it('creates a new empty thought above each selected sibling', () => {
     store.dispatch([
       importText({
         text: `
-            - a
-            - b
-            - c
-            - d
-            - e
-          `,
+          - a
+          - b
+          - c
+          - d
+          - e
+        `,
       }),
-      setCursor(['c']),
+      setCursor(['b']),
+      addMulticursor(['b']),
       addMulticursor(['c']),
       addMulticursor(['d']),
     ])
 
-    executeCommandWithMulticursor(newThoughtCommand, { store })
+    executeCommandWithMulticursor(newThoughtAboveCommand, { store })
 
-    const state = store.getState()
-    const exported = exportContext(state, [HOME_TOKEN], 'text/plain')
-    expect(exported).toBe(`- __ROOT__
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    // Each selected thought gets its own new thought directly above it, rather than the selection collapsing to a single insertion.
+    // The empty lines below intentionally end in a trailing space, which `${''}` preserves.
+    expect(exported).toEqual(`- ${HOME_TOKEN}
   - a
+  - ${''}
   - b
   - ${''}
   - c
+  - ${''}
   - d
   - e`)
+  })
 
-    // expect multicursor to be cleared
-    expect(hasMulticursor(state)).toBeFalse()
+  it('creates a new empty thought above selected thoughts in different parents and at different depths', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - a1
+            - a2
+          - b
+            - b1
+        `,
+      }),
+      setCursor(['a', 'a1']),
+      addMulticursor(['a', 'a1']),
+      addMulticursor(['a', 'a2']),
+      addMulticursor(['b']),
+      addMulticursor(['b', 'b1']),
+    ])
 
-    // expect cursor to be on the new thought
-    expectPathToEqual(state, state.cursor, [''])
+    executeCommandWithMulticursor(newThoughtAboveCommand, { store })
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+    - ${''}
+    - a1
+    - ${''}
+    - a2
+  - ${''}
+  - b
+    - ${''}
+    - b1`)
+  })
+
+  it('places the cursor in the new thought above the last selected thought', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - a1
+          - b
+            - b1
+        `,
+      }),
+      setCursor(['a', 'a1']),
+      addMulticursor(['a', 'a1']),
+      addMulticursor(['b', 'b1']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtAboveCommand, { store })
+
+    const state = store.getState()
+
+    // The cursor is left in the last thought created rather than restored to a1, where it started.
+    expectPathToEqual(state, state.cursor, ['b', ''])
+  })
+
+  it('clears the multicursor after execution', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+          - c
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtAboveCommand, { store })
+
+    expect(hasMulticursor(store.getState())).toBeFalse()
+  })
+
+  it('reverts every created thought on a single undo', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+          - c
+        `,
+      }),
+      setCursor(['a']),
+      addMulticursor(['a']),
+      addMulticursor(['b']),
+      addMulticursor(['c']),
+    ])
+
+    executeCommandWithMulticursor(newThoughtAboveCommand, { store })
+
+    // Precondition: all three thoughts were created, otherwise the undo below would have nothing to revert.
+    expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - ${''}
+  - a
+  - ${''}
+  - b
+  - ${''}
+  - c`)
+
+    store.dispatch(undo())
+
+    const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toEqual(`- ${HOME_TOKEN}
+  - a
+  - b
+  - c`)
   })
 })

--- a/src/commands/newThoughtAbove.ts
+++ b/src/commands/newThoughtAbove.ts
@@ -11,7 +11,6 @@ const newThoughtAboveCommand: Command = {
   description: 'Create a new thought immediately above the current thought.',
   gesture: 'rul',
   multicursor: {
-    filter: 'first-sibling',
     clearMulticursor: true,
     preventSetCursor: true,
   },


### PR DESCRIPTION
## What

New Thought (above) declared `multicursor: { filter: 'first-sibling', clearMulticursor: true, preventSetCursor: true }`. The `first-sibling` filter collapses each sibling group to a single insertion, so selecting several sibling thoughts and invoking the command created **one** new thought rather than one per selected thought. This removes the filter, leaving `{ clearMulticursor: true, preventSetCursor: true }`, so the standard multicursor loop creates a new empty thought directly above **each** selected thought.

## Why

This is an explicit product decision by the user to migrate New Thought (above) away from the `first-sibling` filter: a creation command invoked on a multiselect should create one thought per selected thought. The old declaration meant a three-thought selection produced a single new thought, silently discarding most of the user's selection.

`exec` is `newThought({ insertBefore: true })` — a new empty **sibling** before the cursor thought. Unlike the subthought commands (where each selected thought is a distinct insertion parent), selected siblings here share an insertion parent, which is exactly the case `first-sibling` collapsed. Per-cursor execution composes correctly anyway: the loop recomputes each path against the already-mutated tree between iterations, so inserting above `b` does not disturb where the insertion above `c` lands. The new thoughts interleave with the selection (`_, a, _, b, _, c`) rather than bunching up at one position.

Both remaining options were verified to be load-bearing under the new semantics rather than carried over on faith. Against a naive `multicursor: true`, two of the five tests fail:

- **`preventSetCursor`** — without it the loop restores the original cursor at the end, leaving the caret on the previously-focused thought instead of the empty thought the user just asked for. The cursor test fails with `['a', 'a1']` instead of `['b', '']`.
- **`clearMulticursor`** — without it the loop re-adds a multicursor on each originally selected thought, leaving a stale selection over the *old* thoughts while the caret sits in a new empty one; the next keystroke would apply to that stale multiselect. The multicursor test fails with the selection still set.

`canExecute` is just `isDocumentEditable()`, which is cursor-independent, so the up-front `filteredPaths.every(...)` check cannot block the run for any selection. The `isTouch`-conditional keyboard shortcut is untouched.

## Tests

`src/commands/__tests__/newThoughtAbove.ts` (`multicursor` describe block), 5 tests, all passing:

- creates a new empty thought above each selected sibling
- creates a new empty thought above selected thoughts in different parents and at different depths
- places the cursor in the new thought above the last selected thought
- clears the multicursor after execution
- reverts every created thought on a single undo

The file's single pre-existing test pinned the first-sibling collapse (selecting `c` and `d` produced one new thought above `c`); it was converted to the new semantics rather than deleted, and its cursor and multicursor assertions were split into their own tests.

**Proof against the old declaration.** Temporarily restoring `filter: 'first-sibling'` fails 3 of the 5 tests, each on its intended assertion:

- *above each selected sibling* — selecting `b`, `c`, `d` produced `a, _, b, c, d, e` instead of `a, _, b, _, c, _, d, e`.
- *different parents and depths* — the selected siblings `a1`/`a2` collapsed to one insertion above `a1`, so `a2` got nothing; the cross-parent insertions above `b` and `b1` were unaffected, since each is alone in its sibling group.
- *single undo* — the precondition assertion caught only one new thought instead of three.

The cursor and multicursor tests pass under the old filter, as expected — those two options are unchanged by this PR, and their evidence is the naive `multicursor: true` run above.

`yarn lint` (tsc + eslint + prettier) is clean.

## Notes for reviewers

- **The empty-thought lines in the expected outlines end in a trailing space.** `exportContext` emits `  - ` for an empty thought; the tests write it as `` - ${''} `` so the trailing space survives formatting. Please don't tidy it away.
- The cross-parent test deliberately mixes three conditions in one selection — two siblings under a nested parent, a root-level thought, and a thought one level deeper — because they share a single insertion pass and the interesting risk is their interaction, not each in isolation.
- The cursor test asserts `['b', '']` rather than `['']`, so the assertion identifies *which* new thought the caret landed in rather than matching any empty thought.
- The undo test asserts the post-execution outline as a precondition, since it would otherwise pass vacuously if nothing had been created.
- No doc change was needed: `docs/commands.md` describes this command's single-cursor behavior but not its multicursor declaration, and the generic `filter` option documentation is left alone since `filter` remains valid for other commands.
- Scoped to `src/commands/newThoughtAbove.ts` (a one-line deletion) and its test file. Nothing outside the command's own suite pinned the first-sibling behavior.
- New Thought and the New Subthought family are being migrated the same way in parallel (#4926, #4927, #4928), which is where the matching `{ clearMulticursor, preventSetCursor }` shape comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
