### PR TITLE
Allow Extract to execute on a multiselect

### DIFF
--- a/src/commands/__tests__/extractThought.ts
+++ b/src/commands/__tests__/extractThought.ts
@@ -1,12 +1,21 @@
 import { findAllByLabelText, screen } from '@testing-library/react'
 import { act } from 'react'
 import { extractThoughtActionCreator as extractThought } from '../../actions/extractThought'
+import { importTextActionCreator as importText } from '../../actions/importText'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
 import childIdsToThoughts from '../../selectors/childIdsToThoughts'
+import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
+import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import initStore from '../../test-helpers/initStore'
 import findThoughtByText from '../../test-helpers/queries/findThoughtByText'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import extractThoughtCommand from '../extractThought'
 
 /**
  * Set range selection.
@@ -23,6 +32,8 @@ const setSelection = (element: HTMLElement, selectionStart: number, selectionEnd
 
   return range.toString()
 }
+
+beforeEach(initStore)
 
 describe('Extract thought', () => {
   beforeEach(createTestApp)
@@ -94,5 +105,167 @@ describe('Extract thought', () => {
     const cursorThoughts = childIdsToThoughts(store.getState(), store.getState().cursor!)
 
     expect(cursorThoughts).toMatchObject([{ value: thoughtValue.slice(0, 9) }])
+  })
+
+  describe('multicursor', () => {
+    it('extracts from the thought being edited when several thoughts are selected', async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+            - charlie delta
+            - echo
+          `,
+        }),
+        setCursor(['alpha bravo']),
+      ])
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const thought = await findThoughtByText('alpha bravo')
+      expect(thought).toBeTruthy()
+      setSelection(thought!, 6, 11)
+
+      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+
+      executeCommandWithMulticursor(extractThoughtCommand, { store })
+
+      // The other selected thoughts keep their values. Slicing them at the selection's offsets would have left
+      // "charlita" with the child "e del", and "echo" with an empty child.
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha
+    - bravo
+  - charlie delta
+  - echo`)
+    })
+
+    it('extracts from the thought being edited when a different thought is selected', async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+            - charlie delta
+          `,
+        }),
+        setCursor(['alpha bravo']),
+      ])
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const thought = await findThoughtByText('alpha bravo')
+      expect(thought).toBeTruthy()
+      setSelection(thought!, 6, 11)
+
+      // select a thought other than the one being edited, as alt-clicking its bullet does
+      store.dispatch([addMulticursor(['charlie delta'])])
+
+      executeCommandWithMulticursor(extractThoughtCommand, { store })
+
+      // The extraction applies to the thought that owns the selection, not to the selected thought.
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha
+    - bravo
+  - charlie delta`)
+    })
+
+    it('leaves the cursor and the selected thoughts selected', async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+            - charlie delta
+            - echo
+          `,
+        }),
+        setCursor(['alpha bravo']),
+      ])
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const thought = await findThoughtByText('alpha bravo')
+      expect(thought).toBeTruthy()
+      setSelection(thought!, 6, 11)
+
+      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+
+      executeCommandWithMulticursor(extractThoughtCommand, { store })
+
+      // Precondition: the extraction occurred, otherwise the assertions below would hold vacuously.
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha
+    - bravo
+  - charlie delta
+  - echo`)
+
+      const state = store.getState()
+
+      expectPathToEqual(state, state.cursor, ['alpha'])
+      expect(
+        Object.values(state.multicursors).map(path => childIdsToThoughts(state, path).map(thought => thought.value)),
+      ).toEqual([['alpha'], ['charlie delta'], ['echo']])
+    })
+
+    it('an alert should be shown if there is no selection and several thoughts are selected', async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+            - charlie delta
+          `,
+        }),
+        setCursor(['alpha bravo']),
+        addMulticursor(['alpha bravo']),
+        addMulticursor(['charlie delta']),
+      ])
+
+      // Flush the throttled "2 thoughts selected" alert from the multiselect so that it cannot overwrite the alert
+      // raised by the command below.
+      await act(vi.runOnlyPendingTimersAsync)
+
+      executeCommandWithMulticursor(extractThoughtCommand, { store })
+
+      expect(await screen.findByText('No text selected to extract')).toBeTruthy()
+
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha bravo
+  - charlie delta`)
+    })
+
+    it('reverts the extraction on a single undo', async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+            - charlie delta
+            - echo
+          `,
+        }),
+        setCursor(['alpha bravo']),
+      ])
+
+      await act(vi.runOnlyPendingTimersAsync)
+
+      const thought = await findThoughtByText('alpha bravo')
+      expect(thought).toBeTruthy()
+      setSelection(thought!, 6, 11)
+
+      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+
+      executeCommandWithMulticursor(extractThoughtCommand, { store })
+
+      // Precondition: the extraction occurred, otherwise the undo below would have nothing to revert.
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha
+    - bravo
+  - charlie delta
+  - echo`)
+
+      store.dispatch(undo())
+
+      expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - alpha bravo
+  - charlie delta
+  - echo`)
+    })
   })
 })

--- a/src/commands/extractThought.ts
+++ b/src/commands/extractThought.ts
@@ -8,10 +8,12 @@ const extractThought: Command = {
   label: 'Extract',
   description: 'Extract selected part of a thought as its child',
   keyboard: { key: 'e', control: true, meta: true },
-  multicursor: {
-    disallow: true,
-    error: 'Cannot extract multiple thoughts.',
-  },
+  // Extract takes its input from the browser text selection, of which the document has exactly one. The
+  // extractThought action slices state.cursor's value at that selection's character offsets, so the offsets are only
+  // meaningful for the thought that owns the selection. Executing on state.cursor is therefore the only well-defined
+  // behavior: the per-cursor loop of multicursor: true would slice every other selected thought at offsets that index
+  // into a different string, mangling their values and giving short ones an empty child.
+  multicursor: false,
   svg: ExtractThoughtIcon,
   canExecute: state => {
     return !!state.cursor || hasMulticursor(state)


### PR DESCRIPTION
## What

Extract declared `multicursor: { disallow: true }`, so selecting several thoughts and invoking it only produced the error alert "Cannot extract multiple thoughts." This changes the declaration to `multicursor: false`, so the command executes on `state.cursor` — where the text selection actually lives — and the selected thoughts stay selected.

## Why

`multicursor: false` is the honest answer here, and the per-cursor loop is not merely useless but actively destructive.

Extract takes its input from the **browser text selection**, of which the document has exactly one. [`extractThought`](https://github.com/cybersemics/em/blob/main/src/actions/extractThought.ts) reads `selection.offsetStart()` / `selection.offsetEnd()` — global, document-wide character offsets — and slices `state.cursor`'s value with them:

```ts
const newValue = `${value.slice(0, selectionStart)}${value.slice(selectionEnd, value.length)}`.trim()
const childValue = value.slice(selectionStart, selectionEnd)
```

Those offsets index into the string of the one thought that owns the selection. Nothing moves the browser selection during the multicursor loop — the loop is synchronous, so no re-render occurs, and `clearSelection` middleware only clears on a null/divider/root cursor — so every iteration after the first slices a *different* string at offsets that mean nothing in it.

Verified by running the suite against a naive `multicursor: true`. With `bravo` selected in `alpha bravo`, and `charlie delta` and `echo` also selected:

```
- alpha
  - bravo        ← correct: the thought that owns the selection
- charlita       ← "charlie delta" sliced at offsets 6–11 belonging to another string
  - e del        ← an arbitrary character range promoted to a child
- echo
  -              ← "echo" is shorter than offset 6, so slice(6, 11) is empty
```

`multicursor: true` also swallows the command's own feedback: when there is no text selected, each iteration raises "No text selected to extract", but the loop's closing `addMulticursor` restore changes the multicursor count, and the throttled alert from `multicursorAlertMiddleware` overwrites it with "2 thoughts selected".

With no live selection at all (`selection.isActive()` false), the action returns state unchanged on every iteration — so `multicursor: true` is a pure no-op wrapped in an empty undo bracket. There is no per-cursor semantic to recover: a second thought has no selection of its own, and inventing one (searching each thought for the selected substring) would be a new feature with no UI affordance.

`execMulticursor` dispatching once would work, but merely re-implements the short-circuit `multicursor: false` already provides — the same reasoning as #4921.

**This also fixes a latent data-corruption bug.** `disallow` executes directly when exactly *one* thought is selected, moving the cursor onto it first. So with the caret in `alpha bravo` (selection `bravo`) and `charlie delta` selected — reachable by alt-clicking another thought's bullet while editing — the old code moved the cursor to `charlie delta` and applied the *edited* thought's offsets to it:

```
- alpha bravo    ← the thought the user was actually editing: untouched
- charlita       ← corrupted
  - e del
```

Now the extraction applies to `alpha bravo`, and `charlie delta` is left alone.

The single-selection Command Center flow (`openCommandCenter` selects the cursor thought) is unaffected: `disallow` already skipped its `setCursor` when the cursor was on the selected thought, so it extracted correctly and kept the selection — exactly what `multicursor: false` does.

## Tests

Extended `src/commands/__tests__/extractThought.ts` with a `multicursor` describe block. The tests stay at the file's existing JSDOM level (`createTestApp` + a real jsdom `Range`) rather than moving to a store test, because the browser selection *is* the subject here and `docs/testing.md` forbids mocking the behavior under test:

- extracts from the thought being edited when several thoughts are selected — whole-outline assertion, so the other selected thoughts are proven untouched (this is the assertion that catches `charlita` / `e del` / the empty child)
- extracts from the thought being edited when a *different* thought is selected — the corruption case above
- leaves the cursor and the selected thoughts selected — with an extracted-outline precondition so it cannot pass vacuously
- an alert should be shown if there is no selection and several thoughts are selected — the no-text-selected path degrades to the same alert as a single cursor, rather than to the disallow error
- reverts the extraction on a single undo — with an extracted-outline precondition, since under `disallow` the undo would have had nothing to revert

Red-side proof, run locally against both wrong declarations:

- Against the previous `disallow: true` declaration, **all 5 fail** and the 3 pre-existing tests still pass.
- Against a naive `multicursor: true`, **all 5 fail** — 3 on the corrupted outline, 1 on the swallowed alert, 1 on the precondition.

`yarn vitest run --project unit src/commands/__tests__/extractThought.ts`: 8 passed. `yarn lint` (including `tsc`): clean.

One test-infrastructure addition: `beforeEach(initStore)` at file scope. `createTestApp`/`cleanupTestApp` alone did not clear the thoughtspace between tests in this file — the first `importText`-based test's result leaked into the next one — which is the same problem documented in `deleteEmptyThoughtOrOutdent.ts`, and the same fix that file uses. It also cut the file's runtime from ~12s to ~2.5s.

## Notes for reviewers

- `canExecute` is left as `!!state.cursor || hasMulticursor(state)`. Under `multicursor: false` the `hasMulticursor` clause is inert — the action requires a cursor, and `setCursor` clears multicursors unless `preserveMulticursor` is passed (only `Editable`, `useEditMode`, `BulletPositioner`, and `selectBetween` do, all of which set a cursor), so a multiselect with a null cursor is not reachable in normal flows. Tightening it would be an unrelated change to toolbar enablement, so it is left alone.
- `src/__tests__/commands.ts` contains no `extractThought` disallow test, so nothing needed removing there. `docs/commands.md` describes Extract's user-facing behavior but not its multicursor declaration, so no doc change was needed.
- Unrelated pre-existing doc inaccuracy noticed in passing, not fixed here: `docs/cursor-and-caret.md` says the `split`/`splitNode` selection helpers are "Used by the Split Sentences command and the Extract command", but `selection.split` is called from `src/commands/newThought.ts`, not from Extract, which uses `offsetStart`/`offsetEnd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
