### PR TITLE
Remove the disallow option from Command.multicursor

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,8 +135,6 @@ When `state.multicursors` is non-empty, the user has one or more thoughts select
 
 | Option | Meaning |
 |---|---|
-| `disallow` | Block execution and show an alert when *more than one* thought is selected. A single selected thought is executed on directly, as if only the cursor were set, so the cursor is not restored afterwards. Use sparingly — usually `multicursor: false` or `filter` is better. |
-| `error` | The alert message shown when `disallow` is true and more than one thought is selected. String or `(state) => string`. |
 | `execMulticursor(cursors, dispatch, getState)` | Custom replacement for the per-cursor loop. |
 | `onComplete(filteredCursors, dispatch, getState)` | Callback after the loop finishes. |
 | `preventSetCursor` | Don't restore the cursor at the end. |

--- a/src/@types/Command.ts
+++ b/src/@types/Command.ts
@@ -33,15 +33,11 @@ interface Command {
   /**
    * Determines how the command behaves when multiple thoughts are selected. This is a required property because multicursor support is nontrivial, and it must be thought through for each new command that is added.
    * - If true, the command will be executed for each cursor. Optional object for more control.
-   * - If false, the command will be executed as if there were no multicursors. The command will be executed on state.cursor as usual and any thoughts that are selected will stay selected. This is ideal for commands that do not interact with the thoughtspace, such as opening the Command Universe or navigating to a modal. If instead you want to disallow the command when multiple thoughts are selected, set { disallow: true }.
+   * - If false, the command will be executed as if there were no multicursors. The command will be executed on state.cursor as usual and any thoughts that are selected will stay selected. This is ideal for commands that do not interact with the thoughtspace, such as opening the Command Universe or navigating to a modal.
    **/
   multicursor:
     | boolean
     | {
-        /** If true, execution of the command will be prevented and the user will be shown an alert when more than one thought is selected. A single selected thought is executed on directly, as if only the cursor were set, so the cursor is not restored afterwards. This should only be used if the command makes absolutely no sense when multiple thoughts are selected. In most cases, even if there is no multiselect behavior, you can just execute the command on state.cursor (by setting multicursor: false) or execute the command on the first or last sibling (by setting { filter: 'first-sibling' } or { filter: 'last-sibling' ). */
-        disallow?: boolean
-        /** An error message to display when multicursor mode is not enabled. */
-        error?: ((state: State) => string) | string
         /** Optional override for executing the command for multiple cursors. */
         execMulticursor?: (cursors: Path[], dispatch: Dispatch, getState: () => State) => void
         /** A callback that is invoked when the command finishes executing for all filtered multicursors. */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,7 +38,6 @@ import getThoughtById from './selectors/getThoughtById'
 import getUserSetting from './selectors/getUserSetting'
 import hasMulticursor from './selectors/hasMulticursor'
 import isAllSelected from './selectors/isAllSelected'
-import isMulticursorPath from './selectors/isMulticursorPath'
 import isRedoEnabled from './selectors/isRedoEnabled'
 import isUndoEnabled from './selectors/isUndoEnabled'
 import splitChain from './selectors/splitChain'
@@ -517,31 +516,6 @@ export const executeCommandWithMulticursor = (
   const multicursor = typeof command.multicursor === 'boolean' ? {} : command.multicursor
 
   const paths = documentSort(state, Object.values(state.multicursors))
-
-  // if multicursor is disallowed for this command, alert and exit early
-  // Only multiple selected thoughts are disallowed. A single selected thought is executed as usual, otherwise commands would be blocked whenever exactly one thought is selected, e.g. by opening the Command Center.
-  if (multicursor.disallow) {
-    if (paths.length > 1) {
-      const errorMessage = !multicursor.error
-        ? 'Cannot execute this command with multiple thoughts.'
-        : typeof multicursor.error === 'function'
-          ? multicursor.error(commandStore.getState())
-          : multicursor.error
-      commandStore.dispatch(
-        alert(errorMessage, {
-          alertType: AlertType.MulticursorError,
-        }),
-      )
-      return
-    }
-
-    // Execute the single selected thought here rather than falling through to the multicursor loop below, which restores the cursor when it is done. That restore dispatches setCursor, which resets noteFocus and would move the caret out of a note just created by the note command.
-    // For the same reason, only set the cursor when it is not already on the selected thought.
-    if (!state.cursor || !isMulticursorPath(state, state.cursor)) {
-      commandStore.dispatch(setCursor({ path: paths[0] }))
-    }
-    return executeCommand(command, { store: commandStore, type, event, keyboardIndex })
-  }
 
   // For each multicursor, place the cursor on the path and execute the command by calling executeCommand.
   const filteredPaths = filterCursors(state, paths, multicursor.filter)


### PR DESCRIPTION
## What

Removes the `disallow` option, and the `error` option that existed only to customize its alert, from `Command['multicursor']`:

- `src/@types/Command.ts` — both properties dropped from the multicursor object type, and the `multicursor` doc comment no longer points readers at `{ disallow: true }`.
- `src/commands.ts` — the alert-and-exit branch at the top of `executeCommandWithMulticursor` is gone, along with the single-selection direct-execution path it contained, and the now-unused `isMulticursorPath` import.
- `docs/commands.md` — the `disallow` and `error` rows are removed from the multicursor options table.

## Why

`disallow` blocked a command outright when more than one thought was selected. Every command that used it now declares real multicursor behavior, so the option has no remaining users. Leaving it available invites new commands to opt out of multiselect rather than think the behavior through, which is what the required `multicursor` field exists to force.

Removing the single-selection carve-out is the subtler half. It executed a lone selected thought directly, skipping the loop's end-of-run cursor restore, because that restore dispatches `setCursor`, which resets `noteFocus` and would pull the caret out of a note the Note command had just created. Commands needing that guarantee now declare `preventSetCursor: true`, which is narrower and visible at the declaration site.

The conversions that made this possible: Swap Parent #4917, Bump Thought Down #4920, Apply Color #4921, Clear Thought #4520, New Subthought (above) #4926, New Subthought (next) #4927, New Grandchild #4928, Bind Context #4934, Extract #4935, Generate Thought #4936.

## Tests

None added — this removes an option, and the behavior it gated is covered by the per-command suites in the conversion PRs above.

The two tests in `src/__tests__/commands.ts` that exercised `disallow` were removed in #4917, when Swap Parent stopped using it.
