### PR TITLE
Select parents on Cursor Back when thoughts are multiselected

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -125,7 +125,7 @@ Both filter `globalCommands` by name and respect `hideFromDesktopCommandUniverse
 
 When `state.multicursors` is non-empty, the user has one or more thoughts selected. A selection of exactly one thought is common — on mobile, opening the Command Center selects the cursor thought. Every command must declare how it behaves in this case via the required `multicursor` field — there is no implicit default.
 
-- **`multicursor: false`** — execute on `state.cursor` as if no multicursor existed; selection stays. For commands that don't interact with the thoughtspace (e.g. opening modals). The cursor-navigation commands also declare `multicursor: false` yet still respond to a selection, since navigating a multiselect means moving the selection itself rather than executing once per selected thought: [`cursorUp`](../src/commands/cursorUp.ts) and [`cursorDown`](../src/commands/cursorDown.ts) read `state.multicursors` in their own `exec` to extend or collapse the selection, and the [`cursorForward`](../src/actions/cursorForward.ts) reducer replaces the selection with the thoughts one level forward.
+- **`multicursor: false`** — execute on `state.cursor` as if no multicursor existed; selection stays. For commands that don't interact with the thoughtspace (e.g. opening modals). The cursor-navigation commands also declare `multicursor: false` yet still respond to a selection, since navigating a multiselect means moving the selection itself rather than executing once per selected thought: [`cursorUp`](../src/commands/cursorUp.ts) and [`cursorDown`](../src/commands/cursorDown.ts) read `state.multicursors` in their own `exec` to extend or collapse the selection, and the [`cursorForward`](../src/actions/cursorForward.ts) and [`cursorBack`](../src/actions/cursorBack.ts) reducers replace the selection with the thoughts one level forward or back.
 - **`multicursor: true`** — execute once per selected thought.
 - **`multicursor: { ... }`** — fine-grained control with these options:
 
@@ -185,7 +185,7 @@ The full list of user-facing commands. For the canonical, always-up-to-date set,
 
 ### Back
 
-Move the cursor up a level. If Clear Thought is active, cancel it instead and leave the cursor where it is.
+Move the cursor up a level. If Clear Thought is active, cancel it instead and leave the cursor where it is. When thoughts are selected, deselect them and select the parent of each selected thought instead — except on desktop, where <kbd>Escape</kbd> clears the selection rather than moving it.
 
 <kbd>Escape</kbd>
 

--- a/src/actions/__tests__/cursorBack.ts
+++ b/src/actions/__tests__/cursorBack.ts
@@ -1,9 +1,22 @@
+import State from '../../@types/State'
+import importText from '../../actions/importText'
+import toggleContextView from '../../actions/toggleContextView'
+import childIdsToThoughts from '../../selectors/childIdsToThoughts'
+import contextToPath from '../../selectors/contextToPath'
+import addMulticursor from '../../test-helpers/addMulticursorAtFirstMatch'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import setCursor from '../../test-helpers/setCursorFirstMatch'
+import hashPath from '../../util/hashPath'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 import cursorBack from '../cursorBack'
+import cursorForward from '../cursorForward'
 import newSubthought from '../newSubthought'
 import newThought from '../newThought'
+
+/** Converts the multicursor set to a list of contexts in a readable way. */
+const multicursorContexts = (state: State): string[][] =>
+  Object.values(state.multicursors).map(path => childIdsToThoughts(state, path).map(thought => thought.value))
 
 it('move cursor to parent', () => {
   const steps = [newThought('a'), newSubthought('b'), cursorBack]
@@ -19,4 +32,117 @@ it('remove cursor from root thought', () => {
   const stateNew = reducerFlow(steps)(initialState())
 
   expect(stateNew.cursor).toEqual(null)
+})
+
+// https://github.com/cybersemics/em/issues/3526
+describe('multicursor', () => {
+  it('select the parents of the selected thoughts', () => {
+    const text = `
+      - x
+        - =children
+          - =pin
+        - a
+          - b
+          - c
+        - d
+          - e
+        - f
+          - g
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['x', 'a', 'b']),
+      addMulticursor(['x', 'a', 'b']),
+      addMulticursor(['x', 'a', 'c']),
+      addMulticursor(['x', 'd', 'e']),
+      cursorBack,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    // b and c share the parent a, which is selected only once
+    expect(multicursorContexts(stateNew)).toEqual([
+      ['x', 'a'],
+      ['x', 'd'],
+    ])
+  })
+
+  it('select the context view thought when its contexts are selected', () => {
+    const text = `
+      - a
+        - m
+          - x
+      - b
+        - m
+          - y
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      addMulticursor(['a', 'm']),
+      // select the contexts a and b of the context view thought m
+      cursorForward,
+      cursorBack,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(multicursorContexts(stateNew)).toEqual([['a', 'm']])
+  })
+
+  it('keep a selected thought selected when it is the parent of another selected thought', () => {
+    const text = `
+      - x
+        - a
+          - b
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['x']),
+      addMulticursor(['x', 'a']),
+      addMulticursor(['x', 'a', 'b']),
+      cursorBack,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(multicursorContexts(stateNew)).toEqual([['x'], ['x', 'a']])
+  })
+
+  it('do nothing if all of the selected thoughts are in the root context', () => {
+    const text = `
+      - a
+      - b
+    `
+    const steps = [importText({ text }), setCursor(['a']), addMulticursor(['a']), addMulticursor(['b']), cursorBack]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(multicursorContexts(stateNew)).toEqual([['a'], ['b']])
+  })
+
+  it('collapse the newly selected parents so that the previously selected children are hidden', () => {
+    // x needs a second child, otherwise a is already expanded by the only-child rule
+    const text = `
+      - x
+        - a
+          - b
+          - c
+        - d
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['x']),
+      addMulticursor(['x', 'a']),
+      // select b and c, which expands their deselected parent a
+      cursorForward,
+      cursorBack,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    expect(multicursorContexts(stateNew)).toEqual([['x', 'a']])
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['x', 'a'])!)]).toBeFalsy()
+  })
 })

--- a/src/actions/cursorBack.ts
+++ b/src/actions/cursorBack.ts
@@ -1,16 +1,49 @@
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
+import addMulticursor from '../actions/addMulticursor'
 import cursorHistory from '../actions/cursorHistory'
+import removeMulticursor from '../actions/removeMulticursor'
 import searchReducer from '../actions/search'
 import setCursor from '../actions/setCursor'
+import expandThoughts from '../selectors/expandThoughts'
+import hasMulticursor from '../selectors/hasMulticursor'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import isAbsolute from '../util/isAbsolute'
 import parentOf from '../util/parentOf'
 import reducerFlow from '../util/reducerFlow'
 import toggleAbsoluteContext from './toggleAbsoluteContext'
 
-/** Moves the cursor up one level. */
+/** Replaces the multiselect with the parents of each selected thought. Parents shared by multiple selected thoughts are selected once, since the multicursor set is keyed by path. */
+const multicursorBack = (state: State): State => {
+  const paths = Object.values(state.multicursors)
+
+  // Root-level thoughts contribute no parent, since the root cannot be selected.
+  const backPaths = paths.filter(path => path.length > 1).map(parentOf)
+
+  // do nothing if all selected thoughts are at the root level, so that an extra Back gesture does not destroy the selection
+  if (backPaths.length === 0) return state
+
+  const stateNew = reducerFlow([
+    // Deselecting before selecting is safe within a single action, since multicursorAlertMiddleware only sees the
+    // final state and thus never a momentarily empty multiselect (which would close the Command Center on mobile).
+    // A selected thought that is also the parent of another selected thought is deselected and reselected.
+    ...paths.map(path => removeMulticursor({ path })),
+    ...backPaths.map(path => addMulticursor({ path })),
+  ])(state)
+
+  return {
+    ...stateNew,
+    // Selected thoughts are kept collapsed by expandThoughts, so expansion must be recalculated for the newly
+    // selected parents to collapse the previously selected children.
+    // https://github.com/cybersemics/em/issues/4738
+    expanded: expandThoughts(stateNew, stateNew.cursor),
+  }
+}
+
+/** Moves the cursor up one level. When thoughts are selected, replaces the selection with their parents instead of moving the cursor. */
 const cursorBack = (state: State): State => {
+  if (hasMulticursor(state)) return multicursorBack(state)
+
   const { cursor: cursorOld, isKeyboardOpen, search, rootContext } = state
 
   const isAbsoluteRoot = isAbsolute(rootContext)

--- a/src/commands/cursorBack.ts
+++ b/src/commands/cursorBack.ts
@@ -36,7 +36,8 @@ const cursorBackCommand: Command = {
 
     const { cursor, search } = state
 
-    if (cursor || search != null) {
+    // a multicursor can exist without a cursor, e.g. a thought selected by long press, so it must be checked in addition to the cursor for the selection to be moved back a level (touch only, since escape clears the multicursor on desktop above)
+    if (cursor || search != null || hasMulticursor(state)) {
       dispatch(cursorBack())
 
       // clear browser selection if cursor has been removed
@@ -48,7 +49,8 @@ const cursorBackCommand: Command = {
 
     // As a convenience, allow cursorBack to scroll to the top if the cursor is already null.
     // Only do this after the cursor is already null to avoid disrupting the user when they are simply moving up a level to adjust autofocus and immediately back down a level to a sibling.
-    if (!cursor) {
+    // Not when thoughts are selected, since then Back moves the selection rather than the cursor.
+    if (!cursor && !hasMulticursor(state)) {
       scrollTo('top', 'smooth')
     }
   }),


### PR DESCRIPTION
Fixes #3526

Cursor Back (swipe →, gesture `r`) moved the hidden cursor up a level and left the selection untouched when multiple thoughts were selected. It now deselects them and selects each of their parents instead — the reverse of #4898.

## Changes

- **`src/actions/cursorBack.ts`** — a new `multicursorBack` branch at the top of the reducer, the mirror of `multicursorForward`:
  - Replaces the selection with `parentOf` each selected path. Parents shared by several selected thoughts (e.g. `b` and `c` under `a`) are selected once, since the multicursor set is keyed by `hashPath`. Context view needs no special handling — the parent of a context path in the visible tree is the context view thought itself.
  - Root-level thoughts contribute no parent, since the root cannot be selected. If the entire selection is at the root, the reducer does nothing (mirroring Forward's no-op at a leaf), so an extra back swipe does not destroy the selection.
  - Deselect-then-reselect happens inside one action via `reducerFlow`, so `multicursorAlertMiddleware` never sees a momentarily empty multiselect (which would close the Command Center on mobile).
  - `expanded` is recalculated, per the invariant that any reducer changing `state.multicursors` must do so (docs/glossary.md). The newly selected parents stay collapsed, hiding the previously selected children — the zoom-out mirror of #4738.
- **`src/commands/cursorBack.ts`** — the dispatch gate now also fires when a multicursor exists without a cursor, which is reachable on touch: long press selects via `toggleMulticursor` without setting the cursor. The scroll-to-top convenience is suppressed while thoughts are selected. Desktop <kbd>Escape</kbd> still clears the selection before dispatching, unchanged.
- **`src/actions/__tests__/cursorBack.ts`** — five multicursor tests mirroring the Forward suite: the issue's tree with dedup (`b`, `c`, `e` → `a`, `d`), a context-view round trip, a selected parent of another selected thought staying selected, the all-at-root no-op, and the expansion recalculation.
- **`docs/commands.md`** — the cursor-navigation note under `multicursor: false` now covers both reducers; the **Back** reference entry describes the multiselect behavior.

## Safety of other `cursorBack` dispatch sites

- `moveCursorBackward` (Shift+Tab, table view) dispatches `cursorBack()` from inside the per-thought multicursor loop, but the loop's plain `setCursor` clears `state.multicursors` before each exec (`src/actions/setCursor.ts`), so it cannot hit the new branch.
- `cursorBackTable` (ArrowLeft) dispatches `setCursor` directly with `preserveMulticursor` — unaffected.
- `NewThought` dispatches `cursorBack()` when a new-thought button hidden by autofocus is clicked; with a multiselect this now moves the selection back a level, consistent with the command's new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)