### PR TITLE
Fix delayed autofocus cleanup so hidden thoughts are shimmed

### DIFF
--- a/src/components/__tests__/LayoutTree.ts
+++ b/src/components/__tests__/LayoutTree.ts
@@ -2,10 +2,14 @@ import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import dispatch from '../../test-helpers/dispatch'
+import queryThoughtByText from '../../test-helpers/queries/queryThoughtByText'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 
 beforeEach(createTestApp)
-afterEach(cleanupTestApp)
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await cleanupTestApp()
+})
 
 it('unmount TreeNodes on collapse', async () => {
   await dispatch(
@@ -33,4 +37,36 @@ it('unmount TreeNodes on collapse', async () => {
 
   // collapse a and unmount b
   expect(document.querySelectorAll('[aria-label="tree-node"]').length).toBe(2)
+})
+
+it('unmounts distant thoughts after navigation and remounts them on return', async () => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 20))
+
+  await dispatch(
+    importText({
+      text: `
+        - a
+          - b
+            - c
+              - d
+                - e
+                  - f
+                    - g
+      `,
+    }),
+  )
+
+  await dispatch(setCursor(['a']))
+  expect(await queryThoughtByText('a')).not.toBeNull()
+
+  await dispatch(setCursor(['a', 'b', 'c', 'd', 'e', 'f']))
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(await queryThoughtByText('a')).toBeNull()
+  // hide-parent thoughts stay mounted so they can fade back in when navigating up.
+  expect(await queryThoughtByText('d')).not.toBeNull()
+  expect(await queryThoughtByText('f')).not.toBeNull()
+
+  await dispatch(setCursor(['a']))
+  expect(await queryThoughtByText('a')).not.toBeNull()
 })

--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -10,6 +10,19 @@ import waitUntil from '../helpers/waitUntil'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
+/** Returns the persistent tree node that contains the editable with the given value. */
+const getTreeNode = async (value: string) => {
+  const editable = (await waitForEditable(value)).asElement()
+  if (!editable) throw new Error(`Editable "${value}" not found.`)
+
+  const treeNode = (
+    await editable.evaluateHandle(element => (element as Element).closest('[aria-label="tree-node"]'))
+  ).asElement()
+  if (!treeNode) throw new Error(`Tree node for "${value}" not found.`)
+
+  return treeNode
+}
+
 it('set the cursor to a thought in the home context on load', async () => {
   const importText = `
   - a
@@ -92,8 +105,10 @@ it('do nothing when clicking on a hidden ancestor', async () => {
         - d`
   await paste(importText)
   await waitForEditable('d')
+  const ancestorTreeNode = await getTreeNode('a')
   await clickThought('d')
-  await clickThought('a')
+  await ancestorTreeNode.waitForSelector('[data-editable]', { hidden: true })
+  await click(ancestorTreeNode)
 
   const thoughtValue = await getEditingText()
   expect(thoughtValue).toBe('d')
@@ -107,6 +122,8 @@ it('do nothing when clicking on a hidden great uncle', async () => {
   - d`
   await paste(importText)
 
+  const greatUncleTreeNode = await getTreeNode('d')
+
   // click a to expand b and c
   await waitForEditable('a')
   await clickThought('a')
@@ -115,7 +132,8 @@ it('do nothing when clicking on a hidden great uncle', async () => {
   // for some reason we need to sleep before clicking c, otherwise the cursor is moved to d
   await waitForEditable('c')
   await clickThought('c')
-  await clickThought('d')
+  await greatUncleTreeNode.waitForSelector('[data-editable]', { hidden: true })
+  await click(greatUncleTreeNode)
 
   const thoughtValue = await getEditingText()
   expect(thoughtValue).toBe('c')

--- a/src/hooks/__tests__/useDelayedAutofocus.ts
+++ b/src/hooks/__tests__/useDelayedAutofocus.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+import Autofocus from '../../@types/Autofocus'
+import useDelayedAutofocus from '../useDelayedAutofocus'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it('updates the selected autofocus after the delay', () => {
+  const { result, rerender } = renderHook(
+    ({ autofocus }: { autofocus: Autofocus }) =>
+      useDelayedAutofocus(autofocus, {
+        delay: 750,
+        selector: autofocusNew => autofocusNew === 'hide',
+      }),
+    { initialProps: { autofocus: 'show' as Autofocus } },
+  )
+
+  rerender({ autofocus: 'hide' })
+
+  act(() => vi.advanceTimersByTime(749))
+  expect(result.current).toBe(false)
+
+  act(() => vi.advanceTimersByTime(1))
+  expect(result.current).toBe(true)
+})
+
+it('cancels a delayed update on unmount', () => {
+  const { rerender, unmount } = renderHook(
+    ({ autofocus }: { autofocus: Autofocus }) =>
+      useDelayedAutofocus(autofocus, { delay: 750, selector: value => value }),
+    { initialProps: { autofocus: 'show' as Autofocus } },
+  )
+
+  rerender({ autofocus: 'hide' })
+  expect(vi.getTimerCount()).toBe(1)
+
+  unmount()
+  expect(vi.getTimerCount()).toBe(0)
+})

--- a/src/hooks/useDelayedAutofocus.ts
+++ b/src/hooks/useDelayedAutofocus.ts
@@ -14,7 +14,6 @@ const useDelayedAutofocus = <T = string>(
   // This ensures that the component is only re-rendered when the selector result changes, not every time the delayed autofocus value changes.
   const [autofocusDelayed, setAutofocusDelayed] = useState(selector(autofocus))
   const lastAutofocusRef = useRef(autofocus)
-  const unmounted = useRef(false)
   const autofocusTimerRef = useRef<number>(0)
   useEffect(
     () => {
@@ -25,7 +24,6 @@ const useDelayedAutofocus = <T = string>(
         (lastAutofocusRef.current === 'show' || lastAutofocusRef.current === 'dim')
       ) {
         autofocusTimerRef.current = setTimeout(() => {
-          if (unmounted.current) return
           setAutofocusDelayed(selector(autofocus))
           lastAutofocusRef.current = autofocus
         }, delay) as unknown as number
@@ -35,7 +33,7 @@ const useDelayedAutofocus = <T = string>(
       }
 
       return () => {
-        unmounted.current = true
+        clearTimeout(autofocusTimerRef.current)
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Addresses #2399.

Related to the [iOS Safari deep-navigation report in #4325](https://github.com/cybersemics/em/pull/4325#issuecomment-5314524042).

## Problem

`useDelayedAutofocus` sets an `unmounted` ref in its effect cleanup. React runs that cleanup before every `autofocus`-driven rerun, not only on unmount, so the ref becomes permanently true after the first transition. Subsequent delayed updates are discarded.

During progressive deep navigation, thoughts that move to `hide` therefore never become lightweight fixed-height shims. Their full editor trees remain mounted after leaving the visible layout, causing DOM and WebContent memory to grow with depth.

## Solution

- Cancel the pending autofocus timer in effect cleanup instead of latching an `unmounted` flag.
- Add hook coverage for the delayed update and cancellation on unmount.
- Add a mounted-layout regression test that verifies distant `hide` thoughts are unmounted, `hide-parent` thoughts remain mounted for the existing fade-in behavior, and navigating back remounts the ancestor.

This is deliberately narrower than #2582: it does not change `Subthought`/`VirtualThought` layout, opacity, or `hide-parent` behavior that was implicated in the Safari regression in #2650.

## Physical-device results

Measured on an iPhone 13 mini running iOS 26.6 in Mobile Safari with the same 150-level `Hello1` … `Hello150` fixture and a 75-step slow-scroll run lasting about 65 seconds. WebContent process metrics were sampled at roughly 1 Hz.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Average WebContent CPU | 50.8% | 41.0% | -19.2% |
| Peak WebContent CPU | 70.4% | 49.8% | -29.2% |
| Average physical footprint | 966.2 MB | 535.3 MB | -44.6% |
| Peak physical footprint | 1,024 MB | 561 MB | -45.2% |
| Mounted editables at depth 150 | 150 | 4 | -97.3% |
| DOM nodes at depth 150 | 4,566 | 1,937 | -57.6% |

The before/after builds were based on the same TreeCRDT integration revision because that is the reported surface; the affected hook and layout code are identical to upstream `main`. An unpatched upstream-main control showed the same retention behavior and averaged 926.6 MB during the scroll.

These are directional measurements from one physical-device run per build, not a formal benchmark. Neither build hard-reloaded on iOS 26.6; the original hard reload was reported on iOS 26.5.2, so confirmation on the affected device is still needed. Navigating back 20 levels after the patched run did not reproduce the y-position drift from #2650.

## Verification

- Focused hook/component tests: 4 passed. On the pre-fix implementation, the delayed hook value remains false and the distant `a` thought remains mounted.
- `yarn lint:tsc`
- `yarn lint:src`
- `yarn build`
- Physical iPhone deep navigation, slow scrolling, and 20-level back navigation
