### PR TITLE
feat(splitSentences): split slash-delimited thoughts into nested descendants

### DIFF
--- a/src/actions/__tests__/splitSentences.ts
+++ b/src/actions/__tests__/splitSentences.ts
@@ -786,6 +786,97 @@ describe('dash splitting', () => {
   })
 })
 
+describe('slash splitting', () => {
+  it('splits thought with slashes into a chain of descendants', () => {
+    const value = 'one/two/three'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one
+    - two
+      - three`)
+  })
+
+  it('splits thought with a single slash into main thought and subthought', () => {
+    const value = 'one/two'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one
+    - two`)
+  })
+
+  it('splits thought with slashes and extra spaces', () => {
+    const value = 'one / two / three'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one
+    - two
+      - three`)
+  })
+
+  it('does not split when slash is at the beginning', () => {
+    const value = '/one'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - /one`)
+  })
+
+  it('does not split when slash is at the end', () => {
+    const value = 'one/'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one/`)
+  })
+
+  it('splits by slash when there is only one sentence ending with a period', () => {
+    const value = 'one/two.'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one
+    - two.`)
+  })
+
+  it('splits by sentences when both slashes and multiple sentences are present', () => {
+    const value = 'one/two. three.'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one/two.
+  - three.`)
+  })
+
+  it('splits by dash before slash when both are present', () => {
+    const value = 'one - two/three'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - one
+    - two/three`)
+  })
+
+  it('does not split a url containing slashes', () => {
+    const value = 'https://abc.com/xyz/def'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - https://abc.com/xyz/def`)
+  })
+
+  it('preserves formatting on each slash-delimited segment', () => {
+    const value = '<b>one/two</b>'
+    const exported = splitThought(value)
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - **one**
+    - **two**`)
+  })
+})
+
 describe('formatting', () => {
   // https://github.com/cybersemics/em/issues/4229
   it('preserves formatting on every comma-delimited segment, including segments in the middle', () => {

--- a/src/util/splitSentence.ts
+++ b/src/util/splitSentence.ts
@@ -265,6 +265,25 @@ const splitSentence = (value: string): SplitResult[] => {
       }
     }
 
+    // Check for slash and split into a chain of descendants, each part a child of the previous
+    // e.g. "one/two/three" -> "- one  - two (child)  - three (grandchild)"
+    if (plainValue.includes('/')) {
+      let offset = 0
+      const boundaries = plainValue.split('/').map(part => {
+        const start = offset
+        offset += part.length + 1
+        return { start, end: start + part.length }
+      })
+      const parts = boundaries.filter(({ start, end }) => plainValue.slice(start, end).trim() !== '')
+      // Only split if the slash has content on both sides
+      if (parts.length > 1) {
+        return parts.map(({ start, end }, i) => ({
+          value: trimHtml(sliceHtmlByTextOffsets(value, start, end)),
+          ...(i > 0 ? { insertNewSubThought: true } : null),
+        }))
+      }
+    }
+
     // if we're sub-sentence or in one sentence territory, split by comma, or by the word "and" if there is no comma
     // e.g. "john, johnson, john doe" -> "- john - johnson - john doe"
     // e.g. "Alice and the Lion" -> "- Alice - the Lion"


### PR DESCRIPTION
## Summary

Split Sentences now splits a slash-delimited thought into a chain of descendants:

`one/two/three` becomes

```
- one
  - two
    - three
```

## Behavior

- Each slash-delimited part is nested under the previous one, reusing the existing `insertNewSubThought` mechanism (the same one used by dash and parenthetical splits, which nests naturally since `newThought` moves the cursor to each new thought).
- Whitespace around slashes is trimmed (`one / two` → `one` > `two`).
- A leading or trailing slash does not trigger a split, matching dash behavior.
- Precedence is unchanged for existing behavior: sentence punctuation still wins (`one/two. three.` splits into sibling sentences), the dash check runs first (`one - two/three` → `one` > `two/three`), and URLs are unaffected.
- Formatting is preserved on each segment by slicing the original HTML at text offsets.

## Tests

New `slash splitting` suite (10 cases) in `src/actions/__tests__/splitSentences.ts` covering the nested chain, whitespace, edge slashes, precedence, URLs, and formatting. All 106 splitSentences tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)