### PR TITLE
chore(deps): upgrade lottie-react to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "immer": "^11.1.16",
     "ipfs-http-client": "^43.0.1",
     "lodash": "^4.18.1",
-    "lottie-react": "^2.4.1",
+    "lottie-react": "^3.1.0",
     "marked": "^18.0.9",
     "moize": "^6.1.7",
     "motion": "^13.1.0",

--- a/src/components/icons/LottieAnimation.tsx
+++ b/src/components/icons/LottieAnimation.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash'
-import Player, { LottieRefCurrentProps } from 'lottie-react'
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { Lottie, LottieHandle } from 'lottie-react'
+import React, { useMemo, useRef } from 'react'
 import AnimatedColor from '../../@types/lottie/AnimatedColor'
 import ColorProperty from '../../@types/lottie/ColorProperty'
 import LottieData from '../../@types/lottie/LottieData'
@@ -124,7 +124,7 @@ const changeLineColor = (data: LottieData, newColor: string): LottieData => {
 /**
  * LottieAnimation Component.
  *
- * This component utilizes the 'lottie-react' Player to render a Lottie animation.
+ * This component utilizes the 'lottie-react' Lottie component to render a Lottie animation.
  * It accepts animation data and supports customizable speed and color properties,
  * allowing for dynamic control over the animation's playback rate and the stroke
  * and fill colors of its elements.
@@ -137,45 +137,43 @@ const changeLineColor = (data: LottieData, newColor: string): LottieData => {
  * This does not affect the Lottie animation's JSON content or alter its visual elements.
  */
 const LottieAnimation: React.FC<LottieAnimationProps> = ({ animationData, speed = 1, color, onComplete }) => {
-  const lottieRef = useRef<LottieRefCurrentProps | null>(null)
+  const lottieRef = useRef<LottieHandle>(null)
 
   const animationDataWithColor = useMemo(() => {
     return animationData ? changeLineColor(animationData, color) : null
   }, [animationData, color])
 
-  // skip the animation in Puppeteer tests to avoid inconsistent snapshots
-  if (navigator.webdriver) {
-    useLayoutEffect(() => {
-      if (!lottieRef.current) return
-
-      const lastFrame = lottieRef.current.getDuration(true)! - 1
-      lottieRef.current.goToAndStop(lastFrame)
-      onComplete?.()
-    }, [onComplete])
-  }
-
-  useEffect(() => {
-    if (lottieRef.current && animationDataWithColor) {
-      lottieRef.current.setSpeed(speed)
-    }
-  }, [speed, animationDataWithColor])
+  const subscriptions = useMemo(
+    () => ({
+      complete: onComplete,
+      // skip the animation in Puppeteer tests to avoid inconsistent snapshots
+      ...(navigator.webdriver && {
+        ready: () => {
+          lottieRef.current?.seek({ percent: 100 })
+          onComplete?.()
+        },
+      }),
+    }),
+    [onComplete],
+  )
 
   if (!animationDataWithColor) {
     return null
   }
 
   return (
-    <Player
+    <Lottie
       style={{
         width: '100%',
         height: '100%',
       }}
-      animationData={animationDataWithColor}
+      src={animationDataWithColor}
       lottieRef={lottieRef}
+      speed={speed}
       // turn off autoplay in puppeteer tests
       autoplay={!navigator.webdriver}
       loop={false}
-      onComplete={onComplete}
+      subscriptions={subscriptions}
     />
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11756,7 +11756,7 @@ __metadata:
     jsdom: "npm:^30.0.1"
     lockfile-lint: "npm:^5.0.0"
     lodash: "npm:^4.18.1"
-    lottie-react: "npm:^2.4.1"
+    lottie-react: "npm:^3.1.0"
     marked: "npm:^18.0.9"
     moize: "npm:^6.1.7"
     motion: "npm:^13.1.0"
@@ -17605,22 +17605,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lottie-react@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "lottie-react@npm:2.4.1"
+"lottie-react@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lottie-react@npm:3.1.0"
   dependencies:
-    lottie-web: "npm:^5.10.2"
+    lottie-web: "npm:^5.13.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/7f6a0a2cf2af25deabe7b4d4c9917e47d12016673613c59dcdd8ef52e10e914dd0c1f71d4a275d56aaba03fe9d85b333087f7c8d40a8f967ece4a0444c7a3cdf
+    react: ^18.2.0 || ^19.0.0
+    react-dom: ^18.2.0 || ^19.0.0
+  checksum: 10c0/501c06309c2e5ce2c3d445801d96359c68ca7ec6315f3c7c9c1be421716a548285c96b1915faf881bb4372b230a13ff47dcc4bda1ac12570ddb44a8b0a022766
   languageName: node
   linkType: hard
 
-"lottie-web@npm:^5.10.2":
-  version: 5.12.2
-  resolution: "lottie-web@npm:5.12.2"
-  checksum: 10c0/0aeaf631b10a76afd025df70c2a1486543530708e07a316946c08e55891dac483ffbaf2bf3648ae0b9c54c733118a0a086fd150aa76f7848606214c67ad72c30
+"lottie-web@npm:^5.13.0":
+  version: 5.13.0
+  resolution: "lottie-web@npm:5.13.0"
+  checksum: 10c0/b463ad462169df3f7e04b7f3716274e269842554f1d72b8303ca7245628f2512982a59ae31698b3d57fbcda886228ae160fcb2aa518c6cecd8a95974db2458ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

Upgrades `lottie-react` from 2.4.1 to 3.1.0, following the [official migration guide](https://lottiereact.com/docs/migration). All usage is concentrated in `LottieAnimation.tsx` (the shared player behind the animated toolbar icons), so it is the only component that changed. `AnimatedIcon` is untouched — its `animationData` prop is its own interface.

- Default `Player` import + `LottieRefCurrentProps` → named `Lottie` import + `LottieHandle` (v3 removed the default export)
- `animationData` prop → `src` (accepts the parsed animation object; compared by content, so the color-remapped clone is safe)
- `onComplete` prop → memoized `subscriptions={{ complete }}` object
- `setSpeed` effect → reactive `speed` prop (effect deleted)
- Puppeteer skip path: `getDuration(true) - 1` + `goToAndStop()` in a conditionally-called `useLayoutEffect` → `seek({ percent: 100 })` inside a `ready` subscription. This is required in v3 — loading is async and `LottieHandle` no longer exposes frame counts — and it also removes the conditional hook call. `seek` takes an explicit unit, resolving the frame/seconds ambiguity of `goToAndStop` ([Gamote/lottie-react#92](https://github.com/Gamote/lottie-react/issues/92)).

## Verification

Observed in the running app (dev server + browser automation):

- Toolbar icons (Bold/Italic/Underline) mount the v3 player, play to completion, fire `complete`, and unmount back to the static SVG; the command applies; no console errors.
- With `navigator.webdriver` spoofed to `true`: no autoplay, immediate seek to the final frame (59.999 of 60), immediate `onComplete` and unmount — the behavior the image snapshots rely on.

`tsc` and ESLint pass.

## Reviewer notes

- v3 declines autoplay under `prefers-reduced-motion: reduce` (animation loads, sits on frame 0, `complete` never fires, so the icon stays mounted on the static first frame). v2 played regardless. This seems like the right accessibility behavior to inherit, but flagging it as a deliberate behavior change.
- The Puppeteer image snapshots are the real referee for the webdriver path — worth watching on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)