### PR TITLE
Fix emoji spacing immediately after paste

### DIFF
--- a/src/actions/importText.ts
+++ b/src/actions/importText.ts
@@ -15,6 +15,7 @@ import getThoughtById from '../selectors/getThoughtById'
 import rootedParentOf from '../selectors/rootedParentOf'
 import simplifyPath from '../selectors/simplifyPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
+import addEmojiSpace from '../util/addEmojiSpace'
 import appendToPath from '../util/appendToPath'
 import createId from '../util/createId'
 import head from '../util/head'
@@ -136,8 +137,14 @@ const importText = (
       : destValue.slice(0, htmlReplaceStart || 0) + destValue.slice(htmlReplaceEnd || 0)
 
     const insertPosition = htmlReplaceStart || htmlCaretPosition
-    const newValue = `${replacedDestValue.slice(0, insertPosition)}${text}${replacedDestValue.slice(insertPosition)}`
-    const offset = caretPosition + getTextContentFromHTML(text).length
+    const combinedValue = `${replacedDestValue.slice(0, insertPosition)}${text}${replacedDestValue.slice(insertPosition)}`
+    const newValue = addEmojiSpace(combinedValue)
+    const offsetBeforeEmojiSpace = caretPosition + getTextContentFromHTML(text).length
+    const emojiSpaceInsertionOffset = newValue === combinedValue ? -1 : getTextContentFromHTML(newValue).indexOf(' ')
+    const offset =
+      emojiSpaceInsertionOffset >= 0 && offsetBeforeEmojiSpace >= emojiSpaceInsertionOffset
+        ? offsetBeforeEmojiSpace + 1
+        : offsetBeforeEmojiSpace
 
     return reducerFlow([
       // Force the editable to re-render in order to trigger setSelectionToCursorOffset in useEditMode and restore the caret.

--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -1,38 +1,12 @@
+import getEditingText from '../helpers/getEditingText'
+import getSelection from '../helpers/getSelection'
 import keyboard from '../helpers/keyboard'
 import press from '../helpers/press'
+import setClipboard from '../helpers/setClipboard'
 import waitForEditable from '../helpers/waitForEditable'
-import { page } from '../session'
+import waitForEditingTextChange from '../helpers/waitForEditingTextChange'
 
 vi.setConfig({ testTimeout: 20000 })
-
-/** Custom helper for pasting plain text, avoiding the existing `paste` helper that uses `importText` internally. */
-const pastePlainText = async (text: string) => {
-  // Load text into clipboard
-  await page.evaluate(async text => {
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        'text/plain': new Blob([text], { type: 'text/plain' }),
-      }),
-    ])
-  }, text)
-
-  await press('Insert', { shift: true })
-}
-
-/** Custom helper for pasting HTML, avoiding the existing `paste` helper that uses `importText` internally. */
-const pasteHTML = async (html: string) => {
-  // Load HTML into clipboard
-  await page.evaluate(async html => {
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        'text/plain': new Blob(['Plain text should be ignored when pasting as HTML.'], { type: 'text/plain' }),
-        'text/html': new Blob([html], { type: 'text/html' }),
-      }),
-    ])
-  }, html)
-
-  await press('Insert', { shift: true })
-}
 
 it('escapes typed HTML', async () => {
   await press('Enter', { delay: 10 })
@@ -45,7 +19,8 @@ it('escapes typed HTML', async () => {
 
 it('preserves pasted HTML as text/html in bold case', async () => {
   await press('Enter', { delay: 10 })
-  await pasteHTML('hello <b>world</b>')
+  await setClipboard({ html: 'hello <b>world</b>', text: 'Plain text should be ignored when pasting as HTML.' })
+  await press('Insert', { shift: true })
   const editable = await waitForEditable('hello <b>world</b>')
   expect(editable).toBeTruthy()
 })
@@ -53,9 +28,11 @@ it('preserves pasted HTML as text/html in bold case', async () => {
 // TODO: Broken in due to reverting related code. See: #2814.
 it.skip('preserves pasted HTML as text/html with text color and background color', async () => {
   await press('Enter', { delay: 10 })
-  await pasteHTML(
-    '<font color="#000000" style="background-color: rgb(255, 136, 0);">Hello </font><font color="#000000" style="background-color: rgb(0, 214, 136);">World</font>',
-  )
+  await setClipboard({
+    html: '<font color="#000000" style="background-color: rgb(255, 136, 0);">Hello </font><font color="#000000" style="background-color: rgb(0, 214, 136);">World</font>',
+    text: 'Plain text should be ignored when pasting as HTML.',
+  })
+  await press('Insert', { shift: true })
 
   const editable = await waitForEditable(
     '<span style="background-color: rgb(255, 136, 0);color: #000000;">Hello </span><span style="background-color: rgb(0, 214, 136);color: #000000;">World</span>',
@@ -65,8 +42,24 @@ it.skip('preserves pasted HTML as text/html with text color and background color
 
 it('escapes pasted HTML as text/plain', async () => {
   await press('Enter', { delay: 10 })
-  await pastePlainText('hello <b>world</b>')
+  await setClipboard({ text: 'hello <b>world</b>' })
+  await press('Insert', { shift: true })
 
   const editable = await waitForEditable('hello &lt;b&gt;world&lt;/b&gt;')
   expect(editable).toBeTruthy()
+})
+
+// https://github.com/cybersemics/em/issues/4730
+it('inserts a space immediately after an emoji pasted at the beginning of a thought', async () => {
+  await press('Enter')
+  await keyboard.type('Hello')
+  await waitForEditable('Hello')
+  await press('Home')
+  await setClipboard({ text: '🧠' })
+
+  await press('Insert', { shift: true })
+
+  await waitForEditingTextChange('Hello')
+  expect(await getEditingText()).toBe('🧠 Hello')
+  expect(await getSelection().focusOffset).toBe('🧠 '.length)
 })

--- a/src/e2e/puppeteer/helpers/setClipboard.ts
+++ b/src/e2e/puppeteer/helpers/setClipboard.ts
@@ -1,0 +1,18 @@
+import { page } from '../session'
+
+/** Loads plain text and optional HTML into the browser clipboard for a subsequent user paste action. */
+const setClipboard = async ({ html, text }: { html?: string; text: string }) => {
+  await page.evaluate(
+    async ({ html, text }) => {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/plain': new Blob([text], { type: 'text/plain' }),
+          ...(html ? { 'text/html': new Blob([html], { type: 'text/html' }) } : null),
+        }),
+      ])
+    },
+    { html, text },
+  )
+}
+
+export default setClipboard

--- a/src/e2e/puppeteer/helpers/waitForEditingTextChange.ts
+++ b/src/e2e/puppeteer/helpers/waitForEditingTextChange.ts
@@ -1,0 +1,11 @@
+import { page } from '../session'
+
+/** Waits for the current editable text to differ from the given value. */
+const waitForEditingTextChange = (previousValue: string) =>
+  page.waitForFunction(
+    previousValue => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML !== previousValue,
+    {},
+    previousValue,
+  )
+
+export default waitForEditingTextChange


### PR DESCRIPTION
#4730

## Summary

- normalize inline pasted content using the existing emoji-spacing behavior
- preserve the caret after the inserted space
- add real-browser clipboard regression coverage and shared Puppeteer helpers
- document the new Puppeteer helpers

## Root cause

Single-line clipboard content is routed through `importData` and `importText`, bypassing the normal emoji-spacing input path in `Editable`.

## Testing

- exact Chrome reproduction produced `🧠Hello` before the fix
- exact Chrome reproduction produced `🧠 Hello` with caret offset 3 after the fix