### PR TITLE
Run VirtualThought's size-release cleanup only on unmount

### DIFF
--- a/src/components/VirtualThought.tsx
+++ b/src/components/VirtualThought.tsx
@@ -9,6 +9,7 @@ import State from '../@types/State'
 import ThoughtId from '../@types/ThoughtId'
 import { getAutoscrollPadding } from '../device/preventAutoscroll'
 import useDelayedAutofocus from '../hooks/useDelayedAutofocus'
+import useFreshCallback from '../hooks/useFreshCallback'
 import useLayoutAnimationFrameEffect from '../hooks/useLayoutAnimationFrameEffect'
 import useSelectorEffect from '../hooks/useSelectorEffect'
 import { hasChildren } from '../selectors/getChildren'
@@ -220,15 +221,15 @@ const VirtualThought = ({
   }, [updateSize, value])
 
   // trigger onResize with null on unmount to allow subscribers to clean up
-  useEffect(
-    () => {
-      return () => {
-        onResize?.({ height: null, width: null, id: id, isVisible: true, key: crossContextualKey })
-      }
-    },
-    // these should be memoized and not change for the life of the component, so this is effectively componentWillUnmount
+  // onResize is not stable for the life of the component: TreeNode memoizes it on cliff, which changes whenever the
+  // thought's position in the tree changes. Listing it as a dependency would run the cleanup on every such change,
+  // momentarily dropping the thought's tracked size while it is still mounted. useFreshCallback keeps the reference
+  // stable so the cleanup is only run on unmount, while still calling the latest onResize.
+  const releaseSize = useFreshCallback(
+    () => onResize?.({ height: null, width: null, id: id, isVisible: true, key: crossContextualKey }),
     [crossContextualKey, onResize, id],
   )
+  useEffect(() => releaseSize, [releaseSize])
 
   return (
     <div


### PR DESCRIPTION
Follow-up to #4969, which fixed `useDelayedAutofocus` latching an `unmounted` ref in a cleanup that React re-runs on every dependency change. This is the same mistake in `VirtualThought`, found by auditing the codebase for it.

## Problem

[`VirtualThought`](https://github.com/cybersemics/em/blob/main/src/components/VirtualThought.tsx) releases its tracked size by calling `onResize({ height: null })` in an effect cleanup, annotated:

```ts
// these should be memoized and not change for the life of the component, so this is effectively componentWillUnmount
[crossContextualKey, onResize, id],
```

`onResize` is not stable. `TreeNode` memoizes it as `useCallback(props => setSize({ ...props, cliff }), [cliff, setSize])`, and `cliff` changes whenever a thought's position in the tree changes. React runs the cleanup before every such re-run, so a thought releases its size while still mounted.

Instrumenting the cleanup and adding a sibling (which changes the preceding thought's cliff):

```
=== adding sibling to a1 (changes cliff of a1) ===
CLEANUP-FIRED |_fHZM6U06I_ej stillInDOM= true
  removeSize |_fHZM6U06I_ej
  setSize    |_fHZM6U06I_ej 20
```

## Impact

**No user-visible bug today.** `updateSize`'s dependencies are a superset of this effect's, so its body re-adds the entry in the same passive-effect flush — the trace above shows the `removeSize`/`setSize` pair. What this PR removes is the churn (an in-place `delete` on the `sizes` state object, then a rebuild) and a live trap in the size-tracking path: any future change that breaks the superset relationship, or that makes the removal observable, turns this into a layout bug.

## Solution

Route the call through the existing `useFreshCallback` so the effect's dependency is stable and the cleanup runs only on unmount, while still invoking the latest `onResize`. The comment now describes why the indirection is needed instead of asserting a stability that does not hold.

## Verification

- Re-ran the instrumented trace: the mid-life fire is gone, and all four thoughts still fire on teardown (`stillInDOM= false`).
- `yarn lint:tsc`
- `eslint src/components/VirtualThought.tsx`
- Full unit suite: 1731 passed, 0 failed.

No regression test is included — the current behavior is self-healing, so there is nothing externally observable to assert without instrumenting internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
