### PR TITLE
Clarify hidden-thought shim cursor tests

### DIFF
--- a/src/e2e/puppeteer/__tests__/cursor.ts
+++ b/src/e2e/puppeteer/__tests__/cursor.ts
@@ -10,8 +10,8 @@ import waitUntil from '../helpers/waitUntil'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
-/** Returns the persistent tree node that contains the editable with the given value. */
-const getTreeNode = async (value: string) => {
+/** Captures the outer tree node before autofocus replaces its editable with a height shim. */
+const captureTreeNode = async (value: string) => {
   const editable = (await waitForEditable(value)).asElement()
   if (!editable) throw new Error(`Editable "${value}" not found.`)
 
@@ -97,7 +97,7 @@ it('set the cursor on the cursor grandparent', async () => {
   expect(thoughtValue).toBe('a')
 })
 
-it('do nothing when clicking on a hidden ancestor', async () => {
+it('do nothing when clicking on a hidden ancestor shim', async () => {
   const importText = `
   - a
     - b
@@ -105,7 +105,7 @@ it('do nothing when clicking on a hidden ancestor', async () => {
         - d`
   await paste(importText)
   await waitForEditable('d')
-  const ancestorTreeNode = await getTreeNode('a')
+  const ancestorTreeNode = await captureTreeNode('a')
   await clickThought('d')
   await ancestorTreeNode.waitForSelector('[data-editable]', { hidden: true })
   await click(ancestorTreeNode)
@@ -114,7 +114,7 @@ it('do nothing when clicking on a hidden ancestor', async () => {
   expect(thoughtValue).toBe('d')
 })
 
-it('do nothing when clicking on a hidden great uncle', async () => {
+it('do nothing when clicking on a hidden great uncle shim', async () => {
   const importText = `
   - a
     - b
@@ -122,7 +122,7 @@ it('do nothing when clicking on a hidden great uncle', async () => {
   - d`
   await paste(importText)
 
-  const greatUncleTreeNode = await getTreeNode('d')
+  const greatUncleTreeNode = await captureTreeNode('d')
 
   // click a to expand b and c
   await waitForEditable('a')


### PR DESCRIPTION
Follow-up to #4969.

## Summary

This is a naming-only test cleanup with no runtime behavior change.

- Rename `getTreeNode` to `captureTreeNode` to make its timing contract explicit.
- Clarify that the helper captures the outer tree node before autofocus replaces its editable with a height shim.
- Name the two cursor tests after the hidden shim they click.

The captured outer node remains mounted to preserve layout after its inner `[data-editable]` is removed. Retaining its handle lets the tests wait for that exact editable to disappear and then verify with a real pointer click that the shim remains a no-op zone.

## Verification

- `src/e2e/puppeteer/__tests__/cursor.ts`: 8/8 passed
- `yarn lint:tsc --pretty false`
- `git diff --check`
