### PR TITLE
Fix cursorless Generate Thought test setup

### DIFF
--- a/src/commands/__tests__/generateThought.ts
+++ b/src/commands/__tests__/generateThought.ts
@@ -1,5 +1,4 @@
 import { act } from 'react'
-import { cursorBackActionCreator as cursorBack } from '../../actions/cursorBack'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommand, executeCommandWithMulticursor } from '../../commands'
@@ -509,11 +508,9 @@ describe('multicursor', () => {
           - b
         `,
       }),
-      setCursor(['a']),
+      setCursor(null),
       addMulticursor(['a']),
       addMulticursor(['b']),
-      // Back on a top-level thought clears the cursor and preserves the multicursor.
-      cursorBack(),
     ])
 
     // The keydown handler gates execution on canExecute against the real state, so a cursorless multiselect would not


### PR DESCRIPTION
## Problem

#4936 added a cursorless-multiselect test that calls `cursorBack()` after creating the multicursor selection. #4938 merged first and changed Back to operate on the multicursor selection; for root-level selections it intentionally does nothing, so the hidden cursor remains set.

This causes the current `main` Test workflow and unrelated PRs such as #4972 to fail at the same assertion:

- [current `main` failure](https://github.com/cybersemics/em/actions/runs/32061411757)
- [#4972 failure](https://github.com/cybersemics/em/actions/runs/32074651847)

## Solution

Construct the supported cursorless multiselect directly with `setCursor(null)` before adding the multicursors. This keeps the test focused on Generate Thought rather than depending on Back semantics.

## Verification

- `yarn test --run src/commands/__tests__/generateThought.ts` — 14/14 passed
- `yarn eslint src/commands/__tests__/generateThought.ts`
- `yarn prettier --check src/commands/__tests__/generateThought.ts`
- `yarn lint:tsc --pretty false`