### PR TITLE
feat(ci): file deduplicated tracking issues for flaky puppeteer tests

### DIFF
--- a/.github/workflows/puppeteer-flaky.yml
+++ b/.github/workflows/puppeteer-flaky.yml
@@ -15,6 +15,9 @@
 # Reports:
 #   - Workflow summary
 #   - Optional Discord notification (flakes/infra failures only)
+#   - A tracking issue per intermittently failing test (labelled `test`),
+#     deduplicated against open issues by exact title match. Tests that fail
+#     every iteration are regressions, not flakes, and are not filed.
 #
 # To enable Discord notifications, add a `DISCORD_WEBHOOK_URL` repository secret.
 
@@ -275,6 +278,91 @@ jobs:
             -d "$CONTENT" \
             "$DISCORD_WEBHOOK_URL"
           echo "Discord notification sent."
+
+      # File one tracking issue per intermittently failing test, matching the repo's existing
+      # convention: title `Flaky test: <file> > <full name>`, label `test`.
+      # Deduplicated by exact title match against all open issues, so nightly
+      # runs are idempotent and human-filed issues are respected.
+      - name: File tracking issues
+        if: steps.aggregate.outputs.clean != 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs')
+            const { owner, repo } = context.repo
+
+            // Cap issue creation per run so a catastrophic run (e.g. main broken,
+            // every suite failing) cannot flood the tracker. Dedupe makes the
+            // next run pick up any overflow that is still failing.
+            const MAX_NEW_ISSUES = 10
+
+            const summaryFile = 'flaky-results/flaky-summary.json'
+            if (!fs.existsSync(summaryFile)) {
+              // Aggregator crashed before writing a summary; the Discord step
+              // already reports that case and there is no per-test data to file.
+              core.info('No flaky-summary.json; skipping issue filing.')
+              return
+            }
+            const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'))
+            // Only intermittent failures are flakes. A test that failed every
+            // iteration is a consistent failure (i.e. a regression) and is
+            // reported to Discord and the job summary, but not filed as a flake.
+            const flakes = (summary.failedTests || []).filter(t => t.failed > 0 && t.failed < t.of)
+            if (flakes.length === 0) {
+              core.info('No intermittent failures; skipping issue filing.')
+              return
+            }
+
+            /** Issue title for a failed test, matching the existing manual convention (see e.g. #4640). */
+            const issueTitle = t => {
+              // File-load failures embed a truncated error message in fullName,
+              // which varies run-to-run; normalize so the title dedupes stably.
+              const name = t.fullName.startsWith('(file load') ? '(file load failure)' : t.fullName
+              const file = t.file.split('/').pop()
+              // GitHub caps titles at 256 characters.
+              return `Flaky test: ${file} > ${name}`.slice(0, 256)
+            }
+
+            // Exact-title dedupe against all open issues. listForRepo includes
+            // PRs; filter them out.
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })
+            const openTitles = new Set(openIssues.filter(i => !i.pull_request).map(i => i.title))
+
+            let created = 0
+            for (const t of flakes) {
+              const title = issueTitle(t)
+              if (openTitles.has(title)) {
+                core.info(`Open issue already exists, skipping: ${title}`)
+                continue
+              }
+              if (created >= MAX_NEW_ISSUES) {
+                core.warning(
+                  `Issue cap (${MAX_NEW_ISSUES}) reached; not filing an issue for: ${title}. ` +
+                    'It will be filed by a later run if it is still failing.',
+                )
+                continue
+              }
+              const body = [
+                `Automatically filed by the [Puppeteer Flaky workflow](${process.env.RUN_URL}).`,
+                '',
+                `- **File**: \`${t.file}\``,
+                `- **Test**: ${t.fullName}`,
+                `- **Failed**: ${t.failed}/${t.of} iterations (iterations: ${t.iterations.join(', ')})`,
+                ...(t.firstError ? ['', '**First error**:', '', '```', t.firstError, '```'] : []),
+              ].join('\n')
+              await github.rest.issues.create({ owner, repo, title, body, labels: ['test'] })
+              openTitles.add(title)
+              created++
+              core.info(`Filed issue: ${title}`)
+            }
+            core.info(`Filed ${created} new issue(s); ${flakes.length - created} already tracked or capped.`)
 
       - name: Fail job when flakes or infra failures found
         if: steps.aggregate.outputs.clean != 'true'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -973,6 +973,10 @@ https://github.com/cybersemics/em/pull/2741
 
 In a rendered JSDOM test, wrap timer advancement that causes React updates in `act`.
 
+### Automated flaky-test detection
+
+The `Puppeteer Flaky` workflow (`.github/workflows/puppeteer-flaky.yml`) stress-runs the full Puppeteer suite nightly on `main` (15 iterations by default; `gh workflow run puppeteer-flaky.yml -f iterations=5` to run manually). `scripts/flaky-report.mjs` aggregates the Vitest JSON reports into a workflow summary that distinguishes intermittent failures (likely flakes) from consistent ones (likely regressions). When failures are found, the workflow sends a Discord notification (if the `DISCORD_WEBHOOK_URL` repository secret is set) and files a tracking issue for each **intermittently** failing test — titled `Flaky test: <file> > <full name>`, labelled `test`, and deduplicated by exact title match against open issues, so a test that is already tracked is not re-filed. A test that fails every iteration is a consistent failure rather than a flake; it appears in the summary and the Discord alert but is not filed as an issue.
+
 ### Triggering GitHub Actions workflows manually
 
 In the event of a flaky GitHub Actions workflow, it can be useful to manually trigger multiple runs to flush out failures. The following shell function can be used to automate this process:


### PR DESCRIPTION
Follow-up to #4785.

The nightly Puppeteer stress run reported flakes to the workflow summary and Discord only. A flake found overnight left no durable trail, and the workflow's own failure message — "see the job summary and tracking issue" — pointed at a tracking issue that was never created.

This adds a `File tracking issues` step to the `report` job that files one GitHub issue per flaky test, skipping tests that already have an open issue.

## What changed

**`.github/workflows/puppeteer-flaky.yml`** — new step after `Notify Discord`, gated on the same `clean != 'true'` condition, using `actions/github-script` pinned to the same SHA as `puppeteer-diff-comment.yml`. It consumes the `flaky-summary.json` the aggregator already writes, so **`scripts/flaky-report.mjs` is unchanged** — it stays a pure aggregator rather than gaining API side effects.

**`docs/testing.md`** — new "Automated flaky-test detection" subsection. `grep` across `docs/` found no mention of this workflow at all, so #4785 landed undocumented; this closes that gap too.

## Design notes for reviewers

**Titles match the convention already in use.** Four open issues were filed by hand as `Flaky test: gestures.ts > chaining commands > chained command`, labelled `test` (#4640, #4618, #4709, #4214). The step reproduces that format exactly, so auto-filed and human-filed issues dedupe against each other in both directions. The `test` label is also load-bearing for tooling — `docs/agents/skills.md` documents that the diagnosis skill "checks the project's open issues labelled test for known cases."

**Dedupe lists open issues rather than using the search API.** Search is eventually consistent, so a just-filed issue can be invisible minutes later and get re-filed on the next run. Comparing titles against a paginated list (611 open issues, ~7 pages) is deterministic. `listForRepo` returns PRs too, so those are filtered out.

**Only intermittent failures are filed** (`failed > 0 && failed < of`). A test that fails every iteration is a regression, not a flake — it still appears in the job summary under "Consistent failures (likely regressions)" and in the Discord alert, but gets no issue. The predicate is numeric rather than reading the aggregator's `kind` string so it scales with the `iterations` input: a manual `-f iterations=5` run correctly treats 5/5 as consistent.

**Two guards not strictly required by the feature**, both to keep it from misbehaving:

- **Cap of 10 new issues per run.** If `main` breaks and every suite fails, uncapped filing would dump dozens of issues into the tracker. Overflow logs a warning and is filed by a later run if still failing.
- **Normalized titles for file-load failures.** The aggregator synthesizes those names as `` `(file load) ${truncate(message, 80)}` ``, embedding error text that varies between runs — which would defeat dedupe and file a fresh issue nightly. The title normalizes to `(file load failure)`; the full message stays in the body. Note that a *permanently* broken import fails 15/15 and is therefore filtered out as consistent; this normalization only matters for load failures that are themselves intermittent.

## Verification

The step's script was run against stubbed octokit and summary fixtures, not just read:

- an all-consistent run (15/15) files nothing and returns early
- in a mixed run, 15/15 is skipped while 1/15 and 14/15 are filed; both boundaries behave
- a 5-iteration run skips 5/5 and files 4/5
- a test with an existing open issue is skipped; a PR with a colliding title does not suppress filing
- the cap trips at 10 with warnings
- both early-return paths (no `flaky-summary.json`, infra-failures-only) file nothing

`actionlint` reports the same single pre-existing `SC2129` style warning as `main` and nothing new; Prettier is clean.

**Not verified:** the end-to-end path against the live GitHub API — the first scheduled run is the real test. Reviewers may prefer to trigger `gh workflow run puppeteer-flaky.yml -f iterations=5` once after merge and watch what lands in the tracker.

**Known limit:** two tests sharing both a basename and a full name would collapse into one issue. This matches the existing manual convention, which also keys on basename.

Co-Authored-By: Claude Opus 5 (unknown context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
