### PR TITLE
refactor(ci): move embedded workflow scripts into scripts/ci/

### DIFF
--- a/.github/workflows/puppeteer-diff-comment.yml
+++ b/.github/workflows/puppeteer-diff-comment.yml
@@ -9,7 +9,8 @@
 #
 # SECURITY: the triggering run's artifacts are produced by untrusted fork code, so
 # every value read from them is untrusted input. This job therefore:
-#   - never checks out or executes PR code (data only);
+#   - checks out only the base repo's own code, never the PR's, and executes none of the
+#     triggering run's code (its artifacts are data only);
 #   - uses least-privilege permissions;
 #   - verifies the PR head sha matches the workflow_run head sha (anti-spoofing);
 #   - safely extracts artifacts (no path traversal, PNG-only, size/count caps);
@@ -42,6 +43,15 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
 
     steps:
+      # workflow_run resolves `github.ref` to the default branch, so this checks out the base
+      # repo's own code — never the PR's — solely to make scripts/ci/ available to the
+      # github-script steps below. It must precede the artifact download, which lands untrusted
+      # data in the same workspace that checkout cleans.
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       # Download ALL artifacts from the triggering run. Cross-run download requires
       # run-id + github-token. pr-number is always present for PR runs; __diff_output__
       # is present only when a snapshot test failed.
@@ -59,32 +69,7 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
-            const fs = require('fs')
-            const file = 'artifacts/pr-number/pr-number.txt'
-            if (!fs.existsSync(file)) {
-              core.info('No pr-number artifact found; nothing to do.')
-              return
-            }
-            const raw = fs.readFileSync(file, 'utf8').trim()
-            if (!/^[0-9]+$/.test(raw)) {
-              core.setFailed(`Refusing to proceed: pr-number artifact is not a plain integer (${JSON.stringify(raw)}).`)
-              return
-            }
-            const prNumber = Number(raw)
-            const headSha = context.payload.workflow_run.head_sha
-            const { owner, repo } = context.repo
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
-            // Anti-spoofing: the PR the images claim to belong to must be the one
-            // whose head commit actually triggered the test run.
-            if (pr.head.sha !== headSha) {
-              core.setFailed(
-                `Aborting: PR #${prNumber} head sha ${pr.head.sha} does not match the ` +
-                  `workflow_run head sha ${headSha}. This likely indicates a spoofed pr-number artifact.`,
-              )
-              return
-            }
-            core.setOutput('number', String(prNumber))
-            core.setOutput('author', pr.user ? pr.user.login : '')
+            await require('./scripts/ci/resolve-diff-pr.cjs')({ github, context, core })
 
       # Safely stage diff PNGs, host them on the snapshot-diffs orphan branch, and
       # emit a manifest for the comment step. Only this PR's folder is touched; on
@@ -206,69 +191,4 @@ jobs:
           COLLECTED: ${{ steps.publish.outputs.collected }}
         with:
           script: |
-            const fs = require('fs')
-            const { owner, repo } = context.repo
-            const marker = '<!-- puppeteer-diff -->'
-            const prNumber = Number(process.env.PR)
-            const runId = process.env.RUN_ID
-            const runUrl = process.env.RUN_URL
-            const author = process.env.AUTHOR
-            const collected = Number(process.env.COLLECTED || '0')
-
-            // HTML-escape defensively (filenames are already allowlisted upstream).
-            const esc = s =>
-              String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c])
-
-            let body
-            if (collected > 0) {
-              const manifest = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/committed-images.txt`, 'utf8')
-              const rels = manifest.split('\n').map(l => l.trim()).filter(Boolean)
-              const base = `https://raw.githubusercontent.com/${owner}/${repo}/snapshot-diffs/pr-${prNumber}/${runId}`
-              const blocks = rels
-                .map(rel => {
-                  const url = `${base}/${rel.split('/').map(encodeURIComponent).join('/')}`
-                  const label = esc(rel.replace('/__diff_output__/', ' / '))
-                  return `**${label}**\n\n<img src="${url}" alt="${label}" width="900" />`
-                })
-                .join('\n\n')
-              const authorMention = author ? `@${esc(author)}` : ''
-              // The first path segment of each diff is the test file name (snapshots live in
-              // __image_snapshots__/{testFile}/). Derive the unique set to emit a single
-              // targeted update command scoped to the affected test files.
-              const testFiles = [...new Set(rels.map(rel => rel.split('/')[0]))].filter(Boolean).sort()
-              const updateCommand = `yarn test:puppeteer -u ${testFiles.map(esc).join(' ')}`
-              body = [
-                marker,
-                '### 🖼️ Puppeteer snapshot diffs',
-                '',
-                `${authorMention}: These snapshot tests failed, which indicates a visual regression. Please review your changes. If the visual changes are intentional, update the snapshots for the affected test files:`,
-                '',
-                `\`\`\`\n${updateCommand}\n\`\`\``,
-                '',
-                `<details open><summary>${rels.length} broken snapshot${rels.length === 1 ? '' : 's'}</summary>`,
-                '',
-                `Left: Expected (base branch) | Right: Actual (PR branch)`,
-                blocks,
-                '',
-                '</details>',
-                '',
-                `[View workflow run](${runUrl})`,
-              ].join('\n')
-            } else {
-              body = [
-                marker,
-                '### 🖼️ Puppeteer snapshot diffs',
-                '',
-                `✅ No snapshot diffs in the latest run (${runId}). Any previously reported diffs have been cleared.`,
-                '',
-                `[View workflow run](${runUrl})`,
-              ].join('\n')
-            }
-
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber })
-            const existing = comments.find(c => c.body && c.body.includes(marker))
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body })
-            }
+            await require('./scripts/ci/upsert-diff-comment.cjs')({ github, context })

--- a/.github/workflows/puppeteer-flaky.yml
+++ b/.github/workflows/puppeteer-flaky.yml
@@ -212,19 +212,7 @@ jobs:
 
           cat report.md >> "$GITHUB_STEP_SUMMARY"
 
-          if [ -f flaky-results/flaky-summary.json ]; then
-            CLEAN=$(node -e "console.log(JSON.parse(require('fs').readFileSync('flaky-results/flaky-summary.json','utf8')).clean)")
-            FLAKE_COUNT=$(node -e "const s=JSON.parse(require('fs').readFileSync('flaky-results/flaky-summary.json','utf8')); console.log(s.failedTestCount ?? s.flakeCount ?? 0)")
-            INFRA_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('flaky-results/flaky-summary.json','utf8')).infraFailureCount)")
-          else
-            CLEAN=false
-            FLAKE_COUNT=0
-            INFRA_COUNT=1
-          fi
-
-          echo "clean=$CLEAN" >> "$GITHUB_OUTPUT"
-          echo "flake_count=$FLAKE_COUNT" >> "$GITHUB_OUTPUT"
-          echo "infra_count=$INFRA_COUNT" >> "$GITHUB_OUTPUT"
+          node scripts/ci/flaky-outputs.mjs flaky-results/flaky-summary.json >> "$GITHUB_OUTPUT"
           echo "aggregate_exit=$STATUS" >> "$GITHUB_OUTPUT"
 
       - name: Notify Discord
@@ -241,37 +229,7 @@ jobs:
             exit 0
           fi
 
-          if [ ! -f flaky-results/flaky-summary.json ]; then
-            CONTENT=$(node -e "
-              process.stdout.write(JSON.stringify({
-                content: [
-                  '**Puppeteer flaky-test alert**',
-                  'Aggregator failed before producing a summary.',
-                  process.env.RUN_URL,
-                ].join('\\n'),
-              }))
-            ")
-          else
-            TOP=$(node -e "
-              const s = JSON.parse(require('fs').readFileSync('flaky-results/flaky-summary.json','utf8'))
-              const lines = (s.topOffenders || []).map(t =>
-                '• ' + t.file + ' › ' + t.fullName + ' — failed ' + t.failed + '/' + t.of
-              )
-              process.stdout.write(lines.join('\\n') || '(none)')
-            ")
-            CONTENT=$(node -e "
-              const text = [
-                '**Puppeteer flaky-test alert**',
-                'Failing tests: ' + process.env.FLAKE_COUNT + ' | Infra failures: ' + process.env.INFRA_COUNT,
-                '',
-                'Top offenders:',
-                process.argv[1],
-                '',
-                process.env.RUN_URL,
-              ].join('\\n')
-              process.stdout.write(JSON.stringify({ content: text.slice(0, 1900) }))
-            " "$TOP")
-          fi
+          CONTENT=$(node scripts/ci/flaky-discord-payload.mjs flaky-results/flaky-summary.json)
 
           curl -sS -f -X POST \
             -H 'Content-Type: application/json' \
@@ -279,10 +237,7 @@ jobs:
             "$DISCORD_WEBHOOK_URL"
           echo "Discord notification sent."
 
-      # File one tracking issue per intermittently failing test, matching the repo's existing
-      # convention: title `Flaky test: <file> > <full name>`, label `test`.
-      # Deduplicated by exact title match against all open issues, so nightly
-      # runs are idempotent and human-filed issues are respected.
+      # See scripts/ci/file-flaky-issues.cjs for what gets filed and how it is deduplicated.
       - name: File tracking issues
         if: steps.aggregate.outputs.clean != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -290,79 +245,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const fs = require('fs')
-            const { owner, repo } = context.repo
-
-            // Cap issue creation per run so a catastrophic run (e.g. main broken,
-            // every suite failing) cannot flood the tracker. Dedupe makes the
-            // next run pick up any overflow that is still failing.
-            const MAX_NEW_ISSUES = 10
-
-            const summaryFile = 'flaky-results/flaky-summary.json'
-            if (!fs.existsSync(summaryFile)) {
-              // Aggregator crashed before writing a summary; the Discord step
-              // already reports that case and there is no per-test data to file.
-              core.info('No flaky-summary.json; skipping issue filing.')
-              return
-            }
-            const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'))
-            // Only intermittent failures are flakes. A test that failed every
-            // iteration is a consistent failure (i.e. a regression) and is
-            // reported to Discord and the job summary, but not filed as a flake.
-            const flakes = (summary.failedTests || []).filter(t => t.failed > 0 && t.failed < t.of)
-            if (flakes.length === 0) {
-              core.info('No intermittent failures; skipping issue filing.')
-              return
-            }
-
-            /** Issue title for a failed test, matching the existing manual convention (see e.g. #4640). */
-            const issueTitle = t => {
-              // File-load failures embed a truncated error message in fullName,
-              // which varies run-to-run; normalize so the title dedupes stably.
-              const name = t.fullName.startsWith('(file load') ? '(file load failure)' : t.fullName
-              const file = t.file.split('/').pop()
-              // GitHub caps titles at 256 characters.
-              return `Flaky test: ${file} > ${name}`.slice(0, 256)
-            }
-
-            // Exact-title dedupe against all open issues. listForRepo includes
-            // PRs; filter them out.
-            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
-              owner,
-              repo,
-              state: 'open',
-              per_page: 100,
-            })
-            const openTitles = new Set(openIssues.filter(i => !i.pull_request).map(i => i.title))
-
-            let created = 0
-            for (const t of flakes) {
-              const title = issueTitle(t)
-              if (openTitles.has(title)) {
-                core.info(`Open issue already exists, skipping: ${title}`)
-                continue
-              }
-              if (created >= MAX_NEW_ISSUES) {
-                core.warning(
-                  `Issue cap (${MAX_NEW_ISSUES}) reached; not filing an issue for: ${title}. ` +
-                    'It will be filed by a later run if it is still failing.',
-                )
-                continue
-              }
-              const body = [
-                `Automatically filed by the [Puppeteer Flaky workflow](${process.env.RUN_URL}).`,
-                '',
-                `- **File**: \`${t.file}\``,
-                `- **Test**: ${t.fullName}`,
-                `- **Failed**: ${t.failed}/${t.of} iterations (iterations: ${t.iterations.join(', ')})`,
-                ...(t.firstError ? ['', '**First error**:', '', '```', t.firstError, '```'] : []),
-              ].join('\n')
-              await github.rest.issues.create({ owner, repo, title, body, labels: ['test'] })
-              openTitles.add(title)
-              created++
-              core.info(`Filed issue: ${title}`)
-            }
-            core.info(`Filed ${created} new issue(s); ${flakes.length - created} already tracked or capped.`)
+            await require('./scripts/ci/file-flaky-issues.cjs')({ github, context, core })
 
       - name: Fail job when flakes or infra failures found
         if: steps.aggregate.outputs.clean != 'true'

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -86,6 +86,10 @@ jobs:
       # box (and under repo Environments) rather than as a bot comment. Superseded
       # deployments are automatically marked inactive, so stale preview URLs on older
       # commits are visibly greyed out.
+      #
+      # Kept inline rather than extracted to scripts/ci/ like the other github-script bodies: this
+      # workflow is pull_request_target and checks out the PR head, so a workspace file would be
+      # fork-controlled code running against the base repo's write token.
       - name: Create deployment
         id: deployment
         uses: actions/github-script@v7

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -227,6 +227,22 @@ export default [
       'no-restricted-globals': 0,
     },
   },
+  // actions/github-script evaluates its `script:` body in a CommonJS context and resolves relative
+  // require() paths against the workspace, so the scripts it loads must be CommonJS. package.json
+  // sets "type": "module", hence the .cjs extension.
+  {
+    files: ['**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        module: 'writable',
+        process: 'readonly',
+        require: 'readonly',
+      },
+    },
+  },
   // A constants module is a collection of peer values with no primary export, so there is no
   // meaningful default export to prefer. Named exports keep them individually tree-shakeable and
   // importable by name.

--- a/scripts/ci/file-flaky-issues.cjs
+++ b/scripts/ci/file-flaky-issues.cjs
@@ -1,0 +1,91 @@
+/**
+ * Files one tracking issue per intermittently failing Puppeteer test, matching the repo's existing
+ * convention: title `Flaky test: <file> > <full name>`, label `test`. Deduplicated by exact title
+ * match against all open issues, so nightly runs are idempotent and human-filed issues are
+ * respected.
+ *
+ * Loaded by the `File tracking issues` step of .github/workflows/puppeteer-flaky.yml through
+ * actions/github-script. Reads flaky-results/flaky-summary.json (written by
+ * scripts/flaky-report.mjs) and RUN_URL from the environment.
+ */
+const fs = require('node:fs')
+
+// Cap issue creation per run so a catastrophic run (e.g. main broken, every suite failing) cannot
+// flood the tracker. Dedupe makes the next run pick up any overflow that is still failing.
+const MAX_NEW_ISSUES = 10
+
+const SUMMARY_FILE = 'flaky-results/flaky-summary.json'
+
+/** Issue title for a failed test, matching the existing manual convention (see e.g. #4640). */
+const issueTitle = t => {
+  // File-load failures embed a truncated error message in fullName, which varies run-to-run;
+  // normalize so the title dedupes stably.
+  const name = t.fullName.startsWith('(file load') ? '(file load failure)' : t.fullName
+  const file = t.file.split('/').pop()
+  // GitHub caps titles at 256 characters.
+  return `Flaky test: ${file} > ${name}`.slice(0, 256)
+}
+
+/** Issue body for a failed test, linking back to the run that detected it. */
+const issueBody = t =>
+  [
+    `Automatically filed by the [Puppeteer Flaky workflow](${process.env.RUN_URL}).`,
+    '',
+    `- **File**: \`${t.file}\``,
+    `- **Test**: ${t.fullName}`,
+    `- **Failed**: ${t.failed}/${t.of} iterations (iterations: ${t.iterations.join(', ')})`,
+    ...(t.firstError ? ['', '**First error**:', '', '```', t.firstError, '```'] : []),
+  ].join('\n')
+
+/** Files a deduplicated tracking issue for each intermittently failing test in the run summary. */
+const fileFlakyIssues = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo
+
+  if (!fs.existsSync(SUMMARY_FILE)) {
+    // Aggregator crashed before writing a summary; the Discord step already reports that case and
+    // there is no per-test data to file.
+    core.info('No flaky-summary.json; skipping issue filing.')
+    return
+  }
+  const summary = JSON.parse(fs.readFileSync(SUMMARY_FILE, 'utf8'))
+  // Only intermittent failures are flakes. A test that failed every iteration is a consistent
+  // failure (i.e. a regression) and is reported to Discord and the job summary, but not filed as a
+  // flake.
+  const flakes = (summary.failedTests || []).filter(t => t.failed > 0 && t.failed < t.of)
+  if (flakes.length === 0) {
+    core.info('No intermittent failures; skipping issue filing.')
+    return
+  }
+
+  // Exact-title dedupe against all open issues. listForRepo includes PRs; filter them out.
+  const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'open',
+    per_page: 100,
+  })
+  const openTitles = new Set(openIssues.filter(i => !i.pull_request).map(i => i.title))
+
+  let created = 0
+  for (const t of flakes) {
+    const title = issueTitle(t)
+    if (openTitles.has(title)) {
+      core.info(`Open issue already exists, skipping: ${title}`)
+      continue
+    }
+    if (created >= MAX_NEW_ISSUES) {
+      core.warning(
+        `Issue cap (${MAX_NEW_ISSUES}) reached; not filing an issue for: ${title}. ` +
+          'It will be filed by a later run if it is still failing.',
+      )
+      continue
+    }
+    await github.rest.issues.create({ owner, repo, title, body: issueBody(t), labels: ['test'] })
+    openTitles.add(title)
+    created++
+    core.info(`Filed issue: ${title}`)
+  }
+  core.info(`Filed ${created} new issue(s); ${flakes.length - created} already tracked or capped.`)
+}
+
+module.exports = fileFlakyIssues

--- a/scripts/ci/flaky-discord-payload.mjs
+++ b/scripts/ci/flaky-discord-payload.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Builds the Discord webhook JSON payload for a Puppeteer flaky-stress run and writes it to stdout.
+ * Used by the `Notify Discord` step of .github/workflows/puppeteer-flaky.yml.
+ *
+ * ```sh
+ * node scripts/ci/flaky-discord-payload.mjs <flaky-summary.json>
+ * ```
+ *
+ * A missing summary file means the aggregator crashed before producing one, which gets its own
+ * short payload. Reads RUN_URL, FLAKE_COUNT, and INFRA_COUNT from the environment.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+
+// Discord caps message content at 2000 characters; leave headroom for the closing run URL.
+const MAX_CONTENT = 1900
+
+const HEADING = '**Puppeteer flaky-test alert**'
+
+const summaryFile = process.argv[2]
+if (!summaryFile) {
+  console.error('usage: node scripts/ci/flaky-discord-payload.mjs <flaky-summary.json>')
+  process.exit(2)
+}
+
+/** Renders the top offenders as one bullet per failing test. */
+const topOffenders = summary =>
+  (summary.topOffenders || []).map(t => `• ${t.file} › ${t.fullName} — failed ${t.failed}/${t.of}`).join('\n') ||
+  '(none)'
+
+const content = !existsSync(summaryFile)
+  ? [HEADING, 'Aggregator failed before producing a summary.', process.env.RUN_URL].join('\n')
+  : [
+      HEADING,
+      `Failing tests: ${process.env.FLAKE_COUNT} | Infra failures: ${process.env.INFRA_COUNT}`,
+      '',
+      'Top offenders:',
+      topOffenders(JSON.parse(readFileSync(summaryFile, 'utf8'))),
+      '',
+      process.env.RUN_URL,
+    ].join('\n')
+
+process.stdout.write(JSON.stringify({ content: content.slice(0, MAX_CONTENT) }))

--- a/scripts/ci/flaky-outputs.mjs
+++ b/scripts/ci/flaky-outputs.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Translates a flaky-summary.json into `key=value` step outputs on stdout, for appending to
+ * $GITHUB_OUTPUT. Used by the `Aggregate flaky-test report` step of
+ * .github/workflows/puppeteer-flaky.yml.
+ *
+ * ```sh
+ * node scripts/ci/flaky-outputs.mjs <flaky-summary.json> >> "$GITHUB_OUTPUT"
+ * ```
+ *
+ * A missing summary file means the aggregator crashed before producing one, which is reported as a
+ * single infra failure so the workflow still notifies and fails.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+
+const summaryFile = process.argv[2]
+if (!summaryFile) {
+  console.error('usage: node scripts/ci/flaky-outputs.mjs <flaky-summary.json>')
+  process.exit(2)
+}
+
+const summary = existsSync(summaryFile)
+  ? JSON.parse(readFileSync(summaryFile, 'utf8'))
+  : { clean: false, failedTestCount: 0, infraFailureCount: 1 }
+
+process.stdout.write(
+  [
+    `clean=${summary.clean}`,
+    `flake_count=${summary.failedTestCount ?? summary.flakeCount ?? 0}`,
+    `infra_count=${summary.infraFailureCount}`,
+    '',
+  ].join('\n'),
+)

--- a/scripts/ci/resolve-diff-pr.cjs
+++ b/scripts/ci/resolve-diff-pr.cjs
@@ -1,0 +1,42 @@
+/**
+ * Resolves the PR number from the `pr-number` artifact uploaded by the Puppeteer workflow and
+ * verifies it against the workflow_run head sha, so a crafted pr-number.txt cannot target another
+ * PR.
+ *
+ * Loaded by the `Resolve and verify PR number` step of
+ * .github/workflows/puppeteer-diff-comment.yml through actions/github-script. Sets the `number` and
+ * `author` step outputs, or fails the step when the artifact is untrustworthy.
+ */
+const fs = require('node:fs')
+
+const PR_NUMBER_FILE = 'artifacts/pr-number/pr-number.txt'
+
+/** Resolves and verifies the PR the downloaded diff artifacts belong to. */
+const resolveDiffPr = async ({ github, context, core }) => {
+  if (!fs.existsSync(PR_NUMBER_FILE)) {
+    core.info('No pr-number artifact found; nothing to do.')
+    return
+  }
+  const raw = fs.readFileSync(PR_NUMBER_FILE, 'utf8').trim()
+  if (!/^[0-9]+$/.test(raw)) {
+    core.setFailed(`Refusing to proceed: pr-number artifact is not a plain integer (${JSON.stringify(raw)}).`)
+    return
+  }
+  const prNumber = Number(raw)
+  const headSha = context.payload.workflow_run.head_sha
+  const { owner, repo } = context.repo
+  const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
+  // Anti-spoofing: the PR the images claim to belong to must be the one whose head commit actually
+  // triggered the test run.
+  if (pr.head.sha !== headSha) {
+    core.setFailed(
+      `Aborting: PR #${prNumber} head sha ${pr.head.sha} does not match the ` +
+        `workflow_run head sha ${headSha}. This likely indicates a spoofed pr-number artifact.`,
+    )
+    return
+  }
+  core.setOutput('number', String(prNumber))
+  core.setOutput('author', pr.user ? pr.user.login : '')
+}
+
+module.exports = resolveDiffPr

--- a/scripts/ci/upsert-diff-comment.cjs
+++ b/scripts/ci/upsert-diff-comment.cjs
@@ -1,0 +1,95 @@
+/**
+ * Upserts the Puppeteer snapshot-diff PR comment. Renders diffs inline from fixed raw URLs on the
+ * `snapshot-diffs` branch, or a resolved message when the latest run had no diffs.
+ *
+ * Loaded by the `Upsert PR comment` step of .github/workflows/puppeteer-diff-comment.yml through
+ * actions/github-script. Reads the manifest written by the publish step, plus PR, AUTHOR, RUN_ID,
+ * RUN_URL, and COLLECTED from the environment.
+ */
+const fs = require('node:fs')
+
+const MARKER = '<!-- puppeteer-diff -->'
+
+const HEADING = '### 🖼️ Puppeteer snapshot diffs'
+
+/** HTML-escapes a string defensively (filenames are already allowlisted upstream). */
+const esc = s =>
+  String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c])
+
+/** Comment body listing every diff image inline, with the command to update the affected snapshots. */
+const diffBody = ({ rels, base, author, runUrl }) => {
+  const blocks = rels
+    .map(rel => {
+      const url = `${base}/${rel.split('/').map(encodeURIComponent).join('/')}`
+      const label = esc(rel.replace('/__diff_output__/', ' / '))
+      return `**${label}**\n\n<img src="${url}" alt="${label}" width="900" />`
+    })
+    .join('\n\n')
+  const authorMention = author ? `@${esc(author)}` : ''
+  // The first path segment of each diff is the test file name (snapshots live in
+  // __image_snapshots__/{testFile}/). Derive the unique set to emit a single targeted update
+  // command scoped to the affected test files.
+  const testFiles = [...new Set(rels.map(rel => rel.split('/')[0]))].filter(Boolean).sort()
+  const updateCommand = `yarn test:puppeteer -u ${testFiles.map(esc).join(' ')}`
+  return [
+    MARKER,
+    HEADING,
+    '',
+    `${authorMention}: These snapshot tests failed, which indicates a visual regression. Please review your changes. If the visual changes are intentional, update the snapshots for the affected test files:`,
+    '',
+    `\`\`\`\n${updateCommand}\n\`\`\``,
+    '',
+    `<details open><summary>${rels.length} broken snapshot${rels.length === 1 ? '' : 's'}</summary>`,
+    '',
+    `Left: Expected (base branch) | Right: Actual (PR branch)`,
+    blocks,
+    '',
+    '</details>',
+    '',
+    `[View workflow run](${runUrl})`,
+  ].join('\n')
+}
+
+/** Comment body for a run that produced no diffs, clearing any previously reported ones. */
+const resolvedBody = ({ runId, runUrl }) =>
+  [
+    MARKER,
+    HEADING,
+    '',
+    `✅ No snapshot diffs in the latest run (${runId}). Any previously reported diffs have been cleared.`,
+    '',
+    `[View workflow run](${runUrl})`,
+  ].join('\n')
+
+/** Creates or updates the single marked snapshot-diff comment on the PR. */
+const upsertDiffComment = async ({ github, context }) => {
+  const { owner, repo } = context.repo
+  const prNumber = Number(process.env.PR)
+  const runId = process.env.RUN_ID
+  const runUrl = process.env.RUN_URL
+  const author = process.env.AUTHOR
+  const collected = Number(process.env.COLLECTED || '0')
+
+  let body
+  if (collected > 0) {
+    const manifest = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/committed-images.txt`, 'utf8')
+    const rels = manifest
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean)
+    const base = `https://raw.githubusercontent.com/${owner}/${repo}/snapshot-diffs/pr-${prNumber}/${runId}`
+    body = diffBody({ rels, base, author, runUrl })
+  } else {
+    body = resolvedBody({ runId, runUrl })
+  }
+
+  const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber })
+  const existing = comments.find(c => c.body && c.body.includes(MARKER))
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+  } else {
+    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body })
+  }
+}
+
+module.exports = upsertDiffComment


### PR DESCRIPTION
The Puppeteer Flaky and Puppeteer Diff Comment workflows carried a few hundred lines of JavaScript inside YAML string blocks, where neither prettier nor eslint could reach them — including three `node -e` heredocs that re-read and re-parsed the same `flaky-summary.json` just to build a Discord payload.

Each body now lives in a dedicated file under `scripts/ci/`, which `yarn lint` already covers, and the workflow step is reduced to a single call. **Net −214/+37 lines across the workflows.**

| Script | Replaces |
|---|---|
| `file-flaky-issues.cjs` | `puppeteer-flaky.yml` "File tracking issues" — 74-line `github-script` body |
| `flaky-discord-payload.mjs` | `puppeteer-flaky.yml` "Notify Discord" — three `node -e` heredocs |
| `flaky-outputs.mjs` | `puppeteer-flaky.yml` "Aggregate" — three `node -e` one-liners over the same JSON |
| `resolve-diff-pr.cjs` | `puppeteer-diff-comment.yml` "Resolve and verify PR number" |
| `upsert-diff-comment.cjs` | `puppeteer-diff-comment.yml` "Upsert PR comment" — 66-line body |

## Notes for reviewers

**Why `.cjs` for the `github-script` bodies.** `actions/github-script` evaluates `script:` in a CommonJS context, and its [`wrapRequire`](https://github.com/actions/github-script/blob/main/src/wrap-require.ts) resolves a relative `require()` through `path.resolve()` — i.e. against the step's cwd, `GITHUB_WORKSPACE`. So `require('./scripts/ci/…')` works, but the file must be CommonJS, and `package.json` sets `"type": "module"`. Hence the extension, plus a `**/*.cjs` → `sourceType: 'commonjs'` override in `eslint.config.js`. The two scripts called from bash steps are ordinary `.mjs`.

**`puppeteer-diff-comment.yml` needed a checkout added** — it had none. It is placed ahead of the artifact download, since that lands untrusted data in the same workspace `checkout` cleans, and uses `persist-credentials: false`. On `workflow_run`, `github.ref` resolves to the default branch, so this checks out base-repo code only, never the PR's. The SECURITY header bullet that read "never checks out or executes PR code" is reworded to describe this accurately rather than being left false.

**`vercel-preview.yml` is deliberately left inline.** It has two `github-script` bodies, but it is `pull_request_target` and checks out the PR head — a file under `scripts/ci/` would be fork-controlled code running against the base repo's write token. Extracting it would have been a privilege escalation. A comment on the step records why.

**The bash blocks were left alone** by choice. Worth knowing that `actionlint` already shellchecks embedded `run:` blocks, so the remaining shell in `tdd.yml` and `puppeteer-diff-comment.yml` is not unlinted, just not linted *in CI* — adding `actionlint` to `yarn lint` would close that gap without moving any shell.

## Verification

Behavior is unchanged; this is a pure move.

- Each extracted script was exercised against stub octokit/`core` objects — dedupe hit, issue creation, issue cap; matching / spoofed / malformed / missing `pr-number` artifact; diff and no-diff comment rendering — and produces byte-identical output to the inline versions, including HTML escaping and URL encoding.
- `eslint .` and `prettier --check` pass across the repo.
- `actionlint` is clean on all three workflows (the one `allow-unsafe-pr-checkout` warning is pre-existing stale action metadata).

`docs/testing.md` describes these workflows' behavior, which is unchanged, and nothing in `docs/` documents `scripts/`, so no doc updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)