### PR TITLE
refactor(importText): remove unused preventInline payload option

### DIFF
--- a/src/actions/importText.ts
+++ b/src/actions/importText.ts
@@ -65,9 +65,6 @@ export interface ImportTextPayload {
   /** Set the lastUpdated timestamp on the imported thoughts. Default: now. */
   lastUpdated?: Timestamp
 
-  /** Prevents pasting a single line of text into the destination thought, and always pastes as a child. */
-  preventInline?: boolean
-
   /** Prevents the default behavior of setting the cursor to the last thought at the first level. */
   preventSetCursor?: boolean
 
@@ -97,7 +94,6 @@ const importText = (
     text,
     idbSynced,
     lastUpdated,
-    preventInline,
     preventSetCursor,
     rawDestValue,
     replaceEnd,
@@ -123,7 +119,7 @@ const importText = (
   const destValue = rawDestValue || destThought.value
 
   // if we are only importing a single line of html, then simply modify the current thought
-  if (!preventInline && numLines <= 1 && !isRoam && !isRoot(path)) {
+  if (numLines <= 1 && !isRoam && !isRoot(path)) {
     // insert the text into the destValue in the correct place
     // if cursorCleared is true i.e. clearThought is enabled we don't have to use existing thought to be appended
 


### PR DESCRIPTION
## What changed

Removes the `preventInline` option from `ImportTextPayload` in `src/actions/importText.ts`: the JSDoc'd field, the destructured parameter, and the `!preventInline &&` guard in the single-line inline-paste condition (now `numLines <= 1 && !isRoam && !isRoot(path)`).

## Why

The option was dead code. `grep -rn preventInline src` shows its only references were its own declaration, destructure, and condition check — no action creator, component, or test ever passed it.

## Notes for reviewers

- No behavior change: since no caller passed the flag, `preventInline` was always `undefined` and the guard was always true.
- `yarn vitest --project unit run src/actions/__tests__/importText.ts src/actions/__tests__/importData.ts` passes: 71 passed, 25 skipped (skips are pre-existing).
- No references in `docs/`, so no documentation updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)