### PR TITLE
Clarify iteration wording in flaky-test reports

### DIFF
--- a/scripts/ci/file-flaky-issues.cjs
+++ b/scripts/ci/file-flaky-issues.cjs
@@ -33,7 +33,7 @@ const issueBody = t =>
     '',
     `- **File**: \`${t.file}\``,
     `- **Test**: ${t.fullName}`,
-    `- **Failed**: ${t.failed}/${t.of} iterations (iterations: ${t.iterations.join(', ')})`,
+    `- **Failed**: ${t.failed} of ${t.of} iterations (failed on ${t.iterations.length === 1 ? 'iteration' : 'iterations'} ${t.iterations.join(', ')})`,
     ...(t.firstError ? ['', '**First error**:', '', '```', t.firstError, '```'] : []),
   ].join('\n')
 

--- a/scripts/flaky-report.mjs
+++ b/scripts/flaky-report.mjs
@@ -310,11 +310,12 @@ if (failedTests.length === 0 && infraFailures.length === 0) {
     lines.push(`### ${title}`)
     lines.push('')
     for (const t of list) {
-      const rate = `${t.failed.length}/${expectedIterations}`
       const iters = t.failed.map(i => (runUrl ? `[${i}](${runUrl})` : String(i))).join(', ')
       lines.push(`#### \`${t.file}\` › ${t.fullName}`)
       lines.push('')
-      lines.push(`- **Failed**: ${rate} (iterations: ${iters})`)
+      lines.push(
+        `- **Failed**: ${t.failed.length} of ${expectedIterations} iterations (failed on ${t.failed.length === 1 ? 'iteration' : 'iterations'} ${iters})`,
+      )
       if (t.firstError) {
         lines.push(`- **First error**:`)
         lines.push('')


### PR DESCRIPTION
## What

The flaky-test report rendered each failing test as:

```
- **Failed**: 1/15 iterations (iterations: 7)
```

This uses the word "iterations" for two different things — the total number of iterations the workflow ran, and the list of iteration numbers the test actually failed on — so it reads as if the run had both 7 and 15 iterations. Reported in #4986.

It now renders as:

```
- **Failed**: 1 of 15 iterations (failed on iteration 7)
- **Failed**: 2 of 15 iterations (failed on iterations 2, 11)
```

with singular/plural agreement, in both places the line is produced:

- `scripts/ci/file-flaky-issues.cjs` — the body of the tracking issue filed per intermittently failing test
- `scripts/flaky-report.mjs` — the `$GITHUB_STEP_SUMMARY` report (iteration numbers stay linked to the workflow run)

## Why

Wording only — no change to what is measured, filed, or deduplicated. `t.failed`/`t.iterations` already meant "how many" and "which ones"; only the rendering was ambiguous.

## Notes for the reviewer

- Verified by running both scripts against synthetic Vitest reports (one test failing only on iteration 7, one failing on 2 and 11) and checking the rendered markdown and the issue body passed to `issues.create`, covering both the singular and plural branches.
- Existing filed issues such as #4986 keep their original wording; this only affects newly generated reports.
- `docs/testing.md` describes the workflow but never quotes this line, so no doc update was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)