### PR TITLE
Remove the vestigial schemaVersion

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -25,7 +25,7 @@ The main directory structure is organized as follows. Tests are located in a sub
 - [`/src/index.tsx`](../src/index.tsx) — App entry point: mounts `<App />` into the DOM.
 - [`/src/initialize.ts`](../src/initialize.ts) — Bootstraps the thoughtspace, the offline-status store, the cursor from URL, and global event handlers. Called by `index.tsx`.
 - [`/src/commands.ts`](../src/commands.ts) — Builds the `globalCommands` array, three lookup indices (by id, keyboard, gesture), and the global `keyDown` / `keyUp` / gesture handlers. See [commands.md](commands.md).
-- [`/src/constants.ts`](../src/constants.ts) — App-wide constants (root tokens, timeouts, schema version, settings enum, `LongPressState`, `COMMAND_GROUPS`, etc.). For constants used in only one module, define them locally; promote here when shared.
+- [`/src/constants.ts`](../src/constants.ts) — App-wide constants (root tokens, timeouts, settings enum, `LongPressState`, `COMMAND_GROUPS`, etc.). For constants used in only one module, define them locally; promote here when shared.
 - [`/src/browser.ts`](../src/browser.ts) — Platform detection (`isTouch`, `isSafari`, `isMac`, `isMobile`).
 - [`/src/globals.ts`](../src/globals.ts) — A small set of mutable globals that need to live outside Redux for performance (e.g. `suppressExpansion`).
 - [`/src/colors.config.ts`](../src/colors.config.ts), [`/src/durations.config.ts`](../src/durations.config.ts) — Design-token configuration consumed by Panda CSS.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -158,8 +158,6 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 ## S
 
-**schema version** — `SCHEMA_LATEST` in [`constants.ts`](../src/constants.ts). Sent with every `db.updateThoughts` call so legacy data can be migrated.
-
 **shortcut** — Legacy term for *command*. The folder was renamed `/src/shortcuts → /src/commands`; some doc references and helper names persist.
 
 **SimplePath** — A `Path` branded as having no cycles (no context-view crossings). Required by code that needs a single contiguous context. Get one via `simplifyPath` or by structurally guaranteeing it and casting. See [data-model.md → SimplePath](data-model.md#simplepath).

--- a/src/@types/State.ts
+++ b/src/@types/State.ts
@@ -139,7 +139,6 @@ interface State {
   remoteSearch: boolean
   resourceCache: Index<string>
   rootContext: Context
-  schemaVersion: number
   search: string | null
   searchContexts: Index<Context> | null
   searchLimit?: number

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -96,21 +96,6 @@ export const TUTORIAL_CONTEXT2_PARENT = {
   [TUTORIAL_VERSION_BOOK]: 'Books',
 }
 
-// constants for different schema versions
-export const SCHEMA_INITIAL = 0 // DEPRECATED
-export const SCHEMA_CONTEXTCHILDREN = 1 // DEPRECATED
-export const SCHEMA_ROOT = 2 // change root → __ROOT__
-export const SCHEMA_HASHKEYS = 3 // hash lexemeIndex keys
-export const SCHEMA_META_SETTINGS = 4 // load settings from hidden thoughts via metaprogramming
-export const SCHEMA_UNIQUE_IDS = 5 // add unique ids to thoughts for independent editing (#1495)
-export const SCHEMA_CHILDREN_MAP = 6 // convert children array to childrenMap object (#1587)
-export const SCHEMA_THOUGHT_WITH_CHILDREN = 7 // store all children in the Thought Object to allow O(1) lookup (#1592)
-// 1. lexeme.lemma renamed to Lexeme.lemma
-// 2. Lexeme.contexts changed from array to object
-// 3. lexemeIndex re-keyed with new hashing function to differentiate =archive and =archive
-export const SCHEMA_LEMMA = 8
-export const SCHEMA_LATEST = 8
-
 export const GLOBAL_ROOT_TOKEN = '00000000000000000000000000000000' as ThoughtId
 
 export const ROOT_PARENT_ID = GLOBAL_ROOT_TOKEN

--- a/src/data-providers/DataProvider.ts
+++ b/src/data-providers/DataProvider.ts
@@ -18,7 +18,6 @@ export interface DataProvider<T extends any[] = any> {
     thoughtIndexUpdates: Index<Thought | null>
     lexemeIndexUpdates: Index<Lexeme | null>
     lexemeIndexUpdatesOld: Index<Lexeme | undefined>
-    schemaVersion: number
     movePlacements?: Index<ThoughtId | null>
   }) => Promise<unknown>
   freeThought: (id: ThoughtId) => Promise<void>

--- a/src/data-providers/thoughtspace.ts
+++ b/src/data-providers/thoughtspace.ts
@@ -13,7 +13,6 @@ export type PersistThoughtspaceBatch = Parameters<DataProvider['updateThoughts']
 export type ThoughtspaceStorage = 'memory' | 'persistent'
 
 export type ThoughtspaceMaterializationSnapshot = {
-  schemaVersion: number
   thoughtIndex: Index<Thought>
   lexemeIndex: Index<Lexeme>
 }

--- a/src/data-providers/treecrdt/__tests__/materializationContext.ts
+++ b/src/data-providers/treecrdt/__tests__/materializationContext.ts
@@ -36,7 +36,6 @@ const persistThought = (db: Pick<DataProvider, 'updateThoughts'>, value: string)
     thoughtIndexUpdates: { [THOUGHT_ID]: thought(value) },
     lexemeIndexUpdates: {},
     lexemeIndexUpdatesOld: {},
-    schemaVersion: 0,
   })
 
 it('retains the originating materialization context after rebinding the provider', async () => {
@@ -52,11 +51,11 @@ it('retains the originating materialization context after rebinding the provider
   })
   const provider = createTreecrdtDataProvider()
   const bridgeOne = {
-    getSnapshot: () => ({ schemaVersion: 0, thoughtIndex: {}, lexemeIndex: {} }),
+    getSnapshot: () => ({ thoughtIndex: {}, lexemeIndex: {} }),
     apply: vi.fn(),
   }
   const bridgeTwo = {
-    getSnapshot: () => ({ schemaVersion: 0, thoughtIndex: {}, lexemeIndex: {} }),
+    getSnapshot: () => ({ thoughtIndex: {}, lexemeIndex: {} }),
     apply: vi.fn(),
   }
 

--- a/src/data-providers/treecrdt/__tests__/runtime.ts
+++ b/src/data-providers/treecrdt/__tests__/runtime.ts
@@ -21,7 +21,6 @@ const emptyUpdates = {
   thoughtIndexUpdates: {},
   lexemeIndexUpdates: {},
   lexemeIndexUpdatesOld: {},
-  schemaVersion: 0,
 }
 
 beforeAll(async () => {

--- a/src/data-providers/treecrdt/__tests__/testThoughtspace.ts
+++ b/src/data-providers/treecrdt/__tests__/testThoughtspace.ts
@@ -48,7 +48,6 @@ const persistThoughtsTo = (
     thoughtIndexUpdates: Object.fromEntries(thoughts.map(thought => [thought.id, thought])),
     lexemeIndexUpdates: {},
     lexemeIndexUpdatesOld: {},
-    schemaVersion: 0,
     movePlacements,
   })
 

--- a/src/data-providers/treecrdt/sync/__tests__/materializationThoughtUpdates.ts
+++ b/src/data-providers/treecrdt/sync/__tests__/materializationThoughtUpdates.ts
@@ -49,7 +49,6 @@ const fakeProvider = (thoughts: Index<Thought>): DataProvider => ({
 
 /** Converts test state to the provider-facing materialization snapshot. */
 const materializationSnapshot = (state: ReturnType<typeof initialState>) => ({
-  schemaVersion: state.schemaVersion,
   thoughtIndex: state.thoughts.thoughtIndex,
   lexemeIndex: state.thoughts.lexemeIndex,
 })

--- a/src/data-providers/treecrdt/sync/applyMaterializedThoughtsToStore.ts
+++ b/src/data-providers/treecrdt/sync/applyMaterializedThoughtsToStore.ts
@@ -44,7 +44,6 @@ export async function applyMaterializedThoughtsToStore(
       thoughtIndexUpdates: {},
       lexemeIndexUpdates,
       lexemeIndexUpdatesOld: {},
-      schemaVersion: snapshot.schemaVersion,
     })
   }
 

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -70,7 +70,6 @@ const initializeInternal = async ({ storage }: InitializeOptions) => {
       getSnapshot: () => {
         const state = store.getState()
         return {
-          schemaVersion: state.schemaVersion,
           thoughtIndex: state.thoughts.thoughtIndex,
           lexemeIndex: state.thoughts.lexemeIndex,
         }

--- a/src/redux-enhancers/pushQueue.ts
+++ b/src/redux-enhancers/pushQueue.ts
@@ -92,7 +92,6 @@ const pushQueue: StoreEnhancer<any> =
               thoughtIndexUpdates: batch.thoughtIndexUpdates,
               lexemeIndexUpdates: batch.lexemeIndexUpdates,
               lexemeIndexUpdatesOld: batch.lexemeIndexUpdatesOld,
-              schemaVersion: batch.updates?.schemaVersion ?? 0,
               movePlacements: batch.movePlacements,
               local: batch.local,
             })),

--- a/src/util/hashThought.ts
+++ b/src/util/hashThought.ts
@@ -13,7 +13,6 @@ import normalizeThought from './normalizeThought'
  * - murmurhash.
  *
  * Stored keys MUST match the current hashing algorithm.
- * Use schemaVersion to manage migrations.
  */
 const hashThought: (s: string) => ThoughtHash = moize(
   (value: string) => murmurHash3.x64.hash128(normalizeThought(value)) as ThoughtHash,

--- a/src/util/initialState.ts
+++ b/src/util/initialState.ts
@@ -4,7 +4,7 @@ import State from '../@types/State'
 import Thought from '../@types/Thought'
 import ThoughtIndices from '../@types/ThoughtIndices'
 import Timestamp from '../@types/Timestamp'
-import { ABSOLUTE_TOKEN, EM_TOKEN, HOME_TOKEN, LongPressState, ROOT_PARENT_ID, SCHEMA_LATEST } from '../constants'
+import { ABSOLUTE_TOKEN, EM_TOKEN, HOME_TOKEN, LongPressState, ROOT_PARENT_ID } from '../constants'
 import { clientId, tsidShared } from '../data-providers/thoughtspaceSession'
 import storageModel from '../stores/storageModel'
 import hashThought from '../util/hashThought'
@@ -140,7 +140,6 @@ const initialState = (created: Timestamp = timestamp()) => {
     redoPatches: [],
     resourceCache: {},
     rootContext: [HOME_TOKEN],
-    schemaVersion: SCHEMA_LATEST,
     search: null,
     showDesktopCommandUniverse: false,
     showGestureMenu: false,


### PR DESCRIPTION
`state.schemaVersion` was write-only. It was set once in `initialState` to `SCHEMA_LATEST` (8) and never mutated by any reducer or read by anything — the only non-assignment mention left in the repo was a stale comment in `hashThought`.

Both paths that carried it dead-ended:

- **Materialization** — `initialize.ts` → snapshot → `applyMaterializedThoughtsToStore` → `db.updateThoughts`. The treecrdt provider's `updateThoughtsForClient` destructures only `thoughtIndexUpdates`, `lexemeIndexUpdates`, and `movePlacements`, so the value was dropped on the floor.
- **Push queue** — `pushQueue.ts` read `batch.updates?.schemaVersion ?? 0`. Nothing ever wrote `schemaVersion` into `PushBatch.updates`, so the main write path had been shipping a literal `0` rather than `8`. Nobody noticed, because there was no reader to notice.

The migration machinery it existed for is long gone: `src/migrations/` and `scripts/src/migrate.ts` went in 14718399d8 ("Remove old migrations"), and the yjs provider holding the last live consumer went in 5e38e2028a ("Thoughtspace powered by treecrdt").

## Why remove rather than replace with a commit hash

A schema version earns its keep by being written into the persisted data and compared on read — "stored version < N, run migrations N..latest". That needs a monotonic ordinal. A commit hash isn't orderable, so it would need a hash→ordinal mapping to do the only job the field exists for, which is strictly worse than the integer already there.

A build identifier is genuinely useful, but it answers a different question ("which build wrote this row?") and belongs in a build-info constant or telemetry, not in Redux `State` and not on the `updateThoughts` signature.

Neither precondition for a schema version holds today — the value isn't persisted, and there's no read path. Keeping it is worse than not having it: it advertises a migration capability that doesn't exist, and the glossary told readers it worked. If the data model changes under treecrdt, the mechanism would look nothing like this numeric gate anyway.

## Changes

Purely subtractive:

- `State.schemaVersion` and its `initialState` assignment
- All nine `SCHEMA_*` constants — only `SCHEMA_LATEST` was referenced at all; the other eight were documentation of history
- The `schemaVersion` param on `DataProvider.updateThoughts` and on `ThoughtspaceMaterializationSnapshot`
- Call sites in `initialize.ts`, `applyMaterializedThoughtsToStore.ts`, `pushQueue.ts`, plus four test fixtures
- The glossary entry, the `folder-structure.md` mention, and the stale `hashThought` comment

Left alone: `INDEX_VERSION` in `attributeChildren.ts`, an unrelated and genuinely live version gate for a derived SQLite index.

## Testing

`yarn lint:tsc` and `yarn lint:src` clean; `yarn test` green at 1883 passed / 212 files (the 75 skips are pre-existing — nothing was disabled here). No behavior change, since the value was inert on every path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)