### PR TITLE
Remove the dead orphaned parameter from deleteThought

### DIFF
--- a/src/actions/deleteThought.ts
+++ b/src/actions/deleteThought.ts
@@ -32,8 +32,6 @@ import timestamp from '../util/timestamp'
 interface Payload {
   pathParent: Path
   thoughtId: ThoughtId
-  /** In pending deletes situation, the parent is already deleted, so at such case parent doesn't need to be updated. */
-  orphaned?: boolean
   /** If both local and remote are false, only deallocate thoughts from State, but do not delete them permanently. This is used by freeThoughts. The parent is marked as pending so that the thought will be automatically restored if it becomes visible again. */
   local?: boolean
   remote?: boolean
@@ -47,8 +45,7 @@ interface ThoughtUpdates {
 }
 
 /** Removes a child from a thought and the corresponding Lexeme context. If it was the last instance of the Lexeme, removes it completely from the lexemeIndex. Removes the id from the parent thought event if the thought itself does not exist (See: importFiles > missingChildren). Does not update the cursor. Use deleteThoughtWithCursor or archiveThought for higher-level functions. */
-// @MIGRATION_TODO: Maybe deleteThought doesn't need to know about the orhapned logic directly. Find a better way to handle this.
-const deleteThought = (state: State, { local = true, pathParent, thoughtId, orphaned, remote = true }: Payload) => {
+const deleteThought = (state: State, { local = true, pathParent, thoughtId, remote = true }: Payload) => {
   const deletedThought = getThoughtById(state, thoughtId) as Thought | undefined
   if (!deletedThought) return state
 
@@ -66,10 +63,9 @@ const deleteThought = (state: State, { local = true, pathParent, thoughtId, orph
   const key = deletedThought ? hashThought(value!) : null
   const lexeme = deletedThought ? getLexeme(state, value!) : null
 
-  const parent = orphaned ? null : getThoughtById(state, deletedThought ? deletedThought.parentId : head(pathParent))
+  const parent = getThoughtById(state, deletedThought ? deletedThought.parentId : head(pathParent))
 
-  // Note: When a thought is deleted and there are pending deletes, then on flushing the deletes, the parent won't be available in the tree. So for orphaned thoughts deletion we use special orphaned param
-  if (!orphaned && !parent) {
+  if (!parent) {
     console.error('Parent not found!', thoughtId, deletedThought?.value)
     return state
   }
@@ -214,21 +210,16 @@ const deleteThought = (state: State, { local = true, pathParent, thoughtId, orph
 
   const thoughtIndexUpdates = {
     // Deleted thought's parent
-    // Note: Thoughts in pending deletes won't have their parent in the state. So orphaned thoughts doesn't need to care about its parent update.
-    ...(parent && {
-      [parent.id]: {
-        ...parent,
-        ...(persist
-          ? {
-              childrenMap: keyValueBy(parent?.childrenMap || {}, (key, id) =>
-                id !== thoughtId ? { [key]: id } : null,
-              ),
-              lastUpdated: timestamp(),
-              updatedBy: clientId,
-            }
-          : { pending: true }),
-      } as Thought,
-    }),
+    [parent.id]: {
+      ...parent,
+      ...(persist
+        ? {
+            childrenMap: keyValueBy(parent.childrenMap || {}, (key, id) => (id !== thoughtId ? { [key]: id } : null)),
+            lastUpdated: timestamp(),
+            updatedBy: clientId,
+          }
+        : { pending: true }),
+    } as Thought,
     [thoughtId]: null,
     // descendants
     ...descendantUpdatesResult.thoughtIndex,


### PR DESCRIPTION
Removes the `orphaned` payload parameter of `deleteThought`, which has been unreachable for about three years.

`orphaned` was one half of a two-part delete: `deleteThought` recorded pending descendants it could not reach in `pendingDeletes`, and the `flushDeletes` push-queue middleware later pulled them and re-dispatched `deleteThought` with `orphaned: true`, the parent having been deleted by then. `flushDeletes` went away in ecf0bd5a29 ("Replace push/pushQueue with direct db update.", Feb 2023) and nothing has set `orphaned` since, so it was always `undefined` and every branch it guarded was dead.

## Changes

- Drop `Payload.orphaned` and its JSDoc.
- Drop the `orphaned ? null :` branch on the parent lookup and the `!orphaned &&` in the parent guard. The guard itself is unchanged.
- With the guard now proving `parent` is non-null, the parent entry in `thoughtIndexUpdates` becomes unconditional, so the `...(parent && { ... })` spread and the `parent?.` optional chain go too.
- Delete the three comments describing the old two-part flow, including the `@MIGRATION_TODO` asking how to get the orphaned logic out of this reducer.

No behavior change: every removed path was unreachable.

## Not in this PR

`pendingDeletes` — the other half of the same mechanism — is also dead, in the sense that every remaining reference across `deleteThought`, `updateThoughts`, `mergeBatch` and `PushBatch` is a write or a pass-through with no reader. It is deliberately left alone, because removing it is not a deletion: the `child.pending` branch in `recursiveDeletes` also *returns early*, so pending descendants are never recursed into and never deleted. Deciding what that early return should do now that nothing flushes those deletes is a behavioral change that wants its own tests, and possibly its own bug fix — with `flushDeletes` gone, pending descendants of a deleted thought may be stranded in the datastore. That is inferred from reading the code, not reproduced.

## Testing

- `npx tsc --noEmit -p .` clean.
- Full vitest run: 1893 passed, 75 skipped, 1 failed. The failure is `LayoutTree.virtualization.ts` timing out at 5000ms under full-suite load; it passes in isolation in 1.5s and is unrelated to this change.
- `prettier --check` and `eslint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
