### PR TITLE
Remove the redundant homeContext prop from ContextBreadcrumbs

### DIFF
--- a/src/components/BulletCursorOverlay.tsx
+++ b/src/components/BulletCursorOverlay.tsx
@@ -147,12 +147,6 @@ export default function BulletCursorOverlay({
     thoughtId: head(simplePath),
   })
 
-  const homeContext = useSelector(state => {
-    const pathParent = rootedParentOf(state, path)
-    const showContexts = isContextViewActive(state, path)
-    return showContexts && isRoot(pathParent)
-  })
-
   // Must match the breadcrumbs rendered by Thought so that the cursor overlay is aligned with the thought.
   const contextBreadcrumbsAncestors = useSelector(state => rootedParentOf(state, simplePath), shallowEqual)
 
@@ -182,7 +176,7 @@ export default function BulletCursorOverlay({
             marginTop: '0.462rem',
           })}
         >
-          <ContextBreadcrumbs hidden path={contextBreadcrumbsAncestors} homeContext={homeContext} />
+          <ContextBreadcrumbs hidden path={contextBreadcrumbsAncestors} />
         </div>
       )}
       <ThoughtPositioner path={path} hideBullet={hideBullet} cursorOverlay>

--- a/src/components/ContextBreadcrumbs.tsx
+++ b/src/components/ContextBreadcrumbs.tsx
@@ -155,7 +155,6 @@ const ContextBreadcrumbs = ({
   charLimit,
   hideArchive,
   hidden,
-  homeContext,
   path,
   staticText,
   thoughtsLimit,
@@ -171,7 +170,6 @@ const ContextBreadcrumbs = ({
    * Useful for ThoughtAnnotation spacing.
    */
   hidden?: boolean
-  homeContext?: boolean
   path: Path
   /** Disables click on breadcrumb fragments. */
   staticText?: boolean
@@ -221,7 +219,7 @@ const ContextBreadcrumbs = ({
     >
       {isRoot(simplePath) ? (
         /*
-      If the path is the root context, check homeContext which is true if the context is directly in the root (in which case the HomeLink is already displayed as the thought)
+      If the path is the root context, render the HomeLink as the breadcrumbs.
 
       For example:
 
@@ -234,18 +232,16 @@ const ContextBreadcrumbs = ({
 
       Activating the context view on "a" will show three contexts: ROOT, b, and c/d.
 
-      - The ROOT context will render the HomeLink as a thought. No breadcrumbs are displayed.
+      - The ROOT context will render the HomeLink as a thought. No breadcrumbs are rendered, since Thought does not render ContextBreadcrumbs for the root context.
       - The "b" context will render "b" as a thought and the HomeLink as the breadcrumbs.
       - The "c/d" context will render "d" as a thought and "c" as the breadcrumbs.
     */
-        !homeContext ? (
-          <HomeLink
-            className={css({ position: 'static' })}
-            color={token('colors.gray50')}
-            size={16}
-            iconStyle={homeIconStyle}
-          />
-        ) : null
+        <HomeLink
+          className={css({ position: 'static' })}
+          color={token('colors.gray50')}
+          size={16}
+          iconStyle={homeIconStyle}
+        />
       ) : (
         <TransitionGroup childFactory={factoryManager}>
           {ellipsizedThoughts.map(({ isOverflow, label, nodeRef }, i) => {

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -350,12 +350,6 @@ const ThoughtContainer = ({
     toggleMulticursorOnLongPress: true,
   })
 
-  const homeContext = useSelector(state => {
-    const pathParent = rootedParentOf(state, path)
-    const showContexts = isContextViewActive(state, path)
-    return showContexts && isRoot(pathParent)
-  })
-
   // The ancestors of the context that are rendered as breadcrumbs in the context view.
   // A context that is a direct child of the home context has a simplePath of length 1, so rootedParentOf returns HOME_PATH and ContextBreadcrumbs renders the HomeLink.
   const contextBreadcrumbsAncestors = useSelector(state => rootedParentOf(state, simplePath), shallowEqual)
@@ -513,7 +507,6 @@ const ThoughtContainer = ({
   //   styleContainer,
   //   thought,
   //   grandparent,
-  //   homeContext,
   //   isTable,
   //   invalidOption,
   //   isChildHovering,
@@ -603,7 +596,7 @@ const ThoughtContainer = ({
             marginTop: '0.462rem',
           })}
         >
-          <ContextBreadcrumbs path={contextBreadcrumbsAncestors} homeContext={homeContext} />
+          <ContextBreadcrumbs path={contextBreadcrumbsAncestors} />
         </div>
       )}
 


### PR DESCRIPTION
Follow-up to #5013.

`homeContext` was only ever true for a length-1 `path` whose own context view was active, which cannot coincide with a thought rendered as a context (a context's path always has length ≥ 2). It could therefore never suppress the `HomeLink` at either call site, and with the `!isRoot(simplePath)` guard from #5013 the root context is excluded from rendering breadcrumbs at all.

- `ContextBreadcrumbs`: drop the `homeContext` prop and its type; the root branch now renders `HomeLink` unconditionally. The explanatory comment now states why the ROOT context shows no breadcrumbs (Thought's `!isRoot(simplePath)` guard) instead of pointing at the prop.
- `Thought` and `BulletCursorOverlay`: delete the `homeContext` selectors and the prop pass, plus the stale entry in Thought's commented-out props list.

## Verification

Before removing, both selectors were temporarily made to `throw` when `homeContext` was true and `src/components/__tests__` was run against #5013's head — zero hits.

After the change: `tsc --noEmit` and eslint clean; `ContextView.ts` and `ContextBreadcrumbs.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)