### PR TITLE
Tap iOS toolbar buttons through a helper that scrolls them into view

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -596,6 +596,8 @@ The most important helper is [`exportThoughts`](../src/e2e/puppeteer/helpers/exp
 
 The iOS suite has a separate driver vocabulary in [`../src/e2e/iOS/helpers/`](../src/e2e/iOS/helpers): [`tap`](../src/e2e/iOS/helpers/tap.ts) emits a W3C pointer action, [`keyboard.type`](../src/e2e/iOS/helpers/keyboard.ts) uses WDIO `sendKeys`, and [`gesture`](../src/e2e/iOS/helpers/gesture.ts) emits a touch pointer path. Helpers such as [`tapReturnKey`](../src/e2e/iOS/helpers/tapReturnKey.ts), [`hideKeyboardByTappingDone`](../src/e2e/iOS/helpers/hideKeyboardByTappingDone.ts), and [`showEditMenu`](../src/e2e/iOS/helpers/showEditMenu.ts) cross into native iOS UI when Web content APIs are insufficient.
 
+Tap toolbar buttons with [`tapToolbar`](../src/e2e/iOS/helpers/tapToolbar.ts), the iOS counterpart to Puppeteer's [`clickToolbar`](../src/e2e/puppeteer/helpers/clickToolbar.ts), rather than tapping the button element directly. Most of the toolbar's buttons sit outside a phone-width viewport until the horizontally scrolling toolbar is scrolled, and a tap aimed at an off-screen button hits nothing — silently, since the command simply never runs. `tapToolbar` centers the button first (the toolbar's edges are overlapped by opaque scroll arrows that swallow a tap on a button scrolled only just into view) and taps with a touch pointer, which [`ToolbarButton`](../src/components/ToolbarButton.tsx) requires on a touch device because it binds `onTouchStart`/`onTouchEnd` rather than `onMouseDown`/`onClick`.
+
 Do not import Puppeteer helpers into iOS tests or assume identical driver behavior. Keep the test vocabulary parallel at the level of user intent, not implementation.
 
 ## Test Flags

--- a/src/e2e/iOS/__tests__/caret.ts
+++ b/src/e2e/iOS/__tests__/caret.ts
@@ -28,7 +28,7 @@ describe('Caret', () => {
     await hideKeyboardByTappingDone()
 
     const editableNodeHandle = await waitForEditable('foo')
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
 
     await waitUntil(isKeyboardShown)
     const selectionTextContent = await getSelection().focusNode?.textContent
@@ -40,7 +40,7 @@ describe('Caret', () => {
     await newThought('bar', { insertNewSubthought: true })
 
     const editableNodeHandle = await waitForEditable('foo')
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
 
     await waitUntil(async () => (await getEditingText()) === 'foo')
     const selectionTextContent = await getSelection().focusNode?.textContent
@@ -71,7 +71,7 @@ describe('Caret', () => {
     await newThought('d', { insertNewSubthought: true })
 
     const editableNodeHandle = await waitForEditable('c')
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
     await waitUntil(async () => (await getEditingText()) === 'c')
 
     const selectionTextContent = await getSelection().focusNode?.textContent
@@ -91,7 +91,7 @@ describe('Caret', () => {
     await clickThought('c')
 
     const editableNodeHandle = await waitForEditable('d')
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
     await waitUntil(async () => (await getEditingText()) !== 'c')
 
     const editingText = await getEditingText()
@@ -111,7 +111,7 @@ describe('Caret', () => {
     await clickThought('c')
 
     const editableNodeHandle = await waitForEditable('d')
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
 
     await waitUntil(async () => (await getEditingText()) === 'd')
     const selectionTextContent = await getSelection().focusNode?.textContent
@@ -131,7 +131,7 @@ describe('Caret', () => {
     await clickThought('c')
 
     const editableNodeHandleD = await waitForEditable('d')
-    await tap(editableNodeHandleD, { x: 20, y: 200 })
+    await tap(editableNodeHandleD, { y: 200 })
 
     // Wait until cursor change
     await waitUntil(async () => (await getEditingText()) === 'b')
@@ -154,7 +154,7 @@ describe('Caret', () => {
     await hideKeyboardByTappingDone()
 
     const editableNodeHandleD = await waitForEditable('d')
-    await tap(editableNodeHandleD, { x: 20, y: 200 })
+    await tap(editableNodeHandleD, { y: 200 })
 
     // Wait until cursor change
     await waitUntil(async () => (await getEditingText()) === 'b')
@@ -175,7 +175,7 @@ describe('Caret', () => {
       segmentLength: elementRect.width,
     })
 
-    await tap(editableNodeHandle, { y: 60, x: 20 })
+    await tap(editableNodeHandle, { y: 60 })
 
     const editingText = await getEditingText()
     expect(editingText).toBe('foo')

--- a/src/e2e/iOS/__tests__/format.ts
+++ b/src/e2e/iOS/__tests__/format.ts
@@ -3,10 +3,11 @@
  * Uses WDIO test runner with Mocha framework.
  */
 import clickThought from '../helpers/clickThought'
+import getEditingText from '../helpers/getEditingText'
 import hideKeyboardByTappingDone from '../helpers/hideKeyboardByTappingDone'
 import newThought from '../helpers/newThought'
 import paste from '../helpers/paste'
-import tap from '../helpers/tap.js'
+import tapToolbar from '../helpers/tapToolbar.js'
 
 describe('Format', () => {
   it('applying bold to an unfocused cursor thought does not open the keyboard', async () => {
@@ -21,10 +22,13 @@ describe('Format', () => {
     const scrollBefore = await browser.execute(() => window.scrollY)
 
     // 4. Apply bold by tapping the Bold toolbar icon.
-    const boldButton = await browser.$('[data-testid="toolbar-icon"][aria-label="Bold"]').getElement()
-    await tap(boldButton, { y: 60 })
+    await tapToolbar('Bold')
 
-    // 5. Measure the scroll position again and ensure it did not change (#3999).
+    // 5. Assert that bold was actually applied. Without this the test passes even when the tap misses the button
+    // entirely, since a tap that hits nothing trivially satisfies the scroll assertion below.
+    expect(await getEditingText()).toBe('<b>Thought One</b>')
+
+    // 6. Measure the scroll position again and ensure it did not change (#3999).
     const scrollAfter = await browser.execute(() => window.scrollY)
     expect(scrollAfter).toBe(scrollBefore)
   })
@@ -38,10 +42,7 @@ describe('Format', () => {
     await clickThought('One') // set the cursor on the thought
 
     // Apply a blue background highlight via the toolbar.
-    const textColor = await browser.$('[data-testid="toolbar-icon"][aria-label="Text Color"]').getElement()
-    await tap(textColor, { y: 60, pointerType: 'touch' })
-    const blueBg = await browser.$('[aria-label="background color swatches"] [aria-label="blue"]').getElement()
-    await tap(blueBg, { y: 60, pointerType: 'touch' })
+    await tapToolbar('Text Color', 'background color swatches', 'blue')
 
     /** Native undo closes the keyboard, so the editable will lose focus.
      * Reads the innerHTML of the (single) thought, independent of edit/keyboard state. */

--- a/src/e2e/iOS/__tests__/split.ts
+++ b/src/e2e/iOS/__tests__/split.ts
@@ -26,8 +26,10 @@ describe('Split', () => {
     const editableNodeHandle = await waitForEditable('web scraping')
     await clickThought('web scraping')
 
-    await tap(editableNodeHandle, { y: 60, x: 25 })
-    await tap(editableNodeHandle, { y: 60, x: 25 })
+    // Tap 25px in from the left edge to land the caret between "web " and "scraping". This is the one tap in
+    // the iOS suite whose x is load-bearing, so it opts out of the center default.
+    await tap(editableNodeHandle, { horizontalTapLine: 'left', y: 60, x: 25 })
+    await tap(editableNodeHandle, { horizontalTapLine: 'left', y: 60, x: 25 })
     await tapReturnKey()
 
     const offset = await getSelection()?.focusOffset

--- a/src/e2e/iOS/helpers/tap.ts
+++ b/src/e2e/iOS/helpers/tap.ts
@@ -3,11 +3,14 @@ import type { Element } from 'webdriverio'
 // import getNativeElementRect from './getNativeElementRect'
 
 interface Options {
-  // Where in the horizontal line (inside) of the target node should be tapped
-  horizontalTapLine?: 'left' | 'right'
+  // Where in the horizontal line (inside) of the target node should be tapped. Defaults to center, which
+  // matches how a person taps: told to tap a button, they aim for the middle, not the exact edge. Adjacent
+  // toolbar buttons are inline-block with no margin, so their padding boxes touch and an edge tap is half a
+  // pixel of rounding away from landing on the neighboring command.
+  horizontalTapLine?: 'left' | 'center' | 'right'
   // Pointer type to use for the tap action. Defaults to 'mouse'.
   pointerType?: 'mouse' | 'touch'
-  // Specify specific node on editable to tap. Overrides horizontalClickLine
+  // Specify specific node on editable to tap. Overrides horizontalTapLine
   offset?: number
   // Number of pixels of x offset to add to the tap coordinates
   x?: number
@@ -23,7 +26,7 @@ interface Options {
  */
 const tap = async (
   nodeHandle: Element,
-  { horizontalTapLine = 'left', offset, x = 0, y = 0, pointerType = 'mouse', releaseDelayMs = 100 }: Options = {},
+  { horizontalTapLine = 'center', offset, x = 0, y = 0, pointerType = 'mouse', releaseDelayMs = 100 }: Options = {},
 ) => {
   // Ensure element exists and has an elementId
   const exists = await nodeHandle.isExisting()
@@ -68,7 +71,7 @@ const tap = async (
         x:
           boundingBox.x +
           (horizontalTapLine === 'left'
-            ? 0
+            ? 1
             : horizontalTapLine === 'right'
               ? boundingBox.width - 1
               : boundingBox.width / 2),

--- a/src/e2e/iOS/helpers/tapToolbar.ts
+++ b/src/e2e/iOS/helpers/tapToolbar.ts
@@ -1,0 +1,58 @@
+import type CommandLabel from '../../../@types/CommandLabel'
+import tap from './tap.js'
+import waitForElement from './waitForElement.js'
+
+/** Options shared by the button tap and the dropdown value tap.
+ *
+ * ToolbarButton binds onTouchStart/onTouchEnd when isTouch and onMouseDown/onClick otherwise, so the toolbar is only
+ * reachable with a touch pointer on a device; tap's 'mouse' default never fires the command. The y offset is the
+ * Safari chrome offset used throughout this suite, since tap reads page coordinates but taps in screen coordinates.
+ */
+const tapOptions = { y: 60, pointerType: 'touch' } as const
+
+/**
+ * Tap a toolbar button by its label, and optionally a value in the dropdown that it opens, e.g. `tapToolbar('Bold')` or `tapToolbar('Text Color', 'background color swatches', 'blue')`.
+ *
+ * A picker is rendered inside the toolbar button that opens it (see TextColorWithColorPicker), so values are matched by aria-label within the button. Nested values are given as a path, which is required when a value is ambiguous on its own, e.g. the Text Color dropdown contains both a text and a background swatch labeled "blue", so `tapToolbar('Text Color', 'background color swatches', 'blue')`.
+ */
+const tapToolbar = async (label: CommandLabel, ...values: string[]) => {
+  const toolbarSelector = `[data-testid="toolbar-icon"][aria-label="${label}"]`
+  const button = await waitForElement(toolbarSelector)
+
+  // The toolbar scrolls horizontally and most of its buttons start off-screen, so tapping the button's reported rect
+  // would land outside the viewport and silently do nothing. Center it rather than scrolling it just far enough,
+  // since the toolbar's edges are overlapped by opaque scroll arrows that would swallow the tap.
+  await browser.execute((selector: string) => {
+    // 'instant' matters: ToolbarButton reads the toolbar's scrollLeft at touchstart and again at touchend, and treats
+    // a change of 5px or more as a swipe that suppresses the command. A smooth scroll still animating when the tap
+    // lands would look exactly like that swipe.
+    // 'nearest' keeps the page from scrolling vertically, which the #3999 test asserts does not happen.
+    document.querySelector(selector)!.scrollIntoView({ behavior: 'instant', block: 'nearest', inline: 'center' })
+  }, toolbarSelector)
+
+  await tap(button, tapOptions)
+
+  if (values.length === 0) return
+
+  const valueSelector = `${toolbarSelector} ${values.map(value => `[aria-label="${value}"]`).join(' ')}`
+  const valueElement = await waitForElement(valueSelector)
+
+  // A value that matches more than one element would silently resolve to whichever comes first in the DOM, so require the caller to name the group that contains it.
+  const groups = await browser.execute(
+    (selector: string) =>
+      Array.from(document.querySelectorAll(selector)).map(element =>
+        element.parentElement?.closest('[aria-label]')?.getAttribute('aria-label'),
+      ),
+    valueSelector,
+  )
+  if (groups.length > 1) {
+    const value = values[values.length - 1]
+    throw new Error(
+      `"${value}" matches ${groups.length} elements in the "${label}" dropdown. Name the group that contains it, e.g. tapToolbar('${label}', '${groups[0]}', '${value}').`,
+    )
+  }
+
+  await tap(valueElement, tapOptions)
+}
+
+export default tapToolbar


### PR DESCRIPTION
Adds `tapToolbar`, the iOS counterpart to the puppeteer [`clickToolbar`](https://github.com/cybersemics/em/blob/main/src/e2e/puppeteer/helpers/clickToolbar.ts) helper, and uses it in the iOS format tests.

## The problem

`src/e2e/iOS/__tests__/format.ts` aimed the Bold tap at the button's reported rect. The toolbar is a horizontal scroll container and Bold is its 14th button, so at a phone-width viewport that rect is entirely off-screen and the tap landed on nothing.

The test passed anyway. Its only assertion was that `window.scrollY` had not changed, which is trivially true when no command runs — so it was vacuous.

Measured against the running app at a 430px viewport:

| | Bold rect | hit test at center |
|---|---|---|
| before scrolling | x 589.9, right 630.5 | off-screen |
| `scrollIntoView({ inline: 'nearest' })` | x 389.4, right 430 | `SPAN` / `toolbar` ✗ |
| `scrollIntoView({ inline: 'center' })` | x 226.9, right 267.5 | `svg` / `Bold` ✓ |

Centering is load-bearing: the toolbar's edges are overlapped by an opaque `TriangleRight` scroll arrow that wins the hit test against a button scrolled only just into view. Same result for `Pin All`.

## A second bug

[`ToolbarButton`](https://github.com/cybersemics/em/blob/main/src/components/ToolbarButton.tsx) binds `onTouchStart`/`onTouchEnd` when `isTouch` and `onMouseDown`/`onClick` otherwise. The Bold tap used `tap`'s `pointerType: 'mouse'` default, so it would not have fired the command even with correct coordinates. (The Text Color test already passed `'touch'`.) `tapToolbar` defaults to touch.

## Why not a swipe

Scrolling the button into view is **arrange**, not the act. Per the arrange/act/assert split in `docs/testing.md`, the act is the tap. Routing every toolbar tap through a swipe would make a regression in toolbar scrolling fail every toolbar test instead of one, against the documented invariant that *the trigger under test appears exactly once — in the act*. Coverage of the toolbar's own scrolling belongs in its own test; it is not added here.

There is also a practical reason: `tapUp` treats a ≥5px `scrollLeft` change between touchstart and touchend as a swipe and suppresses the command, so a swipe (or momentum scrolling) immediately before a tap risks eating it. The helper scrolls with `behavior: 'instant'` for the same reason.

## Also

The Bold test now asserts that bold was applied, alongside the existing `scrollY` assertion for #3999, so it can no longer pass without the command having run.

## Reviewer notes

- **This branch includes #5015**, which is not yet merged. Its two commits appear in the diff. Merge #5015 first, or retarget this PR onto it.
- **The iOS suite was not run.** It needs an Appium XCUITest driver that is not installed locally, so the tap coordinates, the `y: 60` Safari chrome offset, and the touch-pointer behavior are unverified on a real device — BrowserStack via CI is the only way to confirm them. The scroll measurements in the table above were taken in a browser at 430px, where the DOM behavior is identical.
- `tsc`, `eslint`, and `prettier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)