### PR TITLE
Fix case-insensitive command search

### DIFF
--- a/src/hooks/__tests__/useFilteredCommands.ts
+++ b/src/hooks/__tests__/useFilteredCommands.ts
@@ -325,9 +325,7 @@ describe('useFilteredCommands', () => {
         expect(commandIds).not.toContain('contextView')
       })
 
-      // Searching with `thOUGHT` should return `New Thought` and `New Subthought`, but it returns empty now.
-      // TODO: remove `.skip` after `useFilteredCommands` hook is updated
-      it.skip('should support case insensitive search', () => {
+      it('should support case insensitive search', () => {
         const { result } = renderHook(() => useFilteredCommands('thOUGHT', {}), { wrapper })
 
         const commandIds = result.current.map(cmd => cmd.id)

--- a/src/hooks/useFilteredCommands.ts
+++ b/src/hooks/useFilteredCommands.ts
@@ -88,13 +88,14 @@ const useFilteredCommands = (
             ? command.labelInverse
             : command.label
         ).toLowerCase()
+        // lowercase the search chars so that they can be matched against the lowercased label
         const chars = search.toLowerCase().split('')
 
         return (
           // include commands with at least one included char and no more than three chars non-matching chars
           // fuzzy matching will prioritize the best commands
           chars.some(char => char !== ' ' && label.includes(char)) &&
-          search.split('').filter(char => char !== ' ' && !label.includes(char)).length <= 3
+          chars.filter(char => char !== ' ' && !label.includes(char)).length <= 3
         )
       }
     })


### PR DESCRIPTION
The fuzzy filter in `useFilteredCommands` lowercases both the command label and the search characters it tests for inclusion, but the non-matching-character count re-split the raw `search` string instead of the lowercased one. Every uppercase character therefore counted as a miss against the lowercased label, and since the filter allows at most three misses, any query with four or more uppercase letters returned nothing at all — `thOUGHT` matched no commands.

Count the misses over the already-lowercased characters.

Unskips `should support case insensitive search` in `src/hooks/__tests__/useFilteredCommands.ts` and removes its TODO.

Conflicts textually with #5020, which touches the adjacent block in the same two files. Neither depends on the other; whichever merges second needs a trivial rebase.