### PR TITLE
Sort commands by the same label they were filtered by

### DIFF
--- a/src/hooks/__tests__/useFilteredCommands.ts
+++ b/src/hooks/__tests__/useFilteredCommands.ts
@@ -210,9 +210,8 @@ describe('useFilteredCommands', () => {
 
       // In the mock commands for testing, Show Hidden Thoughts has inverse label Hide Hidden Thoughts and it is active.
       // Though, sortActiveCommandsFirst is not set - meaning that it is false.
-      // So sorting should reference regular label Show Hidden Thoughts, but the hook uses inverse label.
-      // TODO: remove `.skip` after `useFilteredCommands` hook is updated
-      it.skip('should alphabetize commands by label', () => {
+      // So sorting should reference the regular label Show Hidden Thoughts.
+      it('should alphabetize commands by label', () => {
         const { result } = renderHook(() => useFilteredCommands('', {}), { wrapper })
 
         const labels = result.current.map(cmd => cmd.label)
@@ -259,9 +258,7 @@ describe('useFilteredCommands', () => {
         expect(newThoughtIndex).toBeLessThan(selectAllIndex)
       })
 
-      // Though, sortActiveCommandsFirst is false, sorting functionality references inverse label for sorting which is not correct.
-      // TODO: remove `.skip` after `useFilteredCommands` hook is updated
-      it.skip('should ignore labelInverse when sortActiveCommandsFirst is false', () => {
+      it('should ignore labelInverse when sortActiveCommandsFirst is false', () => {
         const { result } = renderHook(() => useFilteredCommands('', { sortActiveCommandsFirst: false }), { wrapper })
 
         const labels = result.current.map(cmd => cmd.label)

--- a/src/hooks/useFilteredCommands.ts
+++ b/src/hooks/useFilteredCommands.ts
@@ -101,8 +101,11 @@ const useFilteredCommands = (
 
     // sorted commands
     const sorted = _.sortBy(possibleCommands, command => {
+      // sort by the same label that the filter matched against, i.e. only use the inverse label of an active command when active commands are sorted first
       const label = (
-        command.labelInverse && command.isActive?.(store.getState()) ? command.labelInverse : command.label
+        sortActiveCommandsFirst && command.labelInverse && command.isActive?.(store.getState())
+          ? command.labelInverse
+          : command.label
       ).toLowerCase()
 
       // In gesture mode, help command should always be at the end


### PR DESCRIPTION
`useFilteredCommands` substitutes a command's `labelInverse` for its `label` when the command is active, but only when `sortActiveCommandsFirst` is set. The filter branch has honored that flag since the hook was written; the `_.sortBy` key never did, and used `labelInverse` whenever the command was active. A command could therefore be matched by its regular label and then sorted by its inverse one — and since the key also feeds the startsWith and contains ranking terms, those were ranked against a string the user never typed against.

Gate the sort key on `sortActiveCommandsFirst` as well.

`DesktopCommandUniverse` and `GestureMenu` both pass `sortActiveCommandsFirst: true`, so their ordering is unchanged. Only `useCommandList` — the Command Library and the mobile Command Universe — omits the flag, and there the search results now sort by the labels actually rendered.

Unskips `should alphabetize commands by label` and `should ignore labelInverse when sortActiveCommandsFirst is false` and removes their TODOs.

Conflicts textually with #5019, which touches the adjacent block in the same two files. Neither depends on the other; whichever merges second needs a trivial rebase.