### PR TITLE
Do not apply =children/=style to =children itself

### DIFF
--- a/docs/metaprogramming.md
+++ b/docs/metaprogramming.md
@@ -60,7 +60,7 @@ The descendant attribute lookups consult these inheritance points in addition to
 - [`useThoughtStyle`](../src/hooks/useThoughtStyle.ts) reads `=children/=style` from the parent and `=grandchildren/=style` from the grandparent.
 - [`useHideBullet`](../src/hooks/useHideBullet.ts) reads `=bullet/None` directly, plus the `=children/=bullet`/`=grandchildren/=bullet` variants.
 - The pinned-children behavior at `=children/=pin/true` is what replaced the old `=pinChildren` attribute.
-- `=children` and `=grandchildren` thoughts are themselves filtered out of rendering — they never appear as siblings.
+- `=children` and `=grandchildren` thoughts are themselves filtered out of rendering, so they never appear as siblings unless hidden thoughts are shown. When they are shown, [`linearizeTree`](../src/selectors/linearizeTree.ts) exempts `=children` from its own `=style`; `=grandchildren` needs no exemption, since the grandparent style skips a level and so never reaches it.
 
 Not every attribute is propagable. Currently the `=children`/`=grandchildren` inheritance chain is plumbed through for `=style`, `=styleAnnotation`, `=styleContainer`, `=bullet`, and `=pin`; `=descendants` supports only `=pin`. Other attributes apply only to the direct parent.
 

--- a/src/components/__tests__/style.ts
+++ b/src/components/__tests__/style.ts
@@ -65,8 +65,7 @@ it('apply =children/=style to all children', async () => {
   expect(c).not.toHaveStyle({ color: 'rgba(255, 192, 203, 1)' })
 })
 
-// TODO: Broke when upgrading jest from 27.5.1 to 29.7.0 and jsdom 16.6.0 (missing) to 24.0.0
-it.skip('as an exception, do not apply =children/=style to =children itself', async () => {
+it('as an exception, do not apply =children/=style to =children itself', async () => {
   await dispatch([
     importText({
       text: `
@@ -80,6 +79,8 @@ it.skip('as an exception, do not apply =children/=style to =children itself', as
     }),
     toggleHiddenThoughts(),
   ])
+
+  await act(vi.runOnlyPendingTimersAsync)
 
   expect(await findThoughtByText('=children')).not.toHaveStyle({ color: 'rgba(255, 192, 203, 1)' })
 })

--- a/src/selectors/linearizeTree.ts
+++ b/src/selectors/linearizeTree.ts
@@ -99,6 +99,8 @@ const linearizeTree = (
   const grandchildrenAttributeId = findDescendant(state, thoughtId, '=grandchildren')
   const styleChildren = getStyle(state, childrenAttributeId)
   const style = safeRefMerge(styleAccum, styleChildren, styleFromGrandparent)
+  // As an exception, =children/=style is not applied to =children itself, which is visible when hidden thoughts are shown.
+  const styleWithoutChildren = safeRefMerge(styleAccum, styleFromGrandparent)
 
   // =let definitions on this thought are added to the env inherited from ancestors and passed to all descendants.
   // If there are no =let definitions, the inherited env is passed through unchanged to preserve its object reference, otherwise a new reference on every render would defeat the memoization of TreeNode and its descendants.
@@ -163,7 +165,7 @@ const linearizeTree = (
       rank: child.rank,
       showContexts: contextViewActive,
       simplePath: contextViewActive ? thoughtToPath(state, child.id) : appendToPathMemo(simplePath, child.id),
-      style,
+      style: child.id === childrenAttributeId ? styleWithoutChildren : style,
       thoughtId: child.id,
       ...(isTable
         ? { visibleChildrenKeys: getChildren(state, child.id).map(child => crossContextualKey(contextChain, child.id)) }


### PR DESCRIPTION
`linearizeTree` merged `=children/=style` into the single `style` it handed to every child, and `=children` is one of those children. The attribute is hidden in normal use, so the styling only surfaces once hidden thoughts are shown, where `=children` picks up the very style it defines.

A second merged style that omits `styleChildren` is now used for the `=children` node. `=grandchildren` needs no equivalent: the grandparent style skips a level and so never reaches the attribute that declares it.

This unskips `as an exception, do not apply =children/=style to =children itself` in `src/components/__tests__/style.ts`, which had been off since the jest 27 to 29 upgrade. Its `TODO` blamed the jsdom bump, but the test needed only a timer flush to see the rendered tree; once it can see it, it fails on the real bug.