### PR TITLE
Unskip the multicursor undo test by indenting with Tab

### DIFF
--- a/src/commands/__tests__/undo-redo.ts
+++ b/src/commands/__tests__/undo-redo.ts
@@ -474,10 +474,7 @@ describe('undo', () => {
     - d`)
   })
 
-  // Broken when space-to-indent was added.
-  // This test relies on multicursor across levels which will be disallowed soon, so it will need to be updaded anyway.
-  // indentCommand and moveCursorForwar should probably be combined as well.
-  it.skip('undo should restore complex multicursor operations involving multiple command types', () => {
+  it('undo should restore complex multicursor operations involving multiple command types', () => {
     store.dispatch([
       importText({
         text: `
@@ -496,8 +493,8 @@ describe('undo', () => {
       addMulticursor(['d']),
     ])
 
-    // Execute moveCursorForward on selected thoughts
-    executeCommandWithMulticursor(indentCommand, { store })
+    // Indent the selected thoughts under a. Uses moveCursorForward (Tab) rather than the indent command, whose space-to-indent keyboard shortcut only applies to an empty thought.
+    executeCommandWithMulticursor(moveCursorForward, { store })
 
     // Check intermediate state after indent
     let exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')


### PR DESCRIPTION
`executeCommandWithMulticursor` defaults `type` to `'keyboard'`, and since space-to-indent was added the indent command's `exec` bails on a non-empty thought under that type. The test therefore dispatched nothing, and its intermediate expectation of an indented `b`/`c`/`d` failed.

Use `moveCursorForward` (Tab), which is what actually indents a non-empty thought and what the live multicursor test directly above already uses. Assertions are unchanged.