### PR TITLE
Unskip the taskQueue onError test for a rejected task

### DIFF
--- a/src/util/__tests__/taskQueue.ts
+++ b/src/util/__tests__/taskQueue.ts
@@ -728,10 +728,12 @@ describe('taskQueue', { retry: 10 }, () => {
       expect(error).toBe(1)
     })
 
-    // TODO: Why does the end promise time out?
-    it.skip('calls onError when a task throws', async () => {
+    it('calls onError when a task rejects', async () => {
       let counter = 0
-      let error = 0
+      // Collect the errors and assert on them afterwards rather than asserting inside onError. onError is
+      // invoked from the task runner's own catch handler, so an assertion that fails there rejects the task,
+      // which pauses the queue and leaves the end promise pending until the test times out.
+      const errors: unknown[] = []
 
       /** Increments the counter. */
       const inc = () => ++counter
@@ -747,14 +749,13 @@ describe('taskQueue', { retry: 10 }, () => {
 
       await taskQueue({
         onError: err => {
-          expect(err.message).toBe('STOP')
-          error++
+          errors.push(err)
         },
         tasks: [inc, rejectTask, inc],
       }).end
 
       expect(counter).toBe(2)
-      expect(error).toBe(1)
+      expect(errors).toEqual(['STOP'])
     })
 
     it(`on('error', ...) syntax`, async () => {


### PR DESCRIPTION
The skipped test carried a `// TODO: Why does the end promise time out?`. The answer:

The task rejects with the *string* `'STOP'`, not an `Error`, so `expect(err.message).toBe('STOP')` inside the `onError` callback compared `undefined` and failed. `onError` runs from the error emitter, which `taskQueue` triggers from inside the task runner's own `.catch` handler — so the assertion error propagated out of that handler and rejected the task. The runner's outer catch then set `paused = true`, `tick()` never resumed, `end` was never emitted, and the test hit its timeout. The failed assertion was invisible because the timeout is what surfaced.

Collect the errors into an array and assert on them once the queue has ended, which is where an assertion can fail without feeding back into the code under test.

Also renames the test to say it covers a rejection: it had the same name as the live test directly above it, which covers a synchronous throw.