### PR TITLE
Remove the five dead iOS caret tests

### DIFF
--- a/src/e2e/iOS/__tests__/caret.ts
+++ b/src/e2e/iOS/__tests__/caret.ts
@@ -2,11 +2,8 @@
  * IOS Safari caret positioning tests.
  * Uses WDIO test runner with Mocha framework.
  */
-import gestures from '../../../test-helpers/gestures'
 import clickThought from '../helpers/clickThought'
-import editThought from '../helpers/editThought'
 import gesture from '../helpers/gesture'
-import getEditable from '../helpers/getEditable'
 import getEditingText from '../helpers/getEditingText'
 import getElementRectByScreen from '../helpers/getElementRectByScreen'
 import getSelection from '../helpers/getSelection'
@@ -78,26 +75,6 @@ describe('Caret', () => {
     expect(selectionTextContent).toBe('c')
   })
 
-  it.skip('Tap hidden root thought', async () => {
-    const importText = `
-  - a
-    - b
-      - c
-  - d`
-    await newThought()
-    await paste([''], importText)
-    await clickThought('a')
-    await clickThought('b')
-    await clickThought('c')
-
-    const editableNodeHandle = await waitForEditable('d')
-    await tap(editableNodeHandle, { y: 60 })
-    await waitUntil(async () => (await getEditingText()) !== 'c')
-
-    const editingText = await getEditingText()
-    expect(editingText).toBe('b')
-  })
-
   it('Tap hidden uncle', async () => {
     const importText = `
     - a
@@ -116,49 +93,6 @@ describe('Caret', () => {
     await waitUntil(async () => (await getEditingText()) === 'd')
     const selectionTextContent = await getSelection().focusNode?.textContent
     expect(selectionTextContent).toBe('d')
-  })
-
-  it.skip('Tap empty content while keyboard up', async () => {
-    const importText = `
-    - a
-      - b
-        - c
-      - d`
-
-    await newThought()
-    await paste([''], importText)
-    await clickThought('b')
-    await clickThought('c')
-
-    const editableNodeHandleD = await waitForEditable('d')
-    await tap(editableNodeHandleD, { y: 200 })
-
-    // Wait until cursor change
-    await waitUntil(async () => (await getEditingText()) === 'b')
-    expect(await isKeyboardShown()).toBeTruthy()
-    const selectionTextContent = await getSelection().focusNode?.textContent
-    expect(selectionTextContent).toBe('b')
-  })
-
-  it.skip('Tap empty content while keyboard down', async () => {
-    const importText = `
-    - a
-      - b
-        - c
-      - d`
-
-    await newThought()
-    await paste([''], importText)
-    await clickThought('b')
-    await clickThought('c')
-    await hideKeyboardByTappingDone()
-
-    const editableNodeHandleD = await waitForEditable('d')
-    await tap(editableNodeHandleD, { y: 200 })
-
-    // Wait until cursor change
-    await waitUntil(async () => (await getEditingText()) === 'b')
-    expect(await isKeyboardShown()).toBeFalsy()
   })
 
   it('Swipe over cursor', async () => {
@@ -182,74 +116,6 @@ describe('Caret', () => {
 
     const selectionTextContent = await getSelection().focusNode?.textContent
     expect(selectionTextContent).toBe(null)
-  })
-
-  it.skip('Swipe over hidden thought', async () => {
-    const importText = `
-    - a
-      - x
-        - y
-    - b
-    - c
-    - d
-    - e
-    - f
-    - g
-    - h
-    - i`
-
-    await newThought()
-    await paste([''], importText)
-    await waitForEditable('i')
-    await clickThought('a')
-    await clickThought('x')
-    await clickThought('y')
-
-    const editableNodeHandle = await waitForEditable('y')
-    const elementRect = await getElementRectByScreen(editableNodeHandle)
-
-    await gesture(gestures.newThought, {
-      xStart: elementRect.x + 5,
-      yStart: elementRect.y + elementRect.height + 10,
-    })
-    await waitForEditable('')
-
-    await editThought('this-is-new-thought')
-    const newThoughtEditable = await waitForEditable('this-is-new-thought')
-
-    // get first child of parent thought
-    const previousSibling = await browser.execute((newThoughtEditable: HTMLElement) => {
-      const editable = (newThoughtEditable as unknown as HTMLElement)
-        .closest('ul.children')
-        ?.firstElementChild?.querySelector('[data-editable]') as HTMLElement
-      return editable?.innerText
-    }, newThoughtEditable)
-
-    expect(previousSibling).toBe('y')
-  })
-
-  it.skip('Bump Thought Down on a thought that has children', async () => {
-    await newThought('foo')
-    await newThought('bar', { insertNewSubthought: true })
-    await hideKeyboardByTappingDone()
-
-    const editableNodeHandle = await getEditable('foo')
-    await tap(editableNodeHandle)
-
-    await gesture(gestures.bumpThoughtDown)
-    const newThoughtEditable = await editThought('new')
-    const selectionTextContent = await getSelection().focusNode?.textContent
-
-    const childrenTexts = await browser.execute((newThoughtEditable: HTMLElement) => {
-      const children = (newThoughtEditable as unknown as HTMLElement)
-        .closest('ul.children')
-        ?.firstElementChild?.getElementsByTagName('ul')[0]
-        ?.querySelectorAll('[data-editable]') as NodeListOf<HTMLElement>
-      return Array.from(children).map(x => (x as HTMLElement).innerText)
-    }, newThoughtEditable)
-
-    expect(selectionTextContent).toBe('new')
-    expect(childrenTexts).toEqual(['foo', 'bar'])
   })
 
   /**


### PR DESCRIPTION
All five were disabled by 79455a9165 (2022-04-09) as a temporary measure to get BrowserStack green, and none has been revived in the four years since. They are not merely idle — they no longer describe the app.

Three assert behavior that was deliberately changed. `Tap empty content while keyboard up` and `Tap empty content while keyboard down` both expect a tap on empty space to move the cursor, which 48116bea2f made a no-op. `Tap hidden root thought` expects a tap on a hidden thought to walk the cursor back to its parent; `Editable` now clears the selection and closes open dropdowns instead.

The other two query `ul.children`, a class removed in b585d482ef, so `closest()` returns null. `Swipe over hidden thought` would read `innerText` off `undefined` and pass vacuously; `Bump Thought Down on a thought that has children` would throw inside `Array.from`.

Also drops the `gestures`, `editThought`, and `getEditable` imports, which no remaining test in the file used. All three helper modules are still imported elsewhere in the iOS suite.

**Coverage lost.** Swipe-to-create-a-new-thought below a hidden thought (#1147) has no replacement at any level; it is already listed under Manual Test Cases in `docs/testing.md`. Bump Thought Down loses only its touch-gesture entry point — the seven unit tests in `src/commands/__tests__/bumpThoughtDown.ts` still cover the action, including the multicursor, cursor-placement, and undo cases. The three behavior-changed tests cover nothing, since the behavior they assert no longer exists.

The iOS suite requires BrowserStack or a local Appium plus Simulator, so this was triaged statically against the current source rather than by running it; `tsc` and eslint are clean.