### PR TITLE
Unskip two importText tests whose expectations were stale

### DIFF
--- a/src/actions/__tests__/importText.ts
+++ b/src/actions/__tests__/importText.ts
@@ -447,14 +447,14 @@ it('single-line nested html tags', () => {
 </ul>`)
 })
 
-// TODO: Needs to be rewritten to avoid converting from HTML -> JSON -> text -> HTML. See commit.
-it.skip('should strip tags whose font weight is less than or equal to 400', () => {
+// Note: consecutive whitespace is collapsed on import, which is equivalent to how the HTML would be rendered.
+it('should strip tags whose font weight is less than or equal to 400', () => {
   const paste = `<span style="font-weight:400;">Hello world. </span> <span style="font-weight:100;">This is a test </span>`
   const actual = importExport(paste, 'text/html')
   const expectedOutput = `<ul>
   <li>${HOME_TOKEN}${EMPTY_SPACE}
     <ul>
-      <li>Hello world.  This is a test</li>
+      <li>Hello world. This is a test</li>
     </ul>
   </li>
 </ul>`
@@ -899,8 +899,7 @@ it('preserve formatting tags', () => {
   expect(importExport('<b>one</b> and <i>two</i>', 'text/html')).toBe(expectedText)
 })
 
-// TODO
-it.skip('WorkFlowy import with notes', () => {
+it('WorkFlowy import with notes', () => {
   expect(
     importExport(
       `


### PR DESCRIPTION
Neither test described a defect in the importer; both encoded an expectation the importer never promised.

`should strip tags whose font weight is less than or equal to 400` expected two spaces between the two stripped spans. Consecutive whitespace collapses on import, which is what a browser renders for the same HTML, so the single space in the output is correct and the expectation was not.

`WorkFlowy import with notes` needed no change at all: a span carrying `aria-label="note"` already imports as a `=note` attribute.