### PR TITLE
Remove the unused testIfNotCI helper

### DIFF
--- a/src/e2e/puppeteer/helpers/testIfNotCI.ts
+++ b/src/e2e/puppeteer/helpers/testIfNotCI.ts
@@ -1,4 +1,0 @@
-/** Replaces the typical `test` call when the test fails intermittently on CI, but not locally. Skips it in the CI. */
-const testIfNotCI = process.env.CI ? test.skip : test
-
-export default testIfNotCI


### PR DESCRIPTION
`testIfNotCI` swaps `test` for `test.skip` when `CI` is set, so that a test which is flaky only on CI can still run locally.

Nothing imports it. `grep -rn testIfNotCI src/ docs/ .github/` matches only its own definition, so it has never skipped anything and only advertises a pattern the project does not use.

No coverage is lost: the helper has no consumers.