### PR TITLE
Restore the ContextView render tests against the LayoutTree DOM

### DIFF
--- a/src/components/__tests__/ContextView.ts
+++ b/src/components/__tests__/ContextView.ts
@@ -1,4 +1,11 @@
-import { findAllByLabelText, findByLabelText, queryByLabelText, queryByText, screen } from '@testing-library/dom'
+import {
+  findAllByLabelText,
+  findByLabelText,
+  findByRole,
+  queryByLabelText,
+  queryByText,
+  screen,
+} from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
@@ -11,7 +18,6 @@ import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import findAllThoughtsByText from '../../test-helpers/queries/findAllThoughtsByText'
 import findSubthoughts from '../../test-helpers/queries/findSubthoughts'
 import findThoughtByText from '../../test-helpers/queries/findThoughtByText'
-import getClosestByLabel from '../../test-helpers/queries/getClosestByLabel'
 import queryThoughtByText from '../../test-helpers/queries/queryThoughtByText'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import series from '../../util/series'
@@ -150,25 +156,9 @@ describe('freeThoughts', () => {
   })
 })
 
-// TODO: Broke after LayoutTree
-describe.skip('render', () => {
-  it('activate toggleContextView', async () => {
-    store.dispatch([
-      importText({
-        text: `
-          - a
-            - m
-          - b
-            - m
-        `,
-      }),
-      setCursor(['a', 'm']),
-      toggleContextView(),
-    ])
-  })
-
+describe('render', () => {
   it('show all the contexts in which a thought exists', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -181,18 +171,19 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const thoughtM = await findThoughtByText('m')
-    const thoughtContainerM = getClosestByLabel(thoughtM, 'child')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const thoughtsA = await findAllThoughtsByText('a', thoughtContainerM)
-    expect(thoughtsA).toHaveLength(1)
+    const contexts = await findSubthoughts('m')
 
-    const thoughtsB = await findAllThoughtsByText('b', thoughtContainerM)
-    expect(thoughtsB).toHaveLength(1)
+    const contextValues = await series(
+      contexts.map(context => async () => (await findByLabelText(context, 'thought')).textContent),
+    )
+
+    expect(contextValues).toEqual(['a', 'b'])
   })
 
   it('do not expand contexts when cursor is on the context view', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -207,18 +198,14 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const thoughtM = await findThoughtByText('m')
-    const thoughtContainerM = getClosestByLabel(thoughtM, 'child')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const thoughtX = await queryThoughtByText('x', thoughtContainerM)
-    expect(thoughtX).toBeNull()
-
-    const thoughtsY = await queryThoughtByText('y', thoughtContainerM)
-    expect(thoughtsY).toBeNull()
+    expect(await queryThoughtByText('x')).toBeNull()
+    expect(await queryThoughtByText('y')).toBeNull()
   })
 
   it('expand cursor on a cyclic context (the context on which the context view is activated)', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -229,24 +216,19 @@ describe.skip('render', () => {
               - y
         `,
       }),
-      setCursor(['a']),
       setCursor(['a', 'm']),
       toggleContextView(),
       setCursor(['a', 'm', 'a']),
     ])
 
-    const thoughtM = await findThoughtByText('m')
-    const thoughtContainerM = getClosestByLabel(thoughtM, 'child')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const thoughtX = await findThoughtByText('x', thoughtContainerM)
-    expect(thoughtX).toBeTruthy()
-
-    const thoughtsY = await queryThoughtByText('y', thoughtContainerM)
-    expect(thoughtsY).toBeNull()
+    expect(await findThoughtByText('x')).toBeTruthy()
+    expect(await queryThoughtByText('y')).toBeNull()
   })
 
   it('expand cursor on a tangential context (from a different part of the hierarchy)', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -257,24 +239,19 @@ describe.skip('render', () => {
               - y
         `,
       }),
-      setCursor(['a']),
       setCursor(['a', 'm']),
       toggleContextView(),
       setCursor(['a', 'm', 'b']),
     ])
 
-    const thoughtM = await findThoughtByText('m')
-    const thoughtContainerM = getClosestByLabel(thoughtM, 'child')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const thoughtX = await queryThoughtByText('x', thoughtContainerM)
-    expect(thoughtX).toBeNull()
-
-    const thoughtsY = await queryThoughtByText('y', thoughtContainerM)
-    expect(thoughtsY).toBeTruthy()
+    expect(await findThoughtByText('y')).toBeTruthy()
+    expect(await queryThoughtByText('x')).toBeNull()
   })
 
   it('show instructions when thought exists in not found in any other contexts', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -283,6 +260,8 @@ describe.skip('render', () => {
       setCursor(['a']),
       toggleContextView(),
     ])
+
+    await act(vi.runOnlyPendingTimersAsync)
 
     // only search for first part of text since the whole text consists of several text nodes
     const instructions = await screen.findAllByText('This thought is not found in any other contexts', { exact: false })
@@ -290,7 +269,7 @@ describe.skip('render', () => {
   })
 
   it('change bullet to no fill', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -300,12 +279,14 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const bulletGlyph = await screen.findByLabelText('bullet-glyph')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const bulletGlyph = (await findThoughtByText('a'))!.closest('[aria-label="child"]')!.querySelector('[data-bullet]')
     expect(bulletGlyph).toHaveAttribute('fill', 'none')
   })
 
-  it.skip('show breadcrumbs for each thought context', async () => {
-    store.dispatch([
+  it('show breadcrumbs for each thought context', async () => {
+    await dispatch([
       importText({
         text: `
           - a
@@ -323,17 +304,16 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const breadcrumbsAB = await findAllByLabelText(subthoughts[0], 'context-breadcrumbs')
-    expect(breadcrumbsAB[0]).toHaveTextContent('a')
+    const contexts = await findSubthoughts('m')
 
-    const breadcrumbsCDE = await findAllByLabelText(subthoughts[1], 'context-breadcrumbs')
-    expect(breadcrumbsCDE[0]).toHaveTextContent('c • d')
+    expect(await findByLabelText(contexts[0], 'context-breadcrumbs')).toHaveTextContent('a')
+    expect(await findByLabelText(contexts[1], 'context-breadcrumbs')).toHaveTextContent('c • d')
   })
 
   it('render home icon as thought for each thought in the home context', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -346,21 +326,22 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    // first context should render home icon
-    const thoughtB = await findByLabelText(subthoughts[0], 'thought')
-    const homeIconB = await findAllByLabelText(thoughtB, 'home')
-    expect(homeIconB).toHaveLength(1)
+    const contexts = await findSubthoughts('m')
 
-    // second context a/b should not render home icon
-    const thoughtA = await findByLabelText(subthoughts[1], 'thought')
-    const homeIconA = await queryByLabelText(thoughtA, 'home')
-    expect(homeIconA).toBeNull()
+    // the home context renders the home icon in place of the thought
+    const thoughtHome = await findByLabelText(contexts[0], 'thought')
+    expect(await findAllByLabelText(thoughtHome, 'home')).toHaveLength(1)
+
+    // the a/b context renders b as the thought
+    const thoughtB = await findByLabelText(contexts[1], 'thought')
+    expect(queryByLabelText(thoughtB, 'home')).toBeNull()
+    expect(thoughtB).toHaveTextContent('b')
   })
 
   it('render correct superscript on contexts', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         /*
 
@@ -392,17 +373,16 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughtsM = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const superscriptA = subthoughtsM[0].querySelector('sup')
-    expect(superscriptA).toHaveTextContent('3')
+    const contexts = await findSubthoughts('m')
 
-    const superscriptB = subthoughtsM[1].querySelector('sup')
-    expect(superscriptB).toHaveTextContent('4')
+    expect(await findByRole(contexts[0], 'superscript')).toHaveTextContent('3')
+    expect(await findByRole(contexts[1], 'superscript')).toHaveTextContent('4')
   })
 
   it('sort contexts by ancestors (breadcrumbs)', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - b
@@ -417,21 +397,20 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const contexts = await findSubthoughts('m')
 
     // get the textContent of each context's breadcrumbs in order
     const breadcrumbsText = await series(
-      subthoughts.map(subthought => async () => {
-        const breadcrumbs = await findByLabelText(subthought, 'context-breadcrumbs')
-        return breadcrumbs.textContent
-      }),
+      contexts.map(context => async () => (await findByLabelText(context, 'context-breadcrumbs')).textContent),
     )
 
     expect(breadcrumbsText).toEqual(['a', 'b'])
   })
 
   it('sort contexts by ancestors with different depths', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - c
@@ -453,21 +432,20 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
+
+    const contexts = await findSubthoughts('m')
 
     // get the textContent of each context's breadcrumbs in order
     const breadcrumbsText = await series(
-      subthoughts.map(subthought => async () => {
-        const breadcrumbs = await findByLabelText(subthought, 'context-breadcrumbs')
-        return breadcrumbs.textContent
-      }),
+      contexts.map(context => async () => (await findByLabelText(context, 'context-breadcrumbs')).textContent),
     )
 
     expect(breadcrumbsText).toEqual(['a • d', 'a • d • e', 'b', 'c'])
   })
 
   it('sort contexts within the same ancestor by value', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -482,21 +460,20 @@ describe.skip('render', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    // get the breadcrumbs and textContent of each context in order
-    const breadcrumbsText = await series(
-      subthoughts.map(subthought => async () => {
-        const thought = await findByLabelText(subthought, 'thought')
-        return thought.textContent
-      }),
+    const contexts = await findSubthoughts('m')
+
+    // get the textContent of each context in order
+    const contextValues = await series(
+      contexts.map(context => async () => (await findByLabelText(context, 'thought')).textContent),
     )
 
-    expect(breadcrumbsText).toEqual(['c', 'd'])
+    expect(contextValues).toEqual(['c', 'd'])
   })
 
   it('Expand grandchildren of contexts', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -514,9 +491,9 @@ describe.skip('render', () => {
       setCursor(['a', 'm', 'a', 'x']),
     ])
 
-    const contextsM = await findSubthoughts('m')
-    const thoughtX1 = await findThoughtByText('x1', contextsM[0])
-    expect(thoughtX1).toBeTruthy()
+    await act(vi.runOnlyPendingTimersAsync)
+
+    expect(await findThoughtByText('x1')).toBeTruthy()
   })
 })
 

--- a/src/test-helpers/queries/findSubthoughts.ts
+++ b/src/test-helpers/queries/findSubthoughts.ts
@@ -1,16 +1,17 @@
-import { findAllByLabelText } from '@testing-library/dom'
 import findThoughtByText from './findThoughtByText'
-import getClosestByLabel from './getClosestByLabel'
 
-/** Finds all the subthoughts of a thought. Returns the child of each. Use findAllByLabelText([CHILD], 'thought') to select a child thought or use findSubthoughts(CHILD) to find child subthoughts. */
+/** The number of characters of a ThoughtId, which is the unit of a hashed Path in data-path. */
+const THOUGHT_ID_LENGTH = 32
+
+/** Finds the tree nodes of a thought's direct children, in the order they are rendered. LayoutTree renders every visible thought as a flat list of tree nodes, so children are identified by their data-path, which is the concatenation of the ids of their Path. In the context view, the children of a thought are its contexts. */
 export default async function findSubthoughts(value?: HTMLElement | string | null): Promise<HTMLElement[]> {
   if (!value) return []
   const thought = typeof value === 'string' ? await findThoughtByText(value) : value
-  const container = getClosestByLabel(thought, 'child')!
-  // there may be expanded descendant subthoughts, so only select the first
-  const subthoughts = (await findAllByLabelText(container, 'subthoughts'))[0]
-  const children = Array.from(subthoughts.childNodes).filter(
-    child => (child as HTMLElement)?.getAttribute('aria-label') === 'child',
-  )
-  return children as HTMLElement[]
+  const node = thought?.closest('[aria-label="tree-node"]')
+  if (!node) throw new Error(`Thought "${typeof value === 'string' ? value : value.textContent}" is not rendered.`)
+  const path = node.getAttribute('data-path')!
+  return Array.from(document.querySelectorAll<HTMLElement>('[aria-label="tree-node"]')).filter(nodeChild => {
+    const pathChild = nodeChild.getAttribute('data-path')!
+    return pathChild.startsWith(path) && pathChild.length === path.length + THOUGHT_ID_LENGTH
+  })
 }


### PR DESCRIPTION
`describe.skip('render')` in `src/components/__tests__/ContextView.ts` was switched off wholesale with `// TODO: Broke after LayoutTree`, taking 14 tests with it.

It broke because of how the tests queried, not what they asserted. Every one of them scoped its search to `getClosestByLabel(thought, 'child')` — the element that used to contain a thought's rendered descendants. LayoutTree flattened the tree, so that element now holds a single thought and nothing beneath it, and the contexts these tests look for are siblings of it in the flat list. The tests also predate fake timers and dispatched through the store without awaiting, so they raced the render.

`findSubthoughts` is rewritten to match the flat list: a tree node carries its Path in `data-path` as concatenated 32-character ids, so one node is a direct child of another exactly when its `data-path` extends the parent's by one id. Every test that reaches for a thought's contexts goes through it. Each test now awaits its dispatch and flushes pending timers before querying. `ContextView.ts` is `findSubthoughts`'s only caller.

Three assertions could not be restored verbatim and were rewritten against DOM that exists: the bullet is found through the thought's own container rather than a document-wide `bullet-glyph` search, the superscript through its role rather than a raw `sup` tag, and the home icon test now also asserts what the non-home context renders instead of only that it lacks the icon.

Worth knowing what the skip was hiding: unskipping the block with no other change leaves three of the fourteen passing, and two of those could not have failed. `activate toggleContextView` has no assertions at all — it dispatches and ends — and is deleted here rather than rewritten. `do not expand contexts when cursor is on the context view` asserted only that `x` and `y` were absent from a container that under LayoutTree holds no descendants, so it was guaranteed to pass; it now asserts their absence from the document. Only `show instructions when thought exists in not found in any other contexts` was genuinely passing.

`describe.skip('editing')` is left alone — it is skipped for an unrelated reason (contenteditable under user-event v13).