### PR TITLE
Remove the obsolete importData test "empty thought with nested li's"

### DIFF
--- a/src/actions/__tests__/importData.ts
+++ b/src/actions/__tests__/importData.ts
@@ -614,25 +614,6 @@ it("<span> with nested li's", async () => {
 `)
 })
 
-// TODO
-it.skip("empty thought with nested li's", async () => {
-  expect(
-    await importExport(
-      `
-<li>
-  <ul>
-    <li>x</li>
-    <li>y</li>
-  </ul>
-</li>
-`,
-    ),
-  ).toBe(`
-  - x
-  - y
-`)
-})
-
 // TODO: Indentation is off
 it.skip("do not add empty parent thought when empty li node has no nested li's", async () => {
   expect(


### PR DESCRIPTION
The test expected an empty `<li>` wrapping a nested list to disappear, hoisting its children to the root. That is no longer the intended behavior: preserving an empty thought as a parent is what #2167 and #4448 established, and the importData test `blank thoughts with subthoughts` asserts exactly the opposite outcome for the same structure.

Its expected output was also internally inconsistent. It indented `x` and `y` by two spaces while asserting no parent existed, but `importExport` renders root-level thoughts with no indentation, so the expectation could not have been satisfied by either behavior.

No coverage is lost. The empty-parent case is covered by `blank thoughts with subthoughts` and `empty parent`, and the complementary case by `do not add empty parent thought when empty li node has no nested li's`.

Touches the same file as two sibling PRs, so expect a merge conflict with whichever lands second.