### PR TITLE
Assert the implemented soft-wrap behavior in markdownToText

### DIFF
--- a/src/util/__tests__/markdownToText.ts
+++ b/src/util/__tests__/markdownToText.ts
@@ -17,9 +17,9 @@ p3
 `)
   })
 
-  // TODO: This test is skipped while we're evaluating whether to
-  // import separate lines as separate thoughts.
-  it.skip('should import separate lines as separate thoughts', () => {
+  // Soft-wrapped lines are a single paragraph in Markdown, so they are imported as a single thought with encoded line
+  // breaks, the same way multiline code and blockquotes are imported.
+  it('should import soft-wrapped lines as a single thought', () => {
     const markdown = `
 p1
 p2
@@ -27,9 +27,7 @@ p3
 `
 
     expect(markdownToText(markdown)).toBe(`
-- p1
-- p2
-- p3
+- p1&#10;p2&#10;p3
 `)
   })
 
@@ -90,28 +88,6 @@ p3
   - b
   - c
 - Heading 1 again
-`)
-  })
-
-  // TODO: This test is skipped while we're evaluating whether to
-  // import separate lines as separate thoughts.
-  it.skip('should import mixed text and lists', () => {
-    const markdown = `
-p1
-p2
-- a
-  - b
-    - c
-p3
-`
-
-    expect(markdownToText(markdown)).toBe(`
-- p1
-- p2
-- a
-  - b
-    - c
-- p3
 `)
   })
 


### PR DESCRIPTION
Both skipped tests were written against a design that was being evaluated and never adopted: importing each line of a paragraph as its own thought. They were left in place pending that decision, which has since gone the other way.

`should import separate lines as separate thoughts` becomes `should import soft-wrapped lines as a single thought`, asserting what the importer actually does. Soft-wrapped lines are one paragraph in CommonMark, so they import as one thought with encoded line breaks, consistent with how multiline code blocks and blockquotes already import.

`should import mixed text and lists` is removed rather than rewritten. Once the soft-wrapped lines collapse into a single thought, the only remaining question is whether the list is scoped under the preceding paragraph, and `should import mixed paragraphs and lists` already covers that.