### PR TITLE
Unskip the getCommandState span color test

### DIFF
--- a/src/util/__tests__/getCommandState.ts
+++ b/src/util/__tests__/getCommandState.ts
@@ -122,15 +122,16 @@ it('text and background color on font tag', () => {
   })
 })
 
-// NOT IMPLEMENTED
-it.skip('text and background color on span tag', () => {
+// A color in a style attribute is read through CSSOM, which normalizes it to rgb(), unlike the color attribute of a
+// font tag which is read verbatim. Downstream comparisons normalize both forms (see isColorSelected).
+it('text and background color on span tag', () => {
   expect(getCommandState('<span style="color: #000000; background-color: rgb(0, 0, 255);">a</span>')).toStrictEqual({
     bold: false,
     italic: false,
     underline: false,
     strikethrough: false,
     code: false,
-    foreColor: '#000000',
+    foreColor: 'rgb(0, 0, 0)',
     backColor: 'rgb(0, 0, 255)',
   })
 })


### PR DESCRIPTION
The `// NOT IMPLEMENTED` comment was wrong. `extractColors` reads `el.style.color`, which resolves for a span just as it does for a font tag, so span colors have been detected all along.

The only real difference is representation. A color read through a style attribute goes through CSSOM, which normalizes `#000000` to `rgb(0, 0, 0)`, whereas the `color` attribute of a font tag is returned verbatim. That distinction does not reach any caller: `isColorSelected` runs both forms through `rgbToHex` before comparing them.

Note that open PR #4842 adds a test to this file immediately above this one, so whichever lands second may need a trivial conflict resolution.