### PR TITLE
docs(run-test): explain why the puppeteer script owns the dev server

### DIFF
--- a/.github/skills/run-test/SKILL.md
+++ b/.github/skills/run-test/SKILL.md
@@ -44,6 +44,13 @@ GITHUB_ACTIONS="" ./src/e2e/puppeteer/test-puppeteer.sh src/e2e/puppeteer/__test
 
 Prerequisite: **Docker** available (for browserless). The script manages the container and dev server itself — do not start your own, and do not point it at the shared `:9222` Chrome / `:3000` server used during exploration.
 
+That last rule is load-bearing, because a stale dev server fails *silently and misleadingly* rather than loudly. `vite --strictPort` exits immediately when an earlier instance still holds `:2552`, so a restart can leave the old server running, and a liveness check like `nc -z localhost 2552` still succeeds. The suite then runs against whatever source that server started with: an edit you just made — a rebase especially — appears to have no effect, and the run reads as missing functionality rather than a stale environment. If you ever drive Vitest directly (`npx vitest run --project puppeteer-e2e <file>`), which bypasses the script's orphaned-server guard, prove the server is newer than your last edit before you believe a failure:
+
+```bash
+ps -eo pid,lstart,command | grep '[v]ite --host --port 2552'  # started before your edit? kill it, restart, re-check
+curl -sk https://localhost:2552/src/<edited file> | grep '<something you just changed>'
+```
+
 ## iOS — WDIO + Appium
 
 iOS tests run on **BrowserStack** real devices, exactly as iOS reproduction does (see `browser-control-ios`). **This is the path in the agent/Copilot environment — there is no local simulator there.** A local simulator is a local-developer convenience only.


### PR DESCRIPTION
`run-test` told the agent not to start its own dev server but not what goes wrong if it does, and the failure mode is silent rather than loud.

`vite --strictPort` exits immediately when an earlier instance still holds `:2552`, so a restart can leave the previous server running, while a liveness check like `nc -z localhost 2552` still reports the port as live. The suite then runs against whatever source that server started with. An edit that has not taken effect — after a rebase especially — reads as missing functionality rather than as a stale environment, which is exactly the wrong diagnosis to reach for.

Names the trap where the rule already lives, and gives the two checks that settle it, for the case where Vitest is driven directly (in a worktree, say) and the script's orphaned-server guard never runs.