### PR TITLE
Restore the ContextView edit-a-context test

### DIFF
--- a/src/components/__tests__/ContextView.ts
+++ b/src/components/__tests__/ContextView.ts
@@ -497,11 +497,9 @@ describe('render', () => {
   })
 })
 
-// contenteditable is not supported in user-event@v13
-// TODO: user-event@v14 has some peer dependency conflicts
-describe.skip('editing', () => {
+describe('editing', () => {
   it('edit a context', async () => {
-    store.dispatch([
+    await dispatch([
       importText({
         text: `
           - a
@@ -514,25 +512,27 @@ describe.skip('editing', () => {
       toggleContextView(),
     ])
 
-    const subthoughts = await findSubthoughts('m')
+    await act(vi.runOnlyPendingTimersAsync)
 
-    const thoughtA = await findByLabelText(subthoughts[0], 'thought')
+    const contexts = await findSubthoughts('m')
+    const thoughtA = (await findThoughtByText('a', contexts[0]))!
 
     const user = userEvent.setup({ delay: null })
     await user.click(thoughtA)
 
+    await act(vi.runAllTimersAsync)
+
+    // jsdom leaves the caret at offset 0, so the typed character is prepended
     await user.type(thoughtA, 'z')
 
-    await user.type(thoughtA, '{esc}')
-    store.dispatch(toggleContextView())
+    await act(vi.runAllTimersAsync)
 
-    const thoughtA2 = await findAllThoughtsByText('a')
-    expect(thoughtA2).toHaveLength(0)
+    // a context is the thought itself, so renaming it renames the thought everywhere it is rendered:
+    // once in the tree and once as a context of m
+    expect(await findAllThoughtsByText('za')).toHaveLength(2)
+    expect(await queryThoughtByText('a')).toBeNull()
 
-    const thoughtAZ = await findAllThoughtsByText('az')
-    expect(thoughtAZ).toHaveLength(1)
-
-    const thoughtB = await findAllThoughtsByText('b')
-    expect(thoughtB).toHaveLength(1)
+    // the other context is untouched
+    expect(await findAllThoughtsByText('b')).toHaveLength(2)
   })
 })


### PR DESCRIPTION
Stacked on #5035, which rewrites the rest of `ContextView.ts` against the LayoutTree DOM. Review that one first; this branch adds one commit on top and its base should be retargeted to `main` once #5035 merges. With it, `ContextView.ts` has no skipped tests left.

`describe.skip('editing')` carried two reasons: contenteditable was unsupported in user-event v13, and a `TODO` to revisit once v14 landed. v14 is installed, so the stated blocker is gone. What actually remained was a bad click target.

The test clicked the element labelled `thought` — `StaticThought`'s wrapper div, not the contenteditable inside it. Clicking the wrapper leaves `state.cursor` untouched, so the typing that followed went nowhere and the assertions described an edit that never happened. Clicking the contenteditable moves the cursor onto the context and the edit lands.

Two consequences of that, now reflected in the test:

- jsdom leaves the caret at offset 0 rather than at the end of the text, so typing `z` prepends. The expected value is `za`, not `az`.
- A context *is* the thought, so renaming it renames the thought everywhere it renders — once in the tree and once as a context of `m`. The old assertions expected the edit in only one of the two and toggled the context view off to check; both are now asserted directly.

This is the coverage that `src/e2e/puppeteer/__tests__/editContext.ts` duplicates more weakly.