### PR TITLE
Fix cursorDown skipping lines of a wrapped thought

### DIFF
--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -108,6 +108,38 @@ export const isThought = (node?: EventTarget | null): boolean => {
   return isContentEditable(editable) || isNoteEditable(editable)
 }
 
+/**
+ * Returns the client rects of a selection range, measuring the adjacent character when the range itself reports none.
+ *
+ * A range collapsed immediately before an element's first child reports no client rects in Chrome, which is exactly
+ * where the caret lands at offset 0 of a thought. Without a fallback, callers cannot tell which line the caret is on
+ * and assume it is the only line, so cursorDown skips past the remaining lines of a wrapped thought.
+ */
+const getRangeRects = (range: Range): DOMRect[] => {
+  const rects = Array.from(range.getClientRects())
+  if (rects.length) return rects
+
+  // Descend from an element container to the text node that the caret is positioned before.
+  let node: Node | null = range.startContainer
+  let offset = range.startOffset
+  while (node && node.nodeType !== Node.TEXT_NODE) {
+    const child: Node | null = node.childNodes[offset] ?? node.childNodes[node.childNodes.length - 1] ?? null
+    if (!child) return []
+    node = child
+    offset = 0
+  }
+
+  // An empty thought has no character to measure, and legitimately occupies a single line.
+  const length = node?.textContent?.length ?? 0
+  if (!node || !length) return []
+
+  // Measure the character next to the caret, which is always on the same line as the caret.
+  const probe = document.createRange()
+  probe.setStart(node, Math.min(offset, length - 1))
+  probe.setEnd(node, Math.min(offset + 1, length))
+  return Array.from(probe.getClientRects())
+}
+
 /** Returns true if the selection is  on the first line of a multi-line text node. Returns true if there is no selection or if the text node is only a single line. */
 export const isOnFirstLine = (): boolean => {
   const selection = window.getSelection()
@@ -142,13 +174,14 @@ export const isOnLastLine = (): boolean => {
   const { anchorNode: baseNode, rangeCount } = selection
   if (rangeCount === 0) return true
 
-  const clientRects = selection.getRangeAt(0).getClientRects()
-  if (!clientRects?.length) return true
+  const clientRects = getRangeRects(selection.getRangeAt(0))
+  if (!clientRects.length) return true
 
   const { y: rangeY, height: rangeHeight } = clientRects[0]
   if (!rangeY) return true
 
-  const baseNodeParentEl = baseNode?.parentElement as HTMLElement
+  // The anchor is a text node for a caret within the text, but is the editable itself when the caret is at offset 0.
+  const baseNodeParentEl = (baseNode instanceof Element ? baseNode : baseNode?.parentElement) as HTMLElement
   if (!baseNodeParentEl) return true
 
   // baseNodeParentEl is the thought for plain text, but formatted text requires traversing up

--- a/src/e2e/puppeteer/__tests__/caret-multiline.ts
+++ b/src/e2e/puppeteer/__tests__/caret-multiline.ts
@@ -104,7 +104,7 @@ describe('all platforms', () => {
   })
 
   // test case 5
-  it.skip('on 2x cursorDown, the caret should move from the end of a cursor into the 2nd line of the new multi-line cursor.', async () => {
+  it('on 2x cursorDown, the caret should move from the end of a cursor into the 2nd line of the new multi-line cursor.', async () => {
     const multiLineCursor =
       "Beautiful antique furnishings fill this quiet, comfortable flat across from the Acropolis museum. AC works great. It is in an heavily touristic area, but the convenience can't be beat. Highly recommended."
     const importText = `
@@ -275,7 +275,7 @@ describe('all platforms', () => {
     await paste(importText)
 
     const editableNodeHandle = await waitForEditable(multiLineCursor)
-    // due to an outstanding bug (see test case 5), pressing ArrowDown from offset 0 will skip to the next thought
+    // click at offset 1 rather than 0 so that the subsequent ArrowLeft lands on the start of the 2nd line
     await click(editableNodeHandle, { offset: 1 })
     await press('ArrowDown')
     await press('ArrowLeft')


### PR DESCRIPTION
With the caret at offset 0 of a wrapped thought, `cursorDown` jumped to the next thought instead of moving into the thought's second line.

`isOnLastLine` decides that. It reads the geometry of the selection range, but a `Range` collapsed immediately before an element's first child reports zero client rects in Chrome — and that is exactly where the caret sits at offset 0. With no rects, the function took its `if (!clientRects?.length) return true` bail-out and reported the caret as already on the last line.

Measure the character adjacent to the caret when the range itself reports none. That character is always on the caret's line, so it supplies the line geometry the collapsed range withholds. An empty thought has no character to measure and genuinely occupies one line, so it keeps the existing answer.

At offset 0 the selection anchor is also the editable element rather than a text node, so the thought element is now resolved from an `Element` anchor as well as from a text node's parent.

`isOnFirstLine` has the identical bail-out. No test fails on it, so it is left alone rather than changed speculatively.

Test case 5 in `caret-multiline` covers exactly this and is unskipped. The comment in the later test that clicks at offset 1 no longer needs to cite the bug as the reason; it now states the actual reason (the following `ArrowLeft` must land on the start of the second line).