### PR TITLE
Unskip the caret-after-split-on-enter test

### DIFF
--- a/src/e2e/puppeteer/__tests__/caret.ts
+++ b/src/e2e/puppeteer/__tests__/caret.ts
@@ -26,8 +26,7 @@ import { usePersistentTreecrdtStorage } from '../setup'
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
 describe('all platforms', () => {
-  // TODO: Why is this failing?
-  it.skip('caret should be at the beginning of thought after split on enter', async () => {
+  it('caret should be at the beginning of thought after split on enter', async () => {
     const importText = `
     - puppeteer
       - web scraping


### PR DESCRIPTION
The test asserts that splitting a thought with Enter leaves the caret at offset 0 of the new thought. It was skipped behind `// TODO: Why is this failing?`, which never named a cause.

The split rewrites in #4959 and #4960 fixed it. The test body needs no change — only the `.skip` and the obsolete TODO come off.

Note for merge order: #5044 and #5045 also edit `caret.ts`, in different tests, so they will conflict textually with this one.