### PR TITLE
Assert that pasted font tags are preserved verbatim

### DIFF
--- a/src/e2e/puppeteer/__tests__/escape-html.ts
+++ b/src/e2e/puppeteer/__tests__/escape-html.ts
@@ -25,8 +25,7 @@ it('preserves pasted HTML as text/html in bold case', async () => {
   expect(editable).toBeTruthy()
 })
 
-// TODO: Broken in due to reverting related code. See: #2814.
-it.skip('preserves pasted HTML as text/html with text color and background color', async () => {
+it('preserves pasted HTML as text/html with text color and background color', async () => {
   await press('Enter', { delay: 10 })
   await setClipboard({
     html: '<font color="#000000" style="background-color: rgb(255, 136, 0);">Hello </font><font color="#000000" style="background-color: rgb(0, 214, 136);">World</font>',
@@ -34,8 +33,10 @@ it.skip('preserves pasted HTML as text/html with text color and background color
   })
   await press('Insert', { shift: true })
 
+  // Pasted markup is preserved verbatim rather than being re-parsed into equivalent <span style> tags.
+  // See textToHtml, which no longer strips and re-parses HTML: https://github.com/cybersemics/em/pull/2814
   const editable = await waitForEditable(
-    '<span style="background-color: rgb(255, 136, 0);color: #000000;">Hello </span><span style="background-color: rgb(0, 214, 136);color: #000000;">World</span>',
+    '<font color="#000000" style="background-color: rgb(255, 136, 0);">Hello </font><font color="#000000" style="background-color: rgb(0, 214, 136);">World</font>',
   )
   expect(editable).toBeTruthy()
 })


### PR DESCRIPTION
The test pastes two `<font>` tags carrying a text color and a background color and expected them back as `<span style>` tags. That conversion was removed by the revert in #2814 — pasted markup is now preserved as authored — so the test was skipped rather than updated, and colored paste has been unguarded since.

Expect the `<font>` tags themselves. The assertion still checks that both the text color and the background color survive the round trip; only the markup shape it expects changes, to the one the app actually produces.