### PR TITLE
Remove the two skipped layout-shift expansion tests

### DIFF
--- a/src/e2e/puppeteer/__tests__/layout-shift.ts
+++ b/src/e2e/puppeteer/__tests__/layout-shift.ts
@@ -1,5 +1,4 @@
 import { describe, expect } from 'vitest'
-import clickBullet from '../helpers/clickBullet'
 import clickThought from '../helpers/clickThought'
 import paste from '../helpers/paste'
 import press from '../helpers/press'
@@ -154,38 +153,6 @@ describe('thought y position stability', () => {
 
     const { measurePromise } = await measureYShift('c')
     await clickThought('b')
-    expectStableY(await measurePromise)
-  })
-
-  it.skip('non-last subthought should not shift y position when parent is expanded', async () => {
-    await paste(`
-        - a
-          - b
-          - c
-      `)
-    await waitForEditable('b')
-    await clickThought('a')
-    await clickBullet('a')
-
-    const { measurePromise } = await measureYShift('b')
-    await clickBullet('a')
-    expectStableY(await measurePromise)
-  })
-
-  it.skip('last subthought should not shift y position when parent is expanded', async () => {
-    await paste(`
-        - X
-          - A
-          - B
-          - C
-          - D
-          - E
-        - Y
-      `)
-    await press('Escape')
-
-    const { measurePromise } = await measureYShift('E')
-    await clickThought('X')
     expectStableY(await measurePromise)
   })
 })


### PR DESCRIPTION
Both tests were added already skipped by #4254, to document a known bug rather than to guard behavior, so neither has ever run.

They fail deterministically, both by exactly 4.50px:

```
Thought "b" y shifted 4.50px up (before=38.25, after=33.75)
Thought "E" y shifted 4.50px down (before=164.25, after=168.75)
```

4.50px is `cliffPadding` — `fontSize / 4` in `LayoutTree` at an 18px font. A thought that gains or loses a cliff has its `paddingBottom` change before its height is re-measured, so for one frame the next thought is positioned from a stale height and its y moves by the padding.

`usePositionedThoughts` already anticipates this for the one case it can detect cheaply — a new thought rendered at a cliff — and its comment explains why the general case was left alone: it would require persisting each thought's last cliff in a ref. Nobody has done that. A permanently skipped test does not move it along, and in a suite where every other test runs it reads as coverage that does not exist.

## Coverage

The three remaining `layout-shift` tests still guard y stability for a new thought, a new sibling after a thought with children, and a collapse/expand round trip.

What is lost is the record of the unfixed case. Their origin issue #3672 only tracked adding the tests and is closed, so once these go the cliff-padding mistiming has no tracking issue — worth opening one.