### PR TITLE
Match isMultiEditing's caret check to the cursor thought

### DIFF
--- a/docs/cursor-and-caret.md
+++ b/docs/cursor-and-caret.md
@@ -184,7 +184,9 @@ It is rendered as a sibling *after* the `ContentEditable`, and always in the sam
 
 ### Multi edit mode
 
-[`isMultiEditing`](../src/selectors/isMultiEditing.ts) is true when a multiselection is actually being *edited*: the keyboard is open, the cursor is a multicursor member, and the browser selection is inside a thought. Only Clear Thought puts the app in this state (via `useEditMode`'s relaxed multicursor guard); an ordinary multiselection leaves the caret outside any editable, so the predicate consults the DOM selection to tell the two apart.
+[`isMultiEditing`](../src/selectors/isMultiEditing.ts) is true when a multiselection is actually being *edited*: the keyboard is open, the cursor is a multicursor member, and the caret is in the cursor thought. Only Clear Thought puts the app in this state (via `useEditMode`'s relaxed multicursor guard); an ordinary multiselection leaves the caret outside any editable, so the predicate consults the DOM selection to tell the two apart.
+
+The caret is checked against the cursor thought specifically, not merely against some thought. Shift + ArrowUp/ArrowDown moves the cursor onto the next thought and only takes the caret out of the thought the multiselect started from on the following animation frame, so for that frame the caret is in a thought that is not the cursor. Accepting any thought would read that as multi edit mode and make every command below defer to the browser — most visibly Escape, which would exit an editing session that was never entered and leave the multiselection standing.
 
 Commands and gestures that otherwise take over the interaction defer to native editing behavior in this state:
 

--- a/src/commands/__tests__/cursorBack.ts
+++ b/src/commands/__tests__/cursorBack.ts
@@ -1,0 +1,92 @@
+import { act } from 'react'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { keyboardOpenActionCreator as keyboardOpen } from '../../actions/keyboardOpen'
+import { executeCommand } from '../../commands'
+import store from '../../stores/app'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import initStore from '../../test-helpers/initStore'
+import findThoughtByText from '../../test-helpers/queries/findThoughtByText'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import headValue from '../../util/headValue'
+import cursorBackCommand from '../cursorBack'
+import cursorDownCommand from '../cursorDown'
+
+beforeEach(initStore)
+
+/** Synthetic Shift+Down keyboard event. */
+const shiftDownEvent = { shiftKey: true, preventDefault: () => {} } as unknown as KeyboardEvent
+
+/** Returns the sorted values of the current multicursor set. */
+const multicursorValues = (): (string | undefined)[] => {
+  const state = store.getState()
+  return Object.values(state.multicursors)
+    .map(path => headValue(state, path))
+    .sort()
+}
+
+/** Focuses the given editable and places a collapsed caret in it, as clicking a thought does. */
+const setCaret = (editable: HTMLElement) => {
+  editable.focus()
+  const range = document.createRange()
+  range.setStart(editable.childNodes[0], 0)
+  range.collapse(true)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+describe('cursorBack', () => {
+  beforeEach(createTestApp)
+  afterEach(cleanupTestApp)
+
+  // Shift + ArrowDown moves the cursor onto the next thought but leaves the caret behind in the thought the
+  // multiselect started from, and only takes it away on the next animation frame. Escape must clear the
+  // multiselect within that window rather than mistaking it for a multiselection that is being edited (Clear
+  // Thought), which it exits while leaving the multiselection intact.
+  // https://github.com/cybersemics/em/actions/runs/32523529894/job/96900697473
+  it('clears a multiselect extended with Shift + ArrowDown while the caret is still in the first selected thought', async () => {
+    await act(async () => {
+      store.dispatch([
+        importText({
+          text: `
+            - a
+            - b
+            - c
+          `,
+        }),
+        setCursor(['a']),
+        keyboardOpen({ value: true }),
+      ])
+    })
+
+    // place the caret in a, as clicking the thought does
+    setCaret((await findThoughtByText('a'))!)
+
+    // Hold back the animation frame in which cursorDown takes the caret away, and the blur that Editable
+    // performs on the render that follows, so that Escape is executed within the window in which the caret is
+    // still in a.
+    const requestAnimationFrameMock = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0)
+    const blurMock = vi.spyOn(HTMLElement.prototype, 'blur').mockImplementation(() => {})
+
+    try {
+      await act(async () => {
+        executeCommand(cursorDownCommand, { store, event: shiftDownEvent })
+      })
+
+      const state = store.getState()
+      expect(multicursorValues()).toEqual(['a', 'b'])
+      // the cursor is on b, but the caret is still in a
+      expect(state.cursor && headValue(state, state.cursor)).toBe('b')
+      expect(window.getSelection()?.focusNode?.textContent).toBe('a')
+
+      await act(async () => {
+        cursorBackCommand.exec(store.dispatch, store.getState, {} as KeyboardEvent, { type: 'keyboard' })
+      })
+    } finally {
+      requestAnimationFrameMock.mockRestore()
+      blurMock.mockRestore()
+    }
+
+    expect(multicursorValues()).toEqual([])
+  })
+})

--- a/src/e2e/puppeteer/__tests__/multiselect.ts
+++ b/src/e2e/puppeteer/__tests__/multiselect.ts
@@ -24,6 +24,22 @@ const shiftClickThought = async (value: string) => {
   }
 }
 
+/** Waits for the given number of bullets to be highlighted by the multiselect. Reports the number that are
+ * actually highlighted on timeout, since the alternative — puppeteer's own 30 s default, which outlives the
+ * test timeout — fails the test without saying which step never arrived. */
+const waitForHighlightedBullets = async (n: number) => {
+  try {
+    await page.waitForFunction(
+      (n: number) => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === n,
+      { timeout: 10000 },
+      n,
+    )
+  } catch {
+    const highlighted = await page.$$eval('[aria-label="bullet"][data-highlighted="true"]', bullets => bullets.length)
+    throw new Error(`Expected ${n} highlighted bullets, but ${highlighted} were highlighted.`)
+  }
+}
+
 describe('multiselect', () => {
   // https://github.com/cybersemics/em/issues/4740
   it('starts multiselect at the Shift-clicked thought when there is no selection', async () => {
@@ -172,14 +188,10 @@ describe('multiselect', () => {
     await clickThought('c')
 
     await press('ArrowUp', { shift: true })
-    await page.waitForFunction(
-      () => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 2,
-    )
+    await waitForHighlightedBullets(2)
 
     await press('ArrowUp', { shift: true })
-    await page.waitForFunction(
-      () => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 3,
-    )
+    await waitForHighlightedBullets(3)
 
     const visibleThoughts = await page.$$eval('[data-editable]', elements => elements.map(el => el.innerHTML))
 
@@ -199,14 +211,10 @@ describe('multiselect', () => {
     await clickThought('a')
 
     await press('ArrowDown', { shift: true })
-    await page.waitForFunction(
-      () => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 2,
-    )
+    await waitForHighlightedBullets(2)
 
     await press('ArrowDown', { shift: true })
-    await page.waitForFunction(
-      () => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 3,
-    )
+    await waitForHighlightedBullets(3)
 
     /** Returns the rotation of the given thought's bullet. The triangle is rotated a quarter turn to point down when the thought is expanded, and is unrotated to point right when it is collapsed. */
     const bulletRotation = (value: string) =>
@@ -222,9 +230,7 @@ describe('multiselect', () => {
     expect(await bulletRotation('c')).toBe('none')
 
     await press('Escape')
-    await page.waitForFunction(
-      () => document.querySelectorAll('[aria-label="bullet"][data-highlighted="true"]').length === 0,
-    )
+    await waitForHighlightedBullets(0)
 
     // the cursor is still on c, which expands once it is no longer selected
     await waitForEditable('y')

--- a/src/selectors/isMultiEditing.ts
+++ b/src/selectors/isMultiEditing.ts
@@ -1,5 +1,6 @@
 import State from '../@types/State'
 import * as selection from '../device/selection'
+import head from '../util/head'
 import isMulticursorPath from './isMulticursorPath'
 
 /** Returns true if a multiselection is being edited, i.e. the real caret is in the cursor thought and the cursor is one
@@ -8,9 +9,15 @@ import isMulticursorPath from './isMulticursorPath'
  * Commands that would otherwise hijack an ordinary editing keystroke defer to the browser in this state, e.g. Backspace
  * within the text deletes a character and Select All selects the text rather than the thoughts.
  *
- * The browser selection is checked because an ordinary multiselection leaves the caret outside of any thought; only an
- * edited multiselection places it back in one. */
+ * The caret is checked against the cursor thought specifically, not just any thought: Shift + ArrowUp/ArrowDown extends
+ * a multiselection while leaving the caret behind in the thought the selection started from, and only clears it on the
+ * next animation frame. Accepting the caret in any thought would classify that ordinary multiselection as an edited one
+ * until the frame lands, so a command dispatched within it would defer to the browser, e.g. Escape would fail to clear
+ * the multiselection. */
 const isMultiEditing = (state: State): boolean =>
-  !!state.isKeyboardOpen && !!state.cursor && isMulticursorPath(state, state.cursor) && selection.isThought()
+  !!state.isKeyboardOpen &&
+  !!state.cursor &&
+  isMulticursorPath(state, state.cursor) &&
+  selection.isOnEditable(head(state.cursor))
 
 export default isMultiEditing


### PR DESCRIPTION
Fixes the flaky Puppeteer test `multiselect.ts > points the bullet of a selected thought to the right, and expands it when the multiselect is cancelled`, seen in [this run](https://github.com/cybersemics/em/actions/runs/32523529894/job/96900697473) where it consumed the full 20 s test timeout.

## The bug

[`isMultiEditing`](https://github.com/cybersemics/em/blob/main/src/selectors/isMultiEditing.ts) documents itself as "the real caret is in **the cursor thought** and the cursor is one of the selected thoughts", but it checked `selection.isThought()`, which is true whenever any editable holds the focus.

`cursorUp`/`cursorDown` move the cursor onto the next thought and only take the caret out of the thought the multiselect started from on the next animation frame. Within that window the caret is in a thought that is *not* the cursor, so an ordinary Shift + Arrow multiselect reads as an edited one (the Clear Thought state), and every command that defers to multi edit mode does the wrong thing — most visibly Escape, which exits an editing session that was never entered and leaves the multiselection standing.

Nothing clears the multiselect after that but another keystroke, so the test's `waitForFunction` for zero highlighted bullets never resolves and the test dies on its timeout rather than on an assertion.

## The fix

Check the caret against the cursor thought with `selection.isOnEditable(head(cursor))` — the same predicate `indent` and `outdent` already use for "the caret is in the cursor thought". The result can no longer be true for a Shift + Arrow multiselect at any point in the frame, instead of only once the caret happens to have been cleared.

## Notes for the reviewer

- **On the diagnosis.** I reproduced the mechanism end to end in Puppeteer: with a multiselect of a/b/c and the caret placed back in the cursor thought, Escape leaves all three bullets highlighted permanently. What I could **not** reproduce is the natural trigger — across ~200 instrumented iterations (dev and production builds, 4–8× CPU throttling, CPU-starved runs) the caret was always gone by the time Escape was sent. So this is the one mechanism I found that hangs one of that test's three waits forever, proven in isolation, but not a proven causal link to that particular CI run.
- **Behavior change on the other consumers.** `isMultiEditing` also gates `deleteEmptyThoughtOrOutdent`, `selectAll`, `caretRectStore`, and the tap handlers in `Editable`/`useEditMode`. In genuine Clear Thought multi editing the caret is in the cursor thought, so all of them keep their current behavior; the change only shrinks the set of false positives.
- **Diagnosability.** The three bullet-count waits in `multiselect.ts` now go through one helper with a timeout of its own that reports how many bullets *were* highlighted. Puppeteer's 30 s default outlives the file's 20 s test timeout, which is why the original failure named no step.

## Testing

- New `src/commands/__tests__/cursorBack.ts` fails without the fix at the intended assertion with the bug's value (`['a','b']` rather than `[]`), and passes with it.
- Unit suite: 1912 passed, 62 skipped.
- Puppeteer suite: 209 passed, 11 skipped, 40 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)