### PR TITLE
Factor multicursorValues out into a shared test helper

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -568,6 +568,7 @@ The helpers in [`../src/test-helpers/`](../src/test-helpers) cover store setup a
 - **Operate-by-value helpers.** Where a test would otherwise need to look up a `ThoughtId` to dispatch an action, prefer the value-keyed variants:
   - [`newThoughtAtFirstMatch`](../src/test-helpers/newThoughtAtFirstMatch.ts), [`editThoughtByContext`](../src/test-helpers/editThoughtByContext.ts), [`moveThoughtAtFirstMatch`](../src/test-helpers/moveThoughtAtFirstMatch.ts), [`deleteThoughtAtFirstMatch`](../src/test-helpers/deleteThoughtAtFirstMatch.ts), [`addMulticursorAtFirstMatch`](../src/test-helpers/addMulticursorAtFirstMatch.ts).
 - **Read-by-value helpers.** [`getAllChildrenByContext`](../src/test-helpers/getAllChildrenByContext.ts), [`getChildrenRankedByContext`](../src/test-helpers/getChildrenRankedByContext.ts), [`getAllChildrenAsThoughtsByContext`](../src/test-helpers/getAllChildrenAsThoughtsByContext.ts), [`attributeByContext`](../src/test-helpers/attributeByContext.ts), [`contextToThought`](../src/test-helpers/contextToThought.ts).
+- [`multicursorValues`](../src/test-helpers/multicursorValues.ts) — the sorted thought values of the current multicursor set, so multiselect assertions read as values rather than ids.
 - [`expectPathToEqual`](../src/test-helpers/expectPathToEqual.ts) — Jest matcher that compares paths by their thought *values* rather than ids, so test failures are readable.
 - [`dataProviderTest`](../src/test-helpers/dataProviderTest.ts) — shared assertions for storage providers that implement the data provider interface.
 

--- a/src/commands/__tests__/cursorBack.ts
+++ b/src/commands/__tests__/cursorBack.ts
@@ -5,6 +5,7 @@ import { executeCommand } from '../../commands'
 import store from '../../stores/app'
 import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
 import initStore from '../../test-helpers/initStore'
+import multicursorValues from '../../test-helpers/multicursorValues'
 import findThoughtByText from '../../test-helpers/queries/findThoughtByText'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import headValue from '../../util/headValue'
@@ -15,14 +16,6 @@ beforeEach(initStore)
 
 /** Synthetic Shift+Down keyboard event. */
 const shiftDownEvent = { shiftKey: true, preventDefault: () => {} } as unknown as KeyboardEvent
-
-/** Returns the sorted values of the current multicursor set. */
-const multicursorValues = (): (string | undefined)[] => {
-  const state = store.getState()
-  return Object.values(state.multicursors)
-    .map(path => headValue(state, path))
-    .sort()
-}
 
 /** Focuses the given editable and places a collapsed caret in it, as clicking a thought does. */
 const setCaret = (editable: HTMLElement) => {

--- a/src/commands/__tests__/cursorDown.ts
+++ b/src/commands/__tests__/cursorDown.ts
@@ -4,6 +4,7 @@ import contextToPath from '../../selectors/contextToPath'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursorAtFirstMatch } from '../../test-helpers/addMulticursorAtFirstMatch'
 import initStore from '../../test-helpers/initStore'
+import multicursorValues from '../../test-helpers/multicursorValues'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import hashPath from '../../util/hashPath'
 import headValue from '../../util/headValue'
@@ -22,14 +23,6 @@ const shiftDownEvent = { shiftKey: true, preventDefault: () => {} } as unknown a
 
 /** Synthetic Down keyboard event (no shift). */
 const downEvent = { shiftKey: false, preventDefault: () => {} } as unknown as KeyboardEvent
-
-/** Returns the sorted values of the current multicursor set. */
-const multicursorValues = (): (string | undefined)[] => {
-  const state = store.getState()
-  return Object.values(state.multicursors)
-    .map(path => headValue(state, path))
-    .sort()
-}
 
 describe('cursorDown Shift+Down multiselect in table view second column', () => {
   it('extends the multiselect to the next col2 cell within the same cell', () => {

--- a/src/commands/__tests__/cursorUp.ts
+++ b/src/commands/__tests__/cursorUp.ts
@@ -4,6 +4,7 @@ import contextToPath from '../../selectors/contextToPath'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursorAtFirstMatch } from '../../test-helpers/addMulticursorAtFirstMatch'
 import initStore from '../../test-helpers/initStore'
+import multicursorValues from '../../test-helpers/multicursorValues'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import hashPath from '../../util/hashPath'
 import headValue from '../../util/headValue'
@@ -22,14 +23,6 @@ const shiftUpEvent = { shiftKey: true, preventDefault: () => {} } as unknown as 
 
 /** Synthetic Up keyboard event (no shift). */
 const upEvent = { shiftKey: false, preventDefault: () => {} } as unknown as KeyboardEvent
-
-/** Returns the sorted values of the current multicursor set. */
-const multicursorValues = (): (string | undefined)[] => {
-  const state = store.getState()
-  return Object.values(state.multicursors)
-    .map(path => headValue(state, path))
-    .sort()
-}
 
 describe('cursorUp Shift+Up multiselect in table view second column', () => {
   it('extends the multiselect to the previous col2 cell within the same cell', () => {

--- a/src/commands/__tests__/note.ts
+++ b/src/commands/__tests__/note.ts
@@ -7,19 +7,11 @@ import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import initStore from '../../test-helpers/initStore'
+import multicursorValues from '../../test-helpers/multicursorValues'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
-import headValue from '../../util/headValue'
 import noteCommand from '../note'
 
 beforeEach(initStore)
-
-/** Returns the sorted values of the current multicursor set. */
-const multicursorValues = (): (string | undefined)[] => {
-  const state = store.getState()
-  return Object.values(state.multicursors)
-    .map(path => headValue(state, path))
-    .sort()
-}
 
 describe('note', () => {
   it('creates an empty note on the cursor thought and focuses it', () => {

--- a/src/commands/__tests__/swapNote.ts
+++ b/src/commands/__tests__/swapNote.ts
@@ -5,19 +5,12 @@ import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
 import { addMulticursorAtFirstMatchActionCreator as addMulticursor } from '../../test-helpers/addMulticursorAtFirstMatch'
 import initStore from '../../test-helpers/initStore'
+import multicursorValues from '../../test-helpers/multicursorValues'
 import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
 import headValue from '../../util/headValue'
 import swapNoteCommand from '../swapNote'
 
 beforeEach(initStore)
-
-/** Returns the sorted values of the current multicursor set. */
-const multicursorValues = (): (string | undefined)[] => {
-  const state = store.getState()
-  return Object.values(state.multicursors)
-    .map(path => headValue(state, path))
-    .sort()
-}
 
 describe('swapNote', () => {
   it('converts a thought to a note', () => {

--- a/src/test-helpers/multicursorValues.ts
+++ b/src/test-helpers/multicursorValues.ts
@@ -1,0 +1,12 @@
+import store from '../stores/app'
+import headValue from '../util/headValue'
+
+/** Returns the sorted values of the current multicursor set. */
+const multicursorValues = (): (string | undefined)[] => {
+  const state = store.getState()
+  return Object.values(state.multicursors)
+    .map(path => headValue(state, path))
+    .sort()
+}
+
+export default multicursorValues


### PR DESCRIPTION
## What

Five command test files each carried a byte-identical local copy of `multicursorValues`:

```ts
/** Returns the sorted values of the current multicursor set. */
const multicursorValues = (): (string | undefined)[] => {
  const state = store.getState()
  return Object.values(state.multicursors)
    .map(path => headValue(state, path))
    .sort()
}
```

Moved it to `src/test-helpers/multicursorValues.ts` and replaced all five copies with an import.

| File | Call sites |
|---|---|
| `src/commands/__tests__/cursorUp.ts` | 5 |
| `src/commands/__tests__/cursorDown.ts` | 5 |
| `src/commands/__tests__/note.ts` | 2 |
| `src/commands/__tests__/cursorBack.ts` | 2 |
| `src/commands/__tests__/swapNote.ts` | 1 |

## Why

The copies were multiplying — #5051 added the fifth one (in `cursorBack.ts`) while this change was waiting on it to merge. Multiselect assertions are the natural place for this helper to keep spreading, so it belongs in the shared vocabulary rather than being re-pasted per file.

## Notes for reviewers

- The helper reads `store` directly instead of taking a `State` parameter. That keeps every call site unchanged as a bare `multicursorValues()`, and follows the precedent of `prettyPath` and other test helpers that import `stores/app`.
- `note.ts` also drops its now-unused `headValue` import. The other four files still use `headValue` for cursor assertions, so their imports stay.
- Added a one-line entry to the `src/test-helpers/` inventory in `docs/testing.md`, since `testing.instructions.md` points agents at that section to find existing helpers before hand-rolling one.
- No behavior change — tests only.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all six changed/added source files
- All 24 tests across the five affected files pass