### PR TITLE
Require CI waits to stop on a positive signal

### DIFF
--- a/.github/skills/ci-monitor/SKILL.md
+++ b/.github/skills/ci-monitor/SKILL.md
@@ -25,6 +25,29 @@ allowed-tools:
 - For each workflow, report: passed, failed, or still running.
 - For failed workflows, pull the relevant log section showing the error.
 
+## Waiting Without Fooling Yourself
+
+Polling CI means writing a loop that decides when to stop. Get that condition wrong and the loop reports success it never observed — the same hallucinated-results failure mode as not checking at all, just harder to notice.
+
+- **Stop on a positive signal, never on the absence of one.** A loop that exits when the output _lacks_ a token — no `pending`, no `in_progress`, no `failure` — treats every error as completion. A network timeout, an expired token, a rate limit, or a typo'd PR number all print something with no `pending` in it, and the loop exits declaring CI green. Anything you did not positively recognize is _not_ a conclusion; keep waiting.
+- **Branch on exit codes, which distinguish the cases.** `gh pr checks` exits `0` when every check passed and `8` while any is still pending (`gh pr checks --help`, "Additional exit codes"). Treat any other code as transient and retry rather than concluding. Note that `1` means a check failed _or_ `gh` itself errored — auth, a bad PR number — so it is safe to stop on but must be confirmed by reading the output rather than reported as a test failure on its own:
+
+  ```bash
+  for i in $(seq 1 80); do
+    out=$(gh pr checks "$PR" 2>&1); rc=$?
+    [ $rc -eq 0 ] && { echo "PASSED"; printf '%s\n' "$out"; exit 0; }
+    [ $rc -eq 1 ] && { echo "FAILED"; printf '%s\n' "$out"; exit 1; }
+    sleep 30  # 8 = still pending; any other code = transient, retry
+  done
+  echo "TIMEOUT"; exit 2
+  ```
+
+  `gh run watch <id> --exit-status` is a reasonable alternative for a single run, but it still needs a bounded retry around it — it exits nonzero on a dropped connection just as it does on a failing run.
+
+- **Always bound the loop and treat the timeout as its own outcome.** A wait that ends because it ran out of attempts has observed nothing; report it as "still pending after N minutes", never as a result.
+- **Re-query once before acting on what the loop said.** Before merging, reporting green, or moving on, run the status check one more time in the foreground and read it yourself. This is the step that catches a wait that exited for the wrong reason, and it costs one API call.
+- The same rule governs the MCP path: an empty `workflow_runs` array or an errored response means you did not observe the runs, not that they finished.
+
 ## Iteration Loop
 
 When CI checks fail, follow this loop:
@@ -39,7 +62,7 @@ When CI checks fail, follow this loop:
 IMPORTANT:
 
 - Never skip this loop. Always verify checks pass before claiming success.
-- Never assume tests pass without checking. Hallucinating test results is the worst failure mode.
+- Never assume tests pass without checking. Hallucinating test results is the worst failure mode — and a poll loop that exits on the absence of a token is a way of doing it accidentally, so hold every wait to the rules in [Waiting Without Fooling Yourself](#waiting-without-fooling-yourself).
 - If CI still fails after 5 fix-push cycles, stop and escalate to the user with a summary of what you tried and what you observed.
 - If a failure is ambiguous, ask the user rather than guessing.
 - Default to autonomous action. Escalate only when the correct path is genuinely unclear.


### PR DESCRIPTION
## What

Adds a **Waiting Without Fooling Yourself** section to the `ci-monitor` skill, covering how to write a poll loop that can't report a result it never observed, and cross-references it from the existing "hallucinating test results is the worst failure mode" warning.

## Why

This came out of a real failure in the previous session. Waiting for CI on #5053, I used a loop that stopped when `gh pr checks` output no longer contained the token `pending`:

```bash
if ! grep -qE 'pending' <<<"$out"; then echo "ALL CHECKS CONCLUDED"; exit 0; fi
```

A transient network error made `gh` print:

```
Post "https://api.github.com/graphql": dial tcp 140.82.114.5:443: i/o timeout
```

That contains no `pending`, so the loop exited announcing all checks had concluded while `Test` and `Puppeteer` were still running. Nothing was merged on it — I re-queried before acting and caught the discrepancy — but a loop one step more trusting would have merged on a CI result that was never observed.

The general defect: **a termination condition defined by the absence of a token treats every error as success.** Auth expiry, rate limits, a typo'd PR number, and a dropped connection all satisfy it.

## The guidance added

- Stop on a positive signal, never on the absence of one; anything unrecognized is not a conclusion.
- Branch on `gh pr checks` exit codes (`0` all passed, `8` pending), treating other codes as transient and retrying.
- Bound the loop and report a timeout as its own outcome, not as a result.
- Re-query once in the foreground before acting — the step that caught this.
- The same rule governs the MCP path: an empty or errored response means you didn't observe the runs.

## Notes for reviewers

- The `1` case is documented with a caveat rather than stated flatly: `gh` returns `1` both for a failing check and for its own errors. Verified — `gh pr checks 99999999` exits `1` with `Could not resolve to a PullRequest`. So `1` is safe to *stop* on but must be confirmed by reading the output before being reported as a test failure.
- Exit codes `0` and `8` are confirmed against `gh pr checks --help` ("Additional exit codes: 8: Checks pending") and observed in practice this session.
- The documented snippet was executed as written against a passing PR (`rc=0` → PASSED) and against a bad PR number (`rc=1` → not reported as PASSED).
- Edited at `.github/skills/ci-monitor/SKILL.md`; `.claude/skills/ci-monitor` is a symlink to it, so there's one source of truth.
- Prettier-clean; the file was prettier-clean before the change too.