### PR TITLE
fix(vite): exclude .claude from the dev server watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -143,6 +143,14 @@ export default defineConfig({
     // Allow bs-local.com for BrowserStack local testing, and the Cloudflare tunnel pool's
     // hostnames (leading dot matches all *.emthought.cc subdomains) for BrowserStack iOS Safari.
     allowedHosts: ['bs-local.com', '.emthought.cc'],
+    watch: {
+      // Agent worktrees live in .claude/worktrees and are full checkouts of the repo. Creating or
+      // updating one writes files the watcher would otherwise pick up — a nested tsconfig.json in
+      // particular makes Vite clear its cache and force a full reload. Nothing under .claude is app
+      // source, so exclude the whole directory. Appended to Vite's defaults (.git, node_modules,
+      // test-results, cacheDir), not a replacement for them.
+      ignored: ['**/.claude/**'],
+    },
     ...(process.env.PUPPETEER
       ? {
           hmr: {


### PR DESCRIPTION
## Problem

The Vite dev server reloads whenever an agent worktree under `.claude/worktrees` is created or updated.

Worktrees are full checkouts of the repo, so they sit inside the dev server's watch root and every checkout writes a `tsconfig.json`. Vite calls `reloadOnTsconfigChange` on **every** watched file event, and any path ending in `/tsconfig.json` makes it invalidate the entire module graph, clear the tsconfck cache, and broadcast a `full-reload`.

## Reproduction

With a dev server running (vite 7.3.1), writing `.claude/worktrees/<name>/tsconfig.json`:

```
[vite] changed tsconfig file detected: .../.claude/worktrees/fake-repro/tsconfig.json - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.
```

After the change, the same write (plus a nested source file and a second fake worktree) produces no log line at all.

## Fix

Add `server.watch.ignored: ['**/.claude/**']`. Nothing under `.claude` is app source.

Vite **appends** user-supplied `ignored` patterns to its own defaults rather than replacing them, so `**/.git/**`, `**/node_modules/**`, `**/test-results/**` and `cacheDir` stay excluded. The pattern only matches paths containing a `.claude` segment, so watching under `src/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)