### PR TITLE
docs(agents): say when to read the code standards, and name the reducer purity rule

### DIFF
--- a/.github/instructions/code-standards.instructions.md
+++ b/.github/instructions/code-standards.instructions.md
@@ -35,6 +35,9 @@
 ### Functional Programming
 
 - Prefer pure functions.
+- Reducers in `src/actions` must not read the DOM. The browser selection, focus, and element geometry live outside Redux state, so a reducer that reads them returns different state for the same arguments and cannot be exercised without a document. Read them in the action-creator co-located with the reducer and pass the values in the payload, as `extractSubthought` and `extractCategory` do with `selectionStart` and `selectionEnd`.
+  - Generating a value is not the same as reading the environment. Reducers may call `timestamp()` and `createId()`, which the thought and lexeme records require.
+  - `bumpThoughtDown`, `indent`, `moveThoughtDown`, `moveThoughtUp`, `outdent`, and `setCursor` still read the selection from inside the reducer. They predate this rule and are yet to be migrated, so do not take them as the pattern to follow.
 - Prefer ternary operators over if statements.
 - Avoid mutations and side effects when possible.
 - Use `const`; avoid `let`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,6 @@
 
 ## Code standards
 
-See [`.github/instructions/code-standards.instructions.md`](.github/instructions/code-standards.instructions.md) and [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md). These describe the conventions the codebase follows. 
+Read [`.github/instructions/code-standards.instructions.md`](.github/instructions/code-standards.instructions.md) before writing code, and [`.github/instructions/testing.instructions.md`](.github/instructions/testing.instructions.md) before writing tests. These describe the conventions the codebase follows. Read them even when an existing file already shows you a pattern to copy — the pattern may predate the convention, and a convention you have not read loses to one you can see.
 
 Testing guidance lives in [`docs/testing.md`](docs/testing.md) — read it in full before writing tests.


### PR DESCRIPTION
Follow-up to #5055, where the Extract Category action landed with an impure reducer — it sliced the cursor thought at offsets it read from the document. The rule against that existed, in two places, and neither reached the code.

## What went wrong

`docs/folder-structure.md:8` says *"Prefer reducers when possible, as they are pure functions... Only define an action creator if it requires a side effect."* That's correct, but it's a sentence describing a directory — nothing routes an agent to it while writing an action.

`code-standards.instructions.md` § Functional Programming says *"Prefer pure functions"* and *"Avoid mutations and side effects when possible"*. Too abstract to fire, and the *when possible* reads as an escape hatch.

But the bigger problem was the pointer. AGENTS.md said:

> **See** [`code-standards.instructions.md`] and [`testing.instructions.md`]. These describe the conventions the codebase follows.
>
> Testing guidance lives in [`docs/testing.md`] — **read it in full before writing tests**.

One line carries an imperative and a trigger; the other is a bare "see". Predictably, only the first got followed.

And even a read standard competes with what's on screen: Extract Category was modeled on Extract Subthought, which had the same impurity. A convention loses to a concrete file that contradicts it.

## Changes

**`AGENTS.md`** — the code-standards pointer now has the same shape as the testing one (imperative + trigger), plus the bit that would actually have helped: read them *even when an existing file already shows you a pattern to copy*.

**`code-standards.instructions.md`** — states the concrete rule under Functional Programming: reducers in `src/actions` must not read the DOM; read it in the co-located action-creator and pass it in the payload, as `extractSubthought` and `extractCategory` now do.

Two sub-bullets keep the rule honest, because the codebase does not fully comply:

- **`timestamp()` and `createId()` are still fine.** Seven reducers call `timestamp()` and `categorize` calls `createId()`; generating a value is not the same as reading the environment. Without this, the rule reads as a mandate to purge them.
- **Six reducers still read the selection** — `bumpThoughtDown`, `indent`, `moveThoughtDown`, `moveThoughtUp`, `outdent`, `setCursor`. They're named so the next agent doesn't copy them, which is exactly how this bug got in.

## Not done

Lint would beat pattern-copying outright, but `no-restricted-imports` can't express this — the action-creator in the *same file* legitimately imports `device/selection`. It would need a custom rule scoped to the reducer function. Worth doing if this recurs; migrating the six reducers above is the natural prerequisite.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)