### PR TITLE
refactor(actions): read the caret offset in the action-creators

### DIFF
--- a/.github/instructions/code-standards.instructions.md
+++ b/.github/instructions/code-standards.instructions.md
@@ -37,7 +37,6 @@
 - Prefer pure functions.
 - Reducers in `src/actions` must not read the DOM. The browser selection, focus, and element geometry live outside Redux state, so a reducer that reads them returns different state for the same arguments and cannot be exercised without a document. Read them in the action-creator co-located with the reducer and pass the values in the payload, as `extractSubthought` and `extractCategory` do with `selectionStart` and `selectionEnd`.
   - Generating a value is not the same as reading the environment. Reducers may call `timestamp()` and `createId()`, which the thought and lexeme records require.
-  - `bumpThoughtDown`, `indent`, `moveThoughtDown`, `moveThoughtUp`, `outdent`, and `setCursor` still read the selection from inside the reducer. They predate this rule and are yet to be migrated, so do not take them as the pattern to follow.
 - Prefer ternary operators over if statements.
 - Avoid mutations and side effects when possible.
 - Use `const`; avoid `let`.

--- a/src/actions/indent.ts
+++ b/src/actions/indent.ts
@@ -18,8 +18,13 @@ import isEM from '../util/isEM'
 import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
 
+export interface indentPayload {
+  /** The caret offset within the cursor thought, read from the document before the move. Null when the caret is not in the thought's text, in which case state.cursorOffset is used instead. */
+  selectionOffset?: number | null
+}
+
 /** Increases the indentation level of the thought, i.e. Moves it to the end of its previous sibling. */
-const indent = (state: State): State => {
+const indent = (state: State, { selectionOffset }: indentPayload = {}): State => {
   const { cursor } = state
 
   if (!cursor) return state
@@ -53,9 +58,7 @@ const indent = (state: State): State => {
     })
   }
 
-  // calculate offset value based upon selection node before moveThought is dispatched
-  const offset =
-    (selection.isOnEditable(head(cursor)) && selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
+  const offset = (selectionOffset ?? state.cursorOffset) || 0
 
   const cursorNew = appendToPath(parentOf(cursor), prev.id, head(cursor))
 
@@ -73,8 +76,16 @@ const indent = (state: State): State => {
   })
 }
 
-/** Action-creator for indent. */
-export const indentActionCreator = (): Thunk => dispatch => dispatch({ type: 'indent' })
+/**
+ * Action-creator for indent. Reads the caret offset from the document, which the reducer cannot do itself without
+ * reaching outside of state. It must be read before the move, since moveThought re-renders the editable.
+ */
+export const indentActionCreator = (): Thunk => (dispatch, getState) => {
+  const { cursor } = getState()
+  const selectionOffset =
+    cursor && selection.isOnEditable(head(cursor)) && selection.isText() ? (selection.offset() ?? 0) : null
+  dispatch({ type: 'indent', selectionOffset })
+}
 
 export default indent
 

--- a/src/actions/moveThoughtDown.ts
+++ b/src/actions/moveThoughtDown.ts
@@ -16,8 +16,13 @@ import head from '../util/head'
 import headValue from '../util/headValue'
 import parentOf from '../util/parentOf'
 
+export interface moveThoughtDownPayload {
+  /** The caret offset within the cursor thought, read from the document before the move. */
+  offset?: number | null
+}
+
 /** Swaps the thought with its next siblings. */
-const moveThoughtDown = (state: State): State => {
+const moveThoughtDown = (state: State, { offset }: moveThoughtDownPayload = {}): State => {
   const { cursor } = state
 
   if (!cursor) return state
@@ -51,9 +56,6 @@ const moveThoughtDown = (state: State): State => {
     })
   }
 
-  // store selection offset before moveThought is dispatched
-  const offset = selection.offset()
-
   const rankNew = nextThought
     ? // next thought
       getRankAfter(state, simplifyPath(state, pathParent).concat(nextThought.id) as SimplePath)
@@ -72,8 +74,12 @@ const moveThoughtDown = (state: State): State => {
   })
 }
 
-/** Action-creator for moveThoughtDown. */
-export const moveThoughtDownActionCreator = (): Thunk => dispatch => dispatch({ type: 'moveThoughtDown' })
+/**
+ * Action-creator for moveThoughtDown. Reads the caret offset from the document, which the reducer cannot do itself without
+ * reaching outside of state. It must be read before the move, since moveThought re-renders the editable.
+ */
+export const moveThoughtDownActionCreator = (): Thunk => dispatch =>
+  dispatch({ type: 'moveThoughtDown', offset: selection.offset() })
 
 export default moveThoughtDown
 

--- a/src/actions/moveThoughtUp.ts
+++ b/src/actions/moveThoughtUp.ts
@@ -18,8 +18,13 @@ import head from '../util/head'
 import headValue from '../util/headValue'
 import parentOf from '../util/parentOf'
 
+export interface moveThoughtUpPayload {
+  /** The caret offset within the cursor thought, read from the document before the move. */
+  offset?: number | null
+}
+
 /** Swaps the thought with its previous siblings. */
-const moveThoughtUp = (state: State): State => {
+const moveThoughtUp = (state: State, { offset }: moveThoughtUpPayload = {}): State => {
   const { cursor } = state
 
   if (!cursor) return state
@@ -55,9 +60,6 @@ const moveThoughtUp = (state: State): State => {
     })
   }
 
-  // get selection offset before moveThought is dispatched
-  const offset = selection.offset()
-
   const rankNew = prevThought
     ? // previous thought
       getRankBefore(state, simplifyPath(state, pathParent).concat(prevThought.id) as SimplePath)
@@ -78,8 +80,12 @@ const moveThoughtUp = (state: State): State => {
   })
 }
 
-/** Action-creator for moveThoughtUp. */
-export const moveThoughtUpActionCreator = (): Thunk => dispatch => dispatch({ type: 'moveThoughtUp' })
+/**
+ * Action-creator for moveThoughtUp. Reads the caret offset from the document, which the reducer cannot do itself without
+ * reaching outside of state. It must be read before the move, since moveThought re-renders the editable.
+ */
+export const moveThoughtUpActionCreator = (): Thunk => dispatch =>
+  dispatch({ type: 'moveThoughtUp', offset: selection.offset() })
 
 export default moveThoughtUp
 

--- a/src/actions/outdent.ts
+++ b/src/actions/outdent.ts
@@ -17,8 +17,13 @@ import isEM from '../util/isEM'
 import isRoot from '../util/isRoot'
 import parentOf from '../util/parentOf'
 
+export interface outdentPayload {
+  /** The caret offset within the cursor thought, read from the document before the move. Null when the caret is not in the thought's text, in which case state.cursorOffset is used instead. */
+  selectionOffset?: number | null
+}
+
 /** Decreases the indent level of the given thought, moving it to its parent. */
-const outdent = (state: State): State => {
+const outdent = (state: State, { selectionOffset }: outdentPayload = {}): State => {
   const { cursor } = state
   if (!cursor || cursor.length <= 1) return state
 
@@ -53,9 +58,7 @@ const outdent = (state: State): State => {
     })
   }
 
-  // calculate offset value based upon selection node before moveThought is dispatched
-  const offset =
-    (selection.isOnEditable(head(cursor)) && selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
+  const offset = (selectionOffset ?? state.cursorOffset) || 0
 
   const cursorNew: Path = appendToPath(parentOf(parentOf(cursor)), head(cursor))
 
@@ -69,8 +72,16 @@ const outdent = (state: State): State => {
   })
 }
 
-/** Action-creator for outdent. */
-export const outdentActionCreator = (): Thunk => dispatch => dispatch({ type: 'outdent' })
+/**
+ * Action-creator for outdent. Reads the caret offset from the document, which the reducer cannot do itself without
+ * reaching outside of state. It must be read before the move, since moveThought re-renders the editable.
+ */
+export const outdentActionCreator = (): Thunk => (dispatch, getState) => {
+  const { cursor } = getState()
+  const selectionOffset =
+    cursor && selection.isOnEditable(head(cursor)) && selection.isText() ? (selection.offset() ?? 0) : null
+  dispatch({ type: 'outdent', selectionOffset })
+}
 
 export default outdent
 


### PR DESCRIPTION
Follows up #5059 by removing the exception it recorded, rather than correcting it.

`indent`, `outdent`, `moveThoughtDown`, and `moveThoughtUp` each read the browser selection from inside the reducer, to capture the caret offset before the move re-renders the editable. That made them impure — the same state and action produced different results depending on where the caret happened to be. Their action-creators now read it and pass it in, as `extractSubthought` and `extractCategory` already do.

**No reducer in `src/actions` reads the selection now**, so the "yet to be migrated" bullet is deleted outright.

## The split for indent and outdent

These two combined the DOM read with a state fallback:

```ts
const offset =
  (selection.isOnEditable(head(cursor)) && selection.isText() ? selection.offset() || 0 : state.cursorOffset) || 0
```

Only the first half leaves Redux, so that is all the creator supplies — `null` when the caret is not in the thought's text — and the reducer keeps the `state.cursorOffset` fallback rather than taking a payload for something it can already read.

`moveThoughtUp` / `moveThoughtDown` were a one-line move.

## Optional payloads

Unlike `extractSubthought` and `extractCategory`, whose reducers have nothing to slice without the offsets, these four payloads are optional. They are composed bare in `reducerFlow` by their own tests, and `moveThought`'s `...(offset != null ? { offset } : null)` already treats a missing offset the same as a null one — so every existing test keeps working untouched.

## Correction to #5059

Two of the six reducers that PR named were never violations, and are not touched here:

- **`bumpThoughtDown`** — its `selection` is a local `Path[]`, the `documentSort` of the selected thoughts.
- **`setCursor`** — the only mention is inside a comment.

Neither imports `device/selection`. (`setCursor` would have been the hard one — it is composed inside dozens of other reducers, so it could not take a payload from an action-creator.)

## Verification

Full unit suite: **216 files passed, 5 skipped, 0 failures.** That includes `commands/__tests__/undo-redo.ts`, `redo.ts`, and `jump.ts`, which dispatch these action-creators through a real store and so exercise the new thunk path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)