### PR TITLE
refactor(e2e): remove the em.getAllChildrenAsThoughts backdoor

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -123,14 +123,14 @@ This rule is about waiting for real time to pass, not about safety limits or tim
 - Durations that are part of simulated input, such as how long a long press is held or how quickly a swipe moves, are action parameters rather than synchronization waits.
 
 ```ts
-// ❌ Don't: hand-rolled polling against a state backdoor (real code — do not imitate)
+// ❌ Don't: hand-rolled polling against a state backdoor
 const childCount = await page.evaluate(async () => {
   const em = window.em as WindowEm
   for (let i = 0; i < 20; i++) {
-    if (em.getAllChildrenAsThoughts(['A']).length > 0) break
+    if (em.getAllChildrenByContext(['A']).length > 0) break
     await new Promise(resolve => setTimeout(resolve, 50))
   }
-  return em.getAllChildrenAsThoughts(['A']).length
+  return em.getAllChildrenByContext(['A']).length
 })
 ```
 
@@ -525,7 +525,7 @@ DOM reads are different from backdoors: inline `page.evaluate`/`browser.execute`
 
 Backdoors are never the act. The behavior under test always goes through a real user entry point (Principle 2).
 
-A few older tests access `window.em`, set test flags inline, mutate the DOM, or hand-roll waits. Known examples include [`spaceToIndent.ts`](../src/e2e/puppeteer/__tests__/spaceToIndent.ts), the specialized initialization test in [`startup.ts`](../src/e2e/puppeteer/__tests__/startup.ts), replication-delay setup in [`scroll.ts`](../src/e2e/puppeteer/__tests__/scroll.ts), and drag-hover timing in [`drag-and-drop.ts`](../src/e2e/puppeteer/__tests__/drag-and-drop.ts). They predate this policy; do not imitate them. When one is materially changed, move the exception behind a named helper and add it to the category table.
+A few older tests access `window.em`, set test flags inline, mutate the DOM, or hand-roll waits. Known examples include the specialized initialization test in [`startup.ts`](../src/e2e/puppeteer/__tests__/startup.ts), replication-delay setup in [`scroll.ts`](../src/e2e/puppeteer/__tests__/scroll.ts), and drag-hover timing in [`drag-and-drop.ts`](../src/e2e/puppeteer/__tests__/drag-and-drop.ts). They predate this policy; do not imitate them. When one is materially changed, move the exception behind a named helper and add it to the category table.
 
 ## Reviewing Tests
 

--- a/src/e2e/puppeteer/__tests__/spaceToIndent.ts
+++ b/src/e2e/puppeteer/__tests__/spaceToIndent.ts
@@ -1,7 +1,8 @@
-import { WindowEm } from '../../../initialize'
+import exportThoughts from '../helpers/exportThoughts'
 import newThought from '../helpers/newThought'
 import press from '../helpers/press'
 import waitForEditable from '../helpers/waitForEditable'
+import waitUntil from '../helpers/waitUntil'
 import { page } from '../session'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -23,16 +24,16 @@ describe('space-to-indent', () => {
       )
     })
 
+    // The indent lands asynchronously, and both thoughts are leaves until it does. A parent bullet appearing
+    // is the visible signal that A gained a child.
+    await waitUntil(() => !!document.querySelector('[data-bullet="parent"]'), { timeout: 6000 })
+
     // the empty thought should be indented as a subthought of A (its previous sibling), not left as a
     // sibling containing a literal space
-    const childCount = await page.evaluate(async () => {
-      const em = window.em as WindowEm
-      for (let i = 0; i < 20; i++) {
-        if (em.getAllChildrenAsThoughts(['A']).length > 0) break
-        await new Promise(resolve => setTimeout(resolve, 50))
-      }
-      return em.getAllChildrenAsThoughts(['A']).length
-    })
-    expect(childCount).toBe(1)
+    const exported = await exportThoughts()
+    expect(exported).toBe(`
+- A
+  - 
+`)
   })
 })

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -20,7 +20,7 @@ import testFlags from './e2e/testFlags'
 import contextToThoughtId from './selectors/contextToThoughtId'
 import decodeThoughtsUrl from './selectors/decodeThoughtsUrl'
 import exportContext from './selectors/exportContext'
-import { getAllChildren, getAllChildrenAsThoughts, getChildrenRanked } from './selectors/getChildren'
+import { getAllChildren, getChildrenRanked } from './selectors/getChildren'
 import getContexts from './selectors/getContexts'
 import getLexeme from './selectors/getLexeme'
 import getThoughtById from './selectors/getThoughtById'
@@ -187,9 +187,6 @@ const windowEm = {
   }),
   getAllChildrenByContext: withState((state: State, context: Context) =>
     getAllChildren(state, contextToThoughtId(state, context) || null),
-  ),
-  getAllChildrenAsThoughts: withState((state: State, context: Context) =>
-    getAllChildrenAsThoughts(state, contextToThoughtId(state, context) || null),
   ),
   getAllChildrenRankedByContext: withState((state: State, context: Context) =>
     getChildrenRanked(state, contextToThoughtId(state, context) || null),


### PR DESCRIPTION
## What

Removes `getAllChildrenAsThoughts` from the `window.em` backdoor in `src/initialize.ts`, and rewrites its only caller — `src/e2e/puppeteer/__tests__/spaceToIndent.ts` — to work without it.

## Why

The test hand-rolled a 20 × 50ms poll against Redux state to wait for the indent to land, then asserted on a child count. That is the exact anti-pattern `docs/testing.md` warns against — it even quoted this test as "real code — do not imitate". With the caller fixed, the backdoor has no users.

## How the test waits now

Both thoughts are leaves until the indent lands, so A's bullet turning into a parent bullet (`[data-bullet="parent"]`) is the visible signal that A gained a child. The assertion is then `exportThoughts`, which is stronger than the old count — it distinguishes an indented empty thought from a sibling, and from a sibling containing a literal space.

## Verification

Ran the test for real against the Docker/browserless setup, not just typechecked:

- **negative control**: changing the dispatched `beforeinput` data from `' '` to `'x'` makes it fail at the new `waitUntil`, so the wait is load-bearing rather than incidentally satisfied
- runtime drops from ~13.8s to ~8.8s, since the poll no longer runs to completion

## Docs

- the ❌ example now uses `getAllChildrenByContext` (still present on `window.em`) and no longer claims to quote live code
- `spaceToIndent.ts` is dropped from the list of legacy tests that touch `window.em` and hand-roll waits, per that paragraph's own instruction to retire an exception when the test is materially changed

Unrelated finding, left alone: `docs/testing.md` links `src/e2e/puppeteer/helpers/reloadWithProductionTiming.ts` in the sanctioned-backdoor table, and that file has never existed in this repo — it arrived with the doc in #4763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)