### PR TITLE
fix(swapParent): keep the siblings in place

### DIFF
--- a/src/actions/__tests__/swapParent.ts
+++ b/src/actions/__tests__/swapParent.ts
@@ -152,6 +152,38 @@ it('swapped parent should take the rank of the child', () => {
   expectPathToEqual(stateNew, stateNew.cursor, ['d'])
 })
 
+// Regression test for the sibling reordering reported in
+// https://github.com/cybersemics/em/pull/5058#issuecomment-5382410421
+// The parent and the siblings move under the child before the child's own children have left it. Reusing the ranks
+// they held under the parent collided with the ranks already there, and the rerank that a collision triggers
+// resolved the tie in an arbitrary order, moving a sibling the swap should not have touched.
+it('does not reorder the siblings around the parent moving into the cursor thought', () => {
+  const text = `
+    - a
+      - b
+        - w
+        - c
+          - d
+          - e
+        - f
+  `
+
+  const steps = [importText({ text }), setCursor(['a', 'b', 'c']), swapParent]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  // b takes the slot c vacated, between w and f. f in particular stays last.
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - c
+      - w
+      - b
+        - d
+        - e
+      - f`)
+})
+
 describe('context view', () => {
   it('swap as normal and preserve cursor in descendants of contexts in the context view', () => {
     const text = `

--- a/src/actions/swapParent.ts
+++ b/src/actions/swapParent.ts
@@ -10,6 +10,7 @@ import rootedParentOf from '../selectors/rootedParentOf'
 import simplifyPath from '../selectors/simplifyPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import head from '../util/head'
+import keyValueBy from '../util/keyValueBy'
 import parentOf from '../util/parentOf'
 import reducerFlow from '../util/reducerFlow'
 import alert from './alert'
@@ -51,6 +52,17 @@ const swapParent = (state: State): State => {
   const parentChildren = getChildrenRanked(state, parentId)
   const siblings = parentChildren.filter(sibling => sibling.id !== childId)
 
+  // The parent and the siblings arrive under the child before the child's own children have left it, so giving them
+  // the ranks they held under the parent can collide with the ranks already in place. moveThought reranks a context
+  // whose ranks collide, and rerank resolves an exact tie in whatever order the tied thoughts happen to enumerate,
+  // reordering thoughts the swap should have left alone. Ranking them past everything the child currently holds keeps
+  // them clear of it, and once the child's own children have moved out, all that remains is their order relative to
+  // each other — the parent taking the slot the child vacated. The reverse move needs no such offset: the parent has
+  // been emptied by the time the child's children arrive, so they keep the ranks they already had.
+  const ranksUnderChild = keyValueBy(parentChildren, (parentChild, i) => ({
+    [parentChild.id === childId ? parentId : parentChild.id]: (childChildren.at(-1)?.rank ?? -1) + 1 + i,
+  }))
+
   const grandparent = parentOf(parent)
   const grandparentId = head(rootedParentOf(state, parent))
 
@@ -63,11 +75,11 @@ const swapParent = (state: State): State => {
       skipMerge: true,
     }),
 
-    // Then move the parent under the child
+    // Then move the parent under the child, into the slot the child vacated
     moveThought({
       oldPath: simplifyPath(state, parent),
       newPath: simplifyPath(state, [...grandparent, childId, parentId]),
-      newRank: childThought.rank,
+      newRank: ranksUnderChild[parentId],
       skipMerge: true,
     }),
 
@@ -76,7 +88,7 @@ const swapParent = (state: State): State => {
       moveThought({
         oldPath: simplifyPath(state, [...parent, sibling.id]),
         newPath: simplifyPath(state, [...grandparent, childId, sibling.id]),
-        newRank: sibling.rank,
+        newRank: ranksUnderChild[sibling.id],
         skipMerge: true,
       }),
     ),


### PR DESCRIPTION
Swap Parent can reorder siblings it should have left alone. Spun out of [#5058](https://github.com/cybersemics/em/pull/5058#issuecomment-5382410421), where the same defect was found in Swap Grandparent; this one predates that PR.

## Steps to Reproduce

```
- a
  - b
    - w
    - c
      - d
      - e
    - f
```

1. Set the cursor on `a/b/c`.
2. Activate Swap Parent.

### Current Behavior

`f` moves above `b`.

```
- a
  - c
    - w
    - f
    - b
      - d
      - e
```

### Expected Behavior

`b` takes the slot `c` vacated, between `w` and `f`. Nothing else moves.

```
- a
  - c
    - w
    - b
      - d
      - e
    - f
```

## Cause

The parent and the siblings move under the child before the child's own children have left it — there is no move order that avoids this, since the two contexts exchange their children lists. Reusing the ranks they held under the parent collides with the ranks already in place:

| step | move | `c`'s children |
| --- | --- | --- |
| | | `d`=0, `e`=1 |
| 2 | `b` → `c` at rank 0 (`c`'s old rank) | collides with `d` → rerank |
| 3 | `w` → `c` at rank 0, `f` → `c` at rank 2 | collides again → rerank |

`moveThought` reranks a context whose ranks come within `1e-7`, and `rerank` renumbers by `getChildrenRanked` order — which for an exact tie is whatever order the two thoughts happen to enumerate in.

Because it turns on a tie-break, the corruption is intermittent across shapes: with a single grandchild and a single sibling the tie happens to land correctly, which is why the existing tests never caught it. It shows up when the cursor thought is a middle child, or when it carries a meta attribute at a negative rank (`=pin` in the original report).

## Fix

Rank the parent and siblings past everything the child currently holds, with the parent taking the slot the child vacated, rather than reusing the ranks they had under the parent. Once the child's own children have moved out, all that survives is their order relative to each other. The reverse move needs no offset: the parent has been emptied by the time the child's children arrive, so those keep their original ranks.

Identical in shape to the Swap Grandparent fix in #5058.

## Testing

- The reproduction above is committed as a regression test in `src/actions/__tests__/swapParent.ts`. It fails on `main` and passes here, and it is the only test whose result changes.
- Also confirmed the `=pin` variant from the #5058 comment is fixed: with `a > b > c(=pin, d), e` and the cursor on `c`, `e` now stays after `b`.
- Full unit suite green apart from `LayoutTree.virtualization.ts`, which times out under parallel load and passes on its own — unrelated and pre-existing.

Verified at the reducer level rather than in the running app; the tests assert the thought order that the bug report is about.

`docs:` unaffected — the two `swapParent` mentions in `docs/` describe its `sort` call and its caret handling, neither of which changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)