### PR TITLE
fix(tdd): remove a deleted test file from base instead of checking it out

### DIFF
--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -361,20 +361,32 @@ jobs:
             exit 0
           fi
 
+          # Check out a path from the PR head, or delete it when the PR deleted it. git checkout fails outright on a
+          # pathspec that does not exist at the target, so a PR that removes a test or a helper would break the run
+          # here. A deletion is part of the change under test like any other edit, so base has to reflect it too.
+          sync_from_head() {
+            local f="$1"
+            if git cat-file -e "FETCH_HEAD:$f" 2>/dev/null; then
+              echo "Checking out: $f"
+              git checkout FETCH_HEAD -- "$f"
+            else
+              echo "Removing (deleted in PR): $f"
+              git rm -q --ignore-unmatch -- "$f"
+            fi
+          }
+
           # Check out each test file directly from the PR head. This reliably handles
           # both modified files and brand-new test files (including new directories),
           # where git apply --3way can fail because there is no base blob to merge.
           echo "=== Checking out test files from PR head ==="
           for f in $UNIT_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           # Test infrastructure the changed tests may depend on, e.g. a new helper.
           HELPER_FILES=$(echo "${{ needs.detect.outputs.helper_files }}" | base64 -d)
           for f in $HELPER_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           echo "empty=false" >> "$GITHUB_OUTPUT"
@@ -481,19 +493,31 @@ jobs:
             exit 0
           fi
 
+          # Check out a path from the PR head, or delete it when the PR deleted it. git checkout fails outright on a
+          # pathspec that does not exist at the target, so a PR that removes a test or a helper would break the run
+          # here. A deletion is part of the change under test like any other edit, so base has to reflect it too.
+          sync_from_head() {
+            local f="$1"
+            if git cat-file -e "FETCH_HEAD:$f" 2>/dev/null; then
+              echo "Checking out: $f"
+              git checkout FETCH_HEAD -- "$f"
+            else
+              echo "Removing (deleted in PR): $f"
+              git rm -q --ignore-unmatch -- "$f"
+            fi
+          }
+
           # Test support is part of the test, not the application fix. Check it out
           # with the test so the base-branch run reaches the behavioral assertion.
           echo "=== Checking out puppeteer test files and support from PR head ==="
           for f in $PUPPETEER_FILES $PUPPETEER_SUPPORT_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           # Test infrastructure the changed tests may depend on, e.g. a new helper.
           HELPER_FILES=$(echo "${{ needs.detect.outputs.helper_files }}" | base64 -d)
           for f in $HELPER_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           echo "empty=false" >> "$GITHUB_OUTPUT"
@@ -610,19 +634,31 @@ jobs:
             exit 0
           fi
 
+          # Check out a path from the PR head, or delete it when the PR deleted it. git checkout fails outright on a
+          # pathspec that does not exist at the target, so a PR that removes a test or a helper would break the run
+          # here. A deletion is part of the change under test like any other edit, so base has to reflect it too.
+          sync_from_head() {
+            local f="$1"
+            if git cat-file -e "FETCH_HEAD:$f" 2>/dev/null; then
+              echo "Checking out: $f"
+              git checkout FETCH_HEAD -- "$f"
+            else
+              echo "Removing (deleted in PR): $f"
+              git rm -q --ignore-unmatch -- "$f"
+            fi
+          }
+
           # Test support is part of the test, not the application fix. Check it out
           # with the test so the base-branch run reaches the behavioral assertion.
           echo "=== Checking out iOS test files and support from PR head ==="
           for f in $IOS_FILES $IOS_SUPPORT_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           # Test infrastructure the changed tests may depend on, e.g. a new helper.
           HELPER_FILES=$(echo "${{ needs.detect.outputs.helper_files }}" | base64 -d)
           for f in $HELPER_FILES; do
-            echo "Checking out: $f"
-            git checkout FETCH_HEAD -- "$f"
+            sync_from_head "$f"
           done
 
           echo "empty=false" >> "$GITHUB_OUTPUT"

--- a/docs/agents/tdd.md
+++ b/docs/agents/tdd.md
@@ -94,7 +94,7 @@ It then decides whether to skip. It skips if no test files changed; if the pull 
 3. Switch any newly-added skipped tests back on, via [`.github/actions/unskip-added-tests`](../../.github/actions/unskip-added-tests/action.yml).
 4. Run them, and **require them to fail.**
 
-Step 2 copies the files individually rather than applying a patch, because a brand-new test file has nothing on the base branch to patch against. Test infrastructure comes across too, since a test that calls a new helper cannot even compile on the base branch without it.
+Step 2 copies the files individually rather than applying a patch, because a brand-new test file has nothing on the base branch to patch against. Test infrastructure comes across too, since a test that calls a new helper cannot even compile on the base branch without it. A path the pull request *deleted* is removed from the base branch rather than copied — there is no blob at the head to copy, and a deletion is as much a part of the change under test as an edit.
 
 **summary** collapses the three into a single check, so branch protection has one thing to require.
 


### PR DESCRIPTION
## The problem

`tdd.yml`'s `detect` job classifies changed files with `git diff --name-only`, which lists **deletions** alongside edits. Each of the three jobs then loops over that list running `git checkout FETCH_HEAD -- "$f"`. A path the pull request deleted has no blob at the head, so git refuses the pathspec and the step exits nonzero, taking the whole TDD run with it:

```
Checking out: src/e2e/puppeteer/helpers/waitForContextHasChildWithValue.ts
error: pathspec 'src/e2e/puppeteer/helpers/waitForContextHasChildWithValue.ts' did not match any file(s) known to git
```

That is a real failure, not a hypothetical: run [32596773691](https://github.com/cybersemics/em/actions/runs/32596773691), job `TDD — Unit tests`, failed in 8s on #5061 at the "Checkout test files from PR head" step, at a point when that PR deleted the helper.

The `HELPER_FILES` list is the likely way in, because unlike the test-file lists it is never narrowed by `filter_new_tests` — so *any* PR that drops a file under `src/test-helpers/` or an e2e `helpers`/`config`/`setup` directory hits this.

## The fix

Both loops in all three jobs (`unit`, `puppeteer`, `ios`) now go through a `sync_from_head` helper:

```bash
sync_from_head() {
  local f="$1"
  if git cat-file -e "FETCH_HEAD:$f" 2>/dev/null; then
    echo "Checking out: $f"
    git checkout FETCH_HEAD -- "$f"
  else
    echo "Removing (deleted in PR): $f"
    git rm -q --ignore-unmatch -- "$f"
  fi
}
```

Removing the path is the correct outcome rather than merely a way to avoid the error: a deleted helper is part of the change under test exactly as much as an edited one, and leaving base's copy in place would compile the pre-fix run against a file the PR says is gone.

## Verification

**CI cannot fully exercise this fix, because this PR does not itself delete a test file.** The evidence is the local simulation, not a green check here.

- **Simulated against a real deletion.** `origin/main` commit c49b1dbbda deleted `src/e2e/puppeteer/helpers/waitForContextHasChildWithValue.ts`. A detached worktree at its parent, with `FETCH_HEAD` fetched to c49b1dbbda, reproduces exactly the CI setup. Over the real changed-file list (`docs/testing.md` modified, the helper deleted), the old loop reproduces the error message above and exits 1; the new loop exits 0, removes the deleted helper, and leaves `docs/testing.md` matching `FETCH_HEAD`.
- **Shell and YAML.** All three `patch` step scripts were extracted from the workflow and pass `bash -n`; `yaml.safe_load` parses the workflow; the three copies of `sync_from_head` were asserted byte-identical, with both loops per job routed through it and no bare `git checkout FETCH_HEAD` left in any loop body.
- `npx prettier --check` passes on both changed files.

## Docs

`docs/agents/tdd.md` now states that a path the PR deleted is removed from base rather than copied. `docs/testing.md`'s one-line summary of the overlay was reviewed and left alone — it describes the mechanism at a level the change does not falsify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
