### PR TITLE
fix(clear): reset the toolbar dropdown flags

### DIFF
--- a/src/@types/State.ts
+++ b/src/@types/State.ts
@@ -154,13 +154,13 @@ interface State {
    * opens, so it does not participate in the render cycle.
    */
   selectionOffsets: { thoughtId: ThoughtId; start: number; end: number } | null
-  showBulletPicker?: boolean
-  showColorPicker?: boolean
-  showLetterCase?: boolean
+  showBulletPicker: boolean
+  showColorPicker: boolean
+  showLetterCase: boolean
   showDesktopCommandUniverse: boolean
   showGestureMenu: boolean
   showHiddenThoughts: boolean
-  showSortPicker?: boolean
+  showSortPicker: boolean
   showCommandCenter: boolean
   /**
    * The currently shown modal dialog box.
@@ -170,7 +170,7 @@ interface State {
   showModal?: Modal | null
   showSidebar: boolean
   showMobileCommandUniverse?: boolean
-  showUndoSlider?: boolean
+  showUndoSlider: boolean
   /* Status:
       'disconnected'   Logged out or yet to connect, but not in explicit offline mode.
       'connecting'     Connecting.

--- a/src/actions/__tests__/clear.ts
+++ b/src/actions/__tests__/clear.ts
@@ -1,0 +1,16 @@
+import store from '../../stores/app'
+import dispatch from '../../test-helpers/dispatch'
+import initStore from '../../test-helpers/initStore'
+import { clearActionCreator as clear } from '../clear'
+import { toggleDropdownActionCreator as toggleDropdown } from '../toggleDropdown'
+
+beforeEach(initStore)
+
+it('closes an open toolbar dropdown', async () => {
+  await dispatch(toggleDropdown({ dropDownType: 'undoSlider' }))
+  expect(store.getState().showUndoSlider).toBe(true)
+
+  await dispatch(clear({ full: true }))
+
+  expect(store.getState().showUndoSlider).toBe(false)
+})

--- a/src/util/initialState.ts
+++ b/src/util/initialState.ts
@@ -142,6 +142,13 @@ const initialState = (created: Timestamp = timestamp()) => {
     rootContext: [HOME_TOKEN],
     search: null,
     selectionOffsets: null,
+    // clear resets the app by merging initialState() into the previous state through reducerFlow, so a dropdown flag
+    // omitted here would survive a clear and leave the dropdown open.
+    showBulletPicker: false,
+    showColorPicker: false,
+    showLetterCase: false,
+    showSortPicker: false,
+    showUndoSlider: false,
     showDesktopCommandUniverse: false,
     showGestureMenu: false,
     remoteSearch: false,


### PR DESCRIPTION
## What

`clear` did not close the toolbar dropdowns. The five optional dropdown flags — `showBulletPicker`, `showColorPicker`, `showLetterCase`, `showSortPicker`, `showUndoSlider` — now default to `false` in `initialState` and are required in `State`, so a `clear` resets them.

## Why

`clear` resets the app with `reducerFlow([..., state => ({ ...initialState(), ... })])`, and `reducerFlow` merges each reducer's result into the previous state (`{ ...state, ...stateNew }`). Any `State` key that `initialState()` does not set therefore survives a `clear`. The dropdown flags were optional and unset, so a dropdown opened in one JSDOM test was still open after `cleanupTestApp` dispatched `clear({ full: true })`, and the next test's toolbar click closed the slider instead of opening it.

Making the flags required (matching `showCommandCenter`, which was already in `initialState` and so never leaked) means the compiler keeps `initialState` setting them.

## Reviewer notes

- **Why not make `clear` build the state without merging?** That would also drop `storageCache`, which the `storageCache` enhancer seeds only once (when `state` is undefined) and never re-seeds. The theme, tutorial, and user-toolbar selectors fall back to their defaults without it, so logout would flip the theme. The targeted fix avoids that production change.
- Other optional keys still survive `clear` for the same reason (`alert`, `lastUndoableActionType`, `showMobileCommandUniverse`, `toolbarLongPress`, drag-and-drop hover paths, …). None of them caused the observed test leak, so they are left alone here.
- The new store test `src/actions/__tests__/clear.ts` was written first and failed at the post-`clear` assertion (`showUndoSlider` still `true`) before the fix.

## Verification

- `yarn vitest run --project unit src/actions/__tests__/clear.ts src/redux-middleware/__tests__/multicursorAlertMiddleware.ts` — passes (fails at the post-`clear` assertion without the fix)
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` on the changed files — clean
- Full `yarn vitest run --project unit` was still running with no failures at the time of opening; CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
