### PR TITLE
fix(heading): create the attribute instead of renaming the first child

### DIFF
--- a/src/actions/__tests__/setDescendant.ts
+++ b/src/actions/__tests__/setDescendant.ts
@@ -115,6 +115,32 @@ it('omit value to set only attribute', () => {
     - =test`)
 })
 
+it('preserve existing children when setting a nullary attribute', () => {
+  const steps = [
+    importText({
+      text: `
+      - a
+        - b
+        - c
+    `,
+    }),
+    (state: State) =>
+      setDescendant(state, {
+        path: contextToPath(state, ['a'])!,
+        value: '=test',
+      }),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =test
+    - b
+    - c`)
+})
+
 it('set empty attribute', () => {
   const steps = [
     newThought('a'),

--- a/src/actions/__tests__/toggleAttribute.ts
+++ b/src/actions/__tests__/toggleAttribute.ts
@@ -138,6 +138,58 @@ it('toggle nullary attribute off', () => {
   - a`)
 })
 
+it('preserve existing children when toggling a nullary attribute on', () => {
+  const steps = [
+    importText({
+      text: `
+      - a
+        - b
+        - c
+    `,
+    }),
+    (state: State) =>
+      toggleAttribute(state, {
+        path: contextToPath(state, ['a']),
+        values: ['=test'],
+      }),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =test
+    - b
+    - c`)
+})
+
+it('preserve existing children when toggling a nullary attribute off', () => {
+  const steps = [
+    importText({
+      text: `
+      - a
+        - b
+        - c
+        - =test
+    `,
+    }),
+    (state: State) =>
+      toggleAttribute(state, {
+        path: contextToPath(state, ['a']),
+        values: ['=test'],
+      }),
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - b
+    - c`)
+})
+
 it('toggle deep attribute on', () => {
   const steps = [
     newThought('a'),

--- a/src/actions/setDescendant.ts
+++ b/src/actions/setDescendant.ts
@@ -10,6 +10,7 @@ import { registerActionMetadata } from '../util/actionMetadata.registry'
 import appendToPath from '../util/appendToPath'
 import createId from '../util/createId'
 import head from '../util/head'
+import isAttribute from '../util/isAttribute'
 
 interface setDescendantPayload {
   path: Path
@@ -17,23 +18,25 @@ interface setDescendantPayload {
   values?: string[]
 }
 
-/** Sets a sequence of values as descendants. Preserves existing descendants and unrelated siblings, except for the last value, which always gets replaced by the given value. */
+/** Sets a sequence of values as descendants. Attribute keys (e.g. =pin) are found or created, preserving existing descendants and unrelated siblings. A non-attribute last value is the attribute's value slot, and replaces the existing first subthought. */
 const setDescendant = (state: State, { path, value, values }: setDescendantPayload): State => {
   // normalize values to array
   const _values = values || [value!]
   if (!value && (!values || values.length === 0)) return state
 
   const thoughtId = head(path)
-  const firstSubthoughtId = findDescendant(state, thoughtId, _values[0])
-  const idNew = createId()
 
-  // base case: overwrite the first subthought with the last value in the sequence
-  if (_values.length === 1) {
+  // base case: overwrite the first subthought with the value slot
+  // A nullary attribute (e.g. =heading1) is a key, not a value, so it falls through to find-or-create below rather than overwriting an unrelated first child.
+  if (_values.length === 1 && !isAttribute(_values[0])) {
     return setFirstSubthought(state, {
       path: path,
       value: _values[0],
     })
   }
+
+  const firstSubthoughtId = findDescendant(state, thoughtId, _values[0])
+  const idNew = createId()
 
   // otherwise, create the first subthought if it does not exist and recurse
   const stateWithFirstSubthought = firstSubthoughtId
@@ -46,6 +49,7 @@ const setDescendant = (state: State, { path, value, values }: setDescendantPaylo
       })
 
   // recursion
+  // When the sequence ends in an attribute key, the recursive call receives no values and returns the state unchanged.
   return setDescendant(stateWithFirstSubthought, {
     path: appendToPath(path, firstSubthoughtId || idNew),
     values: _values.slice(1),

--- a/src/actions/toggleAttribute.ts
+++ b/src/actions/toggleAttribute.ts
@@ -15,6 +15,7 @@ import { registerActionMetadata } from '../util/actionMetadata.registry'
 import appendToPath from '../util/appendToPath'
 import createId from '../util/createId'
 import head from '../util/head'
+import isAttribute from '../util/isAttribute'
 
 /** Toggles the given attribute value. If the attribute value exists, deletes the entire attribute. If value is not specified, toggles the attribute itself. */
 const toggleAttribute = (
@@ -30,8 +31,9 @@ const toggleAttribute = (
   const firstSubthoughtId = findDescendant(state, thoughtId, _values[0])
   const idNew = createId()
 
-  // base case: delete or overwrite the first subthought with the last value in the sequence
-  if (_values.length === 1) {
+  // base case: delete or overwrite the first subthought with the value slot
+  // A nullary attribute (e.g. =test) is a key, not a value, so it is handled below by its own existence rather than by overwriting an unrelated first child.
+  if (_values.length === 1 && !isAttribute(_values[0])) {
     const firstThought = getThoughtById(state, getAllChildren(state, thoughtId)[0])
 
     // Handle standalone attributes, e.g. =pin as opposed to =pin/true, skip deleting the attribute
@@ -48,6 +50,11 @@ const toggleAttribute = (
         })
   }
 
+  // toggle a nullary attribute off if it exists; otherwise it is created below
+  if (_values.length === 1 && firstSubthoughtId) {
+    return deleteThought(state, { pathParent: path, thoughtId: firstSubthoughtId })
+  }
+
   // otherwise, create the first subthought if it does not exist and recurse
   const stateWithFirstSubthought = firstSubthoughtId
     ? state
@@ -62,6 +69,7 @@ const toggleAttribute = (
       })
 
   // recursion
+  // When the sequence ends in an attribute key, the recursive call receives no values and returns the state unchanged.
   const stateNew = toggleAttribute(stateWithFirstSubthought, {
     path: appendToPath(path, firstSubthoughtId || idNew),
     values: _values.slice(1),

--- a/src/commands/__tests__/headings.ts
+++ b/src/commands/__tests__/headings.ts
@@ -1,0 +1,76 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { executeCommandWithMulticursor } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import { heading1, heading2 } from '../headings'
+
+beforeEach(initStore)
+
+it('add a heading attribute to a leaf', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  executeCommandWithMulticursor(heading1, { store, type: 'keyboard' })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =heading1`)
+})
+
+it('preserve existing children when a heading is applied to a thought with children', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - b
+          - c
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  executeCommandWithMulticursor(heading1, { store, type: 'keyboard' })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =heading1
+    - b
+    - c`)
+})
+
+it('replace the existing heading level and preserve children when a different heading is applied', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+          - =heading1
+          - b
+          - c
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  executeCommandWithMulticursor(heading2, { store, type: 'keyboard' })
+
+  const exported = exportContext(store.getState(), [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - =heading2
+    - b
+    - c`)
+})


### PR DESCRIPTION
No linked issue; reproduced at the store level from the report.

## Summary

Applying a Heading command to a thought that already has children renamed the first child to `=headingN` instead of adding the attribute:

```
- a
  - b
  - c
```

Heading 1 on `a` produced `a / =heading1 / c` — `b` was gone. On a leaf it worked.

`heading` calls `setDescendant({ values: ['=headingN'] })`, whose single-value base case called `setFirstSubthought` unconditionally, treating a nullary attribute key as a value slot. `toggleAttribute` had the same shape for a nullary attribute (`firstThought?.value === '=test' ? delete : setFirstSubthought`), so toggling `=test` on a thought whose first child is `b` renamed `b`. "First" here is `Object.values(childrenMap)[0]` — insertion order, not rank — so which child got renamed was arbitrary.

Both reducers now route a trailing attribute key (`isAttribute`, `/^=\w+$/`) through the existing find-or-create branch. A non-attribute last value (`=pin/true`, note text under `=note`) still replaces the first subthought, which is what every other caller relies on. `heading.ts` is unchanged.

## Tests

- `src/commands/__tests__/headings.ts` (new): a leaf, a thought with children, and switching heading level with children present.
- `src/actions/__tests__/setDescendant.ts`, `src/actions/__tests__/toggleAttribute.ts`: a nullary attribute set/toggled on and off with existing children.

On the base commit the five regression cases fail on the intended assertion with `b` renamed to the attribute (the toggle-off case ends with two `=test` children and no `b`). The leaf case is baseline coverage and passes on base.

## Plan

### 1. Existing surface area

- `docs/metaprogramming.md:7`, `docs/glossary.md:17` — a meta-attribute is identified by its value and stored under that value in `childrenMap`; it is a key, not a slot.
- `src/actions/setDescendant.ts:30-36` — base case `if (_values.length === 1) return setFirstSubthought(...)`; the `findDescendant` result computed for every level was ignored here. The recursive case (`:39-52`) already find-or-creates.
- `src/actions/setFirstSubthought.ts:13-36` — correct for its name: `anyChild` → `editThought`, else `createThought`.
- `src/actions/toggleAttribute.ts:33-48` — `firstThought?.value === _values[0] ? deleteThought : setFirstSubthought`; the equality check only decides delete-vs-overwrite.
- `src/actions/heading.ts:13-29` — deletes every `=heading[1-9]` child, then `setDescendant({ path, values: ['=heading${level}'] })`, so the attribute never exists when the base case runs.
- Single-value `setDescendant` callers `src/components/Note.tsx:180`, `src/actions/formatSelection.ts:154`, `src/actions/formatLetterCase.ts:76` write note text under `=note` (`docs/metaprogramming.md:100`: the first child of `=note` is the note's text) and need overwrite semantics. All `toggleAttribute` callers pass two-element chains.
- `src/actions/deleteAttribute.ts:27-30` already deletes by `findDescendant` match, so the delete side was key-based; this brings create/toggle in line.

### 2. Build vs. extend

Extend: narrow the base-case condition in both reducers so a trailing attribute key takes the existing find-or-create branch. Fixing only `heading.ts` with a direct `createThought` was rejected — it leaves the shared contract wrong for the next nullary-attribute caller and duplicates the rank logic that already lives in the recursive case.

### 3. Adjacent behaviour

- Two-value chains (`['=pin','true']`, `['=view','Table']`, `['=children','=bullet',X]`): last element is non-attribute → unchanged path, covered by existing reducer and command tests.
- Note text writes: unchanged. Note text matching `/^=\w+$/` exactly would now be created beside rather than overwrite; `noteValue` reads via `firstVisibleChild`, which already hides such a note.
- `toggleNote`'s `[noteKey, '']` and the `'set empty attribute'` test: `''` is not an attribute → unchanged.
- `toggleAttribute`'s `!firstThought && _values[0] === 'true'` special case: `'true'` is not an attribute → unchanged.
- Sorted contexts: `toggleAttribute`'s create reuses the recursive case's `getSortedRank`/`getPrevRank` choice (`'preserve sorted context'` test); `setDescendant` keeps `getPrevRank`.
- Multicursor heading: runs once per cursor via `executeCommandWithMulticursor`; reducer-level fix.
- Undo/redo: both reducers are `undoable: true`; the composed primitive changes from `editThought` to `createThought`, both already undoable.

### 4. Approaches

- A (chosen): base case = `_values.length === 1 && !isAttribute(_values[0])`; attribute keys fall through to find-or-create (`setDescendant`) / `firstSubthoughtId ? delete : create` (`toggleAttribute`).
- B: fix `heading.ts` only. Smaller blast radius, leaves the hazard in two shared reducers.
- C: make `setFirstSubthought` attribute-aware. Rejected: its name and contract are "set the first subthought"; the misuse is in callers.

### 5. Diff

- `src/actions/setDescendant.ts`: base case only for a non-attribute last value; an attribute key recurses with `_values.slice(1)` and terminates on the existing empty-values guard. JSDoc restated as the key/value rule.
- `src/actions/toggleAttribute.ts`: same base-case narrowing; a nullary attribute that exists is deleted, one that does not falls through to the existing create.
- Tests as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
