### PR TITLE
fix: remove box artifact in GestureDiagram arrow tip

### DIFF
--- a/src/components/CommandUniverseGridItem.tsx
+++ b/src/components/CommandUniverseGridItem.tsx
@@ -70,6 +70,7 @@ const CommandUniverseGridItem: FC<CommandUniverseGridItemProps> = ({ command, se
             arrowSize={25}
             strokeWidth={7.5}
             arrowhead={'outlined'}
+            glow={false}
           />
         </td>
       ) : null}

--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -544,6 +544,11 @@ const GestureDiagram = ({
               markerUnits='userSpaceOnUse'
               orient='auto-start-reverse'
             >
+              {/* No glow filter here. Markers are rendered as part of the referencing path, so the path's own
+                  drop-shadow already glows the arrowhead. A second filter on this path would be rendered into
+                  the marker's own surface, which is bounded by the marker viewport, and its blur radius would be
+                  measured in the marker's local coordinate system — which viewBox scales up by markerWidth / 10.
+                  The oversized glow then saturates the marker tile and its edge shows as a box around the tip. */}
               <path
                 d={
                   arrowhead === 'filled'
@@ -561,7 +566,6 @@ const GestureDiagram = ({
                 }
                 stroke={arrowhead === 'outlined' ? (color ?? token('colors.fg')) : 'none'}
                 strokeWidth={arrowhead === 'outlined' ? strokeWidth / 3 : 0}
-                style={dropShadow ? { filter: dropShadow } : undefined}
               />
             </marker>
           )}


### PR DESCRIPTION
Fixes #2914

## Problem

The tip of every gesture arrow is surrounded by a faded box.

## Cause

`GestureDiagram` applied the glow drop-shadow twice: once on the shaft `<path>`, and again on the `<path>` inside `<marker>`.

The second one was redundant. SVG markers are rendered as part of the referencing path, so the shaft path's `filter` already glows the arrowhead — the marker did not need its own.

It was also actively harmful. A filter on the marker's path is rendered into the marker's own surface, which is bounded by the marker viewport, and its blur radius is measured in the marker's *local* coordinate system — which `viewBox="0 0 10 10"` scales up by `markerWidth / 10`. In the Command Universe (`arrowSize={25}`, `arrowhead='outlined'` → `markerWidth` 50), that scale is 5×, so a 6.67px blur became ~33 user units — wider than the arrowhead itself. The glow saturated the entire marker tile, and the tile's rectangular edge is the box.

## Fix

Remove the filter from the marker's inner path.


## Results
<img width="317" height="619" alt="image" src="https://github.com/user-attachments/assets/1770f902-d533-4b74-b509-222ad5e50c53" />
