### PR TITLE
fix(dragAndDrop): resolve a dragged SimplePath's sibling in normal view

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -216,7 +216,7 @@ A note on `parentOf` vs `rootedParentOf`: [`rootedParentOf`](../src/selectors/ro
 #### Basic traversal
 
 - [`parentOfThought`](../src/selectors/parentOfThought.ts) — parent `Thought` of a `ThoughtId`.
-- [`nextSibling`](../src/selectors/nextSibling.ts) / [`prevSibling`](../src/selectors/prevSibling.ts) — next/previous sibling, honoring the parent's sort preference. `prevSibling` also handles context view.
+- [`nextSibling`](../src/selectors/nextSibling.ts) / [`prevSibling`](../src/selectors/prevSibling.ts) — next/previous sibling, honoring the parent's sort preference. `prevSibling` also handles context view, inferring it from the parent path. Since nothing distinguishes a `SimplePath` from a context-view `Path` at runtime, a caller holding a `SimplePath` must pass `{ showContexts: false }`, or a thought in a cyclic context — whose simple parent path *is* the path the context view is active on, e.g. `a/m/x` rendered at `a/m~/a/x` — will be looked up among the contexts of `m` rather than its children.
 - [`rootedParentOf`](../src/selectors/rootedParentOf.ts) — parent `Path`, returning `[HOME_TOKEN]` for root children.
 - [`parentOf`](../src/util/parentOf.ts) — parent of a `Path` or `Context` (may be empty).
 - [`appendToPath`](../src/util/appendToPath.ts) — appends one or more thoughts to a `Path` / `SimplePath`, dropping the root token.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -394,6 +394,8 @@ When `cursor` is `a/m~/b/y`, then `contextChain` is (ranks omitted for readabili
 
 Each segment is a `SimplePath`. The transition from one segment to the next happens at each `m~` boundary.
 
+An active context view is not on its own enough to split: the id following the context-view thought must be one of that thought's contexts. The distinction matters in a cyclic context (see [Context view recursion](#context-view-recursion) above), where a `SimplePath` and a context-view `Path` can be the same array of ids. The thought rendered at `a/m~/a/x` has the `SimplePath` `a/m/x`, and a context view is active on `a/m` — but `x` is an ordinary child of `m` rather than a context of it, so `a/m/x` is left whole instead of being split into `[['a', 'm'], ['x']]`.
+
 A more involved example (paste into **em** to try):
 
 ```

--- a/src/actions/archiveThought.ts
+++ b/src/actions/archiveThought.ts
@@ -62,8 +62,9 @@ const archiveThought = (state: State, options: { path?: Path }): State => {
 
   if (!path) return state
 
-  const showContexts = isContextViewActive(state, rootedParentOf(state, path))
   const contextChain = splitChain(state, path)
+  // Only rewrite the operation if the path actually crosses the context view. A SimplePath such as a/m/x is not rewritten even though a context view is active on its parent a/m, otherwise the rewrite would recurse infinitely on the same path.
+  const showContexts = contextChain.length > 1 && isContextViewActive(state, rootedParentOf(state, path))
   const simplePath = contextChain.length > 1 ? lastThoughtsFromContextChain(state, contextChain) : (path as SimplePath)
 
   // rewrite context view operaton in terms of normal view and update cursor

--- a/src/components/DropHover.tsx
+++ b/src/components/DropHover.tsx
@@ -100,7 +100,11 @@ const DropHoverIfVisible = ({
 
     // Don't show drop hover between contiguous selected thoughts
     const contiguousDraggingThoughts = state.draggingThoughts.filter(draggingPath => {
-      const prev = prevSibling(state, draggingPath)
+      // draggingThoughts are SimplePaths, so their siblings must always be resolved in normal view. Without
+      // showContexts:false, prevSibling infers the context view from the dragging thought's simple parent path, which
+      // in a cyclic context is the very path the context view is active on (dragging a/m~/a/x has simple parent a/m),
+      // and looks for x among the contexts of m instead of among the children of m.
+      const prev = prevSibling(state, draggingPath, { showContexts: false })
       const prevPath = prev ? appendToPath(parentOf(draggingPath), prev.id) : null
       return prev && state.draggingThoughts.some(simplePath => equalPath(prevPath, simplePath))
     })

--- a/src/components/__tests__/DropHover.ts
+++ b/src/components/__tests__/DropHover.ts
@@ -1,0 +1,68 @@
+import { act } from 'react'
+import DragThoughtZone from '../../@types/DragThoughtZone'
+import DropThoughtZone from '../../@types/DropThoughtZone'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { longPressActionCreator as longPress } from '../../actions/longPress'
+import { toggleContextViewActionCreator as toggleContextView } from '../../actions/toggleContextView'
+import { LongPressState } from '../../constants'
+import contextToPath from '../../selectors/contextToPath'
+import simplifyPath from '../../selectors/simplifyPath'
+import store from '../../stores/app'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+// https://github.com/cybersemics/em/issues/5089
+it('no error is logged when a thought in a cyclic context is dragged over the thought the context view is on', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - m
+            - x
+        - b
+          - m
+            - y
+      `,
+    }),
+    setCursor(['a', 'm']),
+    toggleContextView(),
+    setCursor(['a', 'm', 'a']),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  const state = store.getState()
+  const pathX = contextToPath(state, ['a', 'm', 'a', 'x'])
+  const pathM = contextToPath(state, ['a', 'm'])
+  if (!pathX || !pathM) throw new Error('Expected the context view of a/m to render x in the cyclic context a/m~/a')
+
+  // beginDrag stores the simplified path of the dragged thought, so dragging a/m~/a/x adds a/m/x to draggingThoughts.
+  // Its parent a/m is the very path the context view is active on, which is what makes the context view ambiguous.
+  const simplePathX = simplifyPath(state, pathX)
+  expectPathToEqual(state, simplePathX, ['a', 'm', 'x'])
+  expectPathToEqual(state, pathM, ['a', 'm'])
+
+  const consoleError = vi.spyOn(console, 'error')
+
+  // drag a/m~/a/x over a/m without releasing
+  await dispatch(
+    longPress({
+      value: LongPressState.DragInProgress,
+      draggingThoughts: [simplePathX],
+      hoveringPath: pathM,
+      hoverZone: DropThoughtZone.ThoughtDrop,
+      sourceZone: DragThoughtZone.Thoughts,
+    }),
+  )
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  expect(consoleError.mock.calls).toEqual([])
+
+  consoleError.mockRestore()
+})

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -2,7 +2,9 @@ import path from 'path'
 import sleep from '../../../util/sleep'
 import configureSnapshots from '../configureSnapshots'
 import clickThought from '../helpers/clickThought'
+import command from '../helpers/command'
 import dragAndDropThought from '../helpers/dragAndDropThought'
+import exportThoughts from '../helpers/exportThoughts'
 import getEditingText from '../helpers/getEditingText'
 import hideHUD from '../helpers/hideHUD'
 import paste from '../helpers/paste'
@@ -447,6 +449,37 @@ describe('drop', () => {
         },
       })
     })
+  })
+
+  // https://github.com/cybersemics/em/issues/5089
+  it.skip('drops a thought dragged out of a cyclic context', async () => {
+    await paste(`
+      - a
+        - m
+          - x
+      - b
+        - m
+          - y
+    `)
+
+    await clickThought('a')
+    await clickThought('m')
+    await command('toggleContextView')
+    // move the cursor to the cyclic context a/m~/a so that x is rendered
+    await press('ArrowDown')
+    await waitForEditable('x')
+
+    await dragAndDropThought('x', 'm', { position: 'before' })
+
+    const exported = await exportThoughts()
+    expect(exported).toBe(`
+- a
+  - x
+  - m
+- b
+  - m
+    - y
+`)
   })
 })
 

--- a/src/e2e/puppeteer/__tests__/drag-and-drop.ts
+++ b/src/e2e/puppeteer/__tests__/drag-and-drop.ts
@@ -452,7 +452,7 @@ describe('drop', () => {
   })
 
   // https://github.com/cybersemics/em/issues/5089
-  it.skip('drops a thought dragged out of a cyclic context', async () => {
+  it('drops a thought dragged out of a cyclic context', async () => {
     await paste(`
       - a
         - m

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -243,7 +243,11 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
             oldPath: thoughtFrom,
             newPath,
             newRank: prevPath ? getRankAfter(state, prevPath) : getRankBefore(state, props.simplePath),
-            afterId: prevPath ? head(prevPath) : (prevSibling(state, props.simplePath)?.id ?? null),
+            // props.simplePath is a SimplePath, so its previous sibling must always be resolved in normal view.
+            // See the note in DropHover on why the context view would otherwise be inferred for a cyclic context.
+            afterId: prevPath
+              ? head(prevPath)
+              : (prevSibling(state, props.simplePath, { showContexts: false })?.id ?? null),
           }),
         )
       }

--- a/src/selectors/splitChain.ts
+++ b/src/selectors/splitChain.ts
@@ -1,7 +1,10 @@
 import Path from '../@types/Path'
 import SimplePath from '../@types/SimplePath'
 import State from '../@types/State'
+import getContexts from '../selectors/getContexts'
+import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
+import headValue from '../util/headValue'
 
 /**
  * Splits a Path into a context chain that contains each of its SimplePaths. For eample, if the Path crosses two context views A and B, the context chain will have length SimplePaths: [ROOT, ...] -> [A, ...] -> [B, ...].
@@ -9,12 +12,19 @@ import isContextViewActive from '../selectors/isContextViewActive'
 const splitChain = (state: State, path: Path): SimplePath[] => {
   const contextChain: SimplePath[] = []
 
-  // Iterate through path. Whenever a context view is found, add the current SimplePath to the contextChain and advance indexSimplePathStart to the starting index of the next SimplePath in the chain.
+  // Iterate through path. Whenever a context view is crossed, add the current SimplePath to the contextChain and advance indexSimplePathStart to the starting index of the next SimplePath in the chain.
   let indexSimplePathStart = 0
-  path.forEach((value, i) => {
+  path.forEach((id, i) => {
     const ancestor = path.slice(0, i + 1) as Path
-    const showContexts = isContextViewActive(state, ancestor)
-    if (showContexts && i < path.length - 1) {
+    const contextId = path[i + 1]
+    const value = headValue(state, ancestor)
+    // An active context view is only crossed if the next id is one of the contexts, i.e. the parent of another instance of the thought. Otherwise the next id is an ordinary child and the path is simple, as with the SimplePath a/m/x of a thought rendered at a/m~/a/x.
+    const crossesContextView =
+      contextId !== undefined &&
+      value !== undefined &&
+      isContextViewActive(state, ancestor) &&
+      getContexts(state, value).some(cxid => getThoughtById(state, cxid)?.parentId === contextId)
+    if (crossesContextView) {
       contextChain.push(path.slice(indexSimplePathStart, i + 1) as SimplePath)
       indexSimplePathStart = i + 1
     }


### PR DESCRIPTION
Fixes #5089

## Problem

Dragging a thought rendered inside a **cyclic context** logs an error on every hover:

```
prevSibling.ts:47 Thought x with Path <a>,<m_a>,<x> missing from context view of <m_a>
```

`state.draggingThoughts` holds `SimplePath`s, so dragging `a/m~/a/x` stores `a/m/x`. `prevSibling` infers the context view from `rootedParentOf(path)`, which for that SimplePath is `a/m` — the very path the context view is active on. It therefore searches the *contexts* of `m` for `x`, finds nothing, logs the error, and returns `null`.

`prevSibling`'s JSDoc already names this exact hazard, and `updateCursorAfterDelete` already applies the prescribed workaround. Nothing distinguishes a `SimplePath` from a context-view `Path` at runtime — in the cyclic case they are the same array of ids — so the caller has to say which it holds.

Introduced by d56a3f5360 (`Fixes #3662`), which added the `prevSibling` call in `DropHover`; the error is unreachable before it.

## Fix

Pass `{ showContexts: false }` at the two call sites holding a `SimplePath`:

- **`src/components/DropHover.tsx`** — the contiguous-drag check the issue reproduces.
- **`src/hooks/useDragAndDropThought.tsx`** — the same defect on **drop**, not reported in the issue. `canDrop` guards `parentOf(props.path)`, which is not a context-view key for a thought inside a cyclic context, so the drop proceeds and `prevSibling(props.simplePath)` misfires. Besides the console error, it hands `moveThought` an `afterId` of `null` instead of the real previous sibling, so the CRDT order and the locally computed rank disagree.

Every other `prevSibling` caller passes a rendered `Path` (usually `state.cursor`), where the inference is correct — those are unchanged. `nextSibling` is normal-view only and has no equivalent inference.

Outside the cyclic case the change is a no-op: `showContexts: false` differs from the inference only when the dragged thought's real parent carries an active context view on that exact path, which is precisely the broken case. In a cyclic context it also *restores* the contiguous-drag suppression, which previously never fired there because `prev` was a context thought rather than a sibling.

## Test

`src/components/__tests__/DropHover.ts` follows the issue's steps — import the outline, toggle the context view on `a/m`, expand `a/m~/a` — then dispatches the `longPress` that the drop target's `hover` handler dispatches, and asserts nothing is logged. Red before the fix with the exact reported message, green after.

JSDOM is the lowest sufficient level: the defect lives in an inline `useSelector` closure, and `prevSibling` returns `null` either way, so the logged error is the only observable difference. Two `expectPathToEqual` guards assert the dragged and hovered paths are the ones named in the error message, so the test cannot pass by never reaching the code.

The drop-handler fix ships without its own test — react-dnd drops cannot be driven in JSDOM (`createTestApp`'s `document.DND` is always `null`, since the ref is never attached) and `drop` is module-private.


## Docs

`docs/data-model.md` now states the `SimplePath` → `{ showContexts: false }` rule where `prevSibling` is documented.
