### PR TITLE
docs(drag-and-drop): fix dead link to useDragAndDropSubThought

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -99,7 +99,7 @@ Notable behavior in [`useDragAndDropThought.tsx`](../src/hooks/useDragAndDropTho
 
 ### `useDragAndDropSubThought`
 
-Used by `DropChild` and `DropEnd`. Drop-only — there is no drag source. See [`useDragAndDropSubThought.ts`](../src/hooks/useDragAndDropSubThought.ts).
+Used by `DropChild` and `DropEnd`. Drop-only — there is no drag source. See [`useDragAndDropSubThought.tsx`](../src/hooks/useDragAndDropSubThought.tsx).
 
 Distinguishing rules from `useDragAndDropThought`:
 


### PR DESCRIPTION
## What changed

`docs/drag-and-drop.md:102` linked to `../src/hooks/useDragAndDropSubThought.ts`, but the hook is `useDragAndDropSubThought.tsx`. Corrected both the link target and the link text.

## Why

The link was dead — it 404s on GitHub and doesn't resolve in editors. It's the known dead reference `docs-sync` flags, and it was pre-existing rather than introduced by any recent change, so it's fixed here on its own.

## Notes for reviewers

One-line docs change; no code affected. It was the only occurrence of the bad path in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)