### PR TITLE
ci: enable Corepack before yarn install in the four workflows missing it

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,9 @@ jobs:
           # For GitHub Pages deployment, persist-credentials: false is often required.
           persist-credentials: false
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install npm dependencies 🛠
         uses: ./.github/actions/install
 

--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -44,9 +44,12 @@ jobs:
           # backfill.ts runs `git log` to compute the prompt version; a shallow
           # clone would make it resolve to "unknown", so fetch full history.
           fetch-depth: 0
+      - name: Enable Corepack
+        run: corepack enable
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'yarn'
       - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build

--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -37,9 +37,12 @@ jobs:
               content: 'eyes',
             })
       - uses: actions/checkout@v6
+      - name: Enable Corepack
+        run: corepack enable
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'yarn'
       - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -20,9 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Enable Corepack
+        run: corepack enable
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'yarn'
       - run: yarn install --immutable
       - name: Build estimate workspace
         run: yarn workspace em-estimate build


### PR DESCRIPTION
## What changed

Adds the `Enable Corepack` step to the four workflows that install dependencies without it, and `cache: 'yarn'` to their `setup-node` steps, matching the ordering in `lint.yml` (checkout → corepack enable → setup-node → install):

- `.github/workflows/estimate-issue-opened.yml`
- `.github/workflows/estimate-command.yml`
- `.github/workflows/estimate-backfill.yml`
- `.github/workflows/docs.yml` — Corepack step only; it has no `setup-node` step, going straight to `./.github/actions/install`

Every other workflow that installs dependencies (`lint`, `test`, `puppeteer`, `tdd`, `ios`, `tauri-release-*`, `vercel-*`, `update-browserslist`, `agent-scripts`, `copilot-setup-steps`) already had it.

## Why — and what this is *not*

This was originally flagged as a latent bug: `ubuntu-latest` ships Yarn 1.22.22, so without `corepack enable` the `yarn install --immutable` in these four would be handled by Yarn 1, which has no `--immutable` flag.

**That reasoning does not hold, and this PR fixes nothing that was broken.** Two things were verified before making the change:

1. **Yarn 1.22 bootstraps `yarnPath`.** Since 1.22.0 it reads `.yarnrc.yml`, finds `yarnPath`, and re-execs the pinned release with the original argv. `.yarn/releases/yarn-4.17.0.cjs` is committed (`.gitignore` has `!.yarn/releases`), so the bootstrap target exists in a fresh checkout. Running the exact runner version (`yarn@1.22.22`, pulled from the registry) inside this repo reports `4.17.0`; against a fixture replicating the yarnrc/release layout, `yarn install --immutable` delegates to Yarn 4 and exits 0.
2. **Yarn 1 would not have errored anyway.** In a fixture with no `yarnPath`, `yarn install --immutable` under Yarn 1 exits 0 — it ignores the unknown flag and performs a normal mutable install.

The four having never executed is beside the point; the `yarnPath` bootstrap is what has kept this invisible.

The step is worth adding regardless, for consistency and defense in depth. The `yarnPath` pin is the only thing that makes `--immutable` meaningful in these four. Drop that pin — as a conventional Yarn 4 + Corepack setup does, relying on `packageManager` alone — and they degrade *silently* (finding 2) while the other thirteen keep working.

## Notes for the reviewer

- Noticed while adding `assign-issue-milestone.yml`, which was modeled on `estimate-issue-opened.yml` but had `corepack enable` added for this reason.
- All four files still parse as YAML. No other changes to these workflows.
- `estimate-command.yml` fails `prettier --check` on a pre-existing double space before `# v7` at line 30. Unrelated to this change and left alone; it is not CI-enforced, since `yarn lint` runs eslint, which does not cover `.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)