### PR TITLE
ci: fix double space before version comments on pinned actions

### DIFF
--- a/.github/workflows/estimate-command.yml
+++ b/.github/workflows/estimate-command.yml
@@ -27,7 +27,7 @@ jobs:
       # React immediately so the commenter sees the command was picked up, before the
       # slow checkout/install/build steps below (which take several minutes) even start.
       - name: Acknowledge command
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/puppeteer-diff-comment.yml
+++ b/.github/workflows/puppeteer-diff-comment.yml
@@ -66,7 +66,7 @@ jobs:
       # workflow_run head sha so a crafted pr-number.txt cannot target another PR.
       - name: Resolve and verify PR number
         id: pr
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await require('./scripts/ci/resolve-diff-pr.cjs')({ github, context, core })
@@ -182,7 +182,7 @@ jobs:
       # resolved message when the latest run had no diffs.
       - name: Upsert PR comment
         if: steps.pr.outputs.number
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PR: ${{ steps.pr.outputs.number }}
           AUTHOR: ${{ steps.pr.outputs.author }}


### PR DESCRIPTION
The SHA-pinning in caa250528a (#4707) emitted two spaces before the `# v7` version comment, leaving three lines failing `prettier --check`:

- `.github/workflows/estimate-command.yml:30`
- `.github/workflows/puppeteer-diff-comment.yml:69`
- `.github/workflows/puppeteer-diff-comment.yml:185`

Prettier is not part of `yarn lint` (which runs `lint:lockfile`, `lint:no-npm`, `lint:src` (eslint), and `lint:tsc`) and is not run by any workflow, so this went unnoticed.

Whitespace only — no behavior change. `prettier --check '.github/workflows/*.yml'` now passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)