### PR TITLE
ci: enforce prettier formatting in yarn lint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,7 @@ packages
 src/components/icons/animations
 desktop/target
 desktop/gen
+.yarn
+ios/App/App/Assets.xcassets
+.github/skills
+.claude/settings.local.json

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,5 @@
 approvedGitRepositories:
-  - "**"
+  - '**'
 
 enableScripts: true
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "icons:web": "yarn --cwd scripts/icons install && yarn --cwd scripts/icons generate:web",
     "lint:lockfile": "npx lockfile-lint",
     "lint:no-npm": "node ./scripts/no-files.js package-lock.json",
+    "lint:prettier": "FORCE_COLOR=1 prettier --check .",
     "lint:src": "FORCE_COLOR=1 NODE_OPTIONS=--max-old-space-size=4096 eslint . --cache --rule 'no-console: [2, { allow: [error, info, warn] }]'",
     "lint:tsc": "tsc",
     "lint": "FORCE_COLOR=1 npm-run-all --serial \"lint:*\"",


### PR DESCRIPTION
## Problem

Nothing in CI checked formatting. `yarn lint` ran `lint:lockfile`, `lint:no-npm`, `lint:src` (eslint), and `lint:tsc`; prettier was installed and configured (`.prettierrc.json`) but wired into nothing — not the lint script, not any workflow. The `.hooks/post-commit` hook runs `lint:src` only, in the background, as a non-blocking notification.

That is how three double spaces before `# v7` comments survived in the workflows since caa250528a (#4707), fixed in #5097 — eslint does not cover `.yml`, so nothing would ever have flagged them.

## Fix

Add `lint:prettier`, which the existing `npm-run-all --serial "lint:*"` glob picks up automatically. [lint.yml](.github/workflows/lint.yml) has no path filters and is the one required status check on main, so formatting drift now blocks merge.

## Verification

Reinjecting the exact double space into `estimate-command.yml:30` makes `yarn lint:prettier` exit `1` and name the file; reverting it exits `0`. Full `yarn lint` passes with the new step alongside eslint and tsc.

## Ignores

`prettier --check .` failed on 13 files before this change. Ignored rather than reformatted:

- `.yarn` — vendored Yarn bundle
- `ios/App/App/Assets.xcassets` — Xcode-managed, would churn on every Xcode write
- `.claude/settings.local.json` — untracked but not gitignored, so it would fail lint locally while being invisible to CI
- `.github/skills` — matches the existing exclusion of `docs`; this repo deliberately keeps prettier off its markdown, and the diff there is almost entirely table padding

`.yarnrc.yml` is the one tracked file actually reformatted: `"**"` → `'**'`, semantically identical YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)