### PR TITLE
test(categorize): pin context-view rejection of multiselected contexts

### DIFF
--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -148,6 +148,132 @@ describe('context view', () => {
       - ${''}
         - y`)
   })
+
+  // In a context view, each row is a different context of the same thought. The rows share a displayed parent — the
+  // path whose context view is open — but their real (SimplePath) parents are the separate contexts they represent,
+  // so there is no single destination to categorize into and the selection must be refused.
+  //
+  // Each test asserts the alert before the exported tree, and that order is load-bearing: setCursorFirstMatch sets
+  // the cursor to null when contextToPath cannot resolve a path, and categorize then returns state unchanged, so a
+  // mistyped path would satisfy the unchanged-tree assertion while exercising nothing. The MulticursorError is only
+  // reachable once the cursor and every multicursor have resolved.
+  describe('multiple contexts', () => {
+    it('disallow categorizing two contexts in a context view, which have different parents', () => {
+      const steps = [
+        importText({
+          text: `
+            - a
+              - m
+                - x
+            - b
+              - m
+                - y`,
+        }),
+        setCursor(['a', 'm']),
+        toggleContextView,
+        setCursor(['a', 'm', 'a']),
+        addMulticursor(['a', 'm', 'a']),
+        addMulticursor(['a', 'm', 'b']),
+        categorize,
+      ]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(stateNew.alert).toMatchObject({
+        alertType: AlertType.MulticursorError,
+        value: 'Cannot categorize thoughts from different parents.',
+      })
+
+      const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - m
+      - x
+  - b
+    - m
+      - y`)
+    })
+
+    it('disallow categorizing three contexts in a context view, which have different parents', () => {
+      const steps = [
+        importText({
+          text: `
+            - a
+              - m
+                - x
+            - b
+              - m
+                - y
+            - c
+              - m
+                - z`,
+        }),
+        setCursor(['a', 'm']),
+        toggleContextView,
+        setCursor(['a', 'm', 'a']),
+        addMulticursor(['a', 'm', 'a']),
+        addMulticursor(['a', 'm', 'b']),
+        addMulticursor(['a', 'm', 'c']),
+        categorize,
+      ]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(stateNew.alert).toMatchObject({
+        alertType: AlertType.MulticursorError,
+        value: 'Cannot categorize thoughts from different parents.',
+      })
+
+      const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - m
+      - x
+  - b
+    - m
+      - y
+  - c
+    - m
+      - z`)
+    })
+
+    it('disallow categorizing a context and its ancestor context, which have different parents', () => {
+      const steps = [
+        importText({
+          text: `
+            - x
+              - m
+                - a
+                  - m
+                    - y`,
+        }),
+        setCursor(['x', 'm', 'a', 'm']),
+        toggleContextView,
+        setCursor(['x', 'm', 'a', 'm', 'a']),
+        addMulticursor(['x', 'm', 'a', 'm', 'a']),
+        addMulticursor(['x', 'm', 'a', 'm', 'x']),
+        categorize,
+      ]
+
+      const stateNew = reducerFlow(steps)(initialState())
+
+      expect(stateNew.alert).toMatchObject({
+        alertType: AlertType.MulticursorError,
+        value: 'Cannot categorize thoughts from different parents.',
+      })
+
+      const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+      expect(exported).toBe(`- ${HOME_TOKEN}
+  - x
+    - m
+      - a
+        - m
+          - y`)
+    })
+  })
 })
 
 describe('multicursor', () => {


### PR DESCRIPTION
Adds the missing rejection coverage for Categorize inside a Context View, so that a change which widens the same-parent guard cannot merge silently.

## Why

Categorize refuses a multiselection whose thoughts do not share a parent. Inside a context view that guard has **no coverage at all** — the only rejection test ([`disallow subcategorizing thoughts from different parents`](https://github.com/cybersemics/em/blob/main/src/actions/__tests__/categorize.ts)) uses normal view, where a displayed `Path` and its `SimplePath` are equal by construction, so the comparison the guard actually performs is never exercised.

Each row of a context view shares its displayed parent with every other row — the path whose context view is open — while its real parent is the separate context it represents. A guard that compares *displayed* parents therefore accepts these selections, and the move code, which derives a single destination from `multicursorPaths[0]` only, relocates thoughts out of unrelated contexts. The ancestor/descendant case additionally produces a parent cycle that detaches the document from the root.

## What is pinned

Three shapes that must always be refused, before and after any fix to #3391, because their thoughts genuinely have different real parents:

1. two context rows in a context view
2. three context rows
3. a context row and its ancestor context row — the shape that produces the parent cycle

Each asserts `AlertType.MulticursorError` **and** that the exported tree is byte-identical to the input; the alert alone would pass even if the tree were mangled.

## What is deliberately *not* pinned

The case #3391 legitimately reports — siblings deep under a single context — currently rejects too, but it *should* succeed. Pinning it would cement that bug. The long-press/simple-path multicursor shape is excluded for the same reason.

## Verification

- 14/14 pass on `main`.
- Applying the one-line guard change from #5100 on top fails **exactly these three** tests and no others.

## Notes

Assertion order is load-bearing. `setCursorFirstMatch` sets the cursor to `null` when `contextToPath` cannot resolve a path, and `categorize` then returns state unchanged — so a mistyped path would satisfy the unchanged-tree assertion while exercising nothing. The `MulticursorError` is only reachable once the cursor and every multicursor have resolved, so asserting it first rules that out. That helper footgun is addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)