### PR TITLE
test(categorize): document the context-view single-cursor failure as a skipped test

### DIFF
--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -149,6 +149,42 @@ describe('context view', () => {
         - y`)
   })
 
+  // Skipped: the single-cursor branch passes the simplified path to moveThought as oldPath, and moveThought
+  // simplifies it again. When the context view is active on a prefix of that simplified path — true only for the
+  // context the view was activated from — the second simplification resolves `x` as a context of `m` rather than as
+  // its child, finds nothing, and moveThought throws "sourceThought not found". The test above passes only because
+  // `b/m/y` does not share the `a/m` prefix.
+  // Unskip when https://github.com/cybersemics/em/issues/5104 is fixed.
+  it.skip('categorize context subthought in the context the context view was activated from', () => {
+    const text = `
+      - a
+        - m
+          - x
+      - b
+        - m
+          - y
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      setCursor(['a', 'm', 'a', 'x']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+    - m
+      - ${'' /* prevent trim_trailing_whitespace */}
+        - x
+  - b
+    - m
+      - y`)
+  })
+
   // In a context view, each row is a different context of the same thought. The rows share a displayed parent — the
   // path whose context view is open — but their real (SimplePath) parents are the separate contexts they represent,
   // so there is no single destination to categorize into and the selection must be refused.


### PR DESCRIPTION
Adds one skipped test documenting #5104, so the known failure is recorded in the suite rather than only in an issue.

## Why

`categorize` throws when the cursor is on a subthought shown under **the context the context view was activated from**:

```
- a
  - m
    - x
- b
  - m
    - y
```

Cursor on `a/m` → Context View → cursor on `x` under the `a` context → Categorize throws `moveThought: sourceThought not found`.

The existing `categorize context subthought` test covers the `b` context, whose real path `b/m/y` does not share the `a/m` prefix the context view is keyed on — which is exactly why the failure has never been caught.

## What this is not

This is **not** the transient TDD red-test marker described in `docs/testing.md`. It is a permanent, tracked skip for a known bug: it carries a prose reason as well as the issue link, and it is not expected to be unskipped in this PR. Per §6, it documents intended behavior and does not count as coverage.

## TDD workflow

This PR is **not** exempt from TDD validation, despite being test-only. `tdd.yml` makes the coverage-only auto-skip conditional on `HAS_SKIPPED_UNIT = false` — "Keep running when skipped tests were added so they can be unskipped and validated against base." Adding `it.skip` sets that flag, so the workflow unskips the test and runs it against base expecting failure. It does fail there (by throwing), so the check should pass and no `skip-tdd` label is needed.

## Verification

- `npx vitest run src/actions/__tests__/categorize.ts` → 11 passed, 1 skipped
- Unskipped locally, it fails with `moveThought: sourceThought not found` thrown from `moveThought.ts:89` via `categorize.ts`
- `prettier --check` clean

## Notes

Two cases from the same review were deliberately **not** added here:

- A suspected `=sort` ordering bug turned out not to be one. em materializes a sort preference into `rank` rather than applying it at render time, so displayed order is always rank order and Categorize already preserves it. The fixture that appeared to show a reversal was a sorted context whose ranks were never materialized — a state the sort actions exist to prevent.
- The unreachable `isRoot` guard (#5105) has no decided correct behavior, so a skipped test there would make an unchosen answer the spec. It is filed as `design-needed` instead.

Touches the same region of `src/actions/__tests__/categorize.ts` as #5102, so whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)