### PR TITLE
ci: disable the em-ai production deployment until its Vercel build is fixed

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -20,10 +20,18 @@ jobs:
 
     strategy:
       # Deploy each Vercel project independently; one failing project must not
-      # block the other.
+      # block the others. Kept while the matrix has a single entry so that
+      # restoring em-ai below needs no other change.
       fail-fast: false
       matrix:
-        project: [em, em-ai]
+        # em-ai is disabled until its Vercel project is configured correctly. Its build
+        # fails typechecking packages/ai/src/prompt.ts (TS2351: the default `openai`
+        # import is not constructable), so every push to main reported a failed
+        # "Deploy em-ai" job alongside a successful "Deploy em":
+        # https://github.com/cybersemics/em/actions/runs/32899468133/job/97969643022
+        # Re-enable by adding em-ai back to this list; the env below already selects
+        # its project ID.
+        project: [em]
 
     # Serialize production deploys per project without cancelling an in-flight
     # deploy, so overlapping pushes to main queue rather than race.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -34,6 +34,8 @@ Other scripts:
 
 The package is deployed by a dedicated Vercel project (`em-ai`) connected to this repository.
 
+> **Note:** Deployment is currently disabled. Vercel's own Git auto-deploy is off for every branch (`vercel.json`), and the [Vercel Production workflow](../../.github/workflows/vercel-production.yml) — which deploys each project on push to `main` — has `em-ai` removed from its matrix, because the Vercel build fails typechecking `src/prompt.ts` with `TS2351` (the default `openai` import is not constructable). Nothing deploys this package until that is fixed and `em-ai` is added back to the matrix. `yarn lint` at the repo root will not catch it: root `tsc` includes only `src/`, so this package is type-checked only by its own `yarn typecheck` and by the Vercel build.
+
 In the Vercel project settings (Settings → Build and Deployment):
 
 - **Root Directory** = `packages/ai`. Keep "Include files outside of the Root Directory" enabled so the Yarn workspace install resolves from the repo root.


### PR DESCRIPTION
Every push to `main` reports a failed **Deploy em-ai** job alongside a successful **Deploy em**. This removes `em-ai` from the deploy matrix so `main` is green again, until the project is configured correctly.

## What was failing

The em-ai job never reaches the deploy step. `vercel build` type-checks the function source and errors:

```
src/prompt.ts(3,20): error TS2351: This expression is not constructable.
  Type 'typeof import("/home/runner/work/em/em/node_modules/openai/index")' has no construct signatures.
```

The default `import OpenAI from 'openai'` isn't constructable under whatever tsconfig the Vercel build resolves. `packages/ai/tsconfig.json` extends the root one, which has `esModuleInterop` and `allowSyntheticDefaultImports` on — but the build resolves `openai` from the hoisted root `node_modules`. Diagnosing that is out of scope here; this PR only stops the red job.

[Failing run](https://github.com/cybersemics/em/actions/runs/32899468133/job/97969643022)

## What changed

- **`.github/workflows/vercel-production.yml`** — matrix goes from `[em, em-ai]` to `[em]`, with a comment recording why and how to undo it.
- **`packages/ai/README.md`** — a note in *Deploying to Vercel*, which otherwise reads as though pushes still deploy the function.

## For reviewers

Two consequences worth being explicit about:

- **`em-ai` is now not deployed at all.** `vercel.json` disables Vercel's Git auto-deploy for every branch (`git.deploymentEnabled` is `false` for `**` and `main`), so this workflow was the only deploy path.
- **Nothing in CI type-checks `packages/ai`.** Root `lint:tsc` runs `tsc` against a tsconfig whose `include` is only `src/**`, and the package's own `typecheck` script isn't wired into any workflow. The error surfaced only in the Vercel build, so disabling the deploy makes it invisible to CI entirely.

Re-enabling is a one-word change: add `em-ai` back to the matrix list. The `VERCEL_PROJECT_ID` expression already selects the right project ID by matrix value, and `fail-fast: false` is still in place so one project failing won't block the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)