### PR TITLE
refactor(preloadSources): replace deprecated contextToPath with thoughtToPath

### DIFF
--- a/src/actions/preloadSources.ts
+++ b/src/actions/preloadSources.ts
@@ -1,11 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 import Thunk from '../@types/Thunk'
 import { loadResourceActionCreator as loadResource } from '../actions/loadResource'
-import contextToPath from '../selectors/contextToPath'
 import getContexts from '../selectors/getContexts'
 import getThoughtById from '../selectors/getThoughtById'
-import thoughtToContext from '../selectors/thoughtToContext'
-import unroot from '../util/unroot'
+import thoughtToPath from '../selectors/thoughtToPath'
 
 /** Fetch and import all =src attributes with =preload. */
 export const preloadSourcesActionCreator = (): Thunk => (dispatch, getState) => {
@@ -25,8 +23,7 @@ export const preloadSourcesActionCreator = (): Thunk => (dispatch, getState) => 
       if (!thought) return false
       const parentThought = getThoughtById(state, thought.parentId)
       if (!parentThought) return false
-      const context = thoughtToContext(state, parentThought.id)
-      return contextToPath(state, unroot(context!))
+      return thoughtToPath(state, parentThought.id)
     })
 
   // preload sources


### PR DESCRIPTION
Part of removing `contextToPath` from application code. Its own doc comment reads *"DEPRECATED... Should be converted to a test-helper only."* This is the first and smallest slice.

## The change

`preloadSources` resolved a path by round-tripping an id through a context:

```ts
const context = thoughtToContext(state, parentThought.id)
return contextToPath(state, unroot(context!))
```

`thoughtToPath` does that directly, in one step:

```ts
return thoughtToPath(state, parentThought.id)
```

## Why the round trip was wrong

`thoughtToContext` discards identity — it returns values. `contextToPath` then resolves those values from the root and takes the **first** same-valued sibling. So the round trip does not necessarily return the thought it started from.

Verified against the real reducers with two sibling thoughts of the same value, each holding `=src`/`=preload`:

| starting `=src` id | `thoughtToContext` | `contextToPath` head | `thoughtToPath` head |
|---|---|---|---|
| `1ca7e3…` | `["a","dup","=src"]` | `1ca7e3…` ✅ | `1ca7e3…` ✅ |
| `2b576e…` | `["a","dup","=src"]` | **`1ca7e3…`** ❌ | `2b576e…` ✅ |

The second `dup`'s `=src` resolves back to the first one's — the same resource loads twice and the other never loads. Both produce a path of the same length, so nothing downstream would have noticed.

Two further divergences also move toward correctness:

- `thoughtToContext` terminates at *any* root token including `ABSOLUTE_TOKEN`, while `contextToPath` hardcodes `startingThoughtId = HOME_TOKEN`. A `=src` under the absolute context was resolved against the HOME tree.
- With a missing ancestor `contextToPath` returned `null` and the resource was silently skipped. `thoughtToPath` splices onto `HOME_PATH`, so `head()` is still the correct id. (It does *not* return a bare `HOME_PATH` here — the inner frame does and the outer frames splice it.)

## None of this can execute today

[`src/initialize.ts:106`](https://github.com/cybersemics/em/blob/main/src/initialize.ts#L106) is:

```ts
store.dispatch(preloadSources)      // <- the action creator, uncalled
store.dispatch(importFiles({ resume: true }))   // <- the line below does call it
```

`preloadSourcesActionCreator` is `(): Thunk => (dispatch, getState) => {…}`, so redux-thunk invokes the *outer* arrow and discards the inner one. The thunk has never run.

I deliberately did **not** fix that here: calling it would begin network fetches at app start for the first time, which deserves its own PR and its own review. Same for a second bug I found while reading — `preloadSources` passes the path to `=src`, but [`loadResource`](https://github.com/cybersemics/em/blob/main/src/actions/loadResource.ts#L20) does `attribute(state, head(path), '=src')` and so wants the path to the thought that *owns* `=src`. Both are noted below as follow-ups.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/actions/preloadSources.ts` — clean
- `npx prettier --check` — clean
- `npx vitest run --project unit` — **220 files passed, 5 skipped; 1959 tests passed**, identical to `main`

There is no test coverage for this file, and none is added: the code is unreachable, so a test would pin behavior that cannot run. Verification here is the type-checker plus the table above, which was produced by exercising the real reducers.

## Follow-ups (not in this PR)

1. `initialize.ts:106` dispatches an uncalled action creator, so `=preload` has never worked. `docs/metaprogramming.md:107` claims it does.
2. `preloadSources` hands `loadResource` the path to `=src` rather than to its owner. Regressed when `parentOf(parent.context)` was dropped.
3. `thoughtToPath`'s doc comment says it returns `null` when ancestors are missing; it returns `HOME_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
