### PR TITLE
refactor(jump): remove the always-false pathExists guard

### DIFF
--- a/src/actions/jump.ts
+++ b/src/actions/jump.ts
@@ -1,7 +1,7 @@
+import Path from '../@types/Path'
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import getThoughtById from '../selectors/getThoughtById'
-import pathExists from '../selectors/pathExists'
 import thoughtToPath from '../selectors/thoughtToPath'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import equalPathHead from '../util/equalPathHead'
@@ -20,16 +20,18 @@ const jump = (state: State, { steps }: { steps: number } = { steps: -1 }): State
     // ignore null cursor
     // ignore same thought
     // ignore deleted thought
-    .find(cursor => cursor && !equalPathHead(cursor, state.cursor) && getThoughtById(state, head(cursor)))
+    .find(
+      (cursor): cursor is Path =>
+        !!cursor && !equalPathHead(cursor, state.cursor) && !!getThoughtById(state, head(cursor)),
+    )
 
   // do nothing if no valid cursor was found
   // e.g. cannot go back any further
   if (lastJumpCursor === undefined) return state
 
-  // it is possible that the thought id exists but has been moved
-  // in this case, reconstruct a SimplePath by traversing from the root
-  const cursorNew =
-    lastJumpCursor && !pathExists(state, lastJumpCursor) ? thoughtToPath(state, head(lastJumpCursor)) : lastJumpCursor
+  // The head thought exists (checked above) but may have been moved, so reconstruct the SimplePath by traversing
+  // from the root rather than trusting the stored Path.
+  const cursorNew = thoughtToPath(state, head(lastJumpCursor))
 
   return {
     ...setCursor(state, {


### PR DESCRIPTION
Part of removing `contextToPath` from application code (*"DEPRECATED... Should be converted to a test-helper only."*). `jump` reached it indirectly, through `pathExists`.

## The guard could never succeed

```ts
const cursorNew =
  lastJumpCursor && !pathExists(state, lastJumpCursor) ? thoughtToPath(state, head(lastJumpCursor)) : lastJumpCursor
```

`pathExists` is `!!contextToPath(state, pathUnranked)` — it resolves a **Context**, an array of thought *values*, from the root.

`lastJumpCursor` is not a Context. It comes from `state.jumpHistory`, typed `(Path | null)[]` and populated with `state.cursor` verbatim by `updateJumpHistoryEnhancer`, so it is an array of **ThoughtIds**. `ThoughtId` is a branded string, so this type-checks silently.

Inside `contextToPath` the match is `child.value === value` — a user-authored thought value compared against a 32-character hex id. It never matches, the reduce throws, the `try/catch` swallows it, and `null` comes back.

Confirmed by exercising the real selectors:

```
realPath (ids) = ["8e6d15b867ab618113d8101292e6fc00","c48de3a96d6689e25f79a9861e991341"]
pathExists(state, realPath as ids)     = false   <- a perfectly valid path
pathExists(state, ["a","b"] as values) = true
```

So `pathExists` was a hard-coded `false` and the ternary has always taken the `thoughtToPath` branch. The comment it carried — *"it is possible that the thought id exists but has been moved / in this case, reconstruct a SimplePath by traversing from the root"* — described a conditional that was never conditional.

## Why the removal is exact, not just equivalent in practice

Three contexts *could* have made `pathExists` truthy: `[HOME_TOKEN]` and `[ABSOLUTE_TOKEN]` (via `isRoot` → `getRootPath`) and `[EM_TOKEN]` (whose reduce over an empty array yields `[]`, and `!![]` is `true`).

None is reachable as a jump history entry — nulls are filtered by the `.find` above, and the cursor is `null` at the root — and `thoughtToPath` returns each of those three unchanged anyway. There is no input for which the two branches differ.

## The type predicate

`Array.prototype.find` is not a type guard, and `=== undefined` does not exclude `null` under `strict`. The removed `lastJumpCursor &&` was doing that narrowing for the compiler, so the predicate takes over:

```ts
.find(
  (cursor): cursor is Path =>
    !!cursor && !equalPathHead(cursor, state.cursor) && !!getThoughtById(state, head(cursor)),
)
```

`head(lastJumpCursor!)` would have compiled too, but the predicate is the honest fix — the `.find` really does establish non-nullness.

## Verification

- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` — clean
- **All 21 tests in `src/commands/__tests__/jump.ts` pass with zero test edits.** That is the equivalence proof: every one already ran through the `thoughtToPath` branch. The directly relevant cases are `jump back to edit after indent` (a moved thought with a surviving id — exactly the scenario the deleted comment described), `jump back to edit after delete`, `jump back to parent of delete`, `jump back from null cursor`, and `jump forward to parent after delete`.
- `npx vitest run --project unit` — **220 files passed, 5 skipped; 1959 tests passed**, identical to `main`.

## Note

`pathExists` now has exactly one caller left, `src/util/initEvents.ts`. It is **not** deleted here — that call site has its own problems (`pathToContext` throws before `pathExists` is even reached for non-root URLs) and needs tests first. Left for a follow-up PR so this one stays a single-file, provably-inert change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
