### PR TITLE
test(toolbar): cover removeToolbarButton

### DIFF
--- a/src/actions/__tests__/removeToolbarButton.ts
+++ b/src/actions/__tests__/removeToolbarButton.ts
@@ -1,0 +1,79 @@
+import Path from '../../@types/Path'
+import { EM_TOKEN } from '../../constants'
+import findDescendant from '../../selectors/findDescendant'
+import { getChildrenRanked } from '../../selectors/getChildren'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import { importTextActionCreator as importText } from '../importText'
+import { removeToolbarButtonActionCreator as removeToolbarButton } from '../removeToolbarButton'
+
+beforeEach(initStore)
+
+/** Returns the command ids on the user toolbar, in rank order. */
+const toolbarCommandIds = () => {
+  const state = store.getState()
+  return getChildrenRanked(state, findDescendant(state, EM_TOKEN, ['Settings', 'Toolbar'])).map(child => child.value)
+}
+
+it('remove a command from the middle of the user toolbar', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('redo'))
+
+  expect(toolbarCommandIds()).toEqual(['undo', 'indent'])
+})
+
+it('remove the first command on the user toolbar', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('undo'))
+
+  expect(toolbarCommandIds()).toEqual(['redo', 'indent'])
+})
+
+it('leave the user toolbar unchanged when the command is not on it', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('bold'))
+
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+})


### PR DESCRIPTION
`removeToolbarButton` has **no automated coverage of any kind** today — `grep -rln 'removeToolbarButton|useDragAndDropToolbarButton|initUserToolbar' src/` returns only source files, and the one Puppeteer test that touches the area only image-snapshots the Customize Toolbar modal.

This PR adds that coverage, ahead of replacing the deprecated `contextToPath` call these files use to build the user toolbar path. It passes against unmodified `main` — that is the point.

## The three cases

Removing a command from the middle of the toolbar, removing the first one, and removing a command that is not on the toolbar at all (the `fromIndex === -1` early return).

## Why the fixture doesn't call `initUserToolbar`

`initUserToolbar` appends a **second `Settings` sibling** rather than merging into the one EM already has. Observed directly:

```
EM children BEFORE            = ["Settings"]                          // holds Tutorial
EM children AFTER  1st call   = ["Settings","Settings"]
EM children AFTER  2nd call   = ["Settings","Settings","Settings"]

findDescendant(EM, ['Settings','Toolbar'])    = null
contextToPath([EM,'Settings','Toolbar'])      = null
```

Both resolvers take the *first* `Settings`, which holds `Tutorial` and has no `Toolbar`, so every toolbar action silently early-returns and nothing is ever customized. Seeding `Toolbar` under EM's existing `Settings` is the only way to reach the state in which the toolbar path is actually used, which is the state these tests need.

That duplicate-`Settings` behavior looks like a real product bug, but it is pre-existing and orthogonal to this migration, so it is **not** touched here. I'll file it separately.

## What these tests discriminate — measured, not assumed

Per [Principle 7](../blob/main/docs/testing.md#7-make-false-positives-difficult), a test is only worth its runtime if it fails for the right reason. I mutated the implementation to find out:

| Mutation | Result |
|---|---|
| `userCommandsPath` forced to `null` | **2 of 3 fail** — `TypeError: pathParent is not iterable` |
| Off-by-one on `fromIndex` (wrong command removed) | **2 of 3 fail** |
| Path *shape*: `thoughtToPath` (EM-prefixed, 3 elements) instead of `contextToPath` (rootless, 2) | **all 3 still pass** ⚠️ |

The first is the failure mode the `!` on `contextToPath(…)!` is hiding today, so it is the one most worth catching.

The third is a genuine limit and I'd rather state it than let a reviewer assume otherwise. `deleteThought` reads only `head(pathParent)` to identify the parent; the full `path` reaches nothing but `delete contextViewsNew[hashPath(path)]`, and no toolbar command ever has a context view. So path shape is practically unobservable at this call site. The follow-up refactor will therefore reproduce the two-element shape **exactly** rather than leaning on these tests to police it.

## Known gap

`useDragAndDropToolbarButton` remains uncovered. Its `drop` handler is module-private and fires through react-dnd, and nothing in the repo simulates a drop today (`testFlags.simulateDrag`/`simulateDrop` only drive Puppeteer visual snapshots). Covering it means building that infrastructure, which is its own piece of work. Flagging rather than quietly leaving it.

## Verification

- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` — clean
- `npx vitest run --project unit` — **221 files / 1962 tests passed**, up from 220 / 1959 on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
