### PR TITLE
refactor(toolbar): build the user toolbar path from ids

### DIFF
--- a/src/actions/__tests__/removeToolbarButton.ts
+++ b/src/actions/__tests__/removeToolbarButton.ts
@@ -1,0 +1,79 @@
+import Path from '../../@types/Path'
+import { EM_TOKEN } from '../../constants'
+import findDescendant from '../../selectors/findDescendant'
+import { getChildrenRanked } from '../../selectors/getChildren'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import { importTextActionCreator as importText } from '../importText'
+import { removeToolbarButtonActionCreator as removeToolbarButton } from '../removeToolbarButton'
+
+beforeEach(initStore)
+
+/** Returns the command ids on the user toolbar, in rank order. */
+const toolbarCommandIds = () => {
+  const state = store.getState()
+  return getChildrenRanked(state, findDescendant(state, EM_TOKEN, ['Settings', 'Toolbar'])).map(child => child.value)
+}
+
+it('remove a command from the middle of the user toolbar', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('redo'))
+
+  expect(toolbarCommandIds()).toEqual(['undo', 'indent'])
+})
+
+it('remove the first command on the user toolbar', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('undo'))
+
+  expect(toolbarCommandIds()).toEqual(['redo', 'indent'])
+})
+
+it('leave the user toolbar unchanged when the command is not on it', () => {
+  const settingsId = findDescendant(store.getState(), EM_TOKEN, ['Settings'])!
+  store.dispatch(
+    importText({
+      path: [EM_TOKEN, settingsId] as Path,
+      text: `
+        - Toolbar
+          - undo
+          - redo
+          - indent
+      `,
+      preventSetCursor: true,
+    }),
+  )
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+
+  store.dispatch(removeToolbarButton('bold'))
+
+  expect(toolbarCommandIds()).toEqual(['undo', 'redo', 'indent'])
+})

--- a/src/actions/removeToolbarButton.ts
+++ b/src/actions/removeToolbarButton.ts
@@ -1,12 +1,12 @@
 /* eslint-disable import/prefer-default-export */
 import CommandId from '../@types/CommandId'
+import Path from '../@types/Path'
 import Thunk from '../@types/Thunk'
 import { alertActionCreator as alert } from '../actions/alert'
 import { deleteThoughtActionCreator as deleteThought } from '../actions/deleteThought'
 import { initUserToolbarActionCreator as initUserToolbar } from '../actions/initUserToolbar'
 import { commandById } from '../commands'
 import { EM_TOKEN } from '../constants'
-import contextToPath from '../selectors/contextToPath'
 import findDescendant from '../selectors/findDescendant'
 import { getChildrenRanked } from '../selectors/getChildren'
 
@@ -19,15 +19,19 @@ export const removeToolbarButtonActionCreator =
     // initialize EM/Settings/Toolbar/Visible with default commands
     dispatch(initUserToolbar())
     const state = getState()
-    const userToolbarThoughtId = findDescendant(state, EM_TOKEN, ['Settings', 'Toolbar'])
+    const settingsId = findDescendant(state, EM_TOKEN, ['Settings'])
+    const userToolbarThoughtId = findDescendant(state, settingsId, 'Toolbar')
     const userCommandChildren = getChildrenRanked(getState(), userToolbarThoughtId)
     const userCommandIds = userCommandChildren.map(subthought => subthought.value)
 
-    // user commands must exist since it was created above
-    const userCommandsPath = contextToPath(getState(), [EM_TOKEN, 'Settings', 'Toolbar'])!
     const fromIndex = userCommandIds.indexOf(commandId)
-    if (fromIndex === -1) return
+    // settingsId and userToolbarThoughtId cannot be null once a command has been found, since userCommandIds is
+    // empty otherwise. They are checked anyway to narrow the type.
+    if (fromIndex === -1 || !settingsId || !userToolbarThoughtId) return
     const fromThoughtId = userCommandChildren[fromIndex].id
+
+    // EM/Settings/Toolbar. The EM token is omitted, reproducing the rootless path contextToPath returned here.
+    const userCommandsPath = [settingsId, userToolbarThoughtId] as Path
 
     dispatch([
       alert(`Removed ${command.label} from toolbar`),

--- a/src/hooks/useDragAndDropToolbarButton.ts
+++ b/src/hooks/useDragAndDropToolbarButton.ts
@@ -4,13 +4,13 @@ import Command from '../@types/Command'
 import CommandId from '../@types/CommandId'
 import DragAndDropType from '../@types/DragAndDropType'
 import DragCommandZone from '../@types/DragCommandZone'
+import SimplePath from '../@types/SimplePath'
 import { dragCommandActionCreator as dragCommand } from '../actions/dragCommand'
 import { initUserToolbarActionCreator as initUserToolbar } from '../actions/initUserToolbar'
 import { moveThoughtActionCreator as moveThought } from '../actions/moveThought'
 import { newThoughtActionCreator as newThought } from '../actions/newThought'
 import { commandById } from '../commands'
 import { EM_TOKEN } from '../constants'
-import contextToPath from '../selectors/contextToPath'
 import findDescendant from '../selectors/findDescendant'
 import { getChildrenRanked } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
@@ -34,18 +34,22 @@ const drop = (commandId: CommandId, monitor: DropTargetMonitor) => {
     initUserToolbar(),
     (dispatch, getState) => {
       const state = getState()
-      const userToolbarThoughtId = findDescendant(state, EM_TOKEN, ['Settings', 'Toolbar'])
+      const settingsId = findDescendant(state, EM_TOKEN, ['Settings'])
+      const userToolbarThoughtId = findDescendant(state, settingsId, 'Toolbar')
       const userCommandChildren = getChildrenRanked(state, userToolbarThoughtId)
       const userCommandIds = userCommandChildren.map(subthought => subthought.value)
 
-      // user commands must exist since it was created above
-      const userCommandsPath = contextToPath(state, [EM_TOKEN, 'Settings', 'Toolbar'])!
       const fromIndex = userCommandIds.indexOf(from.id)
       const toIndex = userCommandIds.indexOf(to.id)
-      if (toIndex === -1) {
+      // settingsId and userToolbarThoughtId cannot be null once toIndex has been found, since userCommandIds is
+      // empty otherwise. They are checked anyway to narrow the type.
+      if (toIndex === -1 || !settingsId || !userToolbarThoughtId) {
         console.error('Missing toIndex for', to.id)
         return
       }
+
+      // EM/Settings/Toolbar. The EM token is omitted, reproducing the rootless path contextToPath returned here.
+      const userCommandsPath = [settingsId, userToolbarThoughtId] as unknown as SimplePath
 
       const toThoughtId = userCommandChildren[toIndex].id
       const toPath = appendToPath(userCommandsPath, toThoughtId)


### PR DESCRIPTION
> **Stacked on #5114** (`test/toolbar-coverage`). Review that one first; this PR's diff is just the two source files.

Part of removing `contextToPath` from application code (*"DEPRECATED... Should be converted to a test-helper only."*).

## The lookup was redundant

Both call sites already had the id of the very thought the path points at, one line above:

```ts
const userToolbarThoughtId = findDescendant(state, EM_TOKEN, ['Settings', 'Toolbar'])
// ...
// user commands must exist since it was created above
const userCommandsPath = contextToPath(state, [EM_TOKEN, 'Settings', 'Toolbar'])!
```

Splitting that `findDescendant` into its two steps yields both ids, and the path is just the pair. It is also exactly the form [`initUserToolbar`](../blob/main/src/actions/initUserToolbar.ts#L19-L20) itself uses to decide whether the toolbar already exists.

## The path shape is preserved exactly — this is the part worth checking

`contextToPath` returns a **rootless** path. It slices a leading `EM_TOKEN` and seeds its reduce with `[]`, so:

```
contextToPath(state, [EM_TOKEN,'Settings','Toolbar'])  →  [settingsId, toolbarId]        // 2 elements
thoughtToPath(state, toolbarId)                        →  [EM_TOKEN, settingsId, toolbarId]  // 3
```

So `thoughtToPath` is **not** a drop-in here, which is the trap this PR avoids. I verified old vs. new in all four reachable states, and they are byte-identical including the `null`s:

| state | `contextToPath` | `[settingsId, toolbarId]` |
|---|---|---|
| Toolbar seeded under EM's existing Settings | `["…04","218046…"]` | `["…04","218046…"]` ✅ |
| Toolbar unresolvable (`initUserToolbar` duplicate Settings) | `null` | `null` ✅ |
| pristine EM, no Toolbar | `null` | `null` ✅ |
| duplicate `Toolbar` siblings under one Settings | `["…04","4cc13e…"]` | `["…04","4cc13e…"]` ✅ |

Resolution is identical by construction, not coincidence: `contextToPath` matches with `getAllChildren(...).find(child => child.value === value)`, and `findDescendant` delegates to `findAnyChild` over the same array for non-attribute values. Neither `'Settings'` nor `'Toolbar'` starts with `=`, so the `childrenMap` fast path is not taken.

## The non-null assertion is replaced by a real check

`contextToPath(…)!` was asserting something that is untrue today — it returns `null` on a stock thoughtspace (see #5114 for why). It was masking a crash: a null `userCommandsPath` reaches `[...pathParent, thoughtId]` in `deleteThought` (`TypeError: pathParent is not iterable`) or `appendToPath(null, id)`, which silently returns a **one-element** path.

The new guard cannot fire in practice — `userCommandIds` is empty whenever either id is null, so `fromIndex`/`toIndex` is already `-1` — but it narrows the type honestly rather than asserting a falsehood. The mutation test in #5114 confirms the crash is what the assertion was hiding.

## One deliberate divergence

The context-view branch of `contextToPath` is dropped. If `isContextViewActive(state, [settingsId])` were ever true, `contextToPath` would search `getContexts(state, 'Settings')` — *every* thought valued `Settings` anywhere in the thoughtspace — and return `firstChild.parentId`, redirecting toolbar deletes and drags into the user's own tree. It is barely reachable (it needs a hand-crafted `/~/__EM__/Settings~` URL), but dropping it is a **fix**, not a regression.

## Types

`removeToolbarButton` uses `Path` rather than `SimplePath`, because `deleteThought` takes an unbranded `Path` and `initUserToolbar` builds its `pathParent` the same way. The drag hook keeps `SimplePath` (as `as unknown as`, matching `newThought.ts:181`) because `getRankBefore` requires the brand.

## Verification

- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` — clean
- `npx vitest run --project unit` — **221 files / 1962 tests passed**, unchanged from the base branch
- The three `removeToolbarButton` tests from #5114 pass

**Worth a manual pass before merge**, since `useDragAndDropToolbarButton` has no automated coverage (see #5114): open Customize Toolbar, remove a button, drag to reorder, and drag a new button in from the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
