### PR TITLE
test(extract): wrap dispatches in act to eliminate React act warnings

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,7 +291,7 @@ Anything that tests a rendered component requires a DOM. If there are no browser
 
 - [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) (RTL)
 
-Mount the app with `createTestApp`, seed state via dispatch (allowed at this level for arrange), and assert on the DOM by `aria-label`/`data-testid`.
+Mount the app with `createTestApp`, seed state via dispatch (allowed at this level for arrange), and assert on the DOM by `aria-label`/`data-testid`. Wrap every dispatch and command execution in `act(() => …)`: the mounted components subscribe to the store, so an unwrapped dispatch re-renders them outside React's act scope and React reports `An update to <Component> inside a test was not wrapped in act(...)`.
 
 Related tests: [components](../src/components/__tests__)
 

--- a/src/commands/__tests__/extractCategory.ts
+++ b/src/commands/__tests__/extractCategory.ts
@@ -55,11 +55,15 @@ describe('Extract category', () => {
   afterEach(cleanupTestApp)
 
   it('an alert should be shown if there is no selection', async () => {
-    store.dispatch([importText({ text: '- this is a thought' }), setCursor(['this is a thought'])])
+    act(() => {
+      store.dispatch([importText({ text: '- this is a thought' }), setCursor(['this is a thought'])])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
-    store.dispatch(extractCategory())
+    act(() => {
+      store.dispatch(extractCategory())
+    })
 
     expect(await screen.findByText('No text selected to extract')).toBeTruthy()
 
@@ -68,7 +72,9 @@ describe('Extract category', () => {
   })
 
   it('the selected part of a thought becomes its new parent', async () => {
-    store.dispatch([importText({ text: '- this is a thought' }), setCursor(['this is a thought'])])
+    act(() => {
+      store.dispatch([importText({ text: '- this is a thought' }), setCursor(['this is a thought'])])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -76,7 +82,9 @@ describe('Extract category', () => {
     expect(thought).toBeTruthy()
     setSelection(thought!, 10, 17)
 
-    store.dispatch(extractCategory())
+    act(() => {
+      store.dispatch(extractCategory())
+    })
 
     expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - thought
@@ -84,15 +92,17 @@ describe('Extract category', () => {
   })
 
   it('the extracted thought keeps its subthoughts', async () => {
-    store.dispatch([
-      importText({
-        text: `
-          - alpha bravo
-            - charlie
-        `,
-      }),
-      setCursor(['alpha bravo']),
-    ])
+    act(() => {
+      store.dispatch([
+        importText({
+          text: `
+            - alpha bravo
+              - charlie
+          `,
+        }),
+        setCursor(['alpha bravo']),
+      ])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -100,7 +110,9 @@ describe('Extract category', () => {
     expect(thought).toBeTruthy()
     setSelection(thought!, 6, 11)
 
-    store.dispatch(extractCategory())
+    act(() => {
+      store.dispatch(extractCategory())
+    })
 
     expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - bravo
@@ -109,7 +121,9 @@ describe('Extract category', () => {
   })
 
   it('the cursor moves to the new category, with the caret at the end of its value', async () => {
-    store.dispatch([newThought({ value: 'alpha bravo' }), setCursor(['alpha bravo'])])
+    act(() => {
+      store.dispatch([newThought({ value: 'alpha bravo' }), setCursor(['alpha bravo'])])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -117,7 +131,9 @@ describe('Extract category', () => {
     expect(thought).toBeTruthy()
     setSelection(thought!, 6, 11)
 
-    store.dispatch(extractCategory())
+    act(() => {
+      store.dispatch(extractCategory())
+    })
 
     const state = store.getState()
     expectPathToEqual(state, state.cursor, ['bravo'])
@@ -126,16 +142,18 @@ describe('Extract category', () => {
 
   describe('multicursor', () => {
     it('moves every selected thought into a category named by the selection', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie
-            - delta
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie
+              - delta
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -143,9 +161,11 @@ describe('Extract category', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 6, 11)
 
-      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie']), addMulticursor(['delta'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie']), addMulticursor(['delta'])])
+      })
 
-      executeCommandWithMulticursor(extractCategoryCommand, { store })
+      act(() => executeCommandWithMulticursor(extractCategoryCommand, { store }))
 
       // Only the thought that owns the selection is sliced; the others are categorized as they are.
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
@@ -156,15 +176,17 @@ describe('Extract category', () => {
     })
 
     it('categorizes the selected thoughts when the thought being edited is not one of them', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -173,9 +195,11 @@ describe('Extract category', () => {
       setSelection(thought!, 6, 11)
 
       // select a thought other than the one being edited, as alt-clicking its bullet does
-      store.dispatch([addMulticursor(['charlie'])])
+      act(() => {
+        store.dispatch([addMulticursor(['charlie'])])
+      })
 
-      executeCommandWithMulticursor(extractCategoryCommand, { store })
+      act(() => executeCommandWithMulticursor(extractCategoryCommand, { store }))
 
       // The two halves of the command apply where each is defined: the text is extracted from the thought that owns
       // the selection, and the categorization applies to the selected thoughts, exactly as Categorize would.
@@ -186,16 +210,18 @@ describe('Extract category', () => {
     })
 
     it('an alert should be shown and no text extracted when the selected thoughts have different parents', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-              - charlie
-            - delta
-          `,
-        }),
-        setCursor(['alpha bravo', 'charlie']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+                - charlie
+              - delta
+            `,
+          }),
+          setCursor(['alpha bravo', 'charlie']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -203,11 +229,13 @@ describe('Extract category', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 0, 4)
 
-      store.dispatch([addMulticursor(['alpha bravo', 'charlie']), addMulticursor(['delta'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo', 'charlie']), addMulticursor(['delta'])])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
-      executeCommandWithMulticursor(extractCategoryCommand, { store })
+      act(() => executeCommandWithMulticursor(extractCategoryCommand, { store }))
 
       expect(await screen.findByText('Cannot categorize thoughts from different parents.')).toBeTruthy()
 
@@ -219,15 +247,17 @@ describe('Extract category', () => {
     })
 
     it('reverts the extraction on a single undo', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -235,9 +265,11 @@ describe('Extract category', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 6, 11)
 
-      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie'])])
+      })
 
-      executeCommandWithMulticursor(extractCategoryCommand, { store })
+      act(() => executeCommandWithMulticursor(extractCategoryCommand, { store }))
 
       // Precondition: the extraction occurred, otherwise the undo below would have nothing to revert.
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
@@ -245,7 +277,9 @@ describe('Extract category', () => {
     - alpha
     - charlie`)
 
-      store.dispatch(undo())
+      act(() => {
+        store.dispatch(undo())
+      })
 
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - alpha bravo
@@ -254,7 +288,9 @@ describe('Extract category', () => {
   })
 
   it('extracts the text that was selected before the Command Universe took the focus', async () => {
-    store.dispatch([importText({ text: '- hello world' }), setCursor(['hello world'])])
+    act(() => {
+      store.dispatch([importText({ text: '- hello world' }), setCursor(['hello world'])])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -263,9 +299,17 @@ describe('Extract category', () => {
 
     // Opening the Command Universe snapshots the selection; its search input then takes it. Executing a command
     // closes the Command Universe first, so the snapshot has to survive the close.
-    store.dispatch(desktopCommandUniverse())
+    act(() => {
+      store.dispatch(desktopCommandUniverse())
+    })
     moveSelectionToSearchInput()
-    store.dispatch([desktopCommandUniverse(), extractCategory()])
+    act(() => {
+      store.dispatch([desktopCommandUniverse(), extractCategory()])
+    })
+
+    // Let the Command Universe's fade-out complete so that it unmounts before the test ends. Otherwise its animated
+    // command icons keep a repeating interval alive, which cleanupTestApp's vi.runAllTimersAsync can never drain.
+    await act(vi.runOnlyPendingTimersAsync)
 
     expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - world

--- a/src/commands/__tests__/extractSubthought.ts
+++ b/src/commands/__tests__/extractSubthought.ts
@@ -57,15 +57,19 @@ describe('Extract Subthought', () => {
 
   it('an alert should be shown if there is no selection', async () => {
     const thoughtValue = 'this is a thought'
-    store.dispatch([
-      newThought({ value: thoughtValue }),
-      newThought({ value: 'sub-thought', insertNewSubthought: true }),
-      setCursor([thoughtValue]),
-    ])
+    act(() => {
+      store.dispatch([
+        newThought({ value: thoughtValue }),
+        newThought({ value: 'sub-thought', insertNewSubthought: true }),
+        setCursor([thoughtValue]),
+      ])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
-    store.dispatch(extractSubthought())
+    act(() => {
+      store.dispatch(extractSubthought())
+    })
 
     const alert = await screen.findByText('No text selected to extract')
     expect(alert).toBeTruthy()
@@ -76,11 +80,13 @@ describe('Extract Subthought', () => {
 
   it('the selected part of a thought is extracted as a child thought', async () => {
     const thoughtValue = 'this is a thought'
-    store.dispatch([
-      newThought({ value: thoughtValue }),
-      newThought({ value: 'sub-thought', insertNewSubthought: true }),
-      setCursor([thoughtValue]),
-    ])
+    act(() => {
+      store.dispatch([
+        newThought({ value: thoughtValue }),
+        newThought({ value: 'sub-thought', insertNewSubthought: true }),
+        setCursor([thoughtValue]),
+      ])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -88,7 +94,9 @@ describe('Extract Subthought', () => {
     expect(thought).toBeTruthy()
 
     const selectedText = setSelection(thought!, 10, 17)
-    store.dispatch([extractSubthought()])
+    act(() => {
+      store.dispatch([extractSubthought()])
+    })
 
     const updatedThought = await findThoughtByText(thoughtValue.slice(0, 9))
     expect(updatedThought?.textContent).toBeTruthy()
@@ -105,7 +113,9 @@ describe('Extract Subthought', () => {
 
   it('the cursor does not get updated on child creation', async () => {
     const thoughtValue = 'this is a test thought'
-    store.dispatch([newThought({ value: thoughtValue }), setCursor([thoughtValue])])
+    act(() => {
+      store.dispatch([newThought({ value: thoughtValue }), setCursor([thoughtValue])])
+    })
 
     await act(vi.runOnlyPendingTimersAsync)
 
@@ -113,7 +123,9 @@ describe('Extract Subthought', () => {
     expect(thought).toBeTruthy()
 
     const selectedText = setSelection(thought!, 10, 22)
-    store.dispatch([extractSubthought()])
+    act(() => {
+      store.dispatch([extractSubthought()])
+    })
 
     const createdThought = await findThoughtByText(selectedText)
     expect(createdThought).toBeTruthy()
@@ -125,16 +137,18 @@ describe('Extract Subthought', () => {
 
   describe('multicursor', () => {
     it('extracts from the thought being edited when several thoughts are selected', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-            - echo
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+              - echo
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -142,9 +156,11 @@ describe('Extract Subthought', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 6, 11)
 
-      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      })
 
-      executeCommandWithMulticursor(extractSubthoughtCommand, { store })
+      act(() => executeCommandWithMulticursor(extractSubthoughtCommand, { store }))
 
       // The other selected thoughts keep their values. Slicing them at the selection's offsets would have left
       // "charlita" with the child "e del", and "echo" with an empty child.
@@ -156,15 +172,17 @@ describe('Extract Subthought', () => {
     })
 
     it('extracts from the thought being edited when a different thought is selected', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -173,9 +191,11 @@ describe('Extract Subthought', () => {
       setSelection(thought!, 6, 11)
 
       // select a thought other than the one being edited, as alt-clicking its bullet does
-      store.dispatch([addMulticursor(['charlie delta'])])
+      act(() => {
+        store.dispatch([addMulticursor(['charlie delta'])])
+      })
 
-      executeCommandWithMulticursor(extractSubthoughtCommand, { store })
+      act(() => executeCommandWithMulticursor(extractSubthoughtCommand, { store }))
 
       // The extraction applies to the thought that owns the selection, not to the selected thought.
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
@@ -185,16 +205,18 @@ describe('Extract Subthought', () => {
     })
 
     it('leaves the cursor and the selected thoughts selected', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-            - echo
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+              - echo
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -202,9 +224,11 @@ describe('Extract Subthought', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 6, 11)
 
-      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      })
 
-      executeCommandWithMulticursor(extractSubthoughtCommand, { store })
+      act(() => executeCommandWithMulticursor(extractSubthoughtCommand, { store }))
 
       // Precondition: the extraction occurred, otherwise the assertions below would hold vacuously.
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
@@ -222,23 +246,25 @@ describe('Extract Subthought', () => {
     })
 
     it('an alert should be shown if there is no selection and several thoughts are selected', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-          `,
-        }),
-        setCursor(['alpha bravo']),
-        addMulticursor(['alpha bravo']),
-        addMulticursor(['charlie delta']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+            `,
+          }),
+          setCursor(['alpha bravo']),
+          addMulticursor(['alpha bravo']),
+          addMulticursor(['charlie delta']),
+        ])
+      })
 
       // Flush the throttled "2 thoughts selected" alert from the multiselect so that it cannot overwrite the alert
       // raised by the command below.
       await act(vi.runOnlyPendingTimersAsync)
 
-      executeCommandWithMulticursor(extractSubthoughtCommand, { store })
+      act(() => executeCommandWithMulticursor(extractSubthoughtCommand, { store }))
 
       expect(await screen.findByText('No text selected to extract')).toBeTruthy()
 
@@ -248,16 +274,18 @@ describe('Extract Subthought', () => {
     })
 
     it('reverts the extraction on a single undo', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-            - echo
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+              - echo
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -265,9 +293,11 @@ describe('Extract Subthought', () => {
       expect(thought).toBeTruthy()
       setSelection(thought!, 6, 11)
 
-      store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      act(() => {
+        store.dispatch([addMulticursor(['alpha bravo']), addMulticursor(['charlie delta']), addMulticursor(['echo'])])
+      })
 
-      executeCommandWithMulticursor(extractSubthoughtCommand, { store })
+      act(() => executeCommandWithMulticursor(extractSubthoughtCommand, { store }))
 
       // Precondition: the extraction occurred, otherwise the undo below would have nothing to revert.
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
@@ -276,7 +306,9 @@ describe('Extract Subthought', () => {
   - charlie delta
   - echo`)
 
-      store.dispatch(undo())
+      act(() => {
+        store.dispatch(undo())
+      })
 
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - alpha bravo
@@ -287,7 +319,9 @@ describe('Extract Subthought', () => {
 
   describe('Command Universe', () => {
     it('extracts the text that was selected before the Command Universe took the focus', async () => {
-      store.dispatch([importText({ text: '- hello world' }), setCursor(['hello world'])])
+      act(() => {
+        store.dispatch([importText({ text: '- hello world' }), setCursor(['hello world'])])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
@@ -296,9 +330,17 @@ describe('Extract Subthought', () => {
 
       // Opening the Command Universe snapshots the selection; its search input then takes it. Executing a command
       // closes the Command Universe first, so the snapshot has to survive the close.
-      store.dispatch(desktopCommandUniverse())
+      act(() => {
+        store.dispatch(desktopCommandUniverse())
+      })
       moveSelectionToSearchInput()
-      store.dispatch([desktopCommandUniverse(), extractSubthought()])
+      act(() => {
+        store.dispatch([desktopCommandUniverse(), extractSubthought()])
+      })
+
+      // Let the Command Universe's fade-out complete so that it unmounts before the test ends. Otherwise its animated
+      // command icons keep a repeating interval alive, which cleanupTestApp's vi.runAllTimersAsync can never drain.
+      await act(vi.runOnlyPendingTimersAsync)
 
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - hello
@@ -306,27 +348,37 @@ describe('Extract Subthought', () => {
     })
 
     it('does not apply the snapshot to a thought other than the one it was taken on', async () => {
-      store.dispatch([
-        importText({
-          text: `
-            - alpha bravo
-            - charlie delta
-          `,
-        }),
-        setCursor(['alpha bravo']),
-      ])
+      act(() => {
+        store.dispatch([
+          importText({
+            text: `
+              - alpha bravo
+              - charlie delta
+            `,
+          }),
+          setCursor(['alpha bravo']),
+        ])
+      })
 
       await act(vi.runOnlyPendingTimersAsync)
 
       const thought = await findThoughtByText('alpha bravo')
       setSelection(thought!, 6, 11)
 
-      store.dispatch(desktopCommandUniverse())
+      act(() => {
+        store.dispatch(desktopCommandUniverse())
+      })
       moveSelectionToSearchInput()
 
       // A command executed from the Command Universe can move the cursor. Slicing the thought it lands on at offsets
       // that index into the thought the snapshot came from would mangle its value.
-      store.dispatch([desktopCommandUniverse(), setCursor(['charlie delta']), extractSubthought()])
+      act(() => {
+        store.dispatch([desktopCommandUniverse(), setCursor(['charlie delta']), extractSubthought()])
+      })
+
+      // Let the Command Universe's fade-out complete so that it unmounts before the test ends. Otherwise its animated
+      // command icons keep a repeating interval alive, which cleanupTestApp's vi.runAllTimersAsync can never drain.
+      await act(vi.runOnlyPendingTimersAsync)
 
       expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
   - alpha bravo

--- a/src/components/__tests__/EditableAutocomplete.ts
+++ b/src/components/__tests__/EditableAutocomplete.ts
@@ -46,7 +46,10 @@ it('keeps the space that commits an iOS autocorrect in the editable (#4828)', as
     }),
   )
   const editable = container.querySelector('[data-editable]') as HTMLElement
-  editable.focus()
+  // Focusing the editable sets the cursor on the thought, which re-renders it.
+  act(() => {
+    editable.focus()
+  })
 
   // Pressing space on a misspelled word makes iOS replace the word...
   editable.innerHTML = 'All'
@@ -90,7 +93,10 @@ it('keeps edit mode active through the iOS autocorrect focus retarget (#4692)', 
     }),
   )
   const editable = container.querySelector('[data-editable]') as HTMLElement
-  editable.focus()
+  // Focusing the editable sets the cursor on the thought, which re-renders it.
+  act(() => {
+    editable.focus()
+  })
 
   // Pressing space on a misspelled word makes iOS replace the word...
   editable.innerHTML = 'All'
@@ -148,7 +154,10 @@ it('keeps multi edit mode through the focus retarget after an iOS autocorrect', 
     }),
   )
   const editable = container.querySelector('[data-editable]') as HTMLElement
-  editable.focus()
+  // Focusing the editable sets the cursor on the thought, which re-renders it.
+  act(() => {
+    editable.focus()
+  })
 
   // Pressing space on a misspelled word makes iOS replace the word...
   editable.innerHTML = 'hello'


### PR DESCRIPTION
## Problem

The unit suite printed **2351** copies of:

```
An update to <Component> inside a test was not wrapped in act(...).
```

across 25 different components (`Editable`, `ToolbarButton`, `LayoutTree`, `VirtualThought`, …).

Tracing every warning back to its dispatch showed they all came from **two test files**: `extractSubthought.ts` and `extractCategory.ts`. Both mount the full app with `createTestApp` and then call `store.dispatch(...)` / `executeCommandWithMulticursor(...)` directly. Every other rendered test — `toggleSort.ts`, `SortPicker.ts`, `applyColor.ts` — already wraps those calls in `act`.

The fan-out from 51 unwrapped call sites to 2351 warnings comes from two multipliers: `multi.ts` maps an action array through `dispatch` element by element, so one `store.dispatch([a, b, c, d])` is four store notifications; and each notification re-renders every subscribed component instance in the mounted tree, with React emitting one warning per fiber. A single `store.dispatch([importText, setCursor, addMulticursor, addMulticursor])` accounted for 112 warnings on its own — 94 of them `ToolbarButton`.

One further warning came from `editable.focus()` in `EditableAutocomplete.ts`, which sets the cursor on the thought and re-renders it.

## Changes

- `extractSubthought.ts`, `extractCategory.ts` — every dispatch and command execution wrapped in `act(() => …)`.
- `EditableAutocomplete.ts` — `editable.focus()` wrapped in `act` in all three tests.
- `docs/testing.md` — the JSDOM-tests section now states the convention and names the warning.

## Reviewer notes

Wrapping the Command Universe dispatches has a side effect worth knowing about: it *mounts* that modal for the first time, and its animated command icons start a repeating 5s interval (`useLottieIntervalAnimation`) that `cleanupTestApp`'s `vi.runAllTimersAsync()` can never drain — the two Command Universe tests hung with `Aborting after running 100000 timers`. Adding `await act(vi.runOnlyPendingTimersAsync)` after the close lets the fade-out finish and unmount it, which clears the interval. Both call sites carry a comment explaining that.

The re-indentation noise in the diff is just the `importText` template literals shifting two spaces as their dispatches moved inside `act` blocks.

No assertions were changed.

## Verification

Full unit suite run twice after the change: **224 files, 1996 passed, 63 skipped, 0 act warnings** (down from 2351). `tsc`, `eslint`, and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)