### PR TITLE
test(setup): stub Lottie interval animations in unit tests

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -108,3 +108,12 @@ if (globalPrototype && globalPrototype !== Object.prototype) {
     }
   })
 }
+
+// Disable the Lottie icon animations, whose 5s repeating interval never runs out of pending timers: any test that
+// mounts an animated icon (e.g. the Command Universe) would make cleanupTestApp's vi.runAllTimersAsync abort with
+// "Aborting after running 100000 timers". Stubbing the hook keeps `animated` false, so LottieAnimation never mounts.
+// Puppeteer tests are handled separately in LottieAnimation, which seeks the animation to its last frame.
+vi.mock('./hooks/useLottieIntervalAnimation', () => ({
+  /** Stubbed useLottieIntervalAnimation that never animates. */
+  default: () => ({ isAnimated: false, onAnimationComplete: noop }),
+}))


### PR DESCRIPTION
## What

Mock `useLottieIntervalAnimation` in `src/setupTests.js` so Lottie icon animations never start in unit tests.

## Why

The hook schedules a `setInterval` that re-fires every 5s for as long as an animated icon is mounted. Because the interval never runs out of pending timers, any test that mounts one — opening the Command Universe, for instance — makes `cleanupTestApp`'s `vi.runAllTimersAsync` abort with:

```
Error: Aborting after running 100000 timers, assuming an infinite loop!
```

The alternative was `await act(vi.runOnlyPendingTimersAsync)` after each close, to let the fade-out unmount the modal and clear the interval — a workaround every affected test has to remember.

## How

With the hook stubbed, `isAnimated` stays false, so `animated` is never true, `LottieAnimation` is never mounted, and no interval is created. Application code is untouched.

Puppeteer tests use a different setup file and are unaffected — they already skip the animation in `LottieAnimation` via `navigator.webdriver` (no autoplay, seek to last frame).

## Verification

A throwaway test that opens the desktop Command Universe and then drains timers fails with the abort above on `main` and passes with this change. Removed before committing, since it only exercises the harness.

- `src/hooks/__tests__`, `src/components/__tests__`, `src/util/__tests__`: 71 files, 625 passed (3 files / 32 tests skipped, pre-existing)
- eslint clean on the setup file

## Reviewer notes

- `setupTests.js` is JS, so nothing type-checks the stub against the hook's return type. If the hook gains a field, tests get `undefined` with no compile error. Converting the setup file to TS would close that gap but is out of scope here.
- A future unit test of the hook itself would need `vi.unmock` / `importActual` to reach the real implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)