### PR TITLE
fix: cancel the pending animation frame in useLayoutAnimationFrameEffect

### DIFF
--- a/src/components/__tests__/LayoutTree.virtualization.ts
+++ b/src/components/__tests__/LayoutTree.virtualization.ts
@@ -29,6 +29,10 @@ it('does not commit when no thought crosses the viewport boundary while preservi
 
   await dispatch(
     importText({
+      // Import leaves the cursor on the last imported thought by default. Nothing below the cursor is
+      // virtualized, so that would mount all 60 thoughts only for the setCursor(null) on the next line to
+      // unmount 51 of them again — the single most expensive thing this test did.
+      preventSetCursor: true,
       text: Array.from({ length: 60 }, (_, index) => `- thought ${index + 1}`).join('\n'),
     }),
   )

--- a/src/hooks/useLayoutAnimationFrameEffect.ts
+++ b/src/hooks/useLayoutAnimationFrameEffect.ts
@@ -19,12 +19,17 @@ const useLayoutAnimationFrameEffect = (
   useLayoutEffect(
     () => {
       const destroyCallbackRef: { current: void | (() => void) } = { current: undefined }
+      // The frame is stored so that cleanup can cancel it while it is still queued. callback is itself a
+      // dependency and is usually re-created on every render, so this effect re-runs constantly; without the
+      // cancel, each render leaves another frame queued and they pile up until they all fire at once, each
+      // measuring a thought that has since re-rendered or unmounted.
+      const frameRef: { current: number } = { current: 0 }
 
       // Wait for next frame to ensure layout is complete
-      requestAnimationFrame(() => {
+      frameRef.current = requestAnimationFrame(() => {
         // For iOS Safari first render of element, wait one more frame
         if (isTouch && isSafari()) {
-          requestAnimationFrame(() => {
+          frameRef.current = requestAnimationFrame(() => {
             destroyCallbackRef.current = callback()
           })
         } else {
@@ -33,6 +38,7 @@ const useLayoutAnimationFrameEffect = (
       })
 
       return () => {
+        cancelAnimationFrame(frameRef.current)
         if (destroyCallbackRef.current) {
           destroyCallbackRef.current()
           destroyCallbackRef.current = undefined


### PR DESCRIPTION
`src/components/__tests__/LayoutTree.virtualization.ts` intermittently failed with `Test timed out in 5000ms` under full-suite parallelism. It was the slowest test in the unit suite by 2.4x over the runner-up, and it reproduced on plain `main`, so it was not caused by any recent change. Rather than raise the timeout, this fixes the two things that made it that slow — one of which is an app bug.

## 1. `useLayoutAnimationFrameEffect` leaked animation frames

CPU-profiling the test put the largest non-GC frame in sinon's fake-timer clock (`firstTimerInRange`, 68ms self time) — an O(n) scan over the pending-timer list. Dumping the clock explained why: **301 pending `AnimationFrame` timers with only 9 thoughts rendered**, 300 of them from one hook.

[`useLayoutAnimationFrameEffect`](https://github.com/cybersemics/em/blob/main/src/hooks/useLayoutAnimationFrameEffect.ts) queued a `requestAnimationFrame` in a layout effect and never cancelled it. Its cleanup only ran the *destroy* callback, which does not exist yet while the frame is still queued, so nothing stopped a frame that had not fired. `callback` is itself a dependency and most call sites pass an inline arrow (`FauxCaret`, `useFauxCaretCssVars`), so the effect re-runs on essentially every render, each run queueing another frame behind the last.

The app-level consequence: every settled state re-measures a thought once per intervening render, and frames left over from an unmount fire against a component that is gone. Cleanup now cancels the queued frame, bounding pending frames at one per live hook instance. In this test the settle step drops from 68ms to 12ms.

## 2. The test's fixture mounted all 60 thoughts, then threw 51 away

`importText` leaves the cursor on the last imported thought, and nothing below the cursor is virtualized — so the import mounted all 60 thoughts (60 contenteditables rather than 9) only for the `setCursor(null)` on the very next line to unmount 51 of them again. The test's premise is a null cursor, so none of that mount was setup the test needed.

`preventSetCursor` leaves the cursor where it already is. The end state is identical and **every assertion is unchanged**; the import step drops from 270ms to 104ms.

## Results

Measured on this PR's base, with and without the two changes, five runs each:

| | alone (median of 5) | in the full unit suite |
|---|---|---|
| before | 869ms | 4275ms (slowest test, 2.4x the runner-up) |
| after | 595ms | 2312ms (not in the top five slowest) |

Its ratio to the mean of the twenty slowest tests went from 2.84 to 1.06 — it is now level with its peers, so `testTimeout` is left alone, globally and per-test.

## Verification

- Full unit suite on this base: **2134 passed, 0 failed**, same skip count as before (nothing silently disabled).
- Because the hook drives height measurement, the height-sensitive Puppeteer suites were run against the same two commits: `render-thoughts`, `thought-wrap`, `virtualization`, `virtualization-height`, `layout-shift`, `editable-gap`, `caret-multiline` — **no image snapshot diffs**. (Two `page.goto` navigation timeouts on a loaded machine; re-running those two files clean gave 29/29.)
- `tsc`, `eslint`, `prettier` clean.

## For reviewers

- The hook has a pre-existing rules-of-hooks violation — `if (!callback) return` sits above the `useLayoutEffect` — that is untouched here. No current call site alternates between defined and undefined, so it is latent rather than live.
- The remaining time is `createTestApp` (~225ms of 534ms), which every component test pays. The only further lever specific to this test would be shrinking the 60-thought fixture, which would cost the long-list realism the test exists to check. Deliberately not done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)