### PR TITLE
refactor(util): factor out isCommandKey for the platform command modifier

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,6 +52,7 @@ import haptics from './util/haptics'
 import hashPath from './util/hashPath'
 import head from './util/head'
 import isAttribute from './util/isAttribute'
+import isCommandKey from './util/isCommandKey'
 import keyValueBy from './util/keyValueBy'
 import parentOf from './util/parentOf'
 import UnreachableError from './util/unreachable'
@@ -846,7 +847,7 @@ export const keyDown = (e: KeyboardEvent) => {
   const state = store.getState()
 
   // track meta key for expansion algorithm
-  if (!(isMac ? e.metaKey : e.ctrlKey)) {
+  if (!isCommandKey(e)) {
     // disable suppress expansion without triggering re-render
     globals.suppressExpansion = false
   }

--- a/src/components/BulletPositioner.tsx
+++ b/src/components/BulletPositioner.tsx
@@ -10,7 +10,7 @@ import { deleteAttributeActionCreator as deleteAttribute } from '../actions/dele
 import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
-import { isMac, isSafari, isTouch, isiPhone } from '../browser'
+import { isSafari, isTouch, isiPhone } from '../browser'
 import { LongPressState } from '../constants'
 import { LongPressProps } from '../hooks/useLongPress'
 import findDescendant from '../selectors/findDescendant'
@@ -25,6 +25,7 @@ import fastClick from '../util/fastClick'
 import getBulletWidth from '../util/getBulletWidth'
 import hashPath from '../util/hashPath'
 import head from '../util/head'
+import isCommandKey from '../util/isCommandKey'
 import isDivider from '../util/isDivider'
 import parentOf from '../util/parentOf'
 
@@ -150,7 +151,7 @@ const BulletPositioner = forwardRef<SVGSVGElement, PropsWithChildren<BulletPosit
 
         // short circuit if toggling multiselect
         // Shift + Click selects the thoughts in between, and Cmd/Ctrl + Click toggles the clicked thought (see Thought)
-        if (!isTouch && (e.shiftKey || (isMac ? e.metaKey : e.ctrlKey))) {
+        if (!isTouch && (e.shiftKey || isCommandKey(e))) {
           return
         }
 

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -19,7 +19,7 @@ import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { toggleDropdownActionCreator as toggleDropdown } from '../actions/toggleDropdown'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
 import { tutorialNextActionCreator as tutorialNext } from '../actions/tutorialNext'
-import { isMac, isSafari, isTouch } from '../browser'
+import { isSafari, isTouch } from '../browser'
 import { commandEmitter } from '../commands'
 import {
   EDIT_THROTTLE,
@@ -59,6 +59,7 @@ import equalPath from '../util/equalPath'
 import getCommandState from '../util/getCommandState'
 import haptics from '../util/haptics'
 import head from '../util/head'
+import isCommandKey from '../util/isCommandKey'
 import isDivider from '../util/isDivider'
 import isDocumentEditable from '../util/isDocumentEditable'
 import strip from '../util/strip'
@@ -997,7 +998,7 @@ const Editable = ({
           // since Thought's handleMultiselect owns them, and toggling here would move multicursorAnchor and thereby
           // collapse the Shift + Click range (see selectBetween). Deselecting the last selected thought ends the
           // multiselect, which closes the Command Center on mobile (see multicursorAlertMiddleware).
-          else if (hasMulticursorSelector(state) && !e.shiftKey && !(isMac ? e.metaKey : e.ctrlKey)) {
+          else if (hasMulticursorSelector(state) && !e.shiftKey && !isCommandKey(e)) {
             dispatch(toggleMulticursor({ path }))
           } else {
             setCursorOnThought()
@@ -1015,9 +1016,8 @@ const Editable = ({
 
     /** Sets the cursor on the thought on click. Handles hidden elements, drags, and editing mode. */
     const onClick = (e: MouseEvent) => {
-      // If CMD/CTRL is pressed, don't focus the editable.
-      const isMultiselectClick = isMac ? e.metaKey : e.ctrlKey
-      if (isMultiselectClick) {
+      // If CMD/CTRL is pressed, this is a multiselect click, so don't focus the editable.
+      if (isCommandKey(e)) {
         e.preventDefault()
         return
       }

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -4,7 +4,7 @@ import { useStore } from 'react-redux'
 import { useDispatch } from 'react-redux'
 import Path from '../../@types/Path'
 import { setCursorActionCreator as setCursor } from '../../actions/setCursor'
-import { isMac, isSafari, isTouch } from '../../browser'
+import { isSafari, isTouch } from '../../browser'
 import { LongPressState } from '../../constants'
 import asyncFocus from '../../device/asyncFocus'
 import getCaretOffset from '../../device/getCaretOffset'
@@ -17,6 +17,7 @@ import hasMulticursor from '../../selectors/hasMulticursor'
 import isMultiEditing from '../../selectors/isMultiEditing'
 import isMulticursorPath from '../../selectors/isMulticursorPath'
 import equalPath from '../../util/equalPath'
+import isCommandKey from '../../util/isCommandKey'
 
 // #4173: Ghost-click suppression state. On a rapid tap between adjacent thoughts, iOS Safari coalesces the
 // two taps into a double-tap and emits a delayed, retargeted synthesized mousedown/click/dblclick on the
@@ -269,9 +270,8 @@ const useEditMode = ({
      * Prevents default behavior and manages autoscroll for certain edge cases where browser selection would be incorrect.
      */
     const onMouseDown = (e: MouseEvent) => {
-      // If CMD/CTRL is pressed, don't focus the editable.
-      const isMultiselectClick = isMac ? e.metaKey : e.ctrlKey
-      if (isMultiselectClick) {
+      // If CMD/CTRL is pressed, this is a multiselect click, so don't focus the editable.
+      if (isCommandKey(e)) {
         e.preventDefault()
         return
       }

--- a/src/components/Thought.tsx
+++ b/src/components/Thought.tsx
@@ -14,7 +14,7 @@ import Thought from '../@types/Thought'
 import ThoughtId from '../@types/ThoughtId'
 import { selectBetweenActionCreator as selectBetween } from '../actions/selectBetween'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
-import { isMac, isTouch } from '../browser'
+import { isTouch } from '../browser'
 import { AlertType, REGEX_TAGS } from '../constants'
 import { MIN_CONTENT_WIDTH_EM } from '../constants'
 import testFlags from '../e2e/testFlags'
@@ -44,6 +44,7 @@ import equalThoughtRanked from '../util/equalThoughtRanked'
 import getBulletWidth from '../util/getBulletWidth'
 import head from '../util/head'
 import isAttribute from '../util/isAttribute'
+import isCommandKey from '../util/isCommandKey'
 import isDescendantPath from '../util/isDescendantPath'
 import isDivider from '../util/isDivider'
 import isRoot from '../util/isRoot'
@@ -530,7 +531,7 @@ const ThoughtContainer = ({
       }
 
       // Cmd/Ctrl + Click toggles the clicked thought in the multicursor selection.
-      if (isMac ? mouseEvent.metaKey : mouseEvent.ctrlKey) {
+      if (isCommandKey(mouseEvent)) {
         e.preventDefault()
         dispatch(toggleMulticursor({ path }))
       }

--- a/src/components/modals/Devices.tsx
+++ b/src/components/modals/Devices.tsx
@@ -10,7 +10,6 @@ import Index from '../../@types/IndexType'
 import Role from '../../@types/Role'
 import Share from '../../@types/Share'
 import { alertActionCreator as alert } from '../../actions/alert'
-import { isMac } from '../../browser'
 import permissionsModel from '../../data-providers/permissionsModel'
 import { permissionsStore } from '../../data-providers/permissionsStore'
 import { accessToken as accessTokenCurrent, tsid } from '../../data-providers/thoughtspaceSession'
@@ -18,6 +17,7 @@ import * as selection from '../../device/selection'
 import useStatus from '../../hooks/useStatus'
 import modalDescriptionClass from '../../recipes/modalDescriptionClass'
 import fastClick from '../../util/fastClick'
+import isCommandKey from '../../util/isCommandKey'
 import strip from '../../util/strip'
 import FadeTransition from '../FadeTransition'
 import ActionButton from './../ActionButton'
@@ -385,7 +385,7 @@ const ShareDetail = React.memo(
         (e: KeyboardEvent) => {
           if (
             e.key === 'c' &&
-            (isMac ? e.metaKey : e.ctrlKey) &&
+            isCommandKey(e) &&
             // do not override copy shortcut if user has text selected
             selection.isCollapsed() !== false &&
             // input selection is not reflected in window.getSelection()

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -22,7 +22,7 @@ import ThoughtId from '../../@types/ThoughtId'
 import { alertActionCreator as alert } from '../../actions/alert'
 import { closeModalActionCreator as closeModal } from '../../actions/closeModal'
 import { errorActionCreator as error } from '../../actions/error'
-import { isIOS, isMac, isTouch } from '../../browser'
+import { isIOS, isTouch } from '../../browser'
 import { HOME_PATH, HOME_TOKEN } from '../../constants'
 import replicateTree from '../../data-providers/data-helpers/replicateTree'
 import { thoughtspaceRuntime } from '../../data-providers/thoughtspace'
@@ -43,6 +43,7 @@ import fastClick from '../../util/fastClick'
 import head from '../../util/head'
 import headValue from '../../util/headValue'
 import initialState from '../../util/initialState'
+import isCommandKey from '../../util/isCommandKey'
 import isRoot from '../../util/isRoot'
 import removeHome from '../../util/removeHome'
 import throttleConcat from '../../util/throttleConcat'
@@ -482,7 +483,7 @@ const ModalExport: FC<{ simplePaths: SimplePath[] }> = ({ simplePaths }) => {
     (e: KeyboardEvent) => {
       if (
         e.key === 'c' &&
-        (isMac ? e.metaKey : e.ctrlKey) &&
+        isCommandKey(e) &&
         exportContent &&
         // do not override copy shortcut if user has text selected
         selection.isCollapsed() !== false &&

--- a/src/hooks/useDragHold.ts
+++ b/src/hooks/useDragHold.ts
@@ -5,10 +5,10 @@ import SimplePath from '../@types/SimplePath'
 import { alertActionCreator as alert } from '../actions/alert'
 import { longPressActionCreator as longPress } from '../actions/longPress'
 import { toggleMulticursorActionCreator as toggleMulticursor } from '../actions/toggleMulticursor'
-import { isMac } from '../browser'
 import { AlertType, LongPressState } from '../constants'
 import hasMulticursor from '../selectors/hasMulticursor'
 import debugLog from '../util/debugLog'
+import isCommandKey from '../util/isCommandKey'
 import useLongPress from './useLongPress'
 
 /** Adds event handlers to detect long press and set state.longPress while the user is long pressing a thought in preparation for a drag. */
@@ -44,7 +44,7 @@ const useDragHold = ({
 
       // Shift + Click and Cmd/Ctrl + Click are handled by the click handler in Thought, which fires before the long press ends.
       // Toggling the multicursor here as well would undo the selection that the click handler just made.
-      const multiselectModifier = !!e && (e.shiftKey || (isMac ? e.metaKey : e.ctrlKey))
+      const multiselectModifier = !!e && (e.shiftKey || isCommandKey(e))
 
       // touchcancel means the system claimed the touch, e.g. when the user swipes up from the bottom edge of the screen to switch apps on iOS. The page sees a touchstart with no touchmove, so the press outlasts the long press timer. A cancelled press is not a deliberate release, so it must not activate the multiselect, which would open the Command Center.
       const cancelled = e?.type === 'touchcancel'

--- a/src/util/isCommandKey.ts
+++ b/src/util/isCommandKey.ts
@@ -1,0 +1,9 @@
+import { isMac } from '../browser'
+
+/**
+ * Returns true if the platform's command modifier was held during an event: Command on Mac, Ctrl on other platforms.
+ * This is the same modifier that a command's keyboard definition declares as `meta`.
+ */
+const isCommandKey = (e: Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>): boolean => (isMac ? e.metaKey : e.ctrlKey)
+
+export default isCommandKey


### PR DESCRIPTION
Fixes #5130.

Nine call sites each inlined `isMac ? e.metaKey : e.ctrlKey` to test the platform's command modifier — Command on Mac, Ctrl elsewhere. This factors that ternary into [`util/isCommandKey`](src/util/isCommandKey.ts) so the platform mapping lives in one place.

```ts
const isCommandKey = (e: Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>): boolean => (isMac ? e.metaKey : e.ctrlKey)
```

The parameter is structural rather than a union of event types, so the same helper accepts the `KeyboardEvent`, `MouseEvent`, `React.MouseEvent`, and `React.TouchEvent` that the call sites pass.

Converted: [`commands.ts`](src/commands.ts), [`Editable.tsx`](src/components/Editable.tsx) (×2), [`useEditMode.ts`](src/components/Editable/useEditMode.ts), [`Thought.tsx`](src/components/Thought.tsx), [`BulletPositioner.tsx`](src/components/BulletPositioner.tsx), [`Devices.tsx`](src/components/modals/Devices.tsx), [`Export.tsx`](src/components/modals/Export.tsx), [`useDragHold.ts`](src/hooks/useDragHold.ts). Seven of the eight files no longer need `isMac` at all; only `commands.ts` still imports it, for the shortcut-hashing and display code that has nothing to do with reading an event.

One of the two `Editable` sites is the branch added by #4968 — the line the original review comment was left on. This branch is rebased onto that merge, so it is included.

In `Editable`'s `onClick` and `useEditMode`'s `onMouseDown` the ternary was assigned to an `isMultiselectClick` local that the helper makes redundant, so it is inlined and the "why" it carried moved into the comment above the branch.

Two nearby platform ternaries are deliberately left alone, since neither reads modifier state off an event: `e.key === (isMac ? 'Meta' : 'Control')` in `keyUp` compares a key *name*, and `isMac ? { metaKey: true } : { ctrlKey: true }` in the `Bullet` tests *constructs* modifiers rather than testing them.

## Verification

No behavior change intended.

- `yarn lint` (tsc, eslint, prettier) passes.
- Full unit suite: 2134 passed, 63 skipped, with one pre-existing failure — `Bullet.ts > multiselect > click on a bullet toggles the clicked thought while a multiselect is active, without expanding or collapsing it`. It fails identically on a clean checkout of `main` at 3fca942 with none of this branch applied, so it is not caused by this refactor. The tree it asserts (`a`, `b`, `c`) matches; only the root label differs, `__ROOT__` expected against the rendered root id.
- `docs/` checked and unaffected: no doc quotes the inlined ternary or the removed locals, no source path moved, and the behavior described in [`drag-and-drop.md`](docs/drag-and-drop.md) and [`cursor-and-caret.md`](docs/cursor-and-caret.md) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)