### PR TITLE
test(categorize): unskip the context-view single-cursor test

### DIFF
--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -190,13 +190,9 @@ describe('context view', () => {
     expect(isContextViewActive(stateNew, contextToPath(stateNew, ['a', 'm']))).toBeTruthy()
   })
 
-  // Skipped: the single-cursor branch passes the simplified path to moveThought as oldPath, and moveThought
-  // simplifies it again. When the context view is active on a prefix of that simplified path — true only for the
-  // context the view was activated from — the second simplification resolves `x` as a context of `m` rather than as
-  // its child, finds nothing, and moveThought throws "sourceThought not found". The test above passes only because
-  // `b/m/y` does not share the `a/m` prefix.
-  // Unskip when https://github.com/cybersemics/em/issues/5104 is fixed.
-  it.skip('categorize context subthought in the context the context view was activated from', () => {
+  // Unlike the test above, the subthought is shown under the context the view was activated from, so its SimplePath
+  // shares the prefix the context view is keyed on. That prefix is what the path resolution has to leave alone.
+  it('categorize context subthought in the context the context view was activated from', () => {
     const text = `
       - a
         - m


### PR DESCRIPTION
Closes #5104.

#5091 changed `splitChain` to split only where the next id is actually a context of the current thought. A SimplePath whose prefix has a context view open — `a/m/x` while the view is open on `a/m` — is therefore no longer mistaken for a context-view crossing, which is what made `moveThought` throw `sourceThought not found`.

That is the failure the skipped test documented, so the `.skip` and its explanation are removed. Verified by checking out `origin/main`, removing the `.skip`, and running the file: 15 passed.

The remaining comment now says only why this case differs from the test above it, since the subthought under the *other* context does not share the prefix and always worked.
