### PR TITLE
fix(test): wait for the cursor between ArrowDown presses in caret-multiline

### DIFF
--- a/src/e2e/puppeteer/__tests__/caret-multiline.ts
+++ b/src/e2e/puppeteer/__tests__/caret-multiline.ts
@@ -2,6 +2,7 @@ import click from '../helpers/click'
 import getSelection from '../helpers/getSelection'
 import paste from '../helpers/paste'
 import press from '../helpers/press'
+import waitForCursor from '../helpers/waitForCursor'
 import waitForEditable from '../helpers/waitForEditable'
 
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
@@ -120,6 +121,10 @@ describe('all platforms', () => {
     await click(editableNodeHandle, { edge: 'left' })
 
     await press('ArrowDown')
+
+    // Wait for the first press to land before pressing again. cursorDown's exec is throttled to one execution per animation frame, so a second keydown that arrives in the same frame is dropped and the cursor silently stops short.
+    await waitForCursor(multiLineCursor)
+
     await press('ArrowDown')
 
     // the focus must be in the middle of the multi-line thought after cursor down


### PR DESCRIPTION
## What

Insert a `waitForCursor` between the two back-to-back `press('ArrowDown')` calls in test case 5 of `src/e2e/puppeteer/__tests__/caret-multiline.ts`.

## Why

`cursorDown`'s `exec` is wrapped in `throttleByAnimationFrame` ([src/commands/cursorDown.ts](https://github.com/cybersemics/em/blob/main/src/commands/cursorDown.ts)), so two ArrowDown keydowns that land in the same animation frame collapse into a single cursor move. Puppeteer dispatches keys far faster than a person can press them, so on a loaded CI machine the second press can be dropped and the cursor silently stops short.

This is the same latent flake that was fixed in `color.ts` for #5118. The established remedy is to wait for the cursor to land between consecutive arrow presses — see the `waitForCursor` calls in `cursor.ts` ("move cursor from formatted thought to first unformatted thought in descending order"), and the cursor-movement paragraph in `docs/testing.md`.

## What a reviewer should know

**This change is not exercised by CI, and I could not verify that it fixes anything.** Two caveats, both worth reading before approving:

1. **Test case 5 is `it.skip`**, and has been since it was introduced in #2543. `yarn test:puppeteer caret-multiline` passes — 10 passed, 1 skipped — but the skipped one is exactly the test this PR touches.

2. **When un-skipped, the test fails, for a pre-existing reason unrelated to the throttle.** I ran both versions locally against the Docker/browserless harness:

   | version | result |
   |---|---|
   | with `waitForCursor` (this PR) | `AssertionError: expected 'd' to be 'Beautiful antique…'` |
   | baseline (`main`, two bare presses) | identical |

   The cursor **overshoots** to `d` rather than stopping short. `waitForCursor(multiLineCursor)` resolved without timing out, so the first press did land; the second press then ran `cursorDown` again instead of moving the caret within the thought — meaning `canExecute`'s `selection.isOnLastLine()` was true when the caret had just arrived at the top of a multi-line thought. That looks like the real bug the test was skipped for, and it is out of scope here. Happy to file an issue for it.

So the value of this PR is narrow but real: the latent flake is gone if and when the test is ever un-skipped. It does not change any currently-running test.

## Related

The `docs/testing.md` "Two controlling conditions" section and the `color.ts` fix for #5118 are on a separate branch that is not in this branch's ancestry, so this change is independent of that PR and does not conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)