### PR TITLE
feat(issue-classifier): enforce the vote contract with Structured Outputs

### DIFF
--- a/scripts/issue-classifier/.env.example
+++ b/scripts/issue-classifier/.env.example
@@ -7,7 +7,7 @@ OPENAI_API_KEY=
 # Repository to operate on. Defaults to cybersemics/em; in Actions it comes from GITHUB_REPOSITORY.
 # ISSUE_CLASSIFIER_REPO=cybersemics/em
 # Inference tuning (all optional; defaults shown):
-# ISSUE_CLASSIFIER_MODEL=gpt-5.6-terra            # OpenAI model used for milestone selection.
+# ISSUE_CLASSIFIER_MODEL=gpt-5.6-terra            # OpenAI model used for milestone selection. Must support Structured Outputs.
 # ISSUE_CLASSIFIER_VOTES=5                        # Self-consistency samples drawn per selection (Chat Completions `n`).
 # ISSUE_CLASSIFIER_REASONING_EFFORT=              # Reasoning effort for reasoning models (none|low|medium|high|xhigh|max). Sent only when set.
 # ISSUE_CLASSIFIER_TEMPERATURE=                   # Sent only when set; most reasoning models reject a non-default temperature.

--- a/scripts/issue-classifier/README.md
+++ b/scripts/issue-classifier/README.md
@@ -28,7 +28,7 @@ Without an issue number the script falls back to `ISSUE_NUMBER` (set by a manual
 
 The prompt is assembled from two halves. The system message is [`instructions.md`](instructions.md) — what each milestone means, real example issue titles from it, and the rules for choosing between them. The user message carries the **currently open** milestones, fetched from the GitHub API on every run, so a milestone created or closed today is reflected immediately with no file to update. The model may only choose a title from that list, or `null`.
 
-Five independent samples are drawn in one request (self-consistency voting via the Chat Completions `n` parameter, which bills the input once and only multiplies the tiny output). Each vote is resolved against the open milestones — leniently, so a dropped emoji or `and` for `&` still matches, while a milestone that is not open is discarded as invalid rather than counted. The modal vote wins.
+Five independent samples are drawn in one request (self-consistency voting via the Chat Completions `n` parameter, which bills the input once and only multiplies the tiny output). Each sample is constrained by a strict JSON schema ([Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs)) built per run from those same open milestones, so a conforming vote carries every field and can only name an open title or `null` — "copied verbatim" is enforced rather than requested, and a vote can no longer be lost to an invented, closed, or embellished title. The lenient resolution behind it — a dropped emoji or `and` for `&` still matches, a milestone that is not open is discarded as invalid rather than counted — remains as the backstop for replies the guarantee does not cover, such as one truncated at the token limit. The modal vote wins.
 
 ### The kind label
 
@@ -66,7 +66,7 @@ The costs here are asymmetric, and not in the intuitive direction. An unmileston
 
 So the only issues that get no milestone are the ones where the votes named none, which means the taxonomy has no home for the issue. That is worth a human's attention in a way that "the model was only fairly sure" never was. A run that fails inference three times, or finds no open milestones at all, comments and fails the workflow: those are broken rather than uncertain.
 
-Inference is tunable via `ISSUE_CLASSIFIER_*` env vars (see `.env.example`): `ISSUE_CLASSIFIER_MODEL`, `ISSUE_CLASSIFIER_VOTES`, `ISSUE_CLASSIFIER_REASONING_EFFORT`, `ISSUE_CLASSIFIER_TEMPERATURE`.
+Inference is tunable via `ISSUE_CLASSIFIER_*` env vars (see `.env.example`): `ISSUE_CLASSIFIER_MODEL` (which must support Structured Outputs), `ISSUE_CLASSIFIER_VOTES`, `ISSUE_CLASSIFIER_REASONING_EFFORT`, `ISSUE_CLASSIFIER_TEMPERATURE`.
 
 ## Evaluation
 

--- a/scripts/issue-classifier/src/compare.ts
+++ b/scripts/issue-classifier/src/compare.ts
@@ -41,7 +41,7 @@ import { fileURLToPath } from 'url'
 import GitHubClient, { type Milestone } from './lib/github.ts'
 import loadInstructions from './lib/loadInstructions.ts'
 import loadSamples, { type Sample } from './lib/loadSamples.ts'
-import type { Confidence } from './lib/parseSelection.ts'
+import { type Confidence, buildResponseFormat } from './lib/parseSelection.ts'
 import selectMilestone from './lib/selectMilestone.ts'
 
 const DEFAULT_REPO = 'cybersemics/em'
@@ -136,19 +136,23 @@ export const parseArgs = (argv: string[]): CompareOptions => {
  * Deliberately a copy of `inference.ts` rather than a call into it: that module reads its model from
  * the environment at import time, which is the right shape for a workflow that runs one model and
  * the wrong shape for a harness that has to alternate between two inside a single process. The
- * request body is otherwise identical field for field, and a divergence would silently make the
- * comparison measure something production does not do.
+ * request body is otherwise identical field for field — the response format comes from the same
+ * buildResponseFormat production uses, so that field cannot diverge at all — and a divergence would
+ * silently make the comparison measure something production does not do.
  */
 export const inferWithModel = async ({
   apiKey,
   prompt,
   instructions,
+  milestoneTitles,
   model,
   votes,
 }: {
   apiKey: string
   prompt: string
   instructions: string
+  /** Open milestone titles the response schema constrains `milestone` and `secondChoice` to. */
+  milestoneTitles: string[]
   model: string
   votes: number
 }): Promise<{ outputs: string[]; usage: Usage }> => {
@@ -165,7 +169,7 @@ export const inferWithModel = async ({
         { role: 'system', content: instructions },
         { role: 'user', content: prompt },
       ],
-      response_format: { type: 'json_object' },
+      response_format: buildResponseFormat(milestoneTitles),
     }),
   })
 
@@ -227,8 +231,8 @@ export const gradeOne = async ({
     instructions,
     openaiApiKey: apiKey,
     retryDelayMs: RETRY_DELAY_MS,
-    infer: async ({ apiKey, prompt, instructions }) => {
-      const result = await inferWithModel({ apiKey, prompt, instructions, model, votes })
+    infer: async ({ apiKey, prompt, instructions, milestoneTitles }) => {
+      const result = await inferWithModel({ apiKey, prompt, instructions, milestoneTitles, model, votes })
       usage.prompt += result.usage.prompt
       usage.cachedPrompt += result.usage.cachedPrompt
       usage.completion += result.usage.completion

--- a/scripts/issue-classifier/src/lib/__tests__/parseSelection.ts
+++ b/scripts/issue-classifier/src/lib/__tests__/parseSelection.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import parseSelection, { LABELS } from '../parseSelection.ts'
+import parseSelection, {
+  CONFIDENCE_LEVELS,
+  LABELS,
+  SelectionResponseSchema,
+  buildResponseFormat,
+} from '../parseSelection.ts'
 
 describe('parseSelection', () => {
   it('parses a complete response', () => {
@@ -62,5 +67,43 @@ describe('parseSelection', () => {
 
   it('rejects output that is not JSON', () => {
     expect(parseSelection('I think this belongs in Layout.')).toBeNull()
+  })
+})
+
+describe('buildResponseFormat', () => {
+  const TITLES = ['🧤 Drag & Drop', '📐 Layout']
+
+  it('offers the model exactly the fields the parse schema accepts, in the same order', () => {
+    // Property order is part of the contract: a strict schema emits keys in declaration order,
+    // which is what keeps `rationale` first so the model reasons before committing.
+    expect(Object.keys(buildResponseFormat(TITLES).json_schema.schema.properties)).toEqual(
+      Object.keys(SelectionResponseSchema.shape),
+    )
+  })
+
+  it('requires every field, so a conforming reply cannot omit one', () => {
+    const schema = buildResponseFormat(TITLES).json_schema.schema
+    expect(schema.required).toEqual(Object.keys(schema.properties))
+    expect(schema.additionalProperties).toBe(false)
+  })
+
+  it('declares a strict json_schema response format', () => {
+    const format = buildResponseFormat(TITLES)
+    expect(format.type).toBe('json_schema')
+    expect(format.json_schema.strict).toBe(true)
+    // The name is sent to the API, which restricts it to 64 characters of [a-zA-Z0-9_-].
+    expect(format.json_schema.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/)
+  })
+
+  it('constrains milestone and secondChoice to the open titles plus null', () => {
+    const { milestone, secondChoice } = buildResponseFormat(TITLES).json_schema.schema.properties
+    expect(milestone).toEqual({ type: ['string', 'null'], enum: [...TITLES, null] })
+    expect(secondChoice).toEqual({ type: ['string', 'null'], enum: [...TITLES, null] })
+  })
+
+  it('constrains label to the seven kinds plus null and confidence to the three levels', () => {
+    const { label, confidence } = buildResponseFormat(TITLES).json_schema.schema.properties
+    expect(label).toEqual({ type: ['string', 'null'], enum: [...LABELS, null] })
+    expect(confidence).toEqual({ type: 'string', enum: [...CONFIDENCE_LEVELS] })
   })
 })

--- a/scripts/issue-classifier/src/lib/__tests__/selectMilestone.ts
+++ b/scripts/issue-classifier/src/lib/__tests__/selectMilestone.ts
@@ -29,6 +29,12 @@ describe('selectMilestone', () => {
     expect(selection).toMatchObject({ milestone: '🧤 Drag & Drop', agreement: 1 })
   })
 
+  it('hands the open milestone titles to inference, where they constrain the response schema', async () => {
+    const infer = vi.fn(async () => [vote('🧤 Drag & Drop')])
+    await selectMilestone(options(infer))
+    expect(infer).toHaveBeenCalledWith(expect.objectContaining({ milestoneTitles: ['🧤 Drag & Drop', '📐 Layout'] }))
+  })
+
   it('returns a medium-confidence vote unchanged, since nothing gates on confidence', async () => {
     const selection = await selectMilestone(options(async () => [vote('🧤 Drag & Drop', 'medium')]))
     expect(selection).toMatchObject({ milestone: '🧤 Drag & Drop', confidence: 'medium' })

--- a/scripts/issue-classifier/src/lib/inference.ts
+++ b/scripts/issue-classifier/src/lib/inference.ts
@@ -1,4 +1,8 @@
+import { buildResponseFormat } from './parseSelection.ts'
+
 // Inference tuning constants, overridable via ISSUE_CLASSIFIER_* env vars for experimentation.
+// The model must support Structured Outputs (strict json_schema response_format); one that does not
+// fails the request outright rather than degrading to unvalidated output.
 const MODEL = process.env.ISSUE_CLASSIFIER_MODEL ?? 'gpt-5.6-terra'
 // Number of independent samples to draw per selection for self-consistency voting. Sent as the
 // Chat Completions `n` parameter, which bills input once and only multiplies the (tiny) output —
@@ -21,16 +25,27 @@ export interface InferenceOptions {
   prompt: string
   /** Milestone selection instructions used as the system message. */
   instructions: string
+  /** Open milestone titles the response schema constrains `milestone` and `secondChoice` to. */
+  milestoneTitles: string[]
   /** Number of samples to draw for voting. Defaults to VOTES; overridable per call. */
   votes?: number
 }
 
 /**
  * Calls the OpenAI chat completions API, drawing `votes` independent samples in a single request
- * via the `n` parameter. Returns the raw string content of every choice (including any malformed
- * ones) for downstream tallying — aggregation and vote-counting live in tallyVotes.
+ * via the `n` parameter. Every sample is constrained to the response schema by Structured Outputs
+ * (see buildResponseFormat), so a conforming reply cannot be malformed or name a milestone that is
+ * not open. Returns the raw string content of every choice — including a refusal or truncated
+ * reply, which arrives as unparseable content — for downstream tallying; aggregation and
+ * vote-counting live in tallyVotes.
  */
-const inference = async ({ apiKey, prompt, instructions, votes = VOTES }: InferenceOptions): Promise<string[]> => {
+const inference = async ({
+  apiKey,
+  prompt,
+  instructions,
+  milestoneTitles,
+  votes = VOTES,
+}: InferenceOptions): Promise<string[]> => {
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -46,7 +61,7 @@ const inference = async ({ apiKey, prompt, instructions, votes = VOTES }: Infere
         { role: 'system', content: instructions },
         { role: 'user', content: prompt },
       ],
-      response_format: { type: 'json_object' },
+      response_format: buildResponseFormat(milestoneTitles),
     }),
   })
 

--- a/scripts/issue-classifier/src/lib/parseSelection.ts
+++ b/scripts/issue-classifier/src/lib/parseSelection.ts
@@ -27,6 +27,14 @@ export type Label = (typeof LABELS)[number]
 /**
  * Schema for a single model response.
  *
+ * The request constrains the model with the strict JSON schema from buildResponseFormat below, so a
+ * conforming reply always carries every field with a valid value and this schema accepts it as a
+ * strict subset. The leniencies here are the backstop for the replies the guarantee does not cover
+ * — a reply truncated at the token limit parses as no JSON at all, and a model that does not
+ * support structured outputs fails the request rather than degrading — and the layers are
+ * deliberate: the wire contract can weaken without votes being thrown away for deviations that have
+ * a safe reading.
+ *
  * `milestone` and `confidence` are both required, because both drive the decision: a response
  * missing either one cannot be acted on, and per the workflow spec a missing field makes the output
  * invalid. `milestone` is nullable rather than optional — an explicit null is the model's way of
@@ -51,6 +59,41 @@ export const SelectionResponseSchema = z.object({
 })
 
 export type SelectionResponse = z.infer<typeof SelectionResponseSchema>
+
+/**
+ * Builds the Chat Completions `response_format` that constrains every sample to the response schema
+ * (OpenAI Structured Outputs, `strict: true`). Built per run rather than kept as a constant because
+ * `milestone` and `secondChoice` are enums of the currently open milestone titles: the "copied
+ * verbatim, or null" instruction the prompt already gives becomes something the model cannot
+ * disobey, so a vote can no longer be lost to an invented, closed, or dash-suffixed title. Behind
+ * it, matchMilestone and the vote-dropping in tallyVotes remain as backstops rather than as the
+ * front line.
+ *
+ * Strict mode requires every property to be listed in `required`, so "the model may decline" is
+ * expressed as a nullable type — null in the enum plus a `["…", "null"]` type — never as an absent
+ * field. Property order is meaningful: a strict schema emits keys in the order declared here, which
+ * is what keeps `rationale` first so the model reasons before committing to a milestone.
+ */
+export const buildResponseFormat = (milestoneTitles: string[]) => {
+  // Declared separately so `required` can be derived from it: strict mode rejects a schema whose
+  // required list does not name every property, and deriving the list makes that rejection
+  // unrepresentable rather than a runtime error waiting on the next added field.
+  const properties = {
+    rationale: { type: 'string' },
+    milestone: { type: ['string', 'null'], enum: [...milestoneTitles, null] },
+    confidence: { type: 'string', enum: [...CONFIDENCE_LEVELS] },
+    label: { type: ['string', 'null'], enum: [...LABELS, null] },
+    secondChoice: { type: ['string', 'null'], enum: [...milestoneTitles, null] },
+  }
+  return {
+    type: 'json_schema' as const,
+    json_schema: {
+      name: 'milestone_selection',
+      strict: true,
+      schema: { type: 'object', properties, required: Object.keys(properties), additionalProperties: false },
+    },
+  }
+}
 
 /**
  * Parses and validates one raw model output. Returns null when the string is not valid JSON or does

--- a/scripts/issue-classifier/src/lib/selectMilestone.ts
+++ b/scripts/issue-classifier/src/lib/selectMilestone.ts
@@ -56,7 +56,7 @@ const selectMilestone = async ({
   let lastError: Error | null = null
   for (let attempt = 1; attempt <= MAX_INFERENCE_ATTEMPTS; attempt++) {
     try {
-      const outputs = await infer({ apiKey: openaiApiKey, prompt, instructions })
+      const outputs = await infer({ apiKey: openaiApiKey, prompt, instructions, milestoneTitles: titles })
       const vote = tallyVotes(outputs, titles)
       if (vote) return vote
       lastError = new Error(`No usable vote in ${outputs.length} samples: ${JSON.stringify(outputs)}`)


### PR DESCRIPTION
Follow-up to #5141.

The classifier's inference call moves from JSON mode (`response_format: { type: 'json_object' }`) to OpenAI Structured Outputs: a strict JSON schema built per run, in which `milestone` and `secondChoice` are enums of the currently open milestone titles. A conforming vote is well-formed by construction and can only name an open title or `null` — the prompt's "copied verbatim, or null" is now enforced rather than requested. The downstream defenses (lenient Zod parse, `matchMilestone`, vote-dropping in `tallyVotes`) are deliberately untouched and remain as backstops for what the guarantee does not cover (e.g. truncation). The prompt is untouched in both halves, so the tuned-prompt eval baseline is not consumed.

## Architectural plan

**Existing surface area.** The only production request site is `inference.ts` (JSON mode, no titles in its options seam); `compare.ts#inferWithModel` is a documented deliberate field-for-field copy whose rationale is inference.ts reading its model from the environment at import time. The response contract is enforced downstream: `parseSelection.ts` (lenient Zod schema, and the stated invariant that "the list the model is offered, the list a vote is checked against, and the list that reaches GitHub cannot drift apart" is why LABELS lives there), `matchMilestone.ts` (three-stage fuzzy resolution), `tallyVotes.ts` (drops votes naming non-open milestones). `selectMilestone.ts` already computes `titles` one line above the infer call. Strict-mode constraints were verified against current OpenAI docs: every property in `required`, `additionalProperties: false`, nullable enum as `type: ["string","null"]` with `null` in the enum, `name` ≤ 64 chars of `[a-zA-Z0-9_-]`, keys emitted in schema declaration order, one-time schema-compile latency per new schema.

**Build vs. extend.** Extend, no new files: one named export `buildResponseFormat(milestoneTitles)` in `parseSelection.ts` (the wire schema is literally "the list the model is offered", so it belongs beside the parse schema); `InferenceOptions` gains a required `milestoneTitles`; `inference.ts` and `compare.ts` both import the builder, which makes the one field that must not diverge between the comparison arms unable to.

**Adjacent behaviour.** Backlog-suffixed milestones stay in the enum (open milestones; rule 2 remains prompt guidance — unchanged from today). Refusals/truncation still arrive as unparseable content → dropped vote → existing retry ladder. `evaluate.ts`/`issue.ts` see no signature change. An `ISSUE_CLASSIFIER_MODEL` override to a model without Structured Outputs support now fails the request loudly (documented in `.env.example`) rather than degrading to unvalidated output. `scripts/estimate` has its own JSON-mode inference and is deliberately out of scope.

**Approaches considered.** (a) Static schema without title enums — rejected: leaves the observed failure class (invented/closed/dash-suffixed titles) standing and half-uses the feature. (b) Per-run schema with title enums — chosen. (c) Deriving the JSON schema from Zod (`z.toJSONSchema`) — rejected: the lenient parse schema deliberately violates strict-mode rules, so it cannot be the source; a hand-written literal plus a drift-guard test (wire properties must equal the parse schema's keys, in order) is transparent and pins the two together.

## Verification beyond CI

- End-to-end with the model's reply canned, against the live open milestones (the same verification style as #5141): the captured request body carries the strict schema with all 31 open titles (ZWJ emoji and the `(backlog)` variant intact) plus `null`, every property required, `additionalProperties: false`, `rationale` first, and the canned reply flows through the tally to a `VoteResult`.
- **Not run:** a live API call (`yarn issue 5130 --dry`) and a train-split `yarn evaluate` — no `OPENAI_API_KEY` is available in the environment this was built in. Both are worth a run with a key before relying on the change, since constrained decoding could in principle shift accuracy even with the prompt frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)