### PR TITLE
fix(categorize): move view and pin options to the new category when all siblings are selected

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,7 +395,7 @@ Create a thought within the first subthought.
 
 ### Categorize
 
-Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's view options — `=view`, `=pin`, `=sort`, `=children/=pin`, and `=descendants/=pin` — follow them into the category, since they describe the thoughts the category now wraps. A `=children` or `=descendants` container that holds other attributes stays behind; only its `=pin` moves.
+Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's view options — `=view`, `=sort`, and a `=pin` scoped through `=children` or `=descendants` — follow them into the category, since they describe the thoughts the category now wraps. A scoped container moves whole, along with any other attributes it holds. The parent's own direct `=pin` stays, since it pins the parent itself rather than the wrapped children.
 
 <kbd>Command + Option + o</kbd> or <kbd>Command + ]</kbd>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,7 +395,7 @@ Create a thought within the first subthought.
 
 ### Categorize
 
-Move the current thought into a new, empty thought at the same level.
+Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's `=view` and `=pin` follow them into the category, since those options describe the thoughts the category now wraps.
 
 <kbd>Command + Option + o</kbd> or <kbd>Command + ]</kbd>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,7 +395,7 @@ Create a thought within the first subthought.
 
 ### Categorize
 
-Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's view options — `=view`, `=sort`, and a `=pin` scoped through `=children` or `=descendants` — follow them into the category, since they describe the thoughts the category now wraps. A scoped container moves whole, along with any other attributes it holds. The parent's own direct `=pin` stays, since it pins the parent itself rather than the wrapped children.
+Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the meta attributes that describe the parent's children — `=view`, `=sort`, and the `=children`, `=grandchildren`, and `=descendants` containers — follow them into the category, each moving whole with everything it holds. The parent's own direct `=pin` stays, since it pins the parent itself rather than the wrapped children.
 
 <kbd>Command + Option + o</kbd> or <kbd>Command + ]</kbd>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,7 +395,7 @@ Create a thought within the first subthought.
 
 ### Categorize
 
-Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's `=view` and `=pin` follow them into the category, since those options describe the thoughts the category now wraps.
+Move the current thought into a new, empty thought at the same level. With a multiselect, every selected thought moves into the new category — and when every visible sibling is selected, the parent's view options — `=view`, `=pin`, `=sort`, `=children/=pin`, and `=descendants/=pin` — follow them into the category, since they describe the thoughts the category now wraps. A `=children` or `=descendants` container that holds other attributes stays behind; only its `=pin` moves.
 
 <kbd>Command + Option + o</kbd> or <kbd>Command + ]</kbd>
 

--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -450,7 +450,7 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
-  it.skip('move =view to the new category when all siblings are selected', () => {
+  it('move =view to the new category when all siblings are selected', () => {
     const steps = [
       importText({
         text: `
@@ -515,7 +515,7 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
-  it.skip('move =pin to the new category when all siblings are selected', () => {
+  it('move =pin to the new category when all siblings are selected', () => {
     const steps = [
       importText({
         text: `

--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -515,6 +515,80 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
+  it('move =children to the new category even when it contains no view options', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =children
+            - =style
+              - color
+                - tomato
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =children
+        - =style
+          - color
+            - tomato
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('move =grandchildren to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =grandchildren
+            - =style
+              - color
+                - tomato
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =grandchildren
+        - =style
+          - color
+            - tomato
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
   it('keep =pin on the parent when all siblings are selected, since it pins the parent itself', () => {
     const steps = [
       importText({

--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -548,6 +548,151 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
+  it('move =sort to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =sort
+            - Alphabetical
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =sort
+        - Alphabetical
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('move =children/=pin to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =children
+            - =pin
+              - true
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =children
+        - =pin
+          - true
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('move =descendants/=pin to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =descendants
+            - =pin
+              - true
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =descendants
+        - =pin
+          - true
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('move only =pin out of =children when =children has other attributes', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =children
+            - =pin
+              - true
+            - =style
+              - color
+                - tomato
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - =children
+      - =style
+        - color
+          - tomato
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =children
+        - =pin
+          - true
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
   it('keep =pin on the parent when only some siblings are selected', () => {
     const steps = [
       importText({

--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -515,7 +515,7 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
-  it('move =pin to the new category when all siblings are selected', () => {
+  it('keep =pin on the parent when all siblings are selected, since it pins the parent itself', () => {
     const steps = [
       importText({
         text: `
@@ -538,9 +538,9 @@ describe('multicursor', () => {
     const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
     expect(exported).toBe(`- ${HOME_TOKEN}
   - A
+    - =pin
+      - true
     - ${'' /* prevent trim_trailing_whitespace */}
-      - =pin
-        - true
       - B
         - C
       - D
@@ -651,7 +651,7 @@ describe('multicursor', () => {
   })
 
   // https://github.com/cybersemics/em/issues/4330
-  it('move only =pin out of =children when =children has other attributes', () => {
+  it('move the entire =children to the new category when it holds other attributes besides =pin', () => {
     const steps = [
       importText({
         text: `
@@ -678,14 +678,13 @@ describe('multicursor', () => {
     const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
     expect(exported).toBe(`- ${HOME_TOKEN}
   - A
-    - =children
-      - =style
-        - color
-          - tomato
     - ${'' /* prevent trim_trailing_whitespace */}
       - =children
         - =pin
           - true
+        - =style
+          - color
+            - tomato
       - B
         - C
       - D

--- a/src/actions/__tests__/categorize.ts
+++ b/src/actions/__tests__/categorize.ts
@@ -448,4 +448,134 @@ describe('multicursor', () => {
       - D
     - E`)
   })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it.skip('move =view to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =view
+            - Table
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =view
+        - Table
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('keep =view on the parent when only some siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =view
+            - Table
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - =view
+      - Table
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - B
+        - C
+    - D
+      - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it.skip('move =pin to the new category when all siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =pin
+            - true
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      addMulticursor(['A', 'D']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - =pin
+        - true
+      - B
+        - C
+      - D
+        - E`)
+  })
+
+  // https://github.com/cybersemics/em/issues/4330
+  it('keep =pin on the parent when only some siblings are selected', () => {
+    const steps = [
+      importText({
+        text: `
+        - A
+          - =pin
+            - true
+          - B
+            - C
+          - D
+            - E`,
+      }),
+      setCursor(['A', 'B']),
+      addMulticursor(['A', 'B']),
+      categorize,
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+    expect(exported).toBe(`- ${HOME_TOKEN}
+  - A
+    - =pin
+      - true
+    - ${'' /* prevent trim_trailing_whitespace */}
+      - B
+        - C
+    - D
+      - E`)
+  })
 })

--- a/src/actions/categorize.ts
+++ b/src/actions/categorize.ts
@@ -3,7 +3,7 @@ import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
 import documentSort from '../selectors/documentSort'
 import findDescendant from '../selectors/findDescendant'
-import { getChildren } from '../selectors/getChildren'
+import { findAnyChild, getChildren } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
 import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
@@ -79,18 +79,32 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
   const newThoughtId = createId()
   const isInContextView = isContextViewActive(state, parentOf(cursor))
 
-  // When every visible sibling is selected, the parent's =view and =pin describe the very thoughts being wrapped, so
-  // they follow them into the new category. A partial selection leaves them on the parent, which keeps unselected
-  // children. An attribute that is itself selected (visible via showHiddenThoughts) is already moved by the selection.
+  // When every visible sibling is selected, the parent's view options — =view, =pin, =sort, =children/=pin, and
+  // =descendants/=pin — describe the very thoughts being wrapped, so they follow them into the new category. A partial
+  // selection leaves them on the parent, which keeps unselected children. An attribute that is itself selected
+  // (visible via showHiddenThoughts) is already moved by the selection.
   const parentId = head(rootedParentOf(state, simplePath))
   const selectedIds = new Set(multicursorPaths.map(path => head(simplifyPath(state, path))))
   const allSelected =
     multicursorPaths.length > 0 && getChildren(state, parentId).every(child => selectedIds.has(child.id))
   const movedAttributes = allSelected
-    ? ['=view', '=pin'].flatMap(value => {
+    ? ['=view', '=pin', '=sort'].flatMap(value => {
         const id = findDescendant(state, parentId, value)
         const thought = id && !selectedIds.has(id) ? getThoughtById(state, id) : null
         return thought ? [thought] : []
+      })
+    : []
+  // A =pin scoped through =children or =descendants moves too, but its container may hold attributes that stay behind
+  // (e.g. =children/=style), so the whole container moves only when =pin is its only child. Otherwise only =pin moves,
+  // into a fresh container created in the category, identified here by a non-null newContainerId.
+  const movedScopedPins = allSelected
+    ? ['=children', '=descendants'].flatMap(value => {
+        const containerId = findDescendant(state, parentId, value)
+        const container = containerId && !selectedIds.has(containerId) ? getThoughtById(state, containerId) : null
+        const pinId = container ? findDescendant(state, container.id, '=pin') : null
+        const pin = pinId ? getThoughtById(state, pinId) : null
+        const pinOnly = container ? !findAnyChild(state, container.id, child => child.value !== '=pin') : false
+        return container && pin ? [{ container, pin, newContainerId: pinOnly ? null : createId() }] : []
       })
     : []
 
@@ -130,6 +144,27 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
         newPath: appendToPath(parentOf(simplePath), newThoughtId, attribute.id),
         newRank: attribute.rank,
       }),
+    ),
+    ...movedScopedPins.map(({ container, pin, newContainerId }) =>
+      newContainerId
+        ? reducerFlow([
+            createThought({
+              path: appendToPath(parentOf(simplePath), newThoughtId),
+              value: container.value,
+              rank: container.rank,
+              id: newContainerId,
+            }),
+            moveThought({
+              oldPath: appendToPath(parentOf(simplePath), container.id, pin.id),
+              newPath: appendToPath(parentOf(simplePath), newThoughtId, newContainerId, pin.id),
+              newRank: pin.rank,
+            }),
+          ])
+        : moveThought({
+            oldPath: appendToPath(parentOf(simplePath), container.id),
+            newPath: appendToPath(parentOf(simplePath), newThoughtId, container.id),
+            newRank: container.rank,
+          }),
     ),
     setCursor({
       path: appendToPath(cursorParent, newThoughtId),

--- a/src/actions/categorize.ts
+++ b/src/actions/categorize.ts
@@ -3,7 +3,7 @@ import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
 import documentSort from '../selectors/documentSort'
 import findDescendant from '../selectors/findDescendant'
-import { findAnyChild, getChildren } from '../selectors/getChildren'
+import { getChildren } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
 import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
@@ -79,32 +79,23 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
   const newThoughtId = createId()
   const isInContextView = isContextViewActive(state, parentOf(cursor))
 
-  // When every visible sibling is selected, the parent's view options — =view, =pin, =sort, =children/=pin, and
-  // =descendants/=pin — describe the very thoughts being wrapped, so they follow them into the new category. A partial
-  // selection leaves them on the parent, which keeps unselected children. An attribute that is itself selected
-  // (visible via showHiddenThoughts) is already moved by the selection.
+  // When every visible sibling is selected, the parent's view options — =view, =sort, and =pin scoped through
+  // =children or =descendants — describe the very thoughts being wrapped, so they follow them into the new category.
+  // A scoped container moves whole, along with any other attributes it holds. The parent's own direct =pin stays,
+  // since it pins the parent itself rather than describing the wrapped children. A partial selection leaves everything
+  // on the parent, which keeps unselected children. An attribute that is itself selected (visible via
+  // showHiddenThoughts) is already moved by the selection.
   const parentId = head(rootedParentOf(state, simplePath))
   const selectedIds = new Set(multicursorPaths.map(path => head(simplifyPath(state, path))))
   const allSelected =
     multicursorPaths.length > 0 && getChildren(state, parentId).every(child => selectedIds.has(child.id))
   const movedAttributes = allSelected
-    ? ['=view', '=pin', '=sort'].flatMap(value => {
+    ? ['=view', '=sort', '=children', '=descendants'].flatMap(value => {
         const id = findDescendant(state, parentId, value)
-        const thought = id && !selectedIds.has(id) ? getThoughtById(state, id) : null
+        // =children and =descendants are view options only when they scope a =pin
+        const isViewOption = value === '=view' || value === '=sort' || !!findDescendant(state, id, '=pin')
+        const thought = id && isViewOption && !selectedIds.has(id) ? getThoughtById(state, id) : null
         return thought ? [thought] : []
-      })
-    : []
-  // A =pin scoped through =children or =descendants moves too, but its container may hold attributes that stay behind
-  // (e.g. =children/=style), so the whole container moves only when =pin is its only child. Otherwise only =pin moves,
-  // into a fresh container created in the category, identified here by a non-null newContainerId.
-  const movedScopedPins = allSelected
-    ? ['=children', '=descendants'].flatMap(value => {
-        const containerId = findDescendant(state, parentId, value)
-        const container = containerId && !selectedIds.has(containerId) ? getThoughtById(state, containerId) : null
-        const pinId = container ? findDescendant(state, container.id, '=pin') : null
-        const pin = pinId ? getThoughtById(state, pinId) : null
-        const pinOnly = container ? !findAnyChild(state, container.id, child => child.value !== '=pin') : false
-        return container && pin ? [{ container, pin, newContainerId: pinOnly ? null : createId() }] : []
       })
     : []
 
@@ -144,27 +135,6 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
         newPath: appendToPath(parentOf(simplePath), newThoughtId, attribute.id),
         newRank: attribute.rank,
       }),
-    ),
-    ...movedScopedPins.map(({ container, pin, newContainerId }) =>
-      newContainerId
-        ? reducerFlow([
-            createThought({
-              path: appendToPath(parentOf(simplePath), newThoughtId),
-              value: container.value,
-              rank: container.rank,
-              id: newContainerId,
-            }),
-            moveThought({
-              oldPath: appendToPath(parentOf(simplePath), container.id, pin.id),
-              newPath: appendToPath(parentOf(simplePath), newThoughtId, newContainerId, pin.id),
-              newRank: pin.rank,
-            }),
-          ])
-        : moveThought({
-            oldPath: appendToPath(parentOf(simplePath), container.id),
-            newPath: appendToPath(parentOf(simplePath), newThoughtId, container.id),
-            newRank: container.rank,
-          }),
     ),
     setCursor({
       path: appendToPath(cursorParent, newThoughtId),

--- a/src/actions/categorize.ts
+++ b/src/actions/categorize.ts
@@ -79,22 +79,20 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
   const newThoughtId = createId()
   const isInContextView = isContextViewActive(state, parentOf(cursor))
 
-  // When every visible sibling is selected, the parent's view options — =view, =sort, and =pin scoped through
-  // =children or =descendants — describe the very thoughts being wrapped, so they follow them into the new category.
-  // A scoped container moves whole, along with any other attributes it holds. The parent's own direct =pin stays,
-  // since it pins the parent itself rather than describing the wrapped children. A partial selection leaves everything
-  // on the parent, which keeps unselected children. An attribute that is itself selected (visible via
-  // showHiddenThoughts) is already moved by the selection.
+  // When every visible sibling is selected, the meta attributes that describe the parent's children — =view, =sort,
+  // and the =children, =grandchildren, and =descendants containers — follow the wrapped thoughts into the new
+  // category, each moving whole with everything it holds. The parent's own direct =pin stays, since it pins the
+  // parent itself rather than describing the wrapped children. A partial selection leaves everything on the parent,
+  // which keeps unselected children. An attribute that is itself selected (visible via showHiddenThoughts) is already
+  // moved by the selection.
   const parentId = head(rootedParentOf(state, simplePath))
   const selectedIds = new Set(multicursorPaths.map(path => head(simplifyPath(state, path))))
   const allSelected =
     multicursorPaths.length > 0 && getChildren(state, parentId).every(child => selectedIds.has(child.id))
   const movedAttributes = allSelected
-    ? ['=view', '=sort', '=children', '=descendants'].flatMap(value => {
+    ? ['=view', '=sort', '=children', '=grandchildren', '=descendants'].flatMap(value => {
         const id = findDescendant(state, parentId, value)
-        // =children and =descendants are view options only when they scope a =pin
-        const isViewOption = value === '=view' || value === '=sort' || !!findDescendant(state, id, '=pin')
-        const thought = id && isViewOption && !selectedIds.has(id) ? getThoughtById(state, id) : null
+        const thought = id && !selectedIds.has(id) ? getThoughtById(state, id) : null
         return thought ? [thought] : []
       })
     : []

--- a/src/actions/categorize.ts
+++ b/src/actions/categorize.ts
@@ -3,6 +3,7 @@ import Thunk from '../@types/Thunk'
 import { AlertType } from '../constants'
 import documentSort from '../selectors/documentSort'
 import findDescendant from '../selectors/findDescendant'
+import { getChildren } from '../selectors/getChildren'
 import getRankBefore from '../selectors/getRankBefore'
 import getThoughtById from '../selectors/getThoughtById'
 import isContextViewActive from '../selectors/isContextViewActive'
@@ -78,6 +79,21 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
   const newThoughtId = createId()
   const isInContextView = isContextViewActive(state, parentOf(cursor))
 
+  // When every visible sibling is selected, the parent's =view and =pin describe the very thoughts being wrapped, so
+  // they follow them into the new category. A partial selection leaves them on the parent, which keeps unselected
+  // children. An attribute that is itself selected (visible via showHiddenThoughts) is already moved by the selection.
+  const parentId = head(rootedParentOf(state, simplePath))
+  const selectedIds = new Set(multicursorPaths.map(path => head(simplifyPath(state, path))))
+  const allSelected =
+    multicursorPaths.length > 0 && getChildren(state, parentId).every(child => selectedIds.has(child.id))
+  const movedAttributes = allSelected
+    ? ['=view', '=pin'].flatMap(value => {
+        const id = findDescendant(state, parentId, value)
+        const thought = id && !selectedIds.has(id) ? getThoughtById(state, id) : null
+        return thought ? [thought] : []
+      })
+    : []
+
   return reducerFlow([
     createThought({
       path: rootedParentOf(state, simplePath),
@@ -108,6 +124,13 @@ const categorize = (state: State, { value = '' }: categorizePayload = {}): State
               newRank: getThoughtById(state, head(path))!.rank,
             }),
           )),
+    ...movedAttributes.map(attribute =>
+      moveThought({
+        oldPath: appendToPath(parentOf(simplePath), attribute.id),
+        newPath: appendToPath(parentOf(simplePath), newThoughtId, attribute.id),
+        newRank: attribute.rank,
+      }),
+    ),
     setCursor({
       path: appendToPath(cursorParent, newThoughtId),
       // Place the caret at the end of the category so the user can keep typing where its value leaves off. For the


### PR DESCRIPTION
#4330

When a multiselect covers every visible child of the parent, Categorize now moves the meta attributes that describe the parent's children — `=view`, `=sort`, and the `=children`, `=grandchildren`, and `=descendants` containers — into the new category along with the selected thoughts, each moving whole with everything it holds. The parent's own direct `=pin` stays, since it pins the parent itself rather than describing the wrapped children. A partial selection leaves everything on the parent, which keeps unselected children.

## Plan

### Existing surface area

- The `categorize` reducer's multicursor branch ([`src/actions/categorize.ts`](../blob/main/src/actions/categorize.ts)) moves each selected thought into the new category keeping its original rank, with paths built from `parentOf(simplePath)`; selections spanning different simple parents are already rejected with a `MulticursorError` before this point.
- `getChildren` ([`src/selectors/getChildren.ts`](../blob/main/src/selectors/getChildren.ts)) returns exactly what the user sees — meta attributes excluded unless `showHiddenThoughts` — and is the same visibility rule Select All uses via `getSiblingPaths`/`isAllSelected`, so "every visible sibling is selected" matches the UI meaning of Select All.
- `findDescendant` gives the O(1) `childrenMap` attribute lookup and was already imported for the `=readonly`/`=unextendable` guards.
- The inverse operation `uncategorize` already special-cases these shapes when dissolving a category: it deletes `=pin`, `=children/=pin`, and `=descendants/=pin`, and moves `=sort` up as a whole subtree. Its extra `sort()` call is needed because its destination may hold existing children to renumber — categorize's destination is a fresh category whose children arrive with already-renumbered ranks, so no sort call is needed here.

### Decision

Extend the reducer only: compute `allSelected` (every `getChildren` child of the real parent is among the selected simple-path heads), then move each of `=view`, `=sort`, `=children`, `=grandchildren`, and `=descendants` as a whole subtree via one `moveThought`, preserving original ranks. All steps run inside the existing `reducerFlow`, keeping undo atomic (`categorize` is registered undoable). `extractCategory` inherits the behavior by design, since it delegates to this reducer.

### Adjacent behavior

- Single-cursor categorize is untouched (a bare cursor is not a selection, matching `isAllSelected`).
- Partial selections are covered by guard tests, including the pre-existing sorted-context multicursor test that pins `=sort` staying on a partial selection.
- Context-view rows with different parents are rejected before this logic; the nested-context-view multiselect (#3391) resolves to a real shared parent where the same tree-level invariant applies.
- An attribute that is itself selected (visible via Show Hidden Thoughts) is moved by the selection loop and skipped by the targeted move, so it cannot move twice.
- Ranks cannot collide: every moved rank originates in the one source context where the thoughts were siblings.
- Root-level selections resolve the parent to `HOME_TOKEN`, where the lookups are simply null.

## Tests

Reducer tests in `src/actions/__tests__/categorize.ts`:

- move `=view` / `=sort` / `=children/=pin` / `=descendants/=pin` / `=grandchildren` to the new category when all siblings are selected
- move the entire `=children` to the new category when it holds other attributes besides `=pin`
- move `=children` to the new category even when it contains no view options
- keep `=pin` on the parent when all siblings are selected, since it pins the parent itself
- keep `=view` / `=pin` on the parent when only some siblings are selected

The "move" tests carry the red side: on the base commit they fail on their export assertions with the attributes remaining on the parent (verified locally before each fix commit). The "keep" tests guard behavior that already works on base and are proven by the normal Test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
