### PR TITLE
feat(estimate): enforce the vote contract with Structured Outputs

### DIFF
--- a/.github/instructions/estimate/estimate.instructions.md
+++ b/.github/instructions/estimate/estimate.instructions.md
@@ -35,7 +35,7 @@ You are an issue estimation assistant for the `em` project, a TypeScript/React/R
   - `rationale`: a brief (one- or two-sentence) explanation of the estimate. Comes first so you reason before committing to a bucket.
   - `estimate`: the chosen category. Required.
   - `confidence`: your confidence in the estimate — exactly one of `high`, `medium`, `low`.
-  - `secondChoice`: the next most likely category if you are uncertain. Optional.
+  - `secondChoice`: the next most likely category if you are uncertain, or `null` if you have no second choice.
 - Format: `{"rationale": "<brief reasoning>", "estimate": "<CATEGORY>", "confidence": "high|medium|low", "secondChoice": "<CATEGORY>"}`
 - CATEGORY (for `estimate` and `secondChoice`) must be exactly one of: XXS, XS, S, M, L, XL, XXL
 - Do not include any markdown or text outside the JSON object.

--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -8,7 +8,7 @@ EVERHOUR_PROJECT_ID=
 # OpenAI API key used for the estimation inference call.
 OPENAI_API_KEY=
 # Inference tuning (all optional; defaults shown):
-# ESTIMATE_MODEL=gpt-5.6-terra          # OpenAI model used for estimation.
+# ESTIMATE_MODEL=gpt-5.6-terra          # OpenAI model used for estimation. Must support Structured Outputs.
 # ESTIMATE_VOTES=5                       # Self-consistency samples drawn per estimate (Chat Completions `n`).
 # ESTIMATE_REASONING_EFFORT=            # Reasoning effort for reasoning models (none|low|medium|high|xhigh|max). Sent only when set.
 # ESTIMATE_TEMPERATURE=                  # Sent only when set; most reasoning models reject a non-default temperature.

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -24,7 +24,7 @@ Dry-run flags: `--dry` skips both the model call and the Everhour write; `--dry-
 
 ## Evaluation
 
-The estimator draws multiple independent samples per issue (self-consistency voting via the Chat Completions `n` parameter) and reports the modal category, so each estimate carries an `agreement` score (fraction of votes that agreed) and a self-reported `confidence`. Both are surfaced in the audit comment.
+The estimator draws multiple independent samples per issue (self-consistency voting via the Chat Completions `n` parameter) and reports the modal category, so each estimate carries an `agreement` score (fraction of votes that agreed) and a self-reported `confidence`. Both are surfaced in the audit comment. Each sample is constrained by a strict JSON schema ([Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs)), so a conforming vote carries every field and can only name a category on the XXS–XXL scale — the response shape the prompt requests is enforced rather than requested, and a vote can no longer be lost to a hallucinated category or a missing field. The lenient parsing behind it — missing `rationale` and `confidence` are defaulted, a malformed vote is discarded rather than aborting the tally — remains as the backstop for replies the guarantee does not cover, such as one truncated at the token limit.
 
 To measure accuracy, run the leave-one-out harness. For each labeled sample it rebuilds the prompt from every _other_ sample, estimates the held-out issue, and compares to the known-correct category. It reports exact-bucket and ±1-bucket accuracy, a confusion matrix, and a calibration breakdown. It makes model calls but never writes to Everhour.
 
@@ -33,7 +33,7 @@ cd scripts/estimate
 yarn evaluate
 ```
 
-Inference is tunable via `ESTIMATE_*` env vars (see `.env.example`): `ESTIMATE_MODEL`, `ESTIMATE_VOTES`, `ESTIMATE_REASONING_EFFORT`, `ESTIMATE_TEMPERATURE`.
+Inference is tunable via `ESTIMATE_*` env vars (see `.env.example`): `ESTIMATE_MODEL` (which must support Structured Outputs), `ESTIMATE_VOTES`, `ESTIMATE_REASONING_EFFORT`, `ESTIMATE_TEMPERATURE`.
 
 Manual correction (via issue comment)
 

--- a/scripts/estimate/src/lib/__tests__/tallyVotes.ts
+++ b/scripts/estimate/src/lib/__tests__/tallyVotes.ts
@@ -51,6 +51,12 @@ describe('tallyVotes', () => {
     expect(result.secondChoice).toBe('M')
   })
 
+  it('normalizes an explicit null secondChoice, the strict schema encoding of "no second choice", to undefined', () => {
+    const result = tallyVotes([vote('L', { secondChoice: null })])
+    expect(result.estimate).toBe('L')
+    expect(result.secondChoice).toBeUndefined()
+  })
+
   it('throws when no votes are valid', () => {
     expect(() => tallyVotes(['nope', '{}', 'also bad'])).toThrow('Failed to validate any estimate vote')
   })

--- a/scripts/estimate/src/lib/__tests__/validateEstimate.ts
+++ b/scripts/estimate/src/lib/__tests__/validateEstimate.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import validateEstimate, { EstimateCategorySchema, EstimateResponseSchema, parseEstimate } from '../validateEstimate.ts'
+import { ESTIMATE_CATEGORIES } from '../../everhour/estimates.ts'
+import validateEstimate, {
+  CONFIDENCE_LEVELS,
+  EstimateCategorySchema,
+  EstimateResponseSchema,
+  RESPONSE_FORMAT,
+  parseEstimate,
+} from '../validateEstimate.ts'
 
 describe('validateEstimate', () => {
   it('parses valid model output and defaults the richer fields', () => {
@@ -59,6 +66,10 @@ describe('parseEstimate', () => {
   it('returns null for an invalid confidence value', () => {
     expect(parseEstimate('{"estimate": "M", "confidence": "certain"}')).toBeNull()
   })
+
+  it('accepts an explicit null secondChoice, the strict schema encoding of "no second choice"', () => {
+    expect(parseEstimate('{"estimate": "M", "secondChoice": null}')?.estimate).toBe('M')
+  })
 })
 
 describe('EstimateCategorySchema', () => {
@@ -82,5 +93,41 @@ describe('EstimateResponseSchema', () => {
 
   it('rejects missing estimate', () => {
     expect(() => EstimateResponseSchema.parse({})).toThrow()
+  })
+})
+
+describe('RESPONSE_FORMAT', () => {
+  it('offers the model exactly the fields the parse schema accepts, in the same order', () => {
+    // Property order is part of the contract: a strict schema emits keys in declaration order,
+    // which is what keeps `rationale` first so the model reasons before committing to a bucket.
+    expect(Object.keys(RESPONSE_FORMAT.json_schema.schema.properties)).toEqual(
+      Object.keys(EstimateResponseSchema.shape),
+    )
+  })
+
+  it('requires every field, so a conforming reply cannot omit one', () => {
+    const schema = RESPONSE_FORMAT.json_schema.schema
+    expect(schema.required).toEqual(Object.keys(schema.properties))
+    expect(schema.additionalProperties).toBe(false)
+  })
+
+  it('declares a strict json_schema response format', () => {
+    expect(RESPONSE_FORMAT.type).toBe('json_schema')
+    expect(RESPONSE_FORMAT.json_schema.strict).toBe(true)
+    // The name is sent to the API, which restricts it to 64 characters of [a-zA-Z0-9_-].
+    expect(RESPONSE_FORMAT.json_schema.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/)
+  })
+
+  it('constrains estimate to the category scale and confidence to the three levels', () => {
+    const { estimate, confidence } = RESPONSE_FORMAT.json_schema.schema.properties
+    expect(estimate).toEqual({ type: 'string', enum: [...ESTIMATE_CATEGORIES] })
+    expect(confidence).toEqual({ type: 'string', enum: [...CONFIDENCE_LEVELS] })
+  })
+
+  it('constrains secondChoice to the category scale plus null', () => {
+    expect(RESPONSE_FORMAT.json_schema.schema.properties.secondChoice).toEqual({
+      type: ['string', 'null'],
+      enum: [...ESTIMATE_CATEGORIES, null],
+    })
   })
 })

--- a/scripts/estimate/src/lib/inference.ts
+++ b/scripts/estimate/src/lib/inference.ts
@@ -1,4 +1,8 @@
+import { RESPONSE_FORMAT } from './validateEstimate.ts'
+
 // Inference tuning constants, overridable via ESTIMATE_* env vars for experimentation.
+// The model must support Structured Outputs (strict json_schema response_format); one that does not
+// fails the request outright rather than degrading to unvalidated output.
 const MODEL = process.env.ESTIMATE_MODEL ?? 'gpt-5.6-terra'
 // Number of independent samples to draw per estimate for self-consistency voting. Sent as the
 // Chat Completions `n` parameter, which bills input once and only multiplies the (tiny) output —
@@ -25,8 +29,11 @@ interface CallOptions {
 
 /**
  * Calls the OpenAI chat completions API, drawing `votes` independent samples in a single request
- * via the `n` parameter. Returns the raw string content of every choice (including any malformed
- * ones) for downstream tallying/validation — aggregation and vote-counting live in tallyVotes.
+ * via the `n` parameter. Every sample is constrained to the response schema by Structured Outputs
+ * (see RESPONSE_FORMAT), so a conforming reply cannot be malformed or name an invalid category.
+ * Returns the raw string content of every choice — including a refusal or truncated reply, which
+ * arrives as unparseable content — for downstream tallying; aggregation and vote-counting live in
+ * tallyVotes.
  */
 const inference = async ({ apiKey, prompt, instructions, votes = VOTES }: CallOptions): Promise<string[]> => {
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -44,7 +51,7 @@ const inference = async ({ apiKey, prompt, instructions, votes = VOTES }: CallOp
         { role: 'system', content: instructions },
         { role: 'user', content: prompt },
       ],
-      response_format: { type: 'json_object' },
+      response_format: RESPONSE_FORMAT,
     }),
   })
 

--- a/scripts/estimate/src/lib/tallyVotes.ts
+++ b/scripts/estimate/src/lib/tallyVotes.ts
@@ -64,7 +64,9 @@ const tallyVotes = (rawOutputs: string[]): VoteResult => {
     totalVotes: rawOutputs.length,
     confidence: winning.confidence,
     rationale: winning.rationale,
-    secondChoice: winning.secondChoice,
+    // The strict response schema requires every property, so a vote with no second choice carries
+    // an explicit null; normalize it to undefined for the optional field downstream.
+    secondChoice: winning.secondChoice ?? undefined,
   }
 }
 

--- a/scripts/estimate/src/lib/validateEstimate.ts
+++ b/scripts/estimate/src/lib/validateEstimate.ts
@@ -1,25 +1,74 @@
 import { z } from 'zod'
+import { ESTIMATE_CATEGORIES } from '../everhour/estimates.ts'
 
-/** Valid estimate categories. */
-export const EstimateCategorySchema = z.enum(['XXS', 'XS', 'S', 'M', 'L', 'XL', 'XXL'])
+/** Valid estimate categories, derived from the canonical scale so the two lists cannot drift apart. */
+export const EstimateCategorySchema = z.enum(ESTIMATE_CATEGORIES)
 
-/** Self-reported confidence level accompanying an estimate. */
-export const ConfidenceSchema = z.enum(['high', 'medium', 'low'])
+/** Self-reported confidence levels accompanying an estimate. */
+export const CONFIDENCE_LEVELS = ['high', 'medium', 'low'] as const
+
+/** Schema for the self-reported confidence accompanying an estimate. */
+export const ConfidenceSchema = z.enum(CONFIDENCE_LEVELS)
 
 /**
- * Schema for the model response. `estimate` is required; the richer fields are optional and
- * defaulted so a minimal `{ "estimate": "M" }` still validates (resilience against a model that
- * omits them). `rationale` is requested first in the prompt so the model reasons before committing
- * to a bucket, but it is not required for a response to be usable.
+ * Schema for the model response.
+ *
+ * The request constrains the model with the strict JSON schema in RESPONSE_FORMAT below, so a
+ * conforming reply always carries every field with a valid value and this schema accepts it as a
+ * strict subset. The leniencies here are the backstop for the replies the guarantee does not cover
+ * — a reply truncated at the token limit parses as no JSON at all, and a model that does not
+ * support structured outputs fails the request rather than degrading — and they are deliberate: a
+ * minimal `{ "estimate": "M" }` still validates, so the wire contract can weaken without votes
+ * being thrown away for omissions that have a safe reading. `rationale` is requested first in the
+ * prompt so the model reasons before committing to a bucket, but it is not required for a response
+ * to be usable.
+ * `secondChoice` accepts null as well as absence, because the strict schema requires every property
+ * and null is the only way a conforming reply can decline to give one.
  */
 export const EstimateResponseSchema = z.object({
   rationale: z.string().default(''),
   estimate: EstimateCategorySchema,
   confidence: ConfidenceSchema.default('medium'),
-  secondChoice: EstimateCategorySchema.optional(),
+  secondChoice: EstimateCategorySchema.nullish(),
 })
 
 export type EstimateResponse = z.infer<typeof EstimateResponseSchema>
+
+/**
+ * The response properties offered to the model, declared separately so `required` can be derived:
+ * strict mode rejects a schema whose required list does not name every property, and deriving the
+ * list makes that rejection unrepresentable rather than a runtime error waiting on the next added
+ * field. Property order is meaningful: a strict schema emits keys in the order declared here, which
+ * is what keeps `rationale` first so the model reasons before committing to a bucket.
+ */
+const properties = {
+  rationale: { type: 'string' },
+  estimate: { type: 'string', enum: [...ESTIMATE_CATEGORIES] },
+  confidence: { type: 'string', enum: [...CONFIDENCE_LEVELS] },
+  secondChoice: { type: ['string', 'null'], enum: [...ESTIMATE_CATEGORIES, null] },
+}
+
+/**
+ * The Chat Completions `response_format` that constrains every sample to the response schema
+ * (OpenAI Structured Outputs, `strict: true`). The JSON-object shape the prompt already requests
+ * becomes something the model cannot disobey, so a vote can no longer be lost to a hallucinated
+ * category or a missing field. Behind it, the lenient parsing in parseEstimate remains as the
+ * backstop rather than as the front line. A constant rather than built per run, unlike the issue
+ * classifier's buildResponseFormat, because the category scale is fixed — nothing in the schema
+ * varies between requests.
+ *
+ * Strict mode requires every property to be listed in `required`, so "no second choice" is
+ * expressed as a nullable type — null in the enum plus a `["string", "null"]` type — never as an
+ * absent field.
+ */
+export const RESPONSE_FORMAT = {
+  type: 'json_schema' as const,
+  json_schema: {
+    name: 'issue_estimate',
+    strict: true,
+    schema: { type: 'object', properties, required: Object.keys(properties), additionalProperties: false },
+  },
+}
 
 const MAX_VALIDATION_ATTEMPTS = 3
 


### PR DESCRIPTION
Follow-up to #5142.

Migrates the estimate script's inference call from `response_format: { type: 'json_object' }` to a strict JSON schema (OpenAI Structured Outputs), the same way #5142 migrated the sibling issue-classifier. A conforming vote now always carries every field, in reason-before-answer order, and can only name a category on the XXS–XXL scale — the shape the prompt requests is enforced rather than requested. The lenient zod parsing remains as the backstop for replies the guarantee does not cover, such as one truncated at the token limit.

## Architectural plan

Produced and critiqued per the `plan` skill before implementation.

**Existing surface area.** The call site was `scripts/estimate/src/lib/inference.ts` (`response_format: { type: 'json_object' }`); both entry points into inference — `estimateIssue.ts` and `evaluate.ts` — call this one module, so a single edit covers production and the eval harness (unlike the classifier, whose `compare.ts` carries its own copy of the request body). The parse site is `validateEstimate.ts` (`EstimateResponseSchema`: `rationale` defaulted, `estimate` required, `confidence` defaulted, `secondChoice` optional — declaration order matches the prompt's requested field order in `buildPrompt.ts`). The canonical category list already existed as `ESTIMATE_CATEGORIES` in `everhour/estimates.ts`; the zod enum duplicated it inline. `docs/agents/readme.md` describes the script only at workflow level, so no `docs/**` file is invalidated.

**Build vs. extend.** Extend — no new files. The response format lives in `validateEstimate.ts` beside the zod schema, where the shape the model is offered and the shape a vote is checked against cannot drift apart. One deliberate divergence from the classifier: its `buildResponseFormat(milestoneTitles)` is a function because the milestone enum is fetched per run; the estimate's scale is fixed, so `RESPONSE_FORMAT` is a constant built with the same derived-`required` construction (`required: Object.keys(properties)`, `additionalProperties: false`, `strict: true`, nullability as `type: ['string','null']` plus `null` in the enum). `EstimateCategorySchema` now derives from `ESTIMATE_CATEGORIES`, and a new `CONFIDENCE_LEVELS` const feeds both `ConfidenceSchema` and the JSON schema, collapsing the duplicated lists.

**Adjacent behaviour.** Strict mode requires every property, so "no second choice" becomes an explicit `null`: the instructions file now says so (previously "Optional", which strict mode makes unexpressible as omission), the zod schema accepts it (`.nullish()` replacing `.optional()`), and `tallyVotes` normalizes it back to `undefined` — every downstream type (`VoteResult`, `Estimate`, the audit comments) is untouched. `validateEstimate` (the throwing path) is test-only today and merely widens. The prompt-version hash moves because `estimate.instructions.md` changed, which is the designed audit mechanism. A model without Structured Outputs support now fails the request loudly instead of degrading — documented in the README and `.env.example`, matching #5142.

**Approaches considered.** (a) static constant mirroring the classifier's hand-written schema — chosen; (b) zero-arg `buildResponseFormat()` for name symmetry — rejected as ceremony implying runtime variation that doesn't exist; (c) deriving the JSON schema from zod via `z.toJSONSchema` — rejected because strict mode's exact nullable/enum encoding and key order aren't under our control there, and the sibling deliberately hand-writes the schema with tests pinning it to the zod shape.

## Tests

New unit tests mirror the classifier's: `RESPONSE_FORMAT` property order equals the zod shape order, `required` lists every property with `additionalProperties: false`, the strict `json_schema` declaration and API name pattern, and the enum contents for `estimate`/`confidence`/`secondChoice`. Parse-level: an explicit `null` `secondChoice` validates; tally-level: it normalizes to `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
