### PR TITLE
Fix toolbar scrolling for keyboard-opened Color Picker

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -100,7 +100,7 @@ const ColorPicker: FC<{ size?: number }> = ({ size }) => {
   const showColorPicker = useSelector(state => state.showColorPicker)
 
   return (
-    <Popover show={showColorPicker} size={size}>
+    <Popover ariaLabel='Color Picker' show={showColorPicker} size={size}>
       {/* Text Color */}
       <div aria-label='text color swatches' className={css({ whiteSpace: 'nowrap' })}>
         <ColorSwatch color='fg' label='default' />

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -7,13 +7,14 @@ import FadeTransition from './FadeTransition'
 import TriangleDown from './TriangleDown'
 
 interface PopoverProps {
+  ariaLabel?: string
   children: React.ReactNode
   show?: boolean
   size?: number
 }
 
 /** A reusable popover component that handles positioning and styling for popup menus. */
-const Popover: FC<PopoverProps> = ({ children, show, size = 18 }) => {
+const Popover: FC<PopoverProps> = ({ ariaLabel, children, show, size = 18 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const fontSize = useSelector(state => state.fontSize)
   const overflow = useWindowOverflow(ref)
@@ -38,6 +39,7 @@ const Popover: FC<PopoverProps> = ({ children, show, size = 18 }) => {
         }}
       >
         <div
+          aria-label={ariaLabel}
           className={css({
             backgroundColor: 'pickerBg',
             borderRadius: '3',

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -102,6 +102,7 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
   const distractionFreeTyping = distractionFreeTypingStore.useState()
   const fontSize = useSelector(state => state.fontSize)
   const arrowWidth = fontSize / 3
+  const showColorPicker = useSelector(state => state.showColorPicker)
   const showDropdown = useSelector(state => state.showColorPicker || state.showLetterCase)
   const positionFixedStyles = usePositionFixed()
 
@@ -172,6 +173,17 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
       window.removeEventListener('resize', updateArrows)
     }
   }, [updateArrows])
+
+  // A keyboard shortcut can open the Color Picker while its toolbar button is outside the scroll viewport.
+  // Center the button after the picker renders so that the picker is fully visible, including when the toolbar
+  // remounts after distraction-free typing.
+  useEffect(() => {
+    if (customize || !showColorPicker) return
+
+    toolbarRef.current
+      ?.querySelector<HTMLElement>('[data-command-id="textColor"]')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+  }, [customize, showColorPicker])
 
   // disable pressing on drag
   useEffect(() => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -174,15 +174,25 @@ const Toolbar: FC<ToolbarProps> = ({ customize, onSelect, selected }) => {
     }
   }, [updateArrows])
 
-  // A keyboard shortcut can open the Color Picker while its toolbar button is outside the scroll viewport.
-  // Center the button after the picker renders so that the picker is fully visible, including when the toolbar
-  // remounts after distraction-free typing.
+  // A keyboard shortcut can open the Color Picker outside the toolbar viewport. Scroll only by the clipped
+  // distance after the picker renders, including when the toolbar remounts after distraction-free typing.
   useEffect(() => {
     if (customize || !showColorPicker) return
 
-    toolbarRef.current
-      ?.querySelector<HTMLElement>('[data-command-id="textColor"]')
-      ?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+    const toolbar = toolbarRef.current
+    const colorPicker = toolbar?.querySelector<HTMLElement>('[aria-label="Color Picker"]')
+    if (!toolbar || !colorPicker) return
+
+    const toolbarRect = toolbar.getBoundingClientRect()
+    const colorPickerRect = colorPicker.getBoundingClientRect()
+    const scrollOffset =
+      colorPickerRect.left < toolbarRect.left
+        ? colorPickerRect.left - toolbarRect.left
+        : colorPickerRect.right > toolbarRect.right
+          ? colorPickerRect.right - toolbarRect.right
+          : 0
+
+    if (scrollOffset !== 0) toolbar.scrollBy({ behavior: 'smooth', left: scrollOffset })
   }, [customize, showColorPicker])
 
   // disable pressing on drag

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -233,6 +233,7 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
     <div
       {...longPress.props}
       aria-label={command.label}
+      data-command-id={commandId}
       data-testid='toolbar-icon'
       data-active={isButtonActive}
       ref={dndRef(node => dragSource(dropTarget(node)))}

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -233,7 +233,6 @@ const ToolbarButton: FC<ToolbarButtonProps> = ({
     <div
       {...longPress.props}
       aria-label={command.label}
-      data-command-id={commandId}
       data-testid='toolbar-icon'
       data-active={isButtonActive}
       ref={dndRef(node => dragSource(dropTarget(node)))}

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -16,6 +16,7 @@ import press from '../helpers/press'
 import setSelection from '../helpers/setSelection'
 import waitForCursor from '../helpers/waitForCursor'
 import waitForEditable from '../helpers/waitForEditable'
+import waitForSelector from '../helpers/waitForSelector'
 import { page } from '../session'
 
 /** Click the first note. Assumes that there will be only a single note. */
@@ -69,6 +70,44 @@ const codeBackgroundColor = () =>
   })
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
+
+// https://github.com/cybersemics/em/issues/4604
+it('scrolls the entire Color Picker into view when opened with the keyboard shortcut', async () => {
+  await page.setViewport({ width: 640, height: 812 })
+  await paste('- One')
+  await clickThought('One')
+
+  const textColorIsOutsideToolbar = await page.evaluate(() => {
+    const toolbar = document.querySelector('[data-testid="toolbar"]')
+    const textColor = document.querySelector('[data-testid="toolbar-icon"][aria-label="Text Color"]')
+    if (!toolbar || !textColor) throw new Error('Toolbar or Text Color button not found.')
+
+    return textColor.getBoundingClientRect().right > toolbar.getBoundingClientRect().right
+  })
+  expect(textColorIsOutsideToolbar).toBe(true)
+
+  await press('h', { meta: true, shift: true })
+  await waitForSelector('[aria-label="text color swatches"]')
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const toolbar = document.querySelector('[data-testid="toolbar"]')
+        const swatchGroups = document.querySelectorAll(
+          '[aria-label="text color swatches"], [aria-label="background color swatches"]',
+        )
+        if (!toolbar || swatchGroups.length !== 2) throw new Error('Toolbar or Color Picker swatches not found.')
+
+        const toolbarRect = toolbar.getBoundingClientRect()
+        const swatchGroupRects = Array.from(swatchGroups).map(group => group.getBoundingClientRect())
+        return {
+          leftEdgeVisible: swatchGroupRects.every(groupRect => groupRect.left >= toolbarRect.left),
+          rightEdgeVisible: swatchGroupRects.every(groupRect => groupRect.right <= toolbarRect.right),
+        }
+      }),
+    )
+    .toEqual({ leftEdgeVisible: true, rightEdgeVisible: true })
+})
 
 it('Set the text color of the text and bullet', async () => {
   const importText = `

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -57,7 +57,6 @@ const setNoteCaret = (offset: number) =>
 /** Waits one frame for selectionchange-driven command state to propagate. */
 const nextFrame = () => page.evaluate(() => new Promise(requestAnimationFrame))
 
-<<<<<<< Updated upstream
 /** Returns the background that actually paints behind the code text of the thought being edited, i.e. the nearest
  * self-or-ancestor of the code element that is not transparent. */
 const codeBackgroundColor = () =>
@@ -70,24 +69,28 @@ const codeBackgroundColor = () =>
         return backgroundColor
     }
     return null
-=======
+  })
+
 /** Returns the horizontal geometry needed to verify Color Picker toolbar scrolling. */
 const getColorPickerGeometry = () =>
   page.evaluate(() => {
     const toolbar = document.querySelector('[data-testid="toolbar"]')
-    const colorPicker = document.querySelector('[aria-label="Color Picker"]')
-    if (!toolbar || !colorPicker) throw new Error('Toolbar or Color Picker not found.')
+    const swatchGroups = document.querySelectorAll(
+      '[aria-label="text color swatches"], [aria-label="background color swatches"]',
+    )
+    if (!toolbar || swatchGroups.length !== 2) throw new Error('Toolbar or Color Picker swatches not found.')
 
     const toolbarRect = toolbar.getBoundingClientRect()
-    const colorPickerRect = colorPicker.getBoundingClientRect()
+    const swatchGroupRects = Array.from(swatchGroups).map(group => group.getBoundingClientRect())
+    const fontSize = parseFloat(window.getComputedStyle(swatchGroups[0]).fontSize)
     return {
-      colorPickerLeft: colorPickerRect.left,
-      colorPickerRight: colorPickerRect.right,
+      colorPickerLeft: Math.min(...swatchGroupRects.map(rect => rect.left)),
+      colorPickerRight: Math.max(...swatchGroupRects.map(rect => rect.right)),
+      edgeTolerance: fontSize / 2,
       scrollLeft: toolbar.scrollLeft,
       toolbarLeft: toolbarRect.left,
       toolbarRight: toolbarRect.right,
     }
->>>>>>> Stashed changes
   })
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
@@ -109,7 +112,7 @@ it('scrolls the Color Picker only as far as needed when opened with the keyboard
   )
 
   await press('h', { meta: true, shift: true })
-  await waitForSelector('[aria-label="Color Picker"]')
+  await waitForSelector('[aria-label="text color swatches"]')
   await nextFrame()
   await nextFrame()
 
@@ -120,7 +123,7 @@ it('scrolls the Color Picker only as far as needed when opened with the keyboard
 
   await press('h', { meta: true, shift: true })
   await expect
-    .poll(() => page.evaluate(() => document.querySelector('[aria-label="Color Picker"]') === null))
+    .poll(() => page.evaluate(() => document.querySelector('[aria-label="text color swatches"]') === null))
     .toBe(true)
   await scrollBy('[data-testid="toolbar"]', -10000, 0)
 
@@ -134,14 +137,14 @@ it('scrolls the Color Picker only as far as needed when opened with the keyboard
   expect(textColorIsOutsideToolbar).toBe(true)
 
   await press('h', { meta: true, shift: true })
-  await waitForSelector('[aria-label="Color Picker"]')
+  await waitForSelector('[aria-label="text color swatches"]')
 
   await expect
     .poll(async () => {
       const geometry = await getColorPickerGeometry()
       return {
         leftEdgeVisible: geometry.colorPickerLeft >= geometry.toolbarLeft,
-        rightEdgeAligned: Math.abs(geometry.colorPickerRight - geometry.toolbarRight) < 1,
+        rightEdgeAligned: Math.abs(geometry.colorPickerRight - geometry.toolbarRight) < geometry.edgeTolerance,
         rightEdgeVisible: geometry.colorPickerRight <= geometry.toolbarRight,
       }
     })

--- a/src/e2e/puppeteer/__tests__/color.ts
+++ b/src/e2e/puppeteer/__tests__/color.ts
@@ -13,6 +13,8 @@ import keyboard from '../helpers/keyboard'
 import multiselectThoughts from '../helpers/multiselectThoughts'
 import paste from '../helpers/paste'
 import press from '../helpers/press'
+import scrollBy from '../helpers/scrollBy'
+import scrollIntoView from '../helpers/scrollIntoView'
 import setSelection from '../helpers/setSelection'
 import waitForCursor from '../helpers/waitForCursor'
 import waitForEditable from '../helpers/waitForEditable'
@@ -55,6 +57,7 @@ const setNoteCaret = (offset: number) =>
 /** Waits one frame for selectionchange-driven command state to propagate. */
 const nextFrame = () => page.evaluate(() => new Promise(requestAnimationFrame))
 
+<<<<<<< Updated upstream
 /** Returns the background that actually paints behind the code text of the thought being edited, i.e. the nearest
  * self-or-ancestor of the code element that is not transparent. */
 const codeBackgroundColor = () =>
@@ -67,15 +70,59 @@ const codeBackgroundColor = () =>
         return backgroundColor
     }
     return null
+=======
+/** Returns the horizontal geometry needed to verify Color Picker toolbar scrolling. */
+const getColorPickerGeometry = () =>
+  page.evaluate(() => {
+    const toolbar = document.querySelector('[data-testid="toolbar"]')
+    const colorPicker = document.querySelector('[aria-label="Color Picker"]')
+    if (!toolbar || !colorPicker) throw new Error('Toolbar or Color Picker not found.')
+
+    const toolbarRect = toolbar.getBoundingClientRect()
+    const colorPickerRect = colorPicker.getBoundingClientRect()
+    return {
+      colorPickerLeft: colorPickerRect.left,
+      colorPickerRight: colorPickerRect.right,
+      scrollLeft: toolbar.scrollLeft,
+      toolbarLeft: toolbarRect.left,
+      toolbarRight: toolbarRect.right,
+    }
+>>>>>>> Stashed changes
   })
 
 vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 })
 
 // https://github.com/cybersemics/em/issues/4604
-it('scrolls the entire Color Picker into view when opened with the keyboard shortcut', async () => {
+it('scrolls the Color Picker only as far as needed when opened with the keyboard shortcut', async () => {
   await page.setViewport({ width: 640, height: 812 })
   await paste('- One')
   await clickThought('One')
+
+  await scrollIntoView('[data-testid="toolbar-icon"][aria-label="Text Color"]', {
+    block: 'nearest',
+    inline: 'center',
+  })
+  await scrollBy('[data-testid="toolbar"]', 20, 0)
+  const scrollLeftBeforeOpeningVisiblePicker = await page.$eval(
+    '[data-testid="toolbar"]',
+    toolbar => toolbar.scrollLeft,
+  )
+
+  await press('h', { meta: true, shift: true })
+  await waitForSelector('[aria-label="Color Picker"]')
+  await nextFrame()
+  await nextFrame()
+
+  const visiblePickerGeometry = await getColorPickerGeometry()
+  expect(visiblePickerGeometry.colorPickerLeft).toBeGreaterThanOrEqual(visiblePickerGeometry.toolbarLeft)
+  expect(visiblePickerGeometry.colorPickerRight).toBeLessThanOrEqual(visiblePickerGeometry.toolbarRight)
+  expect(visiblePickerGeometry.scrollLeft).toBe(scrollLeftBeforeOpeningVisiblePicker)
+
+  await press('h', { meta: true, shift: true })
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector('[aria-label="Color Picker"]') === null))
+    .toBe(true)
+  await scrollBy('[data-testid="toolbar"]', -10000, 0)
 
   const textColorIsOutsideToolbar = await page.evaluate(() => {
     const toolbar = document.querySelector('[data-testid="toolbar"]')
@@ -87,26 +134,22 @@ it('scrolls the entire Color Picker into view when opened with the keyboard shor
   expect(textColorIsOutsideToolbar).toBe(true)
 
   await press('h', { meta: true, shift: true })
-  await waitForSelector('[aria-label="text color swatches"]')
+  await waitForSelector('[aria-label="Color Picker"]')
 
   await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const toolbar = document.querySelector('[data-testid="toolbar"]')
-        const swatchGroups = document.querySelectorAll(
-          '[aria-label="text color swatches"], [aria-label="background color swatches"]',
-        )
-        if (!toolbar || swatchGroups.length !== 2) throw new Error('Toolbar or Color Picker swatches not found.')
-
-        const toolbarRect = toolbar.getBoundingClientRect()
-        const swatchGroupRects = Array.from(swatchGroups).map(group => group.getBoundingClientRect())
-        return {
-          leftEdgeVisible: swatchGroupRects.every(groupRect => groupRect.left >= toolbarRect.left),
-          rightEdgeVisible: swatchGroupRects.every(groupRect => groupRect.right <= toolbarRect.right),
-        }
-      }),
-    )
-    .toEqual({ leftEdgeVisible: true, rightEdgeVisible: true })
+    .poll(async () => {
+      const geometry = await getColorPickerGeometry()
+      return {
+        leftEdgeVisible: geometry.colorPickerLeft >= geometry.toolbarLeft,
+        rightEdgeAligned: Math.abs(geometry.colorPickerRight - geometry.toolbarRight) < 1,
+        rightEdgeVisible: geometry.colorPickerRight <= geometry.toolbarRight,
+      }
+    })
+    .toEqual({
+      leftEdgeVisible: true,
+      rightEdgeAligned: true,
+      rightEdgeVisible: true,
+    })
 })
 
 it('Set the text color of the text and bullet', async () => {


### PR DESCRIPTION
#4604

## Summary

Ensure the toolbar scrolls the Color Picker fully into view when activated with the keyboard shortcut, without unnecessary or excessive movement.

## Implementation

- Measure the rendered Color Picker against the toolbar viewport.
- Leave the toolbar unchanged when the picker is already fully visible.
- Smoothly scroll only by the clipped distance when the picker extends beyond either toolbar edge.
- Preserve customized-toolbar and distraction-free typing behavior.
- Extend Puppeteer coverage for both zero-movement and minimum-distance scrolling.