### PR TITLE
Name rolling desktop release assets without the version so version bumps cannot strand stale builds

### DIFF
--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -3,6 +3,10 @@ name: Tauri Release (main)
 # Publishes a rolling development build of the em desktop app on every push to main.
 # All artifacts are attached to a single, continuously-updated prerelease (tag
 # `pre`), so releases do not accumulate — each push overwrites the assets.
+# Assets are named without the app version (em_main_aarch64.dmg, …) because uploads
+# only replace same-named assets: versioned names change on every version bump,
+# which would strand the previous version's assets on the release indefinitely.
+# Version-free names also give the rolling channel permanent download URLs.
 
 on:
   push:
@@ -153,6 +157,7 @@ jobs:
             > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
           prerelease: true
           releaseDraft: false
+          releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'
           args: ${{ matrix.args }}
 
       - name: Build and publish desktop app (Developer ID + notarization)
@@ -180,4 +185,5 @@ jobs:
             > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
           prerelease: true
           releaseDraft: false
+          releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Problem

The `em desktop (main)` prerelease showed week-old dmgs. tauri-action only replaces same-named assets on the rolling `pre` release, and asset filenames embed the desktop version — so when the version bumped from 1.1.0 to 1.2.0 (351.1.0 → 351.2.0, bcbf88db14), uploads switched to `em_1.2.0_*` names and the `em_1.1.0_*` assets were stranded, frozen at their Aug 20 timestamps. Every version bump strands the previous version's assets this way.

## Fix

Set `releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'` on both tauri-action steps, producing version-free names (`em_main_aarch64.dmg`, `em_main_x64-setup.exe`, …). Every push now replaces all assets in place regardless of version bumps, and the rolling channel gets permanent download URLs. The app itself still reports its real version; the release body carries the commit and run number.

The stale `em_1.1.0_*` assets have already been deleted from the release.

## Post-merge follow-up

The current `em_1.2.0_*` assets are the last version-named uploads. Once the first `em_main_*` build lands after merge, delete them (one-time):

```
for a in $(gh release view pre --json assets --jq '.assets[].name' | grep '1\.2\.0'); do gh release delete-asset pre "$a" --yes; done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)