### PR TITLE
Re-point the pre tag at each built commit so the rolling release header stays current

### DIFF
--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -187,3 +187,22 @@ jobs:
           releaseDraft: false
           releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'
           args: ${{ matrix.args }}
+
+  # Keep the `pre` tag pointing at the commit that was just built, so the release
+  # page's commit chip and the auto-generated source archives match the published
+  # assets. tauri-action only sets the tag target when it first creates the tag and
+  # never moves an existing one (its releaseCommitish input is "unused if the Git
+  # tag already exists"), so without this the tag would sit at its creation commit
+  # forever. Runs only after all platforms publish, so the tag never points at a
+  # commit whose asset set is incomplete. GITHUB_TOKEN pushes do not trigger other
+  # workflows, and the prod release workflow only matches `v*` tags in any case.
+  retag:
+    name: Point pre tag at built commit
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Force-move pre tag to the built commit
+        run: git push --force origin "$GITHUB_SHA:refs/tags/pre"


### PR DESCRIPTION
## Problem

Follow-up to #5168. The `em desktop (main)` release page still shows a stale commit in its header chip (`pre ⊸ 81d55e2`, from July 15): that chip displays the `pre` tag's target commit, and tauri-action only sets the tag target when it first creates the tag — its `releaseCommitish` input is documented as "unused if the Git tag already exists". So while the release body and assets refresh on every push, the tag (and the auto-generated Source code archives derived from it) has pointed at the tag's creation commit forever.

## Fix

Add a `retag` job that runs after all four platform builds publish and force-moves `refs/tags/pre` to the commit that was just built. Gating on the full build matrix means the tag never advances to a commit whose asset set is incomplete.

Safety: pushes made with `GITHUB_TOKEN` do not trigger other workflows, and the only tag-triggered workflow (`tauri-release-prod.yml`) matches `v*` tags only, so moving `pre` cannot start a prod release.

Merging this is self-healing: the merge commit's own run will re-point the tag, clearing the current stale `81d55e2` with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)