### PR TITLE
Never merge a generated thought with contiguous edits in the undo history

### DIFF
--- a/src/actions/editThought.ts
+++ b/src/actions/editThought.ts
@@ -41,6 +41,8 @@ export interface editThoughtPayload {
   oldValue: string
   newValue: string
   path: SimplePath
+  /** Isolate the edit in the undo history: it never merges with a contiguous edit on either side, so it is always its own undo step. Set on programmatic edits such as a generated thought, which are not part of the user's typing stream. */
+  preventMerge?: boolean
 }
 
 /** Changes the text of an existing thought. */

--- a/src/commands/__tests__/generateThought.ts
+++ b/src/commands/__tests__/generateThought.ts
@@ -397,6 +397,105 @@ test('preserve an edit made while the thought is generating as its own undo step
   vi.unstubAllEnvs()
 })
 
+// Unlike the deletion above, an addition matches the generation's own direction (Longer), so without explicit
+// isolation the contiguous-edit rule would merge the generation into the user's edit.
+test('preserve an addition made while the thought is generating as its own undo step', async () => {
+  vi.stubEnv('VITE_AI_URL', 'http://test-ai-url')
+  acknowledgeAiDisclosure()
+
+  /** Resolves the pending AI request. Assigned when the mocked fetch is called, so the test controls exactly when the generation completes. */
+  let resolveAiRequest: (response: { json: () => Promise<{ content: string; err: null }> }) => void = () => {}
+  mockFetch.mockImplementationOnce(
+    () =>
+      new Promise(resolve => {
+        resolveAiRequest = resolve
+      }),
+  )
+
+  await dispatch([
+    importText({
+      text: `
+        - a
+        - b
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  await act(async () => {
+    executeCommand(generateThought)
+  })
+
+  // Precondition: the request is in flight and the cursor thought shows the pending value.
+  expect(mockFetch).toHaveBeenCalledTimes(1)
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a...
+  - b`)
+
+  // The user adds characters to another thought while the generation is still pending.
+  await dispatch(editThought(['b'], 'bee'))
+
+  await act(async () => {
+    resolveAiRequest({ json: () => Promise.resolve({ content: 'generated', err: null }) })
+  })
+
+  // Precondition: the generation was applied after the interleaved edit.
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a generated
+  - bee`)
+
+  await dispatch(undo())
+
+  // Undo reverts only the generation. The interleaved edit is a separate undo step and must survive.
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a
+  - bee`)
+
+  vi.unstubAllEnvs()
+})
+
+// The generation is likewise isolated on the other side: an edit made after it completes never merges into its
+// undo step, so the first undo reverts only that edit.
+test('preserve the generated value when an edit made after generation is undone', async () => {
+  vi.stubEnv('VITE_AI_URL', 'http://test-ai-url')
+  acknowledgeAiDisclosure()
+
+  mockFetch.mockResolvedValueOnce({
+    json: () => Promise.resolve({ content: 'generated', err: null }),
+  })
+
+  await dispatch([
+    importText({
+      text: `
+        - a
+        - b
+      `,
+    }),
+    setCursor(['a']),
+  ])
+
+  await act(async () => {
+    executeCommand(generateThought)
+  })
+
+  // The user adds characters to another thought after the generation has completed.
+  await dispatch(editThought(['b'], 'bee'))
+
+  // Precondition: both the generation and the edit were applied.
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a generated
+  - bee`)
+
+  await dispatch(undo())
+
+  // Undo reverts only the edit that followed the generation.
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}
+  - a generated
+  - b`)
+
+  vi.unstubAllEnvs()
+})
+
 test('continues the current request after always allowing AI', async () => {
   const text = `
       -${' '}

--- a/src/commands/generateThought.ts
+++ b/src/commands/generateThought.ts
@@ -193,6 +193,9 @@ const generateThoughtAtPathActionCreator =
         oldValue: thought.value,
         newValue: valueNew,
         path: simplePath,
+        // The generation completes whenever the request returns, not as part of a typing stream, so it must never
+        // merge with a user edit that happens to be contiguous in the same direction.
+        preventMerge: true,
       }),
     ])
 

--- a/src/redux-enhancers/undoRedoEnhancer.ts
+++ b/src/redux-enhancers/undoRedoEnhancer.ts
@@ -70,9 +70,11 @@ function getNoteOffsetBeforeEdit(action: UnknownAction): number | null {
 /** Compare the text contents of the old and new values to determine the direction of the edit.
  * Returns None if the action is not an editThought action or if the text content length is the same.
  * Formatting edits (bold, italic, color) and case changes (HELLO → hello) preserve text length and return None.
+ * Edits marked preventMerge likewise return None, so a programmatic edit such as a generated thought is never
+ * merged with the user's typing stream on either side.
  */
 function getEditThoughtDirection(action: UnknownAction): EditThoughtDirection {
-  if (!isEditThoughtAction(action)) return EditThoughtDirection.None
+  if (!isEditThoughtAction(action) || action.preventMerge) return EditThoughtDirection.None
 
   const oldText = getTextContent(action.oldValue)
   const newText = getTextContent(action.newValue)
@@ -470,7 +472,7 @@ const undoRedoReducerEnhancer: StoreEnhancer<any> =
 
       // Some actions are merged together into a single undo/redo patch.
       // - Navigation actions are merged with the previous non-navigation action. This matches the behavior of most word processors where undo will revert the last destructive action, and the cursor will be restored to where it was before. For example, if the user edits 'a' to 'aa', moves the cursor to 'b', and then undoes, the cursor will be restored to 'aa' then the edit will be undone.
-      // - Contiguous edits in the same direction are merged into a single edit action. For example, if the user edits 'a' to 'ab' and then 'ab' to 'abc', the undo will revert to 'a' in one step. Formatting edits (None direction) are never merged with any other edits — each formatting change (bold, italic, color) gets its own separate undo step.
+      // - Contiguous edits in the same direction are merged into a single edit action. For example, if the user edits 'a' to 'ab' and then 'ab' to 'abc', the undo will revert to 'a' in one step. Formatting edits (None direction) are never merged with any other edits — each formatting change (bold, italic, color) gets its own separate undo step. Edits marked preventMerge (e.g. a generated thought) are likewise never merged on either side.
       // - The closeAlert action is merged with the previous action so that the alert can be undone.
       // - All actions during the execution of a multicursor command will be merged together. The prevous action will always be setIsMulticursorExecuting.
       // - Chained commands will be merged into the previous command, e.g. Select All + Categorize


### PR DESCRIPTION
A generated value completes whenever its request returns, not as part of the user's typing stream, yet the contiguous-edit rule merged it with a user edit in the same direction. A single undo then reverted both the generation and the user's edit. Follow-up to #5185, which covered the opposite-direction case that already behaved correctly.

Adds a `preventMerge` flag to `editThoughtPayload` that makes `getEditThoughtDirection` return `None`, isolating the edit on both sides exactly like a formatting edit, and sets it on the generation's final `editThought`.

## Plan

**Existing surface area.** Direction-based merging lives only in `undoRedoEnhancer.ts`: `getEditThoughtDirection` (Longer/Shorter/None from text length) and `shouldMergeWithLastEditThought` (merges contiguous same-direction edits). `None` already isolates an edit on both sides — it cannot merge into the previous edit, and `lastEditThoughtDirection = None` prevents the next edit from merging into it — which is how formatting edits get their own undo step. No selector mirrors the direction logic (merging happens at patch creation, before `undoSteps` grouping). `editThoughtPayload` already carries per-dispatch behavior flags (`force`, `noteOffset`), and the action creator spreads the payload onto the action, so a new flag reaches the enhancer through the existing `isEditThoughtAction` guard.

**Build vs. extend.** Extend: one payload field, one condition in `getEditThoughtDirection`, one flag at the dispatch site. No new files or mechanisms.

**Adjacent behaviour.**
- Multicursor generation still reverts in one undo step: that grouping is via `isMulticursorExecuting`, which ignores direction (covered by the existing `reverts every generated thought on a single undo` test).
- The typing stream, note-caret restore, redo, and undo-step grouping are unchanged — only which patch the generation edit lands in changes.
- An edit made *after* generation was already incidentally isolated by the trailing `setCursor` patch resetting the direction tracker; a test now pins that behavior independently of the incidental reset.
- Out of scope: an edit typed during a *multicursor* generation window still merges via the open `isMulticursorExecuting` bracket — that is the transaction-design question raised on #5165, not a direction problem.

**Approaches considered.** (1) `preventMerge` payload flag — chosen: smallest change, explicit at the dispatch site, exact reuse of the formatting-edit semantics. (2) Enhancer-side inference from `generating`/`cursorCleared` — rejected: brittle coupling, and the restore batch clears `generating` before the edit lands. (3) Bracketing the completion in `setIsMulticursorExecuting` — rejected: heavyweight misuse of a multicursor flag for a single-cursor path.

**Verification.** TDD: the new same-direction test failed before the fix (the interleaved addition was reverted together with the generation) and passes after. Full unit suite passes (2229 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)