### PR TITLE
Resolve the desktop release with retries so an API connect timeout can't fail a finished build

### DIFF
--- a/.github/workflows/tauri-release-main.yml
+++ b/.github/workflows/tauri-release-main.yml
@@ -20,7 +20,8 @@ concurrency:
   group: tauri-release-main
   cancel-in-progress: true
 
-# tauri-action needs write access to create/update the GitHub Release.
+# The release job and tauri-action need write access to create/update the
+# GitHub Release.
 permissions:
   contents: write
 
@@ -40,8 +41,82 @@ env:
   APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
 
 jobs:
+  # Resolve the rolling release up front and hand its id to the build matrix.
+  # tauri-action's own release lookup is its only GitHub API call not covered by
+  # its retryAttempts input, and a single 10s connect timeout there has failed an
+  # otherwise-successful build (run 33205754427). Passing releaseId makes
+  # tauri-action skip that unretried lookup entirely, so this job performs it
+  # instead, with explicit retries. It also takes over refreshing the release
+  # name and body, which tauri-action only does when it resolves the release
+  # itself.
+  release:
+    name: Resolve rolling release
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.release.outputs.id }}
+    steps:
+      - name: Get or create the pre release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NAME: em desktop (main)
+          # Interpolated here rather than in the script so the backticks in the
+          # markdown never reach the shell.
+          RELEASE_BODY: |
+            em desktop prerelease build from the latest commit on `main`.
+
+            Commit: ${{ github.sha }}
+            Run: ${{ github.run_number }}
+
+            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
+            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
+        run: |
+          # Retry transient GitHub API failures (connect timeouts, 5xx) with
+          # backoff. Progress goes to stderr so callers can capture stdout.
+          retry() {
+            for attempt in 1 2 3 4 5; do
+              if "$@"; then return 0; fi
+              echo "Attempt $attempt of $1 failed; retrying after backoff." >&2
+              sleep $((attempt * 10))
+            done
+            return 1
+          }
+
+          # Fetch the release for the pre tag, creating it if it does not exist
+          # (first run only — thereafter uploads replace assets on the existing
+          # release). A create that loses a race fails with 422 and the next
+          # attempt's fetch resolves it.
+          resolve() {
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/pre" --jq .id 2>/dev/null ||
+              gh api -X POST "repos/$GITHUB_REPOSITORY/releases" \
+                -f tag_name=pre \
+                -f name="$RELEASE_NAME" \
+                -F prerelease=true \
+                -f target_commitish="$GITHUB_SHA" \
+                --jq .id
+          }
+
+          # Refresh the name and body so the release always describes the
+          # latest build.
+          refresh() {
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              -f name="$RELEASE_NAME" \
+              -f body="$RELEASE_BODY" >/dev/null
+          }
+
+          release_id=$(retry resolve) || {
+            echo "Failed to resolve the pre release after multiple attempts." >&2
+            exit 1
+          }
+          retry refresh || {
+            echo "Failed to update the pre release metadata after multiple attempts." >&2
+            exit 1
+          }
+          echo "id=$release_id" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.platform }} ${{ matrix.args }})
+    needs: release
     strategy:
       fail-fast: false
       matrix:
@@ -145,18 +220,13 @@ jobs:
           # rejected as "damaged". Keep notarization credentials unset in this path.
           APPLE_SIGNING_IDENTITY: '-'
         with:
-          tagName: pre
-          releaseName: em desktop (main)
-          releaseBody: |
-            em desktop prerelease build from the latest commit on `main`.
-
-            Commit: ${{ github.sha }}
-            Run: ${{ github.run_number }}
-
-            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
-            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
-          prerelease: true
-          releaseDraft: false
+          # The release job resolves the release id so tauri-action skips its
+          # own unretried lookup (see that job's comment). Release metadata
+          # (tag, name, body) is managed there as well.
+          releaseId: ${{ needs.release.outputs.id }}
+          # Retry transient build and upload failures (crates.io or GitHub API
+          # network flakes).
+          retryAttempts: 2
           releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'
           args: ${{ matrix.args }}
 
@@ -173,29 +243,24 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: pre
-          releaseName: em desktop (main)
-          releaseBody: |
-            em desktop prerelease build from the latest commit on `main`.
-
-            Commit: ${{ github.sha }}
-            Run: ${{ github.run_number }}
-
-            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
-            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
-          prerelease: true
-          releaseDraft: false
+          # The release job resolves the release id so tauri-action skips its
+          # own unretried lookup (see that job's comment). Release metadata
+          # (tag, name, body) is managed there as well.
+          releaseId: ${{ needs.release.outputs.id }}
+          # Retry transient build and upload failures (crates.io or GitHub API
+          # network flakes).
+          retryAttempts: 2
           releaseAssetNamePattern: '[name]_main_[arch][setup][ext]'
           args: ${{ matrix.args }}
 
   # Keep the `pre` tag pointing at the commit that was just built, so the release
   # page's commit chip and the auto-generated source archives match the published
-  # assets. tauri-action only sets the tag target when it first creates the tag and
-  # never moves an existing one (its releaseCommitish input is "unused if the Git
-  # tag already exists"), so without this the tag would sit at its creation commit
-  # forever. Runs only after all platforms publish, so the tag never points at a
-  # commit whose asset set is incomplete. GITHUB_TOKEN pushes do not trigger other
-  # workflows, and the prod release workflow only matches `v*` tags in any case.
+  # assets. The release job's create only sets the tag target when the tag does
+  # not exist yet (GitHub ignores target_commitish for an existing tag), so
+  # without this the tag would sit at its creation commit forever. Runs only
+  # after all platforms publish, so the tag never points at a commit whose asset
+  # set is incomplete. GITHUB_TOKEN pushes do not trigger other workflows, and
+  # the prod release workflow only matches `v*` tags in any case.
   retag:
     name: Point pre tag at built commit
     needs: build

--- a/.github/workflows/tauri-release-prod.yml
+++ b/.github/workflows/tauri-release-prod.yml
@@ -12,7 +12,8 @@ on:
   # so `github.ref_name` resolves to the version tag.
   workflow_dispatch:
 
-# tauri-action needs write access to create/update the GitHub Release.
+# The release job and tauri-action need write access to create/update the
+# GitHub Release.
 permissions:
   contents: write
 
@@ -32,8 +33,76 @@ env:
   APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
 
 jobs:
+  # Resolve the release for the pushed tag up front and hand its id to the build
+  # matrix. tauri-action's own release lookup is its only GitHub API call not
+  # covered by its retryAttempts input, and a single 10s connect timeout there
+  # has failed an otherwise-successful build (run 33205754427). Passing
+  # releaseId makes tauri-action skip that unretried lookup entirely, so this
+  # job performs it instead, with explicit retries. It also takes over
+  # refreshing the release name and body, which tauri-action only does when it
+  # resolves the release itself.
+  release:
+    name: Resolve release
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.release.outputs.id }}
+    steps:
+      - name: Get or create the version release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NAME: em desktop ${{ github.ref_name }}
+          # Interpolated here rather than in the script so the backticks in the
+          # markdown never reach the shell.
+          RELEASE_BODY: |
+            em desktop release ${{ github.ref_name }}.
+
+            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
+            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
+        run: |
+          # Retry transient GitHub API failures (connect timeouts, 5xx) with
+          # backoff. Progress goes to stderr so callers can capture stdout.
+          retry() {
+            for attempt in 1 2 3 4 5; do
+              if "$@"; then return 0; fi
+              echo "Attempt $attempt of $1 failed; retrying after backoff." >&2
+              sleep $((attempt * 10))
+            done
+            return 1
+          }
+
+          # Fetch the release for the version tag, creating it if it does not
+          # exist. The tag itself always exists here (it triggered the run), so
+          # the release attaches to it as-is. A create that loses a race fails
+          # with 422 and the next attempt's fetch resolves it.
+          resolve() {
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq .id 2>/dev/null ||
+              gh api -X POST "repos/$GITHUB_REPOSITORY/releases" \
+                -f tag_name="$GITHUB_REF_NAME" \
+                -f name="$RELEASE_NAME" \
+                --jq .id
+          }
+
+          # Refresh the name and body so a re-run picks up wording changes.
+          refresh() {
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              -f name="$RELEASE_NAME" \
+              -f body="$RELEASE_BODY" >/dev/null
+          }
+
+          release_id=$(retry resolve) || {
+            echo "Failed to resolve the $GITHUB_REF_NAME release after multiple attempts." >&2
+            exit 1
+          }
+          retry refresh || {
+            echo "Failed to update the $GITHUB_REF_NAME release metadata after multiple attempts." >&2
+            exit 1
+          }
+          echo "id=$release_id" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.platform }} ${{ matrix.args }})
+    needs: release
     strategy:
       fail-fast: false
       matrix:
@@ -137,15 +206,13 @@ jobs:
           # rejected as "damaged". Keep notarization credentials unset in this path.
           APPLE_SIGNING_IDENTITY: '-'
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: em desktop ${{ github.ref_name }}
-          releaseBody: |
-            em desktop release ${{ github.ref_name }}.
-
-            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
-            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
-          prerelease: false
-          releaseDraft: false
+          # The release job resolves the release id so tauri-action skips its
+          # own unretried lookup (see that job's comment). Release metadata
+          # (tag, name, body) is managed there as well.
+          releaseId: ${{ needs.release.outputs.id }}
+          # Retry transient build and upload failures (crates.io or GitHub API
+          # network flakes).
+          retryAttempts: 2
           args: ${{ matrix.args }}
 
       - name: Build and publish desktop app (Developer ID + notarization)
@@ -161,13 +228,11 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: em desktop ${{ github.ref_name }}
-          releaseBody: |
-            em desktop release ${{ github.ref_name }}.
-
-            > ⚠️ These builds are **unsigned** and may trigger Gatekeeper (macOS) or SmartScreen (Windows) warnings.
-            > On macOS, right-click the app and choose **Open** to bypass Gatekeeper (or run `xattr -cr /Applications/em.app`).
-          prerelease: false
-          releaseDraft: false
+          # The release job resolves the release id so tauri-action skips its
+          # own unretried lookup (see that job's comment). Release metadata
+          # (tag, name, body) is managed there as well.
+          releaseId: ${{ needs.release.outputs.id }}
+          # Retry transient build and upload failures (crates.io or GitHub API
+          # network flakes).
+          retryAttempts: 2
           args: ${{ matrix.args }}


### PR DESCRIPTION
Fixes the failure mode of [run 33205754427](https://github.com/cybersemics/em/actions/runs/33205754427/job/98966237440), where the macOS x64 desktop build and bundling **succeeded** and the job then died publishing:

```
⚠️ Unexpected error fetching GitHub release for tag pre: HttpError: Connect Timeout Error (attempted address: api.github.com:443, timeout: 10000ms)
```

The 10 000 ms is undici's (Node fetch) hardcoded connect timeout inside `tauri-apps/tauri-action` — no input or env var raises it, so the timeout itself cannot be increased. Instead, this PR removes the unretried call from the hot path and adds retries around everything that remains.

## What changed

Both Tauri release workflows gain a small `release` job that runs first:

- Resolves (or, on the very first run, creates) the GitHub Release for the tag via `gh api`, inside an explicit retry loop with backoff — the same idiom as `puppeteer-diff-comment.yml`.
- Takes over refreshing the release name/body every run (tauri-action only does that when it resolves the release itself).
- Exposes the numeric release id as a job output.

The build matrix then passes `releaseId` to tauri-action, which makes it skip its own unretried `getOrCreateRelease` entirely (`if (tagName && !releaseId)` in tauri-action's `src/index.ts`), and sets `retryAttempts: 2` so the remaining network calls (asset uploads, updater JSON) retry as well.

Side benefits: the four concurrent get-or-create calls per run collapse to one (removing a latent create race), and a run that can't reach the API at all now fails in ~2 minutes instead of after four full platform builds.

## Architectural plan (per `plan` skill)

**Existing surface area.** tauri-action@v1's `retryAttempts` wraps the build, asset uploads, and updater JSON — but not `getOrCreateRelease` (`src/index.ts:117`), which is exactly the call that failed. Passing `releaseId` (read as `Number(core.getInput('releaseId'))`) skips that block; `tagName`/`releaseName`/`releaseBody`/`prerelease`/`releaseDraft` are used nowhere else (verified by grep of tauri-action source), and the updater JSON keys off the id (`upload-version-json.ts`). The skipped block also contained the every-run name/body refresh (`create-release.ts:140`), which therefore moves to the new job. No `docs/` file covers these workflows — the header comments are the documentation of record and are updated where the change falsified them (write-access comment; the `retag` rationale that attributed tag creation to tauri-action).

**Build vs. extend.** Extends the two existing workflows in place; no new files. A shared composite action was rejected (two consumers; the file pair already deliberately duplicates its structure). Patching tauri-action upstream is the right long-term fix but not on this timeline.

**Adjacent behaviour.** Name/body refresh: 4×/run → 1×/run with byte-identical content. First-ever creation passes `target_commitish` on main (matches tauri-action's default); prod's tag always exists so it is omitted. tauri-action's step outputs stop being set — nothing consumes them. The `No artifacts were found` guard stays armed (`releaseId` truthy). `retryAttempts: 2` means a genuinely broken build compiles up to 3× — bounded by the warm cargo cache and accepted in exchange for retrying crates.io/codesign/upload flakes. On prod the empty release becomes visible ~build-duration earlier; incomplete-asset visibility already spans the whole matrix today. The `retag` job and `concurrency` guard are untouched.

## Verification

- Both YAMLs parse; job wiring (`needs`, `outputs.id`) checked mechanically; prettier passes.
- The release step's script was extracted verbatim from the YAML and run against a stubbed `gh`:
  - transient-failure mode (every call times out twice, then recovers): retries fire, the id is captured, and the PATCH receives the exact multi-line body with backticks intact;
  - first-run mode (GET 404s): the create path returns the new id straight through;
  - and the real read-only lookup `gh api repos/cybersemics/em/releases/tags/pre --jq .id` resolves the live rolling release (354855258).
- The workflows themselves only run on push to `main` / tag push, so the first rolling-release run after merge is the live confirmation.

## Follow-up

If tauri-action ships release-fetch retries under `retryAttempts` upstream (PR planned), the `release` job here can be reverted and only `retryAttempts: 2` kept on the tauri-action steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
