### PR TITLE
Extend the debug log for order-change forensics

### DIFF
--- a/src/components/modals/Settings.tsx
+++ b/src/components/modals/Settings.tsx
@@ -119,6 +119,7 @@ const FontSize = () => {
 /** Controls for the persistent debug log: copy the captured entries to the clipboard or clear them. Only rendered when Debug Logging is enabled. */
 const DebugLog = () => {
   const enabled = useSelector(getUserSetting(Settings.debugCrashLog))
+  const dispatch = useDispatch()
   const [status, setStatus] = useState<string | null>(null)
 
   if (!enabled) return null
@@ -127,9 +128,13 @@ const DebugLog = () => {
     <div className={css({ marginTop: '1em' })}>
       <a
         {...fastClick(() => {
-          const text = debugLog.format()
-          copy(text)
-          setStatus(text ? `Copied ${debugLog.read().length} entries` : 'Log is empty')
+          // dispatch a thunk to read fresh state, so format() can append the state.thoughts dump that resolves
+          // the ids in the entries to values and shows current sibling order
+          dispatch((_, getState) => {
+            const text = debugLog.format(getState())
+            copy(text)
+            setStatus(text ? `Copied ${debugLog.read().length} entries` : 'Log is empty')
+          })
         })}
         className={extendTapRecipe()}
       >

--- a/src/hooks/useDragAndDropSubThought.tsx
+++ b/src/hooks/useDragAndDropSubThought.tsx
@@ -28,6 +28,7 @@ import visibleDistanceAboveCursor from '../selectors/visibleDistanceAboveCursor'
 import store from '../stores/app'
 import animateDroppedThought from '../util/animateDroppedThought'
 import appendToPath from '../util/appendToPath'
+import debugLog from '../util/debugLog'
 import equalPath from '../util/equalPath'
 import haptics from '../util/haptics'
 import hashPath from '../util/hashPath'
@@ -185,6 +186,15 @@ const drop = (props: DroppableSubthoughts, monitor: DropTargetMonitor) => {
       animateDroppedThought({ fromPath, toPath })
     }
   }
+
+  // Attribute the upcoming moveThought actions to a drag-and-drop drop, since drops have no `command` entry in the
+  // debug log (commands.ts only logs keyboard/gesture/toolbar commands).
+  debugLog.log('drop', {
+    zone: 'subthought',
+    targetId: head(props.path),
+    targetValue: getThoughtById(state, head(props.path))?.value,
+    items: draggedItems.length,
+  })
 
   store.dispatch((dispatch, getState) => {
     /** Returns true if the thought should be dropped at the top of a collapsed parent. */

--- a/src/hooks/useDragAndDropThought.tsx
+++ b/src/hooks/useDragAndDropThought.tsx
@@ -39,6 +39,7 @@ import simplifyPath from '../selectors/simplifyPath'
 import store from '../stores/app'
 import selectionRangeStore from '../stores/selectionRangeStore'
 import appendToPath from '../util/appendToPath'
+import debugLog from '../util/debugLog'
 import equalPath from '../util/equalPath'
 import haptics from '../util/haptics'
 import head from '../util/head'
@@ -210,6 +211,16 @@ const drop = (props: ThoughtContainerProps, monitor: DropTargetMonitor) => {
     })
   )
     return
+
+  // Attribute the upcoming moveThought/createThought actions to a drag-and-drop drop, since drops have no `command`
+  // entry in the debug log (commands.ts only logs keyboard/gesture/toolbar commands).
+  debugLog.log('drop', {
+    zone: 'thought',
+    targetId: head(props.simplePath),
+    targetValue: pathToThought(state, props.simplePath)?.value,
+    items: draggedItems.length,
+    showContexts: !!props.showContexts,
+  })
 
   store.dispatch((dispatch, getState) => {
     // set multicursor executing to true if there are multiple thoughts being dragged

--- a/src/redux-enhancers/__tests__/pushQueue.ts
+++ b/src/redux-enhancers/__tests__/pushQueue.ts
@@ -1,0 +1,36 @@
+import { vi } from 'vitest'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import store from '../../stores/app'
+import initStore from '../../test-helpers/initStore'
+import debugLog from '../../util/debugLog'
+
+beforeEach(initStore)
+
+afterEach(() => {
+  debugLog.setEnabled(false)
+  debugLog.clear()
+})
+
+it('logs a push entry when thought updates are flushed to persistence, and pushSynced when the write completes', async () => {
+  debugLog.setEnabled(true)
+  debugLog.clear()
+
+  store.dispatch(importText({ text: '- a' }))
+
+  const pushes = debugLog.read().filter(e => e.type === 'push')
+  expect(pushes.length).toBeGreaterThan(0)
+  expect(pushes[0].thoughtCount as number).toBeGreaterThan(0)
+  expect(pushes[0].local).toBe(true)
+  expect((pushes[0].thoughts as { id: string; value: string }[]).length).toBeGreaterThan(0)
+
+  // The sync confirmation lands once the provider write resolves. Flush only the timers already pending: fake timers
+  // fake requestAnimationFrame, so runAllTimersAsync would loop forever on debugLog's self-rescheduling frame heartbeat.
+  await vi.runOnlyPendingTimersAsync()
+  expect(debugLog.read().some(e => e.type === 'pushSynced')).toBe(true)
+})
+
+it('does not log push entries when debug logging is disabled', async () => {
+  store.dispatch(importText({ text: '- a' }))
+  await vi.runAllTimersAsync()
+  expect(debugLog.read().filter(e => e.type === 'push' || e.type === 'pushSynced')).toEqual([])
+})

--- a/src/redux-enhancers/pushQueue.ts
+++ b/src/redux-enhancers/pushQueue.ts
@@ -9,6 +9,7 @@ import db, { thoughtspaceRuntime } from '../data-providers/thoughtspace'
 import contextToThoughtId from '../selectors/contextToThoughtId'
 import { getChildrenRanked } from '../selectors/getChildren'
 import getThoughtById from '../selectors/getThoughtById'
+import debugLog from '../util/debugLog'
 import isAttribute from '../util/isAttribute'
 import keyValueBy from '../util/keyValueBy'
 import mergeBatch from '../util/mergeBatch'
@@ -85,6 +86,31 @@ const pushQueue: StoreEnhancer<any> =
           }
         })
 
+        // Log the flush so database lastUpdated stamps can be correlated with debug log entries and unlanded writes
+        // detected (a `push` with no matching `pushSynced` is a write that never completed).
+        const debugEnabled = debugLog.isEnabled()
+        const thoughtUpdates = debugEnabled
+          ? (dbQueue ?? []).flatMap(batch => Object.entries(batch.thoughtIndexUpdates))
+          : []
+        if (debugEnabled) {
+          // sample of the thought updates being written; the full set is visible in the corresponding action entries
+          const sample = thoughtUpdates.slice(0, 10).map(([id, thought]) => {
+            if (!thought) return { id, deleted: true }
+            const value = thought.value.length > 100 ? `${thought.value.slice(0, 100)}…` : thought.value
+            return { id, value, rank: thought.rank }
+          })
+          debugLog.log('push', {
+            batches: (dbQueue ?? []).length,
+            thoughtCount: thoughtUpdates.length,
+            deleteCount: thoughtUpdates.filter(([, thought]) => !thought).length,
+            lexemeCount: (dbQueue ?? []).reduce((n, batch) => n + Object.keys(batch.lexemeIndexUpdates).length, 0),
+            moveCount: (dbQueue ?? []).reduce((n, batch) => n + Object.keys(batch.movePlacements ?? {}).length, 0),
+            local: (dbQueue ?? []).some(batch => batch.local !== false),
+            remote: (dbQueue ?? []).some(batch => batch.remote !== false),
+            thoughts: sample,
+          })
+        }
+
         /** Pushes queued updates to the active thoughtspace provider sequentially. */
         const applyDbQueue = async () => {
           await thoughtspaceRuntime.persistPushQueueBatches(
@@ -101,9 +127,11 @@ const pushQueue: StoreEnhancer<any> =
         void applyDbQueue()
           .then(() => {
             dbQueue?.forEach(batch => batch.idbSynced?.())
+            debugLog.log('pushSynced', { thoughtCount: thoughtUpdates.length })
           })
           .catch(err => {
             console.error('Thoughtspace persistence failed', err)
+            debugLog.log('pushError', { error: String(err) })
           })
       }
 

--- a/src/redux-middleware/__tests__/loggerMiddleware.ts
+++ b/src/redux-middleware/__tests__/loggerMiddleware.ts
@@ -1,14 +1,30 @@
+import { vi } from 'vitest'
+import State from '../../@types/State'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { updateThoughtsActionCreator as updateThoughts } from '../../actions/updateThoughts'
+import store from '../../stores/app'
+import contextToThought from '../../test-helpers/contextToThought'
+import { editThoughtByContextActionCreator as editThoughtByContext } from '../../test-helpers/editThoughtByContext'
+import initStore from '../../test-helpers/initStore'
+import { moveThoughtAtFirstMatchActionCreator as moveThoughtAtFirstMatch } from '../../test-helpers/moveThoughtAtFirstMatch'
 import debugLog from '../../util/debugLog'
 import loggerMiddleware from '../loggerMiddleware'
 
 /** A pass-through next handler for the middleware. */
 const next = (action: unknown) => action
 
-/** Invokes the logger middleware for a single action with a no-op store and next. */
+// a minimal fixed state for unit invocations; the same reference is returned before and after the action, so the thought diff is skipped
+const stubState = {
+  thoughts: { thoughtIndex: {}, lexemeIndex: {} },
+  undoPatches: [],
+  redoPatches: [],
+} as unknown as State
+
+/** Invokes the logger middleware for a single action with a stub store and pass-through next. */
 const invoke = (action: unknown) => {
-  // the middleware only uses next(action); store api is unused
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  loggerMiddleware({} as any)(next)(action as any)
+  loggerMiddleware({ getState: () => stubState, dispatch: next } as any)(next)(action as any)
 }
 
 beforeEach(() => {
@@ -18,6 +34,8 @@ beforeEach(() => {
 
 afterEach(() => {
   debugLog.setEnabled(false)
+  debugLog.clear()
+  vi.restoreAllMocks()
 })
 
 it('does not capture actions when debug logging is disabled', () => {
@@ -33,4 +51,151 @@ it('captures every action when debug logging is enabled', () => {
   expect(actionEntries.length).toBe(1)
   expect(actionEntries[0].actionType).toBe('editThought')
   expect(actionEntries[0].payload).toContain('hello')
+})
+
+describe('structured updateThoughts summary', () => {
+  it('logs per-thought id/value/rank/parentId and counts instead of the raw stringified action', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    invoke({
+      type: 'updateThoughts',
+      thoughtIndexUpdates: {
+        abc: { id: 'abc', value: 'hello', rank: 2, parentId: 'root', childrenMap: {}, pending: true },
+        def: null,
+      },
+      lexemeIndexUpdates: { lex1: {} },
+      local: false,
+      remote: false,
+    })
+    const actionEntries = debugLog.read().filter(e => e.type === 'action')
+    expect(actionEntries.length).toBe(1)
+    expect(actionEntries[0]).toMatchObject({
+      actionType: 'updateThoughts',
+      thoughtCount: 2,
+      lexemeCount: 1,
+      local: false,
+      remote: false,
+    })
+    expect(actionEntries[0].thoughts).toEqual([
+      { id: 'abc', value: 'hello', rank: 2, parentId: 'root', pending: true },
+      { id: 'def', deleted: true },
+    ])
+    expect(actionEntries[0].payload).toBeUndefined()
+  })
+})
+
+describe('thought move logging', () => {
+  beforeEach(initStore)
+
+  it('logs a move entry with the old and new rank when a thought is reordered', () => {
+    store.dispatch(
+      importText({
+        text: `
+          - a
+          - b
+        `,
+      }),
+    )
+    const oldRank = contextToThought(store.getState(), ['b'])!.rank
+
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    store.dispatch(moveThoughtAtFirstMatch({ from: ['b'], to: ['b'], newRank: -1 }))
+
+    const moves = debugLog.read().filter(e => e.type === 'move')
+    expect(moves.length).toBe(1)
+    expect(moves[0]).toMatchObject({
+      actionType: 'moveThought',
+      value: 'b',
+      oldRank,
+      newRank: -1,
+    })
+  })
+
+  it('logs a single moveBatch entry when one action reorders more than 10 thoughts', () => {
+    const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
+    store.dispatch(
+      importText({
+        text: values.map(value => `- ${value}`).join('\n'),
+      }),
+    )
+    const thoughts = values.map(value => contextToThought(store.getState(), [value])!)
+
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    // dispatched as a local update; a non-local (reconcile) update with an unchanged lastUpdated would be dropped by
+    // updateThoughts' last-write-wins guard and never reach the state
+    store.dispatch(
+      updateThoughts({
+        thoughtIndexUpdates: Object.fromEntries(
+          thoughts.map(thought => [thought.id, { ...thought, rank: thought.rank + 100 }]),
+        ),
+        lexemeIndexUpdates: {},
+      }),
+    )
+
+    expect(debugLog.read().filter(e => e.type === 'move')).toEqual([])
+    const batches = debugLog.read().filter(e => e.type === 'moveBatch')
+    expect(batches.length).toBe(1)
+    expect(batches[0].count).toBe(11)
+    expect((batches[0].sample as unknown[]).length).toBe(10)
+  })
+})
+
+describe('duplicate rank integrity warning', () => {
+  beforeEach(initStore)
+
+  it('logs an integrity entry and warns when siblings end up with the same rank, without blocking the update', () => {
+    store.dispatch(
+      importText({
+        text: `
+          - a
+          - b
+        `,
+      }),
+    )
+    const a = contextToThought(store.getState(), ['a'])!
+    const b = contextToThought(store.getState(), ['b'])!
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    // dispatched as a local update; a non-local (reconcile) update with an unchanged lastUpdated would be dropped by
+    // updateThoughts' last-write-wins guard and never reach the state
+    store.dispatch(
+      updateThoughts({
+        thoughtIndexUpdates: { [b.id]: { ...b, rank: a.rank } },
+        lexemeIndexUpdates: {},
+      }),
+    )
+
+    const integrity = debugLog.read().filter(e => e.type === 'integrity')
+    expect(integrity.length).toBe(1)
+    expect(integrity[0]).toMatchObject({ issue: 'duplicateRank', rank: a.rank })
+    expect(integrity[0].thoughts).toEqual([
+      { id: a.id, value: 'a' },
+      { id: b.id, value: 'b' },
+    ])
+    expect(consoleWarn).toHaveBeenCalled()
+    // the update itself is not blocked
+    expect(contextToThought(store.getState(), ['b'])!.rank).toBe(a.rank)
+  })
+})
+
+describe('undo/redo attribution', () => {
+  beforeEach(initStore)
+
+  it('logs which action types an undo reverted', () => {
+    store.dispatch(importText({ text: '- a' }))
+    store.dispatch(editThoughtByContext(['a'], 'apple'))
+
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    store.dispatch(undo())
+
+    const undoEntries = debugLog.read().filter(e => e.type === 'undo')
+    expect(undoEntries.length).toBe(1)
+    expect(undoEntries[0].actions).toContain('editThought')
+    expect(undoEntries[0].steps).toBe(1)
+  })
 })

--- a/src/redux-middleware/loggerMiddleware.ts
+++ b/src/redux-middleware/loggerMiddleware.ts
@@ -1,12 +1,125 @@
 import { Dispatch, Middleware, UnknownAction } from 'redux'
+import Index from '../@types/IndexType'
 import State from '../@types/State'
+import Thought from '../@types/Thought'
+import ThoughtId from '../@types/ThoughtId'
 import testFlags from '../e2e/testFlags'
+import { getChildrenRanked } from '../selectors/getChildren'
 import debugLog from '../util/debugLog'
 
-/** Redux Middleware for logging all actions. Logs to the console when testFlags.logActions is set (useful for e2e/remote debugging when Redux Developer Tools are not available), and captures every action into the persistent debugLog when it is enabled (see the Debug Logging setting). */
+/** Maximum number of thought summaries included in a structured updateThoughts entry. */
+const MAX_SUMMARY_THOUGHTS = 20
+
+/** Maximum number of individual move entries per action. Beyond this, one moveBatch entry with a sample is logged instead (e.g. a sort reranking a whole context). */
+const MAX_MOVES = 10
+
+/** Maximum characters of a thought value included in a log entry. */
+const VALUE_MAX_LENGTH = 100
+
+// Duplicate sibling ranks already reported, keyed by `${parentId}:${rank}`, so a persisting duplicate is warned about once rather than on every subsequent action that touches its parent.
+const reportedDuplicateRanks = new Set<string>()
+
+/** Truncates a thought value for compact log output. */
+const truncateValue = (value: string): string =>
+  value.length > VALUE_MAX_LENGTH ? `${value.slice(0, VALUE_MAX_LENGTH)}…` : value
+
+/** Builds a structured summary of an updateThoughts action: per-thought id/value/rank/parentId/pending (capped at MAX_SUMMARY_THOUGHTS), plus counts and the local/remote flags. Far denser and more useful than the raw stringified action, whose truncation cuts JSON mid-field. */
+const summarizeUpdateThoughts = (action: UnknownAction): Record<string, unknown> => {
+  const thoughtUpdates = Object.entries((action.thoughtIndexUpdates ?? {}) as Index<Thought | null>)
+  return {
+    actionType: 'updateThoughts',
+    thoughtCount: thoughtUpdates.length,
+    lexemeCount: Object.keys((action.lexemeIndexUpdates ?? {}) as Index<unknown>).length,
+    local: action.local !== false,
+    remote: action.remote !== false,
+    thoughts: thoughtUpdates.slice(0, MAX_SUMMARY_THOUGHTS).map(([id, thought]) =>
+      thought
+        ? {
+            id,
+            value: truncateValue(thought.value),
+            rank: thought.rank,
+            parentId: thought.parentId,
+            ...(thought.pending ? { pending: true } : null),
+          }
+        : { id, deleted: true },
+    ),
+  }
+}
+
+/** Logs an integrity warning for each set of siblings that share an exact rank under the given parent. Duplicate ranks make sibling order ambiguous and are the signature of a data-integrity fault (see the safeguard in selectors/getRankAfter.ts). Warning only — the update itself is never blocked. */
+const warnDuplicateRanks = (state: State, parentId: ThoughtId): void => {
+  const children = getChildrenRanked(state, parentId)
+  // children are sorted by rank, so duplicates are adjacent
+  children.forEach((child, i) => {
+    if (i === 0 || children[i - 1].rank !== child.rank) return
+    const key = `${parentId}:${child.rank}`
+    if (reportedDuplicateRanks.has(key)) return
+    reportedDuplicateRanks.add(key)
+    const duplicates = children
+      .filter(sibling => sibling.rank === child.rank)
+      .map(sibling => ({ id: sibling.id, value: truncateValue(sibling.value) }))
+    debugLog.log('integrity', { issue: 'duplicateRank', parentId, rank: child.rank, thoughts: duplicates })
+    console.warn(`Duplicate sibling rank ${child.rank} under thought ${parentId}`, duplicates)
+  })
+}
+
+/** Diffs the thoughtIndex across one action and logs a self-describing `move` entry for every thought whose rank or parentId changed (loads and frees, where only one side exists, are skipped). Catches moves from every source — moveThought and the reducers that compose it, drag-and-drop, sort reranking, undo/redo, and remote sync — without special-casing any of them. Also runs the duplicate-rank integrity check on the parents of changed or added thoughts. */
+const logThoughtMoves = (stateBefore: State, stateAfter: State, actionType: string): void => {
+  const indexBefore = stateBefore.thoughts.thoughtIndex
+  const indexAfter = stateAfter.thoughts.thoughtIndex
+  if (indexBefore === indexAfter) return
+
+  const moves = Object.values(indexAfter).flatMap(thought => {
+    const old = indexBefore[thought.id]
+    return old && old !== thought && (old.rank !== thought.rank || old.parentId !== thought.parentId)
+      ? [
+          {
+            actionType,
+            id: thought.id,
+            value: truncateValue(thought.value),
+            oldRank: old.rank,
+            newRank: thought.rank,
+            ...(old.parentId !== thought.parentId
+              ? { oldParentId: old.parentId, newParentId: thought.parentId }
+              : { parentId: thought.parentId }),
+          },
+        ]
+      : []
+  })
+
+  if (moves.length <= MAX_MOVES) {
+    moves.forEach(move => debugLog.log('move', move))
+  } else {
+    debugLog.log('moveBatch', { actionType, count: moves.length, sample: moves.slice(0, MAX_MOVES) })
+  }
+
+  const changedParentIds = new Set(
+    Object.values(indexAfter)
+      .filter(thought => indexBefore[thought.id] !== thought)
+      .map(thought => thought.parentId),
+  )
+  changedParentIds.forEach(parentId => warnDuplicateRanks(stateAfter, parentId))
+}
+
+/** Logs which original action types an undo or redo reverted or replayed, read from the patches popped off the undo/redo stack, so a move restored by undo is distinguishable from a fresh user move. */
+const logUndoRedo = (stateBefore: State, stateAfter: State, actionType: string): void => {
+  if (actionType !== 'undo' && actionType !== 'redo') return
+  const stackBefore = actionType === 'undo' ? stateBefore.undoPatches : stateBefore.redoPatches
+  const stackAfter = actionType === 'undo' ? stateAfter.undoPatches : stateAfter.redoPatches
+  const popped = stackBefore.slice(stackAfter.length)
+  if (popped.length === 0) return
+  const actions = [...new Set(popped.flatMap(patch => patch[0]?.actions ?? []))]
+  debugLog.log(actionType, { steps: popped.length, actions })
+}
+
+/** Redux Middleware for logging all actions. Logs to the console when testFlags.logActions is set (useful for e2e/remote debugging when Redux Developer Tools are not available), and captures every action into the persistent debugLog when it is enabled (see the Debug Logging setting) — along with derived forensics: structured updateThoughts summaries, a `move` entry for every rank or parent change, duplicate-sibling-rank integrity warnings, and undo/redo attribution. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const loggerMiddleware: Middleware<any, State, Dispatch> = () => {
+const loggerMiddleware: Middleware<any, State, Dispatch> = store => {
   return next => action => {
+    // Capture pre-reduction state so thought moves can be diffed. This middleware runs after the thunk middleware, so
+    // `action` is always a resolved plain action and getState() here reflects the state before this action's reducers.
+    const stateBefore = debugLog.isEnabled() ? store.getState() : null
+
     next(action)
 
     const type = (action as UnknownAction).type
@@ -15,18 +128,33 @@ const loggerMiddleware: Middleware<any, State, Dispatch> = () => {
       console.info(type, action)
     }
 
-    // Capture every dispatched action into the persistent rolling log. This middleware runs after the thunk
-    // middleware, so `action` is always a resolved plain action with a `type`. The payload is stringified (and
-    // truncated by debugLog's field cap) so large actions such as updateThoughts cannot blow the buffer.
+    // Capture every dispatched action into the persistent rolling log. The payload is stringified (and truncated by
+    // debugLog's field cap) so large actions cannot blow the buffer; updateThoughts gets a structured summary instead.
     if (debugLog.isEnabled() && action && typeof action === 'object') {
-      const { type: _type, ...payload } = action as UnknownAction
-      let payloadStr: string
-      try {
-        payloadStr = JSON.stringify(payload)
-      } catch {
-        payloadStr = String(payload)
+      if (type === 'updateThoughts') {
+        debugLog.log('action', summarizeUpdateThoughts(action as UnknownAction))
+      } else {
+        const { type: _type, ...payload } = action as UnknownAction
+        let payloadStr: string
+        try {
+          payloadStr = JSON.stringify(payload)
+        } catch {
+          payloadStr = String(payload)
+        }
+        debugLog.log('action', { actionType: type ?? 'unknown', payload: payloadStr })
       }
-      debugLog.log('action', { actionType: type ?? 'unknown', payload: payloadStr })
+
+      // getState() after next(action) reflects the fully reduced state, including enhancer reducers (undo patches
+      // applied, pushQueue drained), since middleware wraps dispatch outside the whole store.
+      if (stateBefore) {
+        const stateAfter = store.getState()
+        try {
+          logThoughtMoves(stateBefore, stateAfter, type ?? 'unknown')
+          logUndoRedo(stateBefore, stateAfter, type ?? 'unknown')
+        } catch {
+          // Logging must never throw.
+        }
+      }
     }
   }
 }

--- a/src/util/__tests__/debugLog.ts
+++ b/src/util/__tests__/debugLog.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import State from '../../@types/State'
 import debugLog from '../debugLog'
 import storage from '../storage'
 
@@ -64,14 +65,14 @@ describe('capacity', () => {
   it('trims to the capacity, keeping the most recent entries', () => {
     debugLog.setEnabled(true)
     debugLog.clear()
-    for (let i = 0; i < 1100; i++) {
+    for (let i = 0; i < 5100; i++) {
       debugLog.log('n', { i })
     }
     const entries = debugLog.read()
-    expect(entries.length).toBe(1000)
+    expect(entries.length).toBe(5000)
     // the oldest 100 were dropped, so the first retained entry is #100
     expect(entries[0].i).toBe(100)
-    expect(entries[entries.length - 1].i).toBe(1099)
+    expect(entries[entries.length - 1].i).toBe(5099)
   })
 })
 
@@ -88,17 +89,35 @@ describe('field cap', () => {
 })
 
 describe('persistence', () => {
-  it('persists entries to localStorage synchronously', () => {
+  it('persists entries to the active chunk key synchronously', () => {
     debugLog.setEnabled(true)
     debugLog.clear()
     debugLog.log('persisted')
-    const raw = storage.getItem('debugLog')
+    const raw = storage.getItem('debugLog-0')
     expect(raw).toBeTruthy()
     expect((JSON.parse(raw!) as { type: string }[]).some(e => e.type === 'persisted')).toBe(true)
   })
 
-  it('hydrates a prior session log on module load', async () => {
-    // seed localStorage as if a prior (crashed) session had persisted a log
+  it('rotates to the next chunk key so appending an entry only rewrites the active chunk', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    for (let i = 0; i < 501; i++) {
+      debugLog.log('n', { i })
+    }
+    expect((JSON.parse(storage.getItem('debugLog-0')!) as unknown[]).length).toBe(500)
+    expect((JSON.parse(storage.getItem('debugLog-1')!) as unknown[]).length).toBe(1)
+  })
+
+  it('hydrates chunked entries from a prior session on module load', async () => {
+    // seed localStorage as if a prior (crashed) session had persisted chunks
+    localStorage.setItem('debugLog-3', JSON.stringify([{ seq: 1500, t: 1, dt: 0, type: 'priorChunk' }]))
+    vi.resetModules()
+    const fresh = (await import('../debugLog')).default
+    expect(fresh.read().some(e => e.type === 'priorChunk')).toBe(true)
+  })
+
+  it('hydrates a legacy single-key log from a prior session on module load', async () => {
+    // seed localStorage as if a session on a pre-chunking version had persisted a log
     localStorage.setItem('debugLog', JSON.stringify([{ seq: 0, t: 1, dt: 0, type: 'prior' }]))
     vi.resetModules()
     const fresh = (await import('../debugLog')).default
@@ -115,12 +134,15 @@ describe('persistence', () => {
 })
 
 describe('clear', () => {
-  it('empties the buffer and removes the localStorage key', () => {
+  it('empties the buffer and removes the localStorage keys', () => {
     debugLog.setEnabled(true)
     debugLog.log('x')
+    localStorage.setItem('debugLog-frame', '123')
     debugLog.clear()
     expect(debugLog.read()).toEqual([])
     expect(storage.getItem('debugLog')).toBeNull()
+    expect(storage.getItem('debugLog-0')).toBeNull()
+    expect(storage.getItem('debugLog-frame')).toBeNull()
   })
 })
 
@@ -133,5 +155,35 @@ describe('format', () => {
     expect(text).toContain('input')
     expect(text).toContain('#0')
     expect(text).toContain('"data":" "')
+  })
+
+  it('appends the last-frame marker when present', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('x')
+    localStorage.setItem('debugLog-frame', '1700000000000')
+    const text = debugLog.format()
+    expect(text).toContain('lastFrameAt: 2023-11-14T22:13:20.000Z')
+  })
+
+  it('appends a state.thoughts dump grouped by parent and ordered by rank', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('x')
+    const state = {
+      thoughts: {
+        thoughtIndex: {
+          t1: { id: 't1', value: 'apple', rank: 1, parentId: 'root', childrenMap: {} },
+          t2: { id: 't2', value: 'banana', rank: 0, parentId: 'root', childrenMap: {}, pending: true },
+        },
+        lexemeIndex: {},
+      },
+    } as unknown as State
+    const text = debugLog.format(state)
+    expect(text).toContain('state.thoughts: 2 thoughts, 0 lexemes')
+    expect(text).toContain('t1 "apple" rank:1 parent:root')
+    expect(text).toContain('t2 "banana" rank:0 parent:root pending')
+    // siblings are ordered by rank within a parent, so banana (rank 0) precedes apple (rank 1)
+    expect(text.indexOf('banana')).toBeLessThan(text.indexOf('apple'))
   })
 })

--- a/src/util/debugLog.ts
+++ b/src/util/debugLog.ts
@@ -1,17 +1,33 @@
 import pkg from '../../package.json'
+import State from '../@types/State'
 import storage from './storage'
 
-/** The localStorage key under which the rolling debug log is persisted. */
+/** The localStorage key prefix under which the rolling debug log is persisted. Entries are sharded across numbered chunk keys (`debugLog-0` … `debugLog-9`) so that appending an entry only rewrites the active chunk instead of the whole buffer. */
 const DEBUG_LOG_KEY = 'debugLog'
 
+/** Number of entries per persisted chunk. */
+const CHUNK_SIZE = 500
+
+/** Number of rotating chunk keys. Capacity = CHUNK_SIZE * CHUNK_COUNT. */
+const CHUNK_COUNT = 10
+
 /** Maximum number of entries retained in the rolling buffer. Older entries are dropped first. */
-const DEBUG_LOG_CAPACITY = 1000
+const DEBUG_LOG_CAPACITY = CHUNK_SIZE * CHUNK_COUNT
 
 /** Maximum length of any single stringified field. Longer values are truncated to protect the ~5MB localStorage quota. */
 const FIELD_MAX_LENGTH = 2000
 
-/** Minimum interval between `frame` heartbeat entries so requestAnimationFrame does not flood the buffer. */
-const FRAME_HEARTBEAT_THROTTLE_MS = 500
+/** The localStorage key holding the timestamp of the most recent animation frame. Updated in place (never appended to the buffer) so a healthy requestAnimationFrame loop leaves a heartbeat without evicting real events. */
+const FRAME_MARKER_KEY = 'debugLog-frame'
+
+/** Minimum interval between writes of the frame marker, so the rAF loop does not hammer localStorage. */
+const FRAME_MARKER_THROTTLE_MS = 500
+
+/** Minimum gap between consecutive animation frames before a `frameGap` entry is appended. A healthy cadence carries no information per entry — only an anomalous gap (jank, GC pause, tab suspension) is worth an entry. */
+const FRAME_GAP_THRESHOLD_MS = 500
+
+/** Maximum characters of a thought value rendered in the format() state dump. */
+const DUMP_VALUE_MAX_LENGTH = 100
 
 /** A single rolling-log entry. `seq`, `t`, `dt`, and `type` form a common envelope; all other fields are event-specific. */
 interface DebugLogEntry {
@@ -21,18 +37,40 @@ interface DebugLogEntry {
   t: number
   /** Milliseconds since the previous entry (high-resolution). A cadence collapsing toward 0 indicates a tight loop. */
   dt: number
-  /** Short event tag, e.g. 'input', 'action', 'guard', 'frame'. */
+  /** Short event tag, e.g. 'input', 'action', 'move', 'frameGap'. */
   type: string
   [key: string]: unknown
 }
 
-/** Loads any previously persisted entries from localStorage so a prior session's log survives a reload or device restart for retrieval. Never throws. */
-const hydrate = (): DebugLogEntry[] => {
+/** Returns the localStorage key of the numbered chunk. */
+const chunkKey = (i: number): string => `${DEBUG_LOG_KEY}-${i}`
+
+/** Returns the chunk ordinal (0 … CHUNK_COUNT-1) that an entry with the given seq belongs to. */
+const chunkOrdinal = (seq: number): number => Math.floor(seq / CHUNK_SIZE) % CHUNK_COUNT
+
+/** Parses one persisted chunk (or the legacy single-key buffer) into an entry array. Never throws. */
+const parseEntries = (raw: string | null): DebugLogEntry[] => {
+  if (!raw) return []
   try {
-    const raw = storage.getItem(DEBUG_LOG_KEY)
-    if (!raw) return []
     const parsed = JSON.parse(raw)
     return Array.isArray(parsed) ? (parsed as DebugLogEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+/** Loads any previously persisted entries from localStorage so a prior session's log survives a reload or device restart for retrieval. Reads the rotating chunk keys plus the legacy single-key buffer (pre-chunking versions), oldest first, trimmed to capacity. Never throws. */
+const hydrate = (): DebugLogEntry[] => {
+  try {
+    const chunked = Array.from({ length: CHUNK_COUNT }, (_, i) => parseEntries(storage.getItem(chunkKey(i))))
+      .flat()
+      .sort((a, b) => a.seq - b.seq)
+    // The legacy key precedes chunked persistence, so its entries are older than any chunk's. The tail of the legacy
+    // buffer is re-persisted into a chunk once new entries arrive (see the chunk priming below), so drop any legacy
+    // entry whose seq already appears in a chunk to avoid double-hydrating it.
+    const chunkedSeqs = new Set(chunked.map(entry => entry.seq))
+    const legacy = parseEntries(storage.getItem(DEBUG_LOG_KEY)).filter(entry => !chunkedSeqs.has(entry.seq))
+    return [...legacy, ...chunked].slice(-DEBUG_LOG_CAPACITY)
   } catch {
     return []
   }
@@ -44,12 +82,19 @@ let entries: DebugLogEntry[] = hydrate()
 let enabled = false
 // monotonic sequence counter
 let seq = entries.length > 0 ? entries[entries.length - 1].seq + 1 : 0
+// the entries of the chunk currently being written, so persist() only serializes CHUNK_SIZE entries.
+// primed with the tail of the hydrated buffer so a resumed session does not clobber the partially-filled chunk on disk.
+let chunk: DebugLogEntry[] = entries.filter(
+  entry => Math.floor(entry.seq / CHUNK_SIZE) === Math.floor((seq - 1) / CHUNK_SIZE),
+)
 // performance.now() of the previous entry, used to compute dt
 let lastTime = 0
 // requestAnimationFrame handle for the frame heartbeat
 let frameId: number | null = null
-// performance.now() of the last emitted frame heartbeat, used to throttle it
-let lastFrameLogged = 0
+// performance.now() of the previous rAF callback, used to measure the inter-frame gap
+let lastFrameTime = 0
+// performance.now() of the last frame marker write, used to throttle it
+let lastMarkerWritten = 0
 
 /** Truncates over-long string fields so a single pathological value cannot exhaust the localStorage quota. */
 const capFields = (fields?: Record<string, unknown>): Record<string, unknown> => {
@@ -65,45 +110,63 @@ const capFields = (fields?: Record<string, unknown>): Record<string, unknown> =>
   return capped
 }
 
-/** Persists the in-memory buffer to localStorage synchronously. On quota errors, drops the oldest half and retries once, then gives up silently. Never throws. */
+/** Persists the active chunk to localStorage synchronously. On quota errors, removes every other chunk (keeping the newest entries) and retries once, then gives up silently. Never throws. */
 const persist = (): void => {
+  const key = chunkKey(chunkOrdinal(chunk[chunk.length - 1]?.seq ?? 0))
   try {
-    storage.setItem(DEBUG_LOG_KEY, JSON.stringify(entries))
+    storage.setItem(key, JSON.stringify(chunk))
   } catch {
-    // Most likely a quota error. Drop the oldest half and retry once so the most recent (most relevant) entries survive.
-    entries.splice(0, Math.ceil(entries.length / 2))
+    // Most likely a quota error. Free the other chunks so the most recent (most relevant) entries survive.
     try {
-      storage.setItem(DEBUG_LOG_KEY, JSON.stringify(entries))
+      Array.from({ length: CHUNK_COUNT }, (_, i) => chunkKey(i))
+        .filter(k => k !== key)
+        .forEach(k => storage.removeItem(k))
+      storage.removeItem(DEBUG_LOG_KEY)
+      storage.setItem(key, JSON.stringify(chunk))
     } catch {
       // Give up silently; logging must never interfere with the app.
     }
   }
 }
 
-/** Appends an entry to the rolling buffer and persists it synchronously. No-op when logging is disabled. Never throws, so instrumentation can never worsen a freeze or break editing. */
+/** Appends an entry to the rolling buffer and persists its chunk synchronously. No-op when logging is disabled. Never throws, so instrumentation can never worsen a freeze or break editing. */
 const log = (type: string, fields?: Record<string, unknown>): void => {
   if (!enabled) return
   try {
     const now = performance.now()
     const dt = lastTime === 0 ? 0 : Math.round(now - lastTime)
     lastTime = now
-    entries.push({ seq: seq++, t: Date.now(), dt, type, ...capFields(fields) })
+    const entry: DebugLogEntry = { seq: seq++, t: Date.now(), dt, type, ...capFields(fields) }
+    entries.push(entry)
     if (entries.length > DEBUG_LOG_CAPACITY) {
       entries.splice(0, entries.length - DEBUG_LOG_CAPACITY)
     }
+    // start a fresh chunk at each chunk boundary; its key rotates onto (and thereby evicts) the oldest persisted chunk
+    if (chunk.length > 0 && chunkOrdinal(entry.seq) !== chunkOrdinal(chunk[chunk.length - 1].seq)) {
+      chunk = []
+    }
+    chunk.push(entry)
     persist()
   } catch {
     // Logging must never throw.
   }
 }
 
-/** The frame heartbeat loop. Records a throttled `frame` entry on each animation frame while logging is enabled. If the log stops but the last `frame` timestamp is stale, the freeze was a synchronous JS loop (rAF never fired again); if `frame` keeps ticking past the last event, the hang is at the native/WebKit layer. */
+/** The frame heartbeat loop. While logging is enabled, writes a small in-place marker (FRAME_MARKER_KEY) at most every 500ms, and appends a `frameGap` entry only when the gap between consecutive animation frames is anomalous. If the log stops and the marker is stale, the freeze was a synchronous JS loop (rAF never fired again); if the marker keeps advancing past the last event, the hang is at the native/WebKit layer. Healthy frames no longer append entries, so idle time cannot evict real events from the buffer. */
 const frameLoop = (): void => {
   if (!enabled) return
   const now = performance.now()
-  if (now - lastFrameLogged >= FRAME_HEARTBEAT_THROTTLE_MS) {
-    lastFrameLogged = now
-    log('frame')
+  if (lastFrameTime !== 0 && now - lastFrameTime >= FRAME_GAP_THRESHOLD_MS) {
+    log('frameGap', { gap: Math.round(now - lastFrameTime) })
+  }
+  lastFrameTime = now
+  if (now - lastMarkerWritten >= FRAME_MARKER_THROTTLE_MS) {
+    lastMarkerWritten = now
+    try {
+      storage.setItem(FRAME_MARKER_KEY, String(Date.now()))
+    } catch {
+      // Marker writes must never interfere with the app.
+    }
   }
   frameId = requestAnimationFrame(frameLoop)
 }
@@ -111,7 +174,8 @@ const frameLoop = (): void => {
 /** Starts the requestAnimationFrame heartbeat. No-op if unavailable (e.g. SSR). */
 const startFrameHeartbeat = (): void => {
   if (typeof requestAnimationFrame !== 'function' || frameId != null) return
-  lastFrameLogged = 0
+  lastFrameTime = 0
+  lastMarkerWritten = 0
   frameId = requestAnimationFrame(frameLoop)
 }
 
@@ -126,22 +190,58 @@ const stopFrameHeartbeat = (): void => {
 /** Returns a copy of the current buffer, including any entries hydrated from a prior session. */
 const read = (): DebugLogEntry[] => [...entries]
 
-/** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. */
-const format = (): string =>
-  entries
+/** Renders one thought of the format() state dump as a single line. */
+const formatThought = (thought: {
+  id: string
+  value: string
+  rank: number
+  parentId: string
+  pending?: boolean
+}): string => {
+  const value =
+    thought.value.length > DUMP_VALUE_MAX_LENGTH ? `${thought.value.slice(0, DUMP_VALUE_MAX_LENGTH)}…` : thought.value
+  return `${thought.id} ${JSON.stringify(value)} rank:${thought.rank} parent:${thought.parentId}${thought.pending ? ' pending' : ''}`
+}
+
+/** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. Appends the last-frame marker and, when state is provided, a compact dump of state.thoughts.thoughtIndex (one line per thought, grouped by parent and ordered by rank) so entry ids can be resolved to values and current sibling order is visible. */
+const format = (state?: State): string => {
+  const entryLines = entries
     .map(({ seq, t, dt, type, ...fields }) => {
       const fieldStr = Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : ''
       return `[${new Date(t).toISOString()}] +${dt}ms #${seq} ${type}${fieldStr}`
     })
     .join('\n')
 
-/** Empties the buffer and removes it from localStorage. */
+  let markerLine = ''
+  try {
+    const marker = storage.getItem(FRAME_MARKER_KEY)
+    markerLine = marker ? `\n--- lastFrameAt: ${new Date(Number(marker)).toISOString()}` : ''
+  } catch {
+    // ignore
+  }
+
+  const dump = state
+    ? [
+        `\n--- state.thoughts: ${Object.keys(state.thoughts.thoughtIndex).length} thoughts, ${Object.keys(state.thoughts.lexemeIndex).length} lexemes`,
+        ...Object.values(state.thoughts.thoughtIndex)
+          .sort((a, b) => (a.parentId < b.parentId ? -1 : a.parentId > b.parentId ? 1 : a.rank - b.rank))
+          .map(formatThought),
+      ].join('\n')
+    : ''
+
+  return `${entryLines}${markerLine}${dump}`
+}
+
+/** Empties the buffer and removes all of its localStorage keys, including the legacy single-key buffer and the frame marker. */
 const clear = (): void => {
   entries = []
+  chunk = []
   seq = 0
   lastTime = 0
   try {
     storage.removeItem(DEBUG_LOG_KEY)
+    storage.removeItem(FRAME_MARKER_KEY)
+    Array.from({ length: CHUNK_COUNT }, (_, i) => storage.removeItem(chunkKey(i)))
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Overview

A debugging session traced an unexplained reorder (a thought that should have been first ended up last) and found the debug log could not answer *when it moved*: the 500ms `frame` heartbeat filled the 1000-entry rolling buffer in ~8 idle minutes, so the `moveThought` action had been evicted hours earlier, and the move had to be reconstructed by hand from persisted `lastUpdated` stamps and vacated ranks. This PR extends the debug log so that the next investigation of this kind is a one-grep answer.

## What changed

- **Frame heartbeat no longer floods the buffer** ([`debugLog.ts`](../blob/HEAD/src/util/debugLog.ts)). Healthy frames update an in-place `debugLog-frame` localStorage marker (≤1 write/500ms) instead of appending entries; only an anomalous inter-frame gap (≥500ms) appends a `frameGap` entry. The freeze-forensics semantics are preserved: a stale marker means rAF stopped (synchronous JS loop), an advancing marker past the last entry means a native-layer hang.
- **Capacity 1000 → 5000, persisted in ten rotating 500-entry chunks** (`debugLog-0` … `debugLog-9`). Appending an entry now rewrites only the active chunk (~≤100KB) instead of the whole buffer, so the synchronous per-entry persist gets *cheaper* while retention rises 5×. Legacy single-key logs hydrate and migrate transparently; quota errors drop the oldest chunks and retry once.
- **Self-describing `move` entries** ([`loggerMiddleware.ts`](../blob/HEAD/src/redux-middleware/loggerMiddleware.ts)). The middleware captures state before/after each action and, when `thoughtIndex` changed by reference, logs a `move` entry (value, `oldRank → newRank`, parent, triggering `actionType`) for every thought whose rank or parent changed — the same predicate `undoRedoEnhancer` uses to detect moves. This catches moves from every source (commands, drag-and-drop, sort reranks, undo/redo, sync) without special-casing any reducer. More than 10 changes in one action collapse into a single `moveBatch` summary.
- **Structured `updateThoughts` summaries** replace the raw stringified action (whose 2000-char truncation cut JSON mid-field): per-thought `{id, value, rank, parentId, pending}` capped at 20, plus counts and the `local`/`remote` flags.
- **Duplicate-sibling-rank integrity warning** (warning only, never a hard fail): after actions that changed thoughts, exact duplicate ranks among the changed thoughts' siblings log an `integrity` entry and `console.warn`, deduped per parent+rank. Surfaces the corruption class behind unexplained reorders at the moment it happens.
- **Undo/redo attribution**: an `undo`/`redo` entry names the original action types read from the popped patch stacks, so a move restored by undo is distinguishable from a fresh user move. No enhancer changes needed.
- **Push flush logging** ([`pushQueue.ts`](../blob/HEAD/src/redux-enhancers/pushQueue.ts)): `push` (batch/thought/lexeme/move counts + a 10-thought sample) before the provider write, `pushSynced` on completion, `pushError` on failure — so database `lastUpdated` stamps can be correlated with log entries and an unlanded write shows as a `push` with no `pushSynced`.
- **Drop attribution** ([`useDragAndDropThought`](../blob/HEAD/src/hooks/useDragAndDropThought.tsx), [`useDragAndDropSubThought`](../blob/HEAD/src/hooks/useDragAndDropSubThought.tsx)): drops log a `drop` entry (zone, target id/value, item count), giving drag-and-drop the attribution parity that keyboard/gesture/toolbar commands already had via `commands.ts`.
- **`state.thoughts` dump at copy time** ([`Settings.tsx`](../blob/HEAD/src/components/modals/Settings.tsx)): the Copy debug log control dispatches a thunk and passes state into `format()`, which appends the `lastFrameAt` marker line plus one line per loaded thought — id, value (capped), rank, parent, pending — sorted by parent then rank, so entry ids resolve to values and current sibling order is visible at a glance.

## Verification

- Full unit suite: 2237 passed, 62 pre-existing skips. New coverage in `src/util/__tests__/debugLog.ts` (chunked persistence, rotation, hydration/migration, clear, format marker + dump), `src/redux-middleware/__tests__/loggerMiddleware.ts` (structured summary, `move`, `moveBatch`, `integrity`, `undo` via the real store), and a new `src/redux-enhancers/__tests__/pushQueue.ts` (`push`/`pushSynced`). `tsc`, `eslint`, and `prettier` clean.
- Live verification in the running app (dev server, Debug Logging enabled through the Settings UI): two minutes of activity produced 23 entries with zero `frame` entries (previously ~240); a real Move Thought Up logged `move {"actionType":"moveThoughtUp","value":"a","oldRank":1.5,"newRank":0.5,…}`; `push`/`pushSynced` pairs appeared per flush; the frame marker advanced while frames ran and froze while rAF was suspended (the intended signal); `format(state)` rendered the marker line and the per-thought dump grouped by parent.

Reviewer notes:

- The `frameGap` branch itself was not observed live (a hidden tab suspends rAF entirely — which the frozen marker correctly reported) and is not practically unit-testable without injecting time; it is three guarded lines covered by review.
- Writing the middleware tests surfaced that `updateThoughts` drops non-local updates whose `lastUpdated` has not advanced (the last-write-wins guard at `updateThoughts.ts:126`); the tests dispatch local updates and carry a comment documenting this.
- The `pushSynced` count can exceed `push` by one when logging is enabled mid-flight (a flush that started before enabling completes after); harmless and only affects the enabling moment.

<details>
<summary>Architectural plan (per <code>.github/skills/plan</code>)</summary>

### 1. Existing surface area

- `src/util/debugLog.ts:7-14` — `DEBUG_LOG_CAPACITY = 1000` and the 500ms `FRAME_HEARTBEAT_THROTTLE_MS`; `frameLoop` (lines 100-108) documents the freeze-forensics contract the change must preserve (stale frame = JS loop; ticking frame past last event = native hang). `log`/`persist` (lines 68-98) establish the two invariants: never throw, synchronous persist per entry.
- `src/redux-middleware/loggerMiddleware.ts:8-29` — ignored the store API (`= () =>`) and stringified every action whole with 2000-char field truncation. Chain position (`src/stores/app.ts:33-46`: `multi, thunk, …, loggerMiddleware`) guarantees plain actions and post-enhancer state; `pushQueue` drains `state.pushQueue` before the middleware ever reads post-state (`pushQueue.ts:129`), which is why push logging must live in the enhancer.
- `src/redux-enhancers/undoRedoEnhancer.ts:123-124` — existing move-detection precedent: `oldThought.parentId !== thought.parentId || oldThought.rank !== thought.rank`. Lines 411/267/226-228 — `'undo'`/`'redo'` action types pop patch stacks whose operations carry the original `actions: ActionType[]`, so the middleware can attribute undo/redo purely from state.
- `src/redux-enhancers/pushQueue.ts:88-107` — the flush point (`applyDbQueue` → `persistPushQueueBatches`, `.then(idbSynced)`, `.catch`); the enhancer already performs side effects by design (`cacheSetting`, `db.freeThought`). `PushBatch.movePlacements` already carries per-moved-thought placement.
- `src/hooks/useDragAndDropThought.tsx:241-252` and `useDragAndDropSubThought.tsx:219-225` — the only DnD dispatch sites (`docs/drag-and-drop.md` confirms), with no debugLog call; `commands.ts:420` shows command attribution.
- `src/components/modals/Settings.tsx:129-133` — the only `format()` caller; code-standards mandates the dispatch-thunk pattern for fresh state, and `stores/app.ts → loggerMiddleware → debugLog` forbids debugLog importing the store (cycle) — a type-only `State` import is safe.
- `Editable.tsx:335` (`debugLog.log('edit', { oldValue, newValue, rank })`) — precedent that thought values already flow into the log, so summaries/dumps do not change its privacy posture.
- Tests: `src/util/__tests__/debugLog.ts` asserted capacity 1000 and the single `debugLog` key; `__tests__/loggerMiddleware.ts` invoked with a `{} as any` store ("store api is unused"), invalidated by this change. No pushQueue test existed. No `docs/` page describes the debug log (grepped), so no doc repair is triggered.

### 2. Build vs. extend

Extend, everywhere — every change lands in the module that already owns the concern (buffer/persistence/format in `debugLog.ts`; all Redux-derived observation in `loggerMiddleware.ts`; flush logging at the only place flush timing is knowable; drop logging at the only DnD dispatch sites; state passed by the only `format()` caller). No new source files. One new test file (`src/redux-enhancers/__tests__/pushQueue.ts`) per the tests-next-to-source convention. Rejected: logging inside reducers (purity rule) and any `undoRedoEnhancer` change (patch stacks already expose what is needed).

### 3. Adjacent behaviour surface

Zero cost when disabled (`isEnabled()` guards all new derivation); never throw (all new logging in the existing never-throw posture, and the flush promise chain unchanged); freeze forensics preserved (marker replaces the positive heartbeat signal, `frameGap` improves the negative one); persist cost bounded (chunk writes ≤ ~100KB vs the previous full-buffer writes; worst-case total ~2.5MB within quota, with drop-oldest fallback); hydration/migration keeps prior-session recovery working and `clear()` removes every key; the diff pass runs only when `thoughtIndex` changed by reference and iterates only loaded thoughts (bounded by freeThoughts); middleware chain semantics unchanged (plain actions only, no dispatches from the middleware, no re-entrancy); integrity warnings resolve siblings through `getChildrenRanked` (unloaded children dropped) and dedupe per parent+rank; editor behaviors (deletion, selection, caret, IME, undo/redo, copy/paste, gestures, multicursor) untouched — no reducer, render-path, or event-handler changes beyond one straight-line log call before each existing drop dispatch; `log()` signature unchanged for all existing call sites and `format()` gains only an optional parameter.

### 4. Approaches considered

- Frames: suppress + marker + chunked capacity raise (chosen) vs. two ring buffers (keeps appending noise) vs. suppression-only at 1000 (simplest, but heavy typing — ~7 entries/keystroke from Editable's instrumentation — can still evict a move within minutes, and chunking reduces per-entry write cost, so the complexity buys retention and performance at once).
- Move logging: post-state diff in the middleware (chosen — one predicate catches every source) vs. logging in `moveThought` (impure; misses sort/undo/sync) vs. special-casing action types (misses reducers that compose `moveThought` internally, e.g. `moveThoughtDown`).
- Copy-time context: caller passes `State` into `format()` via dispatch-thunk (chosen — respects the no-store-import standard and avoids the import cycle) vs. debugLog importing the store (cycle) vs. an id→value legend (rejected in favour of the full dump).

### 5. Critique (passed)

Verified the middleware test harness change is mandatory (the store API is now used); confirmed push logging cannot observe `state.pushQueue` post-reduction (drained by the enhancer); switched duplicate detection to adjacent-equality over `getChildrenRanked`'s sorted output; noted that undoing a move intentionally emits both `undo` and `move` entries; added the frame marker to `clear()`; re-confirmed `moveThoughtDown` dispatches its own type (defeating the special-casing alternative); all placements match `docs/folder-structure.md` and the reducer-purity rule.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
