### PR TITLE
Describe TreeCRDT instead of Yjs in the persistence docs

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -54,7 +54,7 @@ interface Thought {
   childrenMap: Index<ThoughtId>
   created: Timestamp
   lastUpdated: Timestamp
-  /** Public key of the writer; SHA-256(accessToken). See data-providers/yjs/index.ts. */
+  /** Public key of the writer; SHA-256(accessToken). See data-providers/thoughtspaceSession.ts. */
   updatedBy: string
   /** Set when archived. Undefined for live thoughts. */
   archived?: Timestamp
@@ -67,7 +67,7 @@ interface Thought {
 }
 ```
 
-See [Thought.ts](../src/@types/Thought.ts). On disk thoughts are persisted as a separate `ThoughtDb` shape with single-letter keys for compactness — see [persistence.md](persistence.md).
+See [Thought.ts](../src/@types/Thought.ts). Only part of this shape is persisted: TreeCRDT stores a `ThoughtPayload` (`value`, `created`, `lastUpdated`, `updatedBy`, `archived`) on each node and derives `parentId`, `rank`, and `childrenMap` from the tree on read — see [persistence.md → Document model](persistence.md#document-model).
 
 #### rank
 
@@ -83,6 +83,8 @@ So `[1, 2, 5, 6]` becomes `[1, 2, 5, 5.5, 6]` when a thought is inserted between
 
 `importJSON` autoincrements ranks across all imported thoughts (for efficiency), so the absolute ranks may differ from what manual insertion would have produced — but sibling-relative ordering is preserved.
 
+Rank is an in-memory ordering only. TreeCRDT stores sibling order in the tree itself, so `rank` is not persisted: it is re-projected from the stored child order (0, 1, 2, …) every time a thought is read back. Reorders are sent to storage as explicit placements rather than as new rank numbers — see [persistence.md → Order and placement](persistence.md#order-and-placement).
+
 #### pending
 
 A thought with `pending: true` is known to exist (its `id` is in `thoughtIndex`) but its real data has not yet been pulled from local/remote storage. The UI renders pending thoughts with placeholders, and the pull queue ([`pullQueue.ts`](../src/redux-middleware/pullQueue.ts)) drives fetches based on visible pending IDs. See [persistence.md](persistence.md).
@@ -93,7 +95,7 @@ A thought with `pending: true` is known to exist (its `id` is in `thoughtIndex`)
 type ThoughtId = string & Brand<'ThoughtId'>
 ```
 
-A `ThoughtId` is a 21-char nanoid (e.g. `kv9a-vzva-ac4n` shown without dashes). Strings are nominally branded ([`Brand.ts`](../src/@types/Brand.ts)) so a raw string can't accidentally be passed where a `ThoughtId` is expected without an explicit cast.
+A `ThoughtId` is 32 lowercase hex characters — a random 128-bit value minted by [`createId`](../src/util/createId.ts), in the format TreeCRDT requires for a node id. Strings are nominally branded ([`Brand.ts`](../src/@types/Brand.ts)) so a raw string can't accidentally be passed where a `ThoughtId` is expected without an explicit cast.
 
 ### Context
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,13 +8,15 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **absolute context** — A second root context whose ordering reflects recency rather than the home tree. `state.absoluteContextTime` is the timestamp captured when the absolute context was last entered; it shifts visibility for newly added thoughts so they surface in the absolute view. See `childrenFilterPredicate` in [`getChildren.ts`](../src/selectors/getChildren.ts).
 
-**accessToken** — Per-device 21-char nanoid stored in `localStorage`. Authenticates the device against the (currently inert) websocket server. Override with `?auth=<token>`. See [persistence.md → Identity & sharing](persistence.md#identity--sharing).
+**accessToken** — Per-device 21-char nanoid stored in `localStorage`. The device's secret: *clientId* (and from it the *replicaId*) is derived from it, and it keys the device's entry in *permissionsStore*. Override with `?auth=<token>`. See [persistence.md → Identity & sharing](persistence.md#identity--sharing).
 
 **action** — A Redux state-mutating function under [`/src/actions`](../src/actions). Reducers are preferred over thunks; thunks only when a side effect is needed. Compose with [`util/reducerFlow`](../src/util/reducerFlow.ts).
 
 **archived** — Soft-deletion timestamp on `Thought`. Distinct from `=archive`, the meta-attribute parent under which archived thoughts are nested.
 
 **attribute / meta-attribute** — A child thought whose value starts with `=` (e.g. `=pin`, `=style`, `=view`). Meta-attributes change app behaviour for their parent (or, with `=children`/`=grandchildren`, for descendants). Stored under their value in `childrenMap` for `O(1)` lookup. See [metaprogramming.md](metaprogramming.md).
+
+**attribute-child index** — `em_attribute_children`, an app-owned SQLite table mapping each `=attribute` child to its parent and value. It restores the value-keying half of *childrenMap*, which TreeCRDT itself does not store. Rebuilt from the tree when its version changes, then maintained on every write. See [persistence.md → Derived tables](persistence.md#derived-tables).
 
 **autocrop** — Vertical: hides the empty space above a deep cursor by translating the layout container upward and counter-scrolling to keep visible thoughts stable. Horizontal: see *indent*. See [layout-rendering.md → useAutocrop](layout-rendering.md#useautocrop-vertical-autocrop).
 
@@ -23,8 +25,6 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 ## B
 
 **backend (drag)** — react-dnd backend selected by `isTouch`: `TouchBackend` on touch, `HTML5Backend` on desktop. Both patched. See [drag-and-drop.md → Backend selection](drag-and-drop.md#backend-selection).
-
-**background replication** — Loads a Y.Doc and deallocates after first sync; doesn't retain. Used by the doclog controller and one-shot reads. Contrast with *foreground replication*. See [persistence.md → Replication](persistence.md#replication).
 
 **belowCursor** — Flag set on every `TreeThought` after the cursor is encountered during the in-order walk. Used to exclude hidden thoughts below the cursor from `totalHeight` so the document doesn't have a giant trailing dead zone.
 
@@ -60,11 +60,9 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **DataProvider** — The single interface ([`DataProvider.ts`](../src/data-providers/DataProvider.ts)) for storage backends. The active implementation is exported through [`data-providers/thoughtspace.ts`](../src/data-providers/thoughtspace.ts).
 
-**dbQueue / freeQueue** — Two halves of the push-queue split. `dbQueue` writes batches with `local || remote` set; `freeQueue` releases entries from the in-memory cache. See [persistence.md → Push queue](persistence.md#push-queue-redux--yjs).
+**dbQueue / freeQueue** — Two halves of the push-queue split. `dbQueue` writes batches with `local || remote` set; `freeQueue` releases entries from the in-memory cache. See [persistence.md → Push queue](persistence.md#push-queue-redux--treecrdt).
 
-**docKey** — Identifier for a Y.Doc. For a thought, it's the parent's `ThoughtId` (or `ROOT_PARENT_ID` for root contexts). For a Lexeme, `hashThought(value)`. The `docKeys: Map<ThoughtId, string>` in `thoughtspace.ts` is the ledger that maps each thought to the doc that contains it.
-
-**doclog** — Yjs document used to track replication state across clients. Driven by a *background replication* controller.
+**docId** — The TreeCRDT document identifier for the thoughtspace. Equal to *tsid*. See [persistence.md → The TreeCRDT client](persistence.md#the-treecrdt-client).
 
 **DragCanceled / DragHold / DragInProgress / Inactive** — Values of [`LongPressState`](../src/constants.ts), the state machine for the drag/long-press subsystem. See [drag-and-drop.md → State machine](drag-and-drop.md#state-machine-statelongpress).
 
@@ -82,13 +80,13 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **fetchDescendants** — Async iterable that does breadth-first traversal of thought IDs and yields `{ thoughtIndex, lexemeIndex }` chunks. The actual pull engine. See [persistence.md → fetchDescendants](persistence.md#fetchdescendants-the-actual-pull-engine).
 
-**foreground replication** — Default replication mode. Adds the docKey to `thoughtRetained`, subscribes to change events, and keeps the Y.Doc cached until `freeThought` is called. Contrast with *background replication*.
-
-**freeThought / freeLexeme** — Releases a Y.Doc from the in-memory cache (after IDB sync). Idempotent and safe under concurrent re-pull. Distinct from *deleteThought*, which also wipes IDB.
+**freeThought / freeLexeme** — `DataProvider` methods for releasing a thought or Lexeme from the provider's in-memory cache. No-ops under TreeCRDT, which keeps the whole thoughtspace in one SQLite database; freeing memory means dropping entries from the Redux indexes. See [persistence.md → Memory management](persistence.md#memory-management).
 
 ## G
 
 **generating** — Flag on `Thought` set while content is being produced by AI. Distinct from `pending` (loading from storage).
+
+**GLOBAL_ROOT_TOKEN** — The root node of the TreeCRDT tree, and the value `ROOT_PARENT_ID` aliases. `HOME_TOKEN`, `EM_TOKEN`, and `ABSOLUTE_TOKEN` are inserted as its children during initialization. See [`constants.ts`](../src/constants.ts).
 
 **gesture** — Swipe pattern for command activation on touch. Defined per command via the `gesture` field on [`Command`](../src/@types/Command.ts). See [commands.md → Gesture activation](commands.md#gesture-activation).
 
@@ -116,9 +114,13 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 ## M
 
+**materialization** — TreeCRDT applying operations to its SQLite read model, after which `client.onMaterialized` fires. em ignores events produced by its own writes (identified by *writeId*) and refreshes Redux from the rest. See [persistence.md → Change observation](persistence.md#change-observation-materialization).
+
 **meta-attribute** — See *attribute*.
 
 **ministore** — Lightweight non-Redux store for ephemeral UI state, in [`/src/stores`](../src/stores). Used when the value doesn't need to participate in undo/redo, persistence, or selectors (e.g. `editingValue`, `viewport`, `scrollTop`).
+
+**movePlacements** — `Index<ThoughtId | null>` on `PushBatch`. Keyed by moved thought; the value is the sibling to place it after (`null` = first). Carries reorder intent from the action layer to TreeCRDT, which stores sibling order directly instead of by rank. See [persistence.md → Order and placement](persistence.md#order-and-placement).
 
 **multicursor** — Multiple selected thoughts. `state.multicursors: Index<Path>` keyed by `hashPath(path)`. Commands that support multicursor declare it via the `multicursor` field on `Command`. Drag picks up the full set into `draggingThoughts`. See [commands.md → Multicursor](commands.md#multicursor).
 
@@ -132,13 +134,13 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **pending** — Flag on `Thought` indicating the id is known to exist (`thoughtIndex[id]` is set) but the real data hasn't been pulled from local/remote storage yet. UI renders placeholders; the pull queue fetches based on visible pending IDs.
 
-**permissionsClientDoc** — Separate Y.Doc holding `Index<Share>` keyed by access token (one entry per device with access). CRUD in [`permissionsModel.ts`](../src/data-providers/yjs/permissionsModel.ts).
+**permissionsStore** — Ministore holding `Index<Share>` keyed by access token (one entry per device with access), persisted with `idb-keyval` under `em-permissions:${tsid}`. See [`permissionsStore.ts`](../src/data-providers/permissionsStore.ts); CRUD in [`permissionsModel.ts`](../src/data-providers/permissionsModel.ts).
 
 **=pin** — Meta-attribute that keeps a thought expanded. Scoped variants: `=children/=pin` keeps all children of a context expanded (the replacement for the old `=pinChildren`), and `=descendants/=pin` keeps the entire subtree expanded. `=pin` is also pre-loaded eagerly during `fetchDescendants` to avoid a flash of expanded children before `=pin/false` resolves. See [metaprogramming.md](metaprogramming.md#pinning--expansion).
 
-**pull queue** — [`pullQueue.ts`](../src/redux-middleware/pullQueue.ts) middleware that, on every action, computes the visible thought IDs and triggers `pull` for any pending ones. Debounced 10 ms, throttled 100 ms. See [persistence.md → Pull queue](persistence.md#pull-queue-yjs--redux).
+**pull queue** — [`pullQueue.ts`](../src/redux-middleware/pullQueue.ts) middleware that, on every action, computes the visible thought IDs and triggers `pull` for any pending ones. Debounced 10 ms, throttled 100 ms. See [persistence.md → Pull queue](persistence.md#pull-queue-treecrdt--redux).
 
-**push queue** — [`pushQueue.ts`](../src/redux-enhancers/pushQueue.ts) Redux enhancer that drains `state.pushQueue` after every action, partitioning into `dbQueue` (writes) and `freeQueue` (cache release). See [persistence.md → Push queue](persistence.md#push-queue-redux--yjs).
+**push queue** — [`pushQueue.ts`](../src/redux-enhancers/pushQueue.ts) Redux enhancer that drains `state.pushQueue` after every action, partitioning into `dbQueue` (writes) and `freeQueue` (cache release). See [persistence.md → Push queue](persistence.md#push-queue-redux--treecrdt).
 
 ## Q
 
@@ -150,13 +152,17 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **reducerFlow** — [`util/reducerFlow.ts`](../src/util/reducerFlow.ts) — composes a list of reducers into a single reducer. Standard pattern in `actions/`.
 
-**replication** — Loading a Y.Doc into the in-memory cache (from local IDB and, when wired, from the websocket server). `replicateThought` / `replicateLexeme` are idempotent under concurrency. See [persistence.md → Replication](persistence.md#replication).
+**replicaId** — The 32-byte id TreeCRDT mints local operations under, derived from *clientId* by `clientIdToReplicaId`. A low-level CRDT identity, not an auth identity.
+
+**replication** — Loading thoughts out of local storage and into memory. [`replicateTree`](../src/data-providers/data-helpers/replicateTree.ts) walks a subtree in the background without populating Redux; the pull queue is the foreground path. `syncStatusStore.replicationProgress` tracks it for the UI.
 
 **ROOT_CONTEXTS** — `[HOME_TOKEN, ABSOLUTE_TOKEN]`. The two top-level contexts.
 
-**ROOT_PARENT_ID** — Sentinel `ThoughtId` used as the docKey for root-context Y.Docs. Distinct from `HOME_TOKEN` / `ABSOLUTE_TOKEN`, which are the root *thoughts*; `ROOT_PARENT_ID` is the *parent* of those root thoughts in the persistence layer.
+**ROOT_PARENT_ID** — Sentinel `ThoughtId` for the parent of the root thoughts. An alias for `GLOBAL_ROOT_TOKEN`, the TreeCRDT tree root. Distinct from `HOME_TOKEN` / `ABSOLUTE_TOKEN`, which are the root *thoughts*; `ROOT_PARENT_ID` is their *parent*. `getThoughtById` reports it as the `parentId` of any thought whose TreeCRDT parent is the tree root.
 
 ## S
+
+**session lock** — Exclusive Web Lock named `em-treecrdt-session:${tsid}`, held for the lifetime of the page so only one tab opens a thoughtspace at a time. A second tab renders [`ThoughtspaceInUse`](../src/components/ThoughtspaceInUse.tsx) instead of the app. See [persistence.md → Single-tab access](persistence.md#single-tab-access).
 
 **shortcut** — Legacy term for *command*. The folder was renamed `/src/shortcuts → /src/commands`; some doc references and helper names persist.
 
@@ -170,27 +176,29 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 ## T
 
-**tangential context** — A context that hasn't been pulled directly through the cursor's ancestor chain but is referenced via a Lexeme entry in another loaded thought. `replicateThought` walks the Lexeme's `cx-${id}` entries and pulls ancestors so tangential references resolve. See `thoughtspace.ts` lines around the comment "tangential contexts".
+**tangential context** — A context that hasn't been pulled directly through the cursor's ancestor chain but is referenced from elsewhere — via a Lexeme's `contexts`, or by the context view. `fetchDescendants` enqueues the parent of any thought whose parent isn't loaded, so the ancestor chain resolves. See the comment "load ancestors of tangential contexts" in [`fetchDescendants.ts`](../src/data-providers/data-helpers/fetchDescendants.ts).
 
-**Thought** — In-memory record under `state.thoughts.thoughtIndex`. Distinct from `ThoughtDb`, the persisted shape with single-letter keys (`v`, `r`, `m`, …). See [data-model.md → Thought](data-model.md#thought) and [persistence.md → Compact storage keys](persistence.md#compact-storage-keys).
+**Thought** — In-memory record under `state.thoughts.thoughtIndex`. Only part of it is persisted: TreeCRDT stores a *ThoughtPayload* per node and derives `parentId`, `rank`, and `childrenMap` from the tree on read. See [data-model.md → Thought](data-model.md#thought) and [persistence.md → Document model](persistence.md#document-model).
 
-**ThoughtDb** — On-disk shape of a thought: same fields as `Thought` but keyed by single letters to keep CRDT updates compact. `thoughtToDb` / `getThought` translate.
+**ThoughtId** — Branded string identifying a thought: 32 lowercase hex characters (128 bits), the format TreeCRDT requires for a node id. Minted by [`createId`](../src/util/createId.ts). See [`@types/ThoughtId.ts`](../src/@types/ThoughtId.ts).
 
-**ThoughtId** — Branded 21-char nanoid string identifying a thought. See [`@types/ThoughtId.ts`](../src/@types/ThoughtId.ts).
+**ThoughtPayload** — The bytes stored on a TreeCRDT node: JSON-encoded `value`, `created`, `lastUpdated`, `updatedBy`, and optional `archived`. See [`payload.ts`](../src/data-providers/treecrdt/payload.ts).
 
 **thoughtspace** — A user's complete thought tree, identified by *tsid*. The unit of sharing: switching `?share=<tsid>` switches the app onto a different thoughtspace.
 
-**thoughtRetained** — Set of docKeys retained by foreground replication. While a docKey is in this set, its Y.Doc is not deallocated.
+**ThoughtspaceRuntime** — Lifecycle interface around the active provider ([`thoughtspace.ts`](../src/data-providers/thoughtspace.ts)): `acquireAccess`, `init`, `drop`, `waitForIdle`, `persistPushQueueBatches`. Implemented for TreeCRDT in [`runtime.ts`](../src/data-providers/treecrdt/runtime.ts).
+
+**TreeCRDT** — The CRDT that backs local persistence: one operation-based tree per thoughtspace, materialized into SQLite (wa-sqlite, OPFS-backed) and optionally synced over a WebSocket. See [persistence.md](persistence.md).
 
 **TreeThought / TreeThoughtPositioned** — The two parallel lists produced per render: visible thoughts in document order, and the same with `x`/`y`/`width`/`height`/`cliff` filled in. See [layout-rendering.md → Two lists](layout-rendering.md#two-lists-one-ordering).
 
-**tsid** — Thoughtspace ID. 21-char nanoid in `localStorage`. Used as the Y.Doc id prefix for every per-thoughtspace doc (`${tsid}/t/${docKey}`, `${tsid}/l/${key}`, `${tsid}/permissions`). Override with `?share=<tsid>`.
+**tsid** — Thoughtspace ID. 21-char nanoid in `localStorage`. Scopes everything per-thoughtspace: the TreeCRDT `docId`, the OPFS database file (`/treecrdt-em-${tsid}.db`), the session lock, and the permissions key. Override with `?share=<tsid>`.
 
 ## U
 
 **undo step** — What one Undo reverts: a single patch on `state.undoPatches`, or two when a navigation action follows an undoable action or an edit follows a `newThought`. The undo slider moves by undo steps. See [commands.md → Undo history and the undo slider](commands.md#undo-history-and-the-undo-slider).
 
-**updatedBy** — `clientId` of the writer. Stamped on every Thought and Lexeme write so observers can filter out self-originated change events.
+**updatedBy** — `clientId` of the writer. Stamped on every Thought and Lexeme write. (Self-originated materialization events are filtered by *writeId*, not by this field.)
 
 **updateThoughts** — The action ([`actions/updateThoughts.ts`](../src/actions/updateThoughts.ts)) that mutates Redux and queues a push. The push queue persists those batches through the active data provider's `updateThoughts`.
 
@@ -200,6 +208,8 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **VirtualThought** — Component that wraps each rendered thought, measures its height, and reports back via `onResize`. See [layout-rendering.md → VirtualThought](layout-rendering.md#virtualthought--when-does-it-re-measure).
 
-## Y
+## W
 
-**Y.Doc** — A Yjs document. In em, one per parent thought (containing all its children) and one per Lexeme. Persisted locally via `IndexeddbPersistence`. See [persistence.md → Document model](persistence.md#document-model).
+**write barrier** — [`writeBarrier.ts`](../src/data-providers/treecrdt/writeBarrier.ts). Serializes em → TreeCRDT persistence and exposes an idle barrier, so a materialization refresh cannot reapply stale rows over newer optimistic state. Also mints each write's *writeId*.
+
+**writeId** — `em-local:${sourceId}:${n}`, attached to every local TreeCRDT write and echoed on the materialization changes it produces. Lets this tab recognize and skip its own already-applied writes.

--- a/docs/metaprogramming.md
+++ b/docs/metaprogramming.md
@@ -146,6 +146,6 @@ enum Settings {
 
 (See the in-app **Settings** modal for human-readable descriptions of each.)
 
-A separate set of *cached* settings — `CACHED_SETTINGS = ['Theme', 'Tutorial', 'Tutorial Step']` — is also persisted to `localStorage` by the [`pushQueue`](../src/redux-enhancers/pushQueue.ts) enhancer so they're available before Yjs hydrates on first paint. See [persistence.md](persistence.md) for the caching mechanics.
+A separate set of *cached* settings — `CACHED_SETTINGS = ['Theme', 'Tutorial', 'Tutorial Step']` — is also persisted to `localStorage` by the [`pushQueue`](../src/redux-enhancers/pushQueue.ts) enhancer so they're available before the thoughtspace hydrates on first paint. See [persistence.md](persistence.md) for the caching mechanics.
 
 Reads go through [`getSetting`](../src/selectors/getSetting.ts), which first consults the in-memory thought (e.g. `[EM, 'Settings', 'Tutorial']`) and falls back to the localStorage cache when needed.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -3,15 +3,15 @@
 The persistence layer has three tiers:
 
 1. **In-memory state** — Redux store (`state.thoughts.thoughtIndex` and `state.thoughts.lexemeIndex`), holding only thoughts that are currently visible.
-2. **Local persistence** — Yjs CRDT documents persisted with [y-indexeddb](https://github.com/yjs/y-indexeddb).
-3. **Remote sync** — a [Hocuspocus](https://tiptap.dev/hocuspocus) server in [`server/`](../server). **Currently inert on `main`** — see [Remote sync](#remote-sync-currently-inert) below.
+2. **Local persistence** — a [TreeCRDT](https://github.com/cybersemics/treecrdt) operation log materialized into SQLite, running in the browser via [`@treecrdt/wa-sqlite`](https://www.npmjs.com/package/@treecrdt/wa-sqlite) and stored in OPFS.
+3. **Remote sync** — TreeCRDT WebSocket sync ([`@treecrdt/sync`](https://www.npmjs.com/package/@treecrdt/sync)). **Opt-in** — see [Remote sync](#remote-sync-opt-in) below.
 
-Two queues bridge Redux and the local Yjs store:
+Two queues bridge Redux and the local TreeCRDT store:
 
-- **Push queue** ([`redux-enhancers/pushQueue.ts`](../src/redux-enhancers/pushQueue.ts)) drains `state.pushQueue` after every action and writes to Yjs.
-- **Pull queue** ([`redux-middleware/pullQueue.ts`](../src/redux-middleware/pullQueue.ts)) tracks visible thoughts and pulls any pending ones from Yjs.
+- **Push queue** ([`redux-enhancers/pushQueue.ts`](../src/redux-enhancers/pushQueue.ts)) drains `state.pushQueue` after every action and writes to TreeCRDT.
+- **Pull queue** ([`redux-middleware/pullQueue.ts`](../src/redux-middleware/pullQueue.ts)) tracks visible thoughts and pulls any pending ones from TreeCRDT.
 
-The single point of integration with persistence is the [`DataProvider`](../src/data-providers/DataProvider.ts) interface, implemented by the active thoughtspace backend.
+The single point of integration with persistence is the [`DataProvider`](../src/data-providers/DataProvider.ts) interface, implemented by the active thoughtspace backend. [`data-providers/thoughtspace.ts`](../src/data-providers/thoughtspace.ts) exports both the active provider (`db`) and the `ThoughtspaceRuntime` that owns its lifecycle; today both are the TreeCRDT implementation.
 
 ## In-memory state (Redux)
 
@@ -19,129 +19,154 @@ Thoughts live in `state.thoughts.thoughtIndex` (keyed by `ThoughtId`) and `state
 
 Thoughts that are known to exist but haven't been loaded yet are flagged with `pending: true` so the UI can render placeholder rows while the pull queue fetches them.
 
-## Local persistence (Yjs + y-indexeddb)
+## Local persistence (TreeCRDT + SQLite)
+
+### The TreeCRDT client
+
+[`treecrdt/runtime.ts`](../src/data-providers/treecrdt/runtime.ts) owns exactly one `TreecrdtClient`, created by `createTreecrdtClient` with `docId = tsid` and a storage mode chosen at startup:
+
+| `ThoughtspaceStorage` | SQLite storage | Runtime |
+|---|---|---|
+| `'persistent'` (app default) | OPFS file `/treecrdt-em-${tsid}.db`, falling back to memory if OPFS is unavailable | `dedicated-worker` |
+| `'memory'` (unit tests, most e2e) | in-memory | `direct` |
+
+[`index.tsx`](../src/index.tsx) passes `testFlags.thoughtspaceStorage ?? 'persistent'`. If persistent storage was requested but the client came back with `storage === 'memory'`, the runtime logs a warning that changes will not survive a reload. The wa-sqlite WASM assets are emitted into `public/wa-sqlite` by the `treecrdt` Vite plugin (see [`vite.config.ts`](../vite.config.ts)).
+
+The client surface em uses:
+
+- `client.tree` — the materialized read model: `children`, `parent`, `exists`, `getPayload`.
+- `client.local` — local write ops minted for a replica id: `insert`, `move`, `delete`, `payload`. Each returns an `Operation`.
+- `client.runner` — raw SQLite access, used for em's own derived tables.
+- `client.onMaterialized` — subscription fired after ops are materialized into SQLite.
+- `client.drop()` — closes the client and deletes the OPFS database file.
+
+### Single-tab access
+
+The thoughtspace is opened by a single tab at a time. [`sessionLock.ts`](../src/data-providers/treecrdt/sessionLock.ts) requests an exclusive [Web Lock](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) named `em-treecrdt-session:${tsid}` with `ifAvailable: true`; the lock callback deliberately never resolves, so the browser holds the lock for the lifetime of the page and releases it on close or navigation. Native (Capacitor) platforms always report `acquired`, since they cannot open a second tab; a browser without `navigator.locks` reports `unsupported`.
+
+[`index.tsx`](../src/index.tsx) calls `thoughtspaceRuntime.acquireAccess()` *before* initializing or rendering the app. When access is blocked it renders [`ThoughtspaceInUse`](../src/components/ThoughtspaceInUse.tsx) instead, with copy that distinguishes `already-open` from `unsupported`.
 
 ### Document model
 
-- **Each parent's children are stored together in a single Y.Doc.** The doc is keyed by a `docKey`, which is normally the parent's `ThoughtId`. The root contexts (`HOME_TOKEN`, `ABSOLUTE_TOKEN`) and `EM_TOKEN` use a special `ROOT_PARENT_ID` docKey.
-- **Each Lexeme has its own Y.Doc.** Keyed by `hashThought(value)`.
-- The module-level `docKeys: Map<ThoughtId, string>` maps each thought to the docKey of the doc that contains it (i.e. the parent's docKey). This is the ledger that lets the system find a thought without walking the tree.
+There is **one CRDT tree per thoughtspace**, not one document per parent thought:
 
-A thought Y.Doc has two top-level Y.Maps:
-- `getMap('thought')` — single entry `docKey` storing the parent's docKey, used to walk ancestors during tangential-context loading.
-- `getMap('children')` — keyed by `ThoughtId`, each value a `Y.Map<ThoughtYjs>` containing the thought's fields.
+- Each thought is a node in that tree, keyed by its `ThoughtId`. Parent/child structure and sibling order live in the tree itself.
+- `GLOBAL_ROOT_TOKEN` is the tree root, and `ROOT_PARENT_ID` is defined as an alias for it ([`constants.ts`](../src/constants.ts)) — so the two names refer to the same node, and `treeParentId` is a no-op that documents the boundary. Reads go the other way: `getThoughtById` reports `ROOT_PARENT_ID` when the tree has no parent for a node.
+- `SYSTEM_ROOT_THOUGHT_IDS` (`HOME_TOKEN`, `EM_TOKEN`, `ABSOLUTE_TOKEN`) are inserted as children of the global root during initialization, along with `[EM, 'Settings']` at the fixed `SETTINGS_TOKEN` — see `initializeThoughtspaceStorage` in [`treecrdt/thoughtspace.ts`](../src/data-providers/treecrdt/thoughtspace.ts).
 
-A Lexeme Y.Doc has a single top-level Y.Map containing the Lexeme's scalar fields plus per-context entries keyed `cx-${ThoughtId}` whose value is the docKey for that context (so the Lexeme can drive cross-context loading).
+Each node carries a payload: a JSON-encoded `ThoughtPayload` ([`payload.ts`](../src/data-providers/treecrdt/payload.ts)) with `value`, `created`, `lastUpdated`, `updatedBy`, and an optional `archived` timestamp. Everything else about a `Thought` is derived on read (see below). In particular **`rank`, `parentId`, and `childrenMap` are not stored in the payload.**
 
-### Compact storage keys
+### Derived tables
 
-To keep CRDT updates small, ThoughtDb and LexemeDb fields are stored under single-letter keys ([`thoughtspace.ts` lines ~127-151](../src/data-providers/yjs/thoughtspace.ts)):
+Two app-owned tables live alongside the CRDT tables in the same SQLite database. Neither is part of the CRDT, so neither replicates; both are rebuilt or maintained locally.
 
-| Thought key | Lexeme key | Field |
-|---|---|---|
-| `v` | — | `value` |
-| `r` | — | `rank` |
-| `m` | — | `childrenMap` (nested `Y.Map<ThoughtId>`) |
-| `p` | — | `parentId` |
-| `a` | — | `archived` (timestamp, optional) |
-| `c` | `c` | `created` |
-| `l` | `l` | `lastUpdated` |
-| `u` | `u` | `updatedBy` |
-| — | `x` | `contexts` (set of `cx-${id}` keys) |
+- **`em_lexemes`** ([`lexemes.ts`](../src/data-providers/treecrdt/lexemes.ts)) — `id` (the `hashThought(value)` key) → `payload_json` (a serialized `Lexeme`). Lexemes are written by the push queue and refreshed from materialization events.
+- **`em_attribute_children`** ([`attributeChildren.ts`](../src/data-providers/treecrdt/attributeChildren.ts)) — `child_id` → (`parent_id`, `value`) for `=attribute` children only, indexed by `parent_id`. This restores em's `childrenMap` contract, where meta-attributes are keyed by value rather than by id. A companion `em_attribute_children_meta` table records the index version; when it doesn't match `INDEX_VERSION`, `ensureAttributeChildrenIndexReady` rebuilds the index by walking the materialized tree once from the global root. After that it's maintained incrementally on every write and on every materialization batch.
 
-`thoughtToDb` / `getThought` / `getLexeme` translate between these compact shapes and the in-memory `Thought` / `Lexeme` types.
+### Reading a thought
 
-### Document names
+`getThoughtByIdFromClient` assembles a `Thought` from the tree plus the attribute index:
 
-[`documentNameEncoder.ts`](../src/data-providers/yjs/documentNameEncoder.ts) builds Y.Doc guids of the form:
+- `value` / `created` / `lastUpdated` / `updatedBy` / `archived` come from the decoded payload.
+- `parentId` is the tree parent, falling back to `ROOT_PARENT_ID` when the tree reports none.
+- `rank` is the node's **index among its siblings** (`0` when it has no parent). It is a projection of the tree's order, computed per read, not a persisted field.
+- `childrenMap` is built by `createIndexedChildrenMap`: attribute children are keyed by their value (via `childrenMapKey`, which disambiguates duplicates), all other children by their `ThoughtId`. Insertion order follows `client.tree.children`, so `Object.values(childrenMap)` is the authoritative sibling order.
 
-- Thought doc: `${tsid}/t/${docKey}`
-- Lexeme doc: `${tsid}/l/${key}`
-- Permissions doc: `${tsid}/permissions`
+`testFlags.replicationDelay` injects an artificial delay into `getThoughtsByIds`, used by e2e tests that need to observe slow local materialization after a refresh.
 
-`tsid` is the thoughtspace ID — see [Identity & sharing](#identity--sharing).
+### Writes
 
-### Module state in `thoughtspace.ts`
+`updateThoughtsForClient` applies one push-queue batch:
 
-`thoughtspace.ts` keeps eight module-level Maps that together form the in-memory cache of Y.Docs and their lifecycle state:
+1. **Lexemes first.** Each entry in `lexemeIndexUpdates` is upserted into `em_lexemes`, or deleted when `null`.
+2. **Deletions.** Each `null` entry in `thoughtIndexUpdates` becomes a `client.local.delete`, and the thought's row is dropped from the attribute index.
+3. **Upserts.** For a thought that doesn't exist yet, a `client.local.insert` with a resolved placement (see below); for one that does, a `client.local.move` when the parent or the order changed, and a `client.local.payload` when any payload field actually changed. Redundant payload writes are skipped so no-op edits don't mint operations. The attribute index is updated whenever a thought's parent or value changed.
 
-- `thoughtDocs` — cached `Y.Doc` instances by docKey.
-- `thoughtPersistence` — `IndexeddbPersistence` instances by docKey.
-- `thoughtRetained` — Set of docKeys retained by foreground replication; deallocation is blocked while a docKey is in this set.
-- `thoughtIDBSynced` — Promises that resolve when each doc has finished syncing with IDB.
-- `thoughtWebsocketSynced` — websocket-sync promises (currently never populated; see [Remote sync](#remote-sync-currently-inert)).
-- The four `lexeme*` maps are exact mirrors of the above for Lexemes.
+The function returns the `readonly Operation[]` it minted. That array is what the runtime forwards to remote sync.
 
-A separate `docKeys: Map<ThoughtId, string>` is the ThoughtId → parent docKey ledger.
+`DataProvider.updateThoughts` is the public persistence entry point for push-queue thought and lexeme batches. Writes that arrive before the client is bound wait on a readiness promise; a failed initialization or a `drop` rejects those waiters so the next initialization starts clean.
 
-The thoughtspace exposes its callbacks to the rest of the app via a `resolvable<ThoughtspaceConfig>()` promise that is set up by `init()` and consumed by every async operation. `configCache` caches it for synchronous access from idempotent code paths.
+#### Order and placement
 
-### Replication
+TreeCRDT stores sibling order directly, so a reorder is a `move` with an explicit placement (`first`, `last`, or `after: <siblingId>`) rather than a new rank number.
 
-[`replicateThought`](../src/data-providers/yjs/thoughtspace.ts) and [`replicateLexeme`](../src/data-providers/yjs/thoughtspace.ts) hydrate a Y.Doc from local IDB and (when the websocket is wired) from the server. They are **idempotent under concurrency** because they synchronously insert the new Doc into the cache before awaiting any async work — concurrent calls for the same docKey return the same Doc.
+`PushBatch.movePlacements: Index<ThoughtId | null>` carries that intent from the action layer: the key is the moved thought, the value is the sibling to place it after (`null` means first). It is produced by [`moveThought`](../src/actions/moveThought.ts), [`sort`](../src/actions/sort.ts), and the [undo/redo enhancer](../src/redux-enhancers/undoRedoEnhancer.ts).
 
-- **Foreground replication** (default) adds the docKey to `thoughtRetained`, subscribes the children Y.Maps to `onThoughtChange`, and keeps the Doc cached until `freeThought` is called.
-- **Background replication** does not retain the Doc; it deallocates after first sync. Used for the doclog replication controller and one-shot reads.
+`getTreecrdtPlacement` resolves it:
 
-If IDB returns `AbortError` (the app was closed mid-sync), replication retries after `IDB_ERROR_RETRY = 1000` ms.
+- A move of an existing thought **requires** an explicit placement and throws without one.
+- A new insert, or a placement naming a sibling that is no longer there, falls back to `getRankPlacement`, which derives a placement from the thought's numeric `rank`.
 
-### Updates
+The rank fallback is a compatibility bridge while the app still treats `rank` as the canonical display order. It carries a `TODO` to be removed once the create/import/`newThought` paths pass explicit placement and selectors read provider-backed order. See [data-model.md → rank](data-model.md#rank).
 
-- [`updateThought`](../src/data-providers/yjs/thoughtspace.ts) writes a single thought into its parent Y.Doc. If the thought has changed parents, it deletes the entry from the old parent Doc, updates the docKey in `docKeys` and in the Lexeme's `cx-${id}` map, and writes to the new parent. (These three writes span three Docs and are not atomic — there's a known risk of partial-failure inconsistency, called out in a code comment.) `childrenMap` is merged key-by-key as a nested `Y.Map<ThoughtId>`; other fields are written only if the value changed, to avoid emitting redundant CRDT updates.
-- [`updateLexeme`](../src/data-providers/yjs/thoughtspace.ts) adds and removes contexts via `cx-${id}` keys.
-- `DataProvider.updateThoughts` is the public persistence entry point for push-queue thought and lexeme batches.
+### Write barrier
 
-All update paths await `IndexeddbPersistence.whenSynced` (i.e. they resolve when the write hits IDB), but do not wait on the websocket.
+[`writeBarrier.ts`](../src/data-providers/treecrdt/writeBarrier.ts) serializes em → TreeCRDT persistence and exposes an idle barrier. It is a local ordering guard, not a CRDT requirement: it keeps app-state refreshes from racing local persistence, so a materialization refresh can't reapply stale rows over newer optimistic state.
+
+It also stamps every local write with a `writeId` of the form `em-local:${sourceId}:${n}`, where `sourceId` is unique per page load. `isTreecrdtLocalMaterialization` recognizes this tab's own writes by that prefix, so the materialization path can skip events the app already applied optimistically.
+
+### Change observation (materialization)
+
+`client.onMaterialized` fires after operations are materialized into SQLite — for remote ops arriving over sync as well as for local writes. Events whose changes all carry this tab's own `writeId` prefix are ignored, because the app already applied them optimistically. Everything else is handed to `enqueueMaterializedThoughtsToStore`, which serializes refreshes through [`materializationQueue.ts`](../src/data-providers/treecrdt/sync/materializationQueue.ts) so overlapping async events cannot apply out of order.
+
+[`applyMaterializedThoughtsToStore`](../src/data-providers/treecrdt/sync/applyMaterializedThoughtsToStore.ts) then:
+
+1. Waits for the write barrier.
+2. Refreshes `em_attribute_children` from the change list.
+3. Runs [`refreshThoughtsFromMaterializationChanges`](../src/data-providers/treecrdt/sync/materializationThoughtUpdates.ts), which loads the affected thoughts fresh from the provider, derives Lexeme updates (every touched thought adds itself to its value's Lexeme; deletions and value changes remove the stale context; a Lexeme left with no contexts is deleted), and re-projects TreeCRDT sibling order onto `rank` for every parent whose children changed — so the render path, which still sorts by rank, reflects remote reorders.
+4. Persists the derived Lexeme updates, then applies the whole batch through the *materialization bridge*.
+
+The bridge is supplied by [`initialize.ts`](../src/initialize.ts): `getSnapshot` reads the current Redux thought and lexeme indexes, and `apply` dispatches `updateThoughts` with `local: false, remote: false, repairCursor: true`. A thought's `pending` flag is preserved across the refresh, since it is UI state rather than part of the TreeCRDT payload.
 
 ### Memory management
 
-Memory is reclaimed by the `freeQueue` half of the push queue (see below):
+`freeThought` / `freeLexeme` are **no-ops** in the TreeCRDT provider. The whole thoughtspace is a single SQLite database, so there is no per-document cache to release — freeing memory only means dropping entries from the Redux indexes, which the `freeQueue` half of the push queue already does. [`redux-middleware/freeThoughts.ts`](../src/redux-middleware/freeThoughts.ts) dispatches `freeThoughts` once `thoughtIndex` exceeds `globals.freeThoughtsThreshold`.
 
-- `freeThought(docKey)` removes the docKey from `thoughtRetained`, awaits the IDB sync promise, then calls `tryDeallocateThought`.
-- `tryDeallocateThought(docKey)` no-ops if the docKey is still retained (e.g. it was re-pulled before this call ran). Otherwise it destroys the Y.Doc (which destroys the IDB provider), clears all four caches, and removes children's docKey entries.
-- `deleteThought(docKey)` is the destructive variant — it removes the entry from the parent Doc, calls `IndexeddbPersistence.clearData()` (or `clearDocument()` if the doc isn't loaded), and then runs `freeThought`.
+Deleting a thought is not a separate provider call: it is a `null` entry in `thoughtIndexUpdates`, handled by the write path above.
 
-Lexeme variants (`freeLexeme`, `tryDeallocateLexeme`, `deleteLexeme`) work the same way.
+### Runtime lifecycle
 
-### Change observation
+`ThoughtspaceRuntime` ([`thoughtspace.ts`](../src/data-providers/thoughtspace.ts), implemented in [`treecrdt/runtime.ts`](../src/data-providers/treecrdt/runtime.ts)) exposes `acquireAccess`, `init`, `drop`, `waitForIdle`, and `persistPushQueueBatches`.
 
-When another client (or the websocket, when wired) writes to a Y.Doc, the Y.Map observer fires. The handlers filter out self-originated events by checking `e.transaction.origin === doc.clientID`:
+- **`init`** awaits `clientIdReady`, loads the permissions store, creates the client, binds it to the data provider (which seeds storage and subscribes to materialization), and finally tries to start WebSocket sync. `init` and `drop` are serialized on a single lifecycle tail, and adjacent `init` calls are coalesced, so teardown can never interleave with startup.
+- **`waitForIdle`** alternates between the write barrier and the materialization queue until neither version counter changes, then resolves; it rejects after `TREECRDT_IDLE_TIMEOUT = 30000` ms. E2E tests reach it through `em.testHelpers.waitForThoughtspaceRuntimeIdle`.
 
-- [`onThoughtChange`](../src/data-providers/yjs/thoughtspace.ts) reads the changed thought, refreshes children docKey entries, and calls `config.onThoughtChange`. [`initialize.ts`](../src/initialize.ts) wires this to a 100ms-throttled `updateThoughts` dispatch (`local: false, remote: false`) that merges the change into Redux.
-- [`onLexemeChange`](../src/data-providers/yjs/thoughtspace.ts) goes through `updateThoughtsThrottled` directly (also 100ms throttle).
+## Remote sync (opt-in)
 
-## Remote sync (currently inert)
+Remote sync speaks the TreeCRDT sync protocol over a WebSocket ([`treecrdtWebSocketSync.ts`](../src/data-providers/treecrdt/sync/treecrdtWebSocketSync.ts)). It is **off unless `VITE_TREECRDT_SYNC_BASE_URL` is set**, and always skipped in test mode.
 
-The [`server/`](../server) subpackage runs a [`@hocuspocus/server`](https://tiptap.dev/hocuspocus) instance behind Express on port 3001 (websocket route `/hocuspocus`), with optional Redis horizontal scaling via [`@hocuspocus/extension-redis`](https://tiptap.dev/hocuspocus) and Prometheus metrics on `/metrics` — see [`server/src/index.ts`](../server/src/index.ts) and [`server/src/metrics.ts`](../server/src/metrics.ts).
+- The base URL may be a `ws://` / `wss://` endpoint or an `http(s)://` discovery URL ([`sync/config.ts`](../src/data-providers/treecrdt/sync/config.ts)).
+- On start, `connectTreecrdtWebSocketSync` runs `syncOnce()` to catch up, then `startLive()` to subscribe.
+- Outbound: `persistPushQueueBatches` forwards the `Operation[]` returned by each batch flagged `local` to `pushLocalOps`.
+- Inbound ops are materialized by the client and reach Redux through the materialization path above.
 
-**However, the remote-sync path is decommissioned on `main`:**
+Failures are non-fatal by design: a failed start logs a warning and em keeps running against local storage only; a failed `pushLocalOps` logs and moves on.
 
-- The server configures only the Redis extension. **No persistence extension is registered**, so documents would only live in process memory if the server were used. `y-mongodb-provider` is in [`server/package.json`](../server/package.json) and has a type stub at [`src/@types/y-mongodb-provider.d.ts`](../src/@types/y-mongodb-provider.d.ts), but it is not imported in `server/src/index.ts`.
-- The client never constructs a `WebsocketProvider` or `HocuspocusProvider`. [`WebsocketProviderType.ts`](../src/@types/WebsocketProviderType.ts) has its `y-websocket-auth` import commented out and types the provider as `any`.
-- The `thoughtWebsocketSynced` / `lexemeWebsocketSynced` maps in `thoughtspace.ts`, the `remote: true` flag on `replicateThought`, and the `remote: false` field on `updateThoughts` calls all still exist as scaffolding, but nothing populates the maps and nothing constructs a provider.
+The [`server/`](../server) subpackage and [`src/@types/WebsocketProviderType.ts`](../src/@types/WebsocketProviderType.ts) are leftovers from the previous Hocuspocus/Yjs implementation. Nothing in the TreeCRDT client imports them.
 
-In effect, on `main` Yjs is used as a local-only document store. Local IndexedDB is the only persistence path.
-
-## Push queue (Redux → Yjs)
+## Push queue (Redux → TreeCRDT)
 
 [`redux-enhancers/pushQueue.ts`](../src/redux-enhancers/pushQueue.ts) is a Redux store enhancer that runs after every reducer. It drains `state.pushQueue` (a list of `PushBatch` objects pushed there by [`updateThoughts`](../src/actions/updateThoughts.ts) and friends) and partitions it into:
 
-- **`dbQueue`** — batches with `local || remote` set. Applied sequentially through `thoughtspaceRuntime.persistPushQueueBatches`, which calls the active data provider's `updateThoughts`. After provider persistence finishes, any `idbSynced` callback on the original batch is invoked.
-- **`freeQueue`** — state-only batches whose `null` thought/lexeme entries indicate they should be released from the in-memory cache. Triggers `db.freeThought` / `db.freeLexeme`.
+- **`dbQueue`** — batches with `local || remote` set. Applied sequentially through `thoughtspaceRuntime.persistPushQueueBatches`, which wraps them in the write barrier and calls the active data provider's `updateThoughts` with the batch's `thoughtIndexUpdates`, `lexemeIndexUpdates`, `lexemeIndexUpdatesOld`, and `movePlacements`. After provider persistence finishes, any `idbSynced` callback on the original batch is invoked.
+- **`freeQueue`** — state-only batches whose `null` thought/lexeme entries indicate they should be released from the in-memory cache. Calls `db.freeThought` / `db.freeLexeme` (no-ops for TreeCRDT; the Redux-side release is what matters).
 
-The enhancer also caches a small set of critical settings (`CACHED_SETTINGS` in [`constants.ts`](../src/constants.ts)) into `localStorage` so that things like the Tutorial setting are available during the first paint before Yjs hydrates. The corresponding read path is [`selectors/getSetting.ts`](../src/selectors/getSetting.ts).
+The enhancer also caches a small set of critical settings (`CACHED_SETTINGS` in [`constants.ts`](../src/constants.ts)) into `localStorage` so that things like the Tutorial setting are available during the first paint before the thoughtspace hydrates. The corresponding read path is [`selectors/getSetting.ts`](../src/selectors/getSetting.ts).
+
+When [debug logging](../src/util/debugLog.ts) is enabled, each flush emits a `push` entry (batch count, thought/lexeme/move counts, and a sample of the thoughts written) and then either `pushSynced` or `pushError`. A `push` with no matching `pushSynced` is a write that never completed.
 
 Once Redux dispatches a thought update, the data flow is therefore:
 
 ```
 reducer → state.pushQueue → pushQueue enhancer
-      → thoughtspaceRuntime.persistPushQueueBatches
+      → thoughtspaceRuntime.persistPushQueueBatches   (write barrier)
       → DataProvider.updateThoughts
-      → active provider persistence
+      → TreeCRDT local ops + derived table writes
+      → Operation[] forwarded to WebSocket sync (if connected)
       → idbSynced callback is invoked
 ```
 
-## Pull queue (Yjs → Redux)
+## Pull queue (TreeCRDT → Redux)
 
 [`redux-middleware/pullQueue.ts`](../src/redux-middleware/pullQueue.ts) runs after every action. It computes the set of currently visible `ThoughtId`s — cursor, all ancestors, `state.expanded`, plus context-view contexts and their ancestors — and short-circuits if nothing has changed since the last flush. Otherwise it kicks off a flush:
 
@@ -169,22 +194,20 @@ Notable behavior:
 
 ## Identity & sharing
 
-Three tokens are bootstrapped in [`data-providers/yjs/index.ts`](../src/data-providers/yjs/index.ts):
+Three tokens are bootstrapped in [`data-providers/thoughtspaceSession.ts`](../src/data-providers/thoughtspaceSession.ts):
 
-- **`accessToken`** — a per-device 21-char nanoid stored in `localStorage`. Authenticates the device against the (currently inert) websocket server. Can be overridden by `?auth=<token>` in the URL.
-- **`tsid`** — the thoughtspace ID; the Y.Doc id used by all per-thoughtspace docs. Also a 21-char nanoid in `localStorage`. Can be overridden by `?share=<tsid>` to switch the app onto a shared thoughtspace.
-- **`clientId`** — a public key derived as `SHA-256(accessToken)`, base64-encoded. Available asynchronously via the exported `clientIdReady` promise. Stamped on every Thought and Lexeme write as `updatedBy`.
+- **`accessToken`** — a per-device 21-char nanoid stored in `localStorage`. It is the device's secret: `clientId` is derived from it, and it keys the device's permissions entry. Nothing currently transmits it — the sync client connects without auth. Can be overridden by `?auth=<token>` in the URL.
+- **`tsid`** — the thoughtspace ID. Also a 21-char nanoid in `localStorage`. It is the TreeCRDT `docId`, the OPFS filename (`/treecrdt-em-${tsid}.db`), the Web Lock name, and the permissions storage key. Can be overridden by `?share=<tsid>` to switch the app onto a shared thoughtspace.
+- **`clientId`** — a public key derived as `SHA-256(accessToken)`, base64-encoded. Available asynchronously via the exported `clientIdReady` promise. Stamped on every Thought and Lexeme write as `updatedBy`, and converted by `clientIdToReplicaId` into the 32-byte replica id TreeCRDT mints local operations under.
 
-A separate Y.Doc, `permissionsClientDoc`, holds an `Index<Share>` keyed by access token (one entry per device with access). It is persisted locally via IDB at the doc name `${tsid}/permissions`. CRUD lives in [`permissionsModel.ts`](../src/data-providers/yjs/permissionsModel.ts):
+Device permissions live in [`permissionsStore.ts`](../src/data-providers/permissionsStore.ts): a [ministore](glossary.md#m) holding `Index<Share>` keyed by access token (one entry per device with access), persisted with `idb-keyval` under `em-permissions:${tsid}`. It is loaded during runtime initialization and skipped entirely in unit tests. CRUD lives in [`permissionsModel.ts`](../src/data-providers/permissionsModel.ts):
 
-- **add** — generates a new access token, adds a `Share` to `permissionsMap`, alerts the user.
+- **add** — generates a new access token, adds a `Share`, alerts the user.
 - **delete** — removes the entry. If it's the *current* device and there are still others, dispatches `clear` (logs out). If it's the *last* device, calls `storage.clear()`, `db.clear()`, dispatches `clear`, and reloads.
 - **update** — patches name/role.
 
-[`useSharedType`](../src/hooks/useSharedType.ts) is a React hook for subscribing components to Y types in the permissions doc.
-
 ## Cleanup
 
-[`db.clear`](../src/data-providers/yjs/thoughtspace.ts) iterates `thoughtDocs` and `lexemeDocs` and calls `deleteThought` / `deleteLexeme` on every entry, removing all local IDB data for the thoughtspace. Used by the device-removal flow above.
+`db.clear` is the runtime's `drop`. It detaches the data provider (rejecting any writes still waiting on initialization), stops WebSocket sync, unsubscribes the materialization listener, and calls `client.drop()`, which closes SQLite and — for OPFS storage — deletes the thoughtspace's database file. Used by the device-removal flow above, and by e2e tests through `em.testHelpers.dropThoughtspace`.
 
-Tests skip IDB initialization entirely (`import.meta.env.MODE !== 'test'` guard at the bottom of [`yjs/index.ts`](../src/data-providers/yjs/index.ts)) to avoid `TransactionInactiveError` in `fake-indexeddb`.
+Unit tests and most e2e runs initialize with `storage: 'memory'`, so they never touch OPFS; persistence-specific Puppeteer suites opt into OPFS explicitly. See [testing.md](testing.md).


### PR DESCRIPTION
## What

Brings `docs/persistence.md` and its dependent docs in line with the TreeCRDT storage layer. `docs/` still described the Yjs implementation in full — per-parent `Y.Doc`s persisted with `y-indexeddb`, an inert Hocuspocus server, a `docKeys` ledger, compact single-letter storage keys — none of which the code has any more.

- **`docs/persistence.md`** — rewritten against `src/data-providers/treecrdt/`. Local persistence is one TreeCRDT tree per thoughtspace materialized into SQLite via `@treecrdt/wa-sqlite`, OPFS-backed in a dedicated worker (`'persistent'`) or in-memory/direct (`'memory'`). New sections cover the pieces that had no Yjs counterpart: the single-tab session lock, the app-owned `em_lexemes` and `em_attribute_children` tables, the write barrier and its `writeId` scheme, materialization as the change-observation path, order/placement (`movePlacements`), and the runtime lifecycle. Remote sync is now opt-in behind `VITE_TREECRDT_SYNC_BASE_URL`.
- **`docs/glossary.md`** — retired `Y.Doc`, `docKey`, `doclog`, `thoughtRetained`, `ThoughtDb`, `permissionsClientDoc`, and foreground/background replication; added `attribute-child index`, `docId`, `GLOBAL_ROOT_TOKEN`, `materialization`, `movePlacements`, `replicaId`, `session lock`, `ThoughtPayload`, `ThoughtspaceRuntime`, `TreeCRDT`, `write barrier`, `writeId`.
- **`docs/data-model.md`**, **`docs/metaprogramming.md`** — the `ThoughtDb` claim, the `data-providers/yjs/index.ts` path, and the "before Yjs hydrates" note.

## Why

`docs/` is how an unfamiliar subsystem gets read — by people and by agents planning changes against it. A persistence doc describing a storage engine the repo no longer uses is worse than no doc.

## Notes for review

The push queue, pull queue, and `fetchDescendants` sections were re-verified against the code and kept as-is; the only edits there are the section headings and the anchors that point at them.

Three claims that were not Yjs references, but that the rewrite would have contradicted, were corrected in the same pass:

- **`rank` is no longer persisted.** `getThoughtByIdFromClient` re-projects it from TreeCRDT sibling order on every read; reorders travel as explicit placements. Noted in `data-model.md`'s rank section.
- **`ThoughtId` is 32 lowercase hex chars**, the format TreeCRDT requires for a node id (`src/util/createId.ts:3`) — both docs still said 21-char nanoid.
- **`accessToken` is never transmitted.** Both docs said it authenticates the device against a websocket server; grep shows nothing sends it. It seeds `clientId`/`replicaId` and keys the device's permissions entry.

Docs-only — no source changes. Prettier is clean, and every internal link and anchor in the four files resolves. Three broken links elsewhere (`testing.md`, `metaprogramming.md`'s `useDragAndDropSubThought` link, `agents/external-agents.md`) are pre-existing on `main` and untouched.

`persistence.md` currently notes that `server/` and `src/@types/WebsocketProviderType.ts` are unreferenced Yjs-era leftovers. That sentence should come out when the dead code does — it is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)