### PR TITLE
docs(write-issue): configure Blocked by as a GitHub relationship

### DIFF
--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-issue
 description: >-
-  ALWAYS USE THIS SKILL when creating or editing a GitHub issue in this repo — filing a new bug, splitting one out of a comment thread, or adding reproduction steps to an issue that lacks them.
+  ALWAYS USE THIS SKILL when creating or editing a GitHub issue in this repo — filing a new bug, splitting one out of a comment thread, adding reproduction steps to an issue that lacks them, or marking one blocked by another.
 allowed-tools:
   - bash
 ---
@@ -88,6 +88,36 @@ Add `design-needed` when the correct behaviour has not been decided.
 
 Leave priority and triage labels — `hold`, `low-priority`, `unable-to-reproduce`, `human` — to the maintainers.
 
+## Blocked by
+
+"Blocked by" is a GitHub relationship, not a line of body text. `Blocked by #5228` in the body renders as a plain reference: the issue is not marked blocked, it does not show as blocked in issue lists or projects, and #5228 does not show what it is holding up.
+
+Set the relationship with `gh`, at creation or after:
+
+```bash
+gh issue create --title "..." --body-file body.md --blocked-by 5228
+```
+
+```bash
+gh issue edit 5226 --add-blocked-by 5228
+```
+
+Both take a comma-separated list of issue numbers or issue URLs; `--remove-blocked-by` undoes it. Configure it from the blocked issue only — GitHub records the inverse itself, and #5228 lists #5226 under Blocking. Where the new issue is the prerequisite rather than the dependent, `--blocking` and `--add-blocking` are the same thing pointed the other way.
+
+Verify it landed, since a body reference and a relationship look alike once rendered:
+
+```bash
+gh issue view 5226 --repo cybersemics/em --json blockedBy
+```
+
+Prefer `gh` to the REST endpoint, `POST /repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by`, which takes `issue_id` — the blocker's numeric database id, from `gh api repos/cybersemics/em/issues/5228 --jq .id` — rather than its issue number.
+
+Keep a `## Notes` bullet beside the relationship where the reason is not obvious from the two titles. The relationship carries the fact; only the note carries the why. [#5226](https://github.com/cybersemics/em/issues/5226):
+
+> Blocked by #5228, which makes Select All toggle to Deselect All on desktop as well as touch. The third step is that toggle, so it has to exist first.
+
+`- [ ] Blocked by #5228` is not a substitute. Nothing tracks a checkbox.
+
 ## Evidence
 
 Screenshots and videos are usually already in the conversation that prompted the issue. Copy the attachment markup across verbatim, `<img src="https://github.com/user-attachments/...">` and all; those URLs stay valid in another issue. Do not re-upload or re-host, and do not describe an image you could link.
@@ -110,6 +140,7 @@ New issues often originate in a comment thread on another issue or PR.
 - An Expected Behavior that specifies the fix rather than naming the goal.
 - A paragraph of preamble establishing what you did and did not reproduce, where a clause would do.
 - A screenshot with no steps.
+- A `Blocked by` line in the body with no relationship configured on GitHub.
 
 ## When something is unknown
 


### PR DESCRIPTION
The `write-issue` skill had nothing on issue dependencies, so an agent writing `Blocked by #N` into the body produced a plain cross-reference and stopped there. On #5226 the timeline shows `blocked_by_added` four hours after creation, by a maintainer, by hand.

## What changed

A `## Blocked by` section in `.github/skills/write-issue/SKILL.md`, after `## Labels`:

- Names what body-only text costs — the issue is not marked blocked, does not show as blocked in issue lists or projects, and the blocker does not show what it is holding up.
- `gh issue create --blocked-by 5228` at creation, `gh issue edit 5226 --add-blocked-by 5228` after. Comma-separated issue numbers or URLs; `--remove-blocked-by` undoes it.
- Configure from the blocked issue only — GitHub records the inverse itself. `--blocking` / `--add-blocking` for when the new issue is the prerequisite.
- Verify with `gh issue view <n> --json blockedBy`, since a body reference and a relationship look alike once rendered.
- The REST endpoint takes `issue_id`, the blocker's numeric database id, not its issue number — and `gh issue view --json id` returns the GraphQL node id, not that id. Prefer `gh`.
- The relationship carries the fact; a `## Notes` bullet carries the why. #5226's bullet is quoted as the model. `- [ ] Blocked by #N` is called out as not a substitute.

Also:

- `A Blocked by line in the body with no relationship configured on GitHub.` added to Common defects.
- Frontmatter description extended with "or marking one blocked by another", so the skill triggers when setting a dependency is the whole task.

## Notes for review

Flags verified against gh 2.98.0; `--blocked-by` on `create` and `--add-blocked-by` on `edit` both landed in recent releases, so this assumes a reasonably current gh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
