### PR TITLE
docs(write-issue): note that a blocker must be an issue, not a pull request

### DIFF
--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -104,6 +104,8 @@ gh issue edit 5226 --add-blocked-by 5228
 
 Both take a comma-separated list of issue numbers or issue URLs; `--remove-blocked-by` undoes it. Configure it from the blocked issue only — GitHub records the inverse itself, and #5228 lists #5226 under Blocking. Where the new issue is the prerequisite rather than the dependent, `--blocking` and `--add-blocking` are the same thing pointed the other way.
 
+The blocker must be an issue. A pull request number is refused: `gh` cannot resolve it — `Could not resolve to an Issue with the number of 5085` — and the REST endpoint refuses the pull request's own database id with `Target issue may only be an issue`. Where the prerequisite is a pull request, block on the issue that pull request implements and name the pull request in the `## Notes` bullet, as [#5236](https://github.com/cybersemics/em/issues/5236) does with #4400 and #5085. If no such issue exists, open one for what the pull request delivers, let the pull request close it, and block on that.
+
 Verify it landed, since a body reference and a relationship look alike once rendered:
 
 ```bash


### PR DESCRIPTION
## Summary

Records in the `write-issue` skill that GitHub's issue dependencies cannot name a pull request as the blocker, and what to do instead.

## Why

Filing #5236 called for it to be blocked by #5085, which is a pull request. Both routes refuse it:

- `gh issue edit 5236 --add-blocked-by 5085` → `Could not resolve to an Issue with the number of 5085` (`gh` resolves the reference through `repository.issue`, which excludes pull requests)
- `POST /repos/cybersemics/em/issues/5236/dependencies/blocked_by` with the pull request's own database id → `422 Target issue may only be an issue`

Nothing in the skill said so, and the failure is only visible after the issue has already been created. #5236 is instead blocked by #4400, the issue #5085 implements, with the pull request named in its `## Notes` bullet.

## What changed

One paragraph in the `## Blocked by` section of [`.github/skills/write-issue/SKILL.md`](.github/skills/write-issue/SKILL.md), placed after the paragraph that describes what `--blocked-by` accepts — the point at which a reader would otherwise assume a pull request number works. It states the constraint, quotes both failure strings so the guidance is recognizable from either error, prescribes blocking on the issue the pull request implements, and covers the case where no such issue exists yet: open one for what the pull request delivers and let the pull request close it.

## Notes for the reviewer

- Documentation only. No code, and `.github/skills` is in `.prettierignore`, so the file is outside the formatting check.
- #5236 is the worked example cited in the new paragraph, so the guidance points at a relationship that is live rather than hypothetical.
