### PR TITLE
Mark finished Copilot pull requests ready for review

### DIFF
--- a/.github/workflows/pr-ready.yml
+++ b/.github/workflows/pr-ready.yml
@@ -1,0 +1,81 @@
+# Takes a finished Copilot pull request out of draft once every check on it has passed.
+#
+# Copilot opens its pull requests as a draft and never takes them out of one: when a session ends
+# it requests a review and stops. Nothing else moves it either, so the pull request sits in draft
+# — invisible to reviewers, ineligible for auto-merge — until someone notices. Every non-draft
+# Copilot pull request in this repository was undrafted by hand.
+#
+# Runs:
+#   - Automatically, when a check completes on a `copilot/*` branch (see below)
+#   - Manually: `gh workflow run pr-ready.yml -f pr=5224`
+#
+# Why every completion and not just the successes. A pull request's checks finish at different
+# times, so triggering on `success` would fire while other checks were still running. This triggers
+# on every completion and the step bails unless it is the last one out — the same arrangement
+# dependabot-fix.yml uses, and for the same reason.
+#
+# Why not an instruction in the prompt files. The agent would have to run `gh pr ready` itself, and
+# its token cannot be relied on to carry `contents: write` — no Copilot session in this repository
+# has ever undrafted its own pull request. An instruction that silently fails is worse than none.
+# Here the permission is declared below and the trigger is a signal this repository owns outright.
+#
+# GITHUB_TOKEN is sufficient; no PAT is involved. `markPullRequestReadyForReview` needs
+# `contents: write` alongside `pull-requests: write` (cli/cli#6924), both granted below. The usual
+# reason to reach for a PAT does not apply: a GITHUB_TOKEN mutation raises no further workflow runs,
+# and nothing in this repository triggers on `ready_for_review`.
+#
+# `workflow_run` reads this file from the default branch, so edits here have no effect until they
+# are merged to main.
+
+name: PR Ready
+
+on:
+  workflow_run:
+    workflows: ['Lint', 'Test', 'Puppeteer', 'BrowserStack', 'Vercel Preview', 'TDD', 'Agent Scripts']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number to mark ready for review'
+        required: true
+        type: string
+
+# Serialize per branch so two checks finishing at once cannot both reach the mutation. Never
+# cancel: a queued run is the one that would notice the last check completing.
+concurrency:
+  group: pr-ready-${{ github.event.workflow_run.head_branch || inputs.pr }}
+  cancel-in-progress: false
+
+permissions:
+  checks: read # list the check runs on the pull request head
+  contents: write # markPullRequestReadyForReview requires it — see cli/cli#6924
+  pull-requests: write # read the pull request and take it out of draft
+
+jobs:
+  ready:
+    name: Mark ready for review
+    runs-on: ubuntu-latest
+    # Cheap gate so the six other completions on a normal pull request cost nothing. Author,
+    # draft status, session state, and the checks themselves are verified in the step below.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.event.workflow_run.head_branch, 'copilot/') &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
+
+    steps:
+      # `workflow_run` resolves `github.ref` to the default branch, so this checks out the base
+      # repo's own code — never the pull request's — solely to make scripts/ci/ available below.
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Mark ready for review
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          # Empty on workflow_dispatch, where PR_NUMBER identifies the pull request instead.
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PR_NUMBER: ${{ inputs.pr }}
+        with:
+          script: |
+            await require('./scripts/ci/mark-copilot-pr-ready.cjs')({ github, context, core })

--- a/docs/agents/readme.md
+++ b/docs/agents/readme.md
@@ -90,7 +90,8 @@ flowchart TD
     I --> E
     H -- yes --> J["<b>Exit gate</b> — end-session skill"]
     J --> J1["Nothing left untrue, nothing left behind,<br/>nothing claimed that was not observed"]
-    J1 --> K["Done"]
+    J1 --> J2["<b>PR Ready</b> — a workflow takes the<br/>pull request out of draft"]
+    J2 --> K["Done"]
 
     click C "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#issue-repro" "The issue-repro skill"
     click C1 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#browser-control" "How the browser is brought up"
@@ -103,6 +104,7 @@ flowchart TD
     click I "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#test-diagnosis" "The test-diagnosis skill"
     click J "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#end-session" "The end-session skill"
     click J1 "https://github.com/cybersemics/em/blob/HEAD/docs/agents/skills.md#end-session" "The exit checklist, step by step"
+    click J2 "https://github.com/cybersemics/em/blob/HEAD/.github/workflows/pr-ready.yml" "The PR Ready workflow"
 ```
 
 Both gates exist to stop the same failure. An agent that starts reading source code before it has seen the bug happen will form a theory from the code and then go looking for evidence to support it. Making it reproduce the problem first means it has a real observation to work from. Making it write the plan against quoted, existing code means it extends what is there instead of building something new beside it.
@@ -150,6 +152,7 @@ end-session: escalating — checklist passed per .github/skills/end-session/SKIL
 │   └── unskip-added-tests/          Switches .skip tests back on — see tdd.md
 └── workflows/
     ├── copilot-setup-steps.yml      Builds the agent's environment
+    ├── pr-ready.yml                 Undrafts a finished PR whose checks passed
     └── tdd.yml                      Checks new tests genuinely fail first
 
 scripts/
@@ -172,10 +175,11 @@ CLAUDE.md            → AGENTS.md
 .claude/skills       → .agents/skills
 ```
 
-Two workflows are part of this system rather than ordinary CI:
+Three workflows are part of this system rather than ordinary CI:
 
 - **[`copilot-setup-steps.yml`](../../.github/workflows/copilot-setup-steps.yml)** builds the environment the agent wakes up in — the display, the browser, the dev server, credentials. It must be named exactly that, and its job must be called `copilot-setup-steps`, or Copilot ignores it. Covered in [Environment](environment.md#what-the-setup-step-builds).
 - **[`tdd.yml`](../../.github/workflows/tdd.yml)** independently verifies that any new test genuinely fails before the fix. Covered in [The TDD workflow](tdd.md#how-the-check-works).
+- **[`pr-ready.yml`](../../.github/workflows/pr-ready.yml)** takes a finished Copilot pull request out of draft once every check on it has passed. Copilot opens a draft and never leaves one — at the end of a session it requests a review and stops — so without this the pull request waits in draft until a human notices it, invisible to reviewers and ineligible for auto-merge. It fires on every check completion and [`scripts/ci/mark-copilot-pr-ready.cjs`](../../scripts/ci/mark-copilot-pr-ready.cjs) bails unless it is the last one out, the same arrangement [`Dependabot Fix`](../testing.md#failing-dependabot-pull-requests) uses. Three further guards decide the rest: the pull request must still be a draft authored by the agent, since a human's draft is deliberate and the `copilot/` branch prefix is not proof of authorship; its newest `copilot_work_*` timeline event must be `copilot_work_finished`, because the agent pushes several commits per session and each one runs the full suite, so green checks alone would undraft work still in progress; and no check may have failed, a draft being the correct state for a pull request that is red. Doing this from the prompt files instead was considered and rejected — the agent would have to run `gh pr ready` itself, no Copilot session in this repository has ever managed it, and an instruction that silently fails is worse than none.
 
 The rest (`test`, `lint`, `puppeteer`, `ios`, the Vercel and Tauri workflows) are normal project CI. The agent has to make them pass, but they were not built for it.
 

--- a/scripts/ci/mark-copilot-pr-ready.cjs
+++ b/scripts/ci/mark-copilot-pr-ready.cjs
@@ -1,0 +1,153 @@
+/**
+ * Takes a finished Copilot pull request out of draft once every check on it has passed.
+ *
+ * Loaded by the `Mark ready for review` step of .github/workflows/pr-ready.yml through
+ * actions/github-script. Reads HEAD_BRANCH (or PR_NUMBER on a manual dispatch) from the
+ * environment.
+ *
+ * Copilot opens its pull requests as a draft and never takes them out of one: when a session ends
+ * it requests a review and stops. Nothing else moves it either, so the pull request sits in draft
+ * — invisible to reviewers, ineligible for auto-merge — until someone notices. Every non-draft
+ * Copilot pull request in this repository was undrafted by hand. The instruction files are the
+ * wrong place to fix that, because the agent's own token cannot be relied on to carry the
+ * permission, and an instruction that silently fails is worse than none. The checks are a signal
+ * this repository owns outright.
+ *
+ * The workflow fires on every check completion, so most calls here stop at one of the guards
+ * below; only the run that sees the last check complete reaches the mutation. Being
+ * `workflow_run`-triggered, this reports no check of its own to the head commit and so never waits
+ * on itself.
+ */
+
+/**
+ * The only pull request author this acts on. A human's draft is deliberate and must be left alone,
+ * and the `copilot/` branch prefix alone is not proof of one. Note this is the REST `user.login`,
+ * which is `Copilot` — `gh pr view` reports the same account as `app/copilot-swe-agent`.
+ */
+const COPILOT = 'Copilot'
+
+/**
+ * Conclusions that mean a check genuinely failed. `cancelled` is excluded because that is what
+ * Cancel PR Runs does to a merged pull request's in-flight checks, and `skipped`, `neutral`, and
+ * `stale` never indicate a broken build.
+ */
+const FAILED_CONCLUSIONS = new Set(['failure', 'timed_out', 'action_required'])
+
+/** The timeline events that bracket an agent session, newest of which says whether one is running. */
+const WORK_EVENTS = new Set(['copilot_work_started', 'copilot_work_finished'])
+
+/** Takes a finished Copilot pull request out of draft once its checks are green. */
+const markCopilotPrReady = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo
+  // A manual dispatch names the pull request; the automatic trigger names its branch. Neither is
+  // taken on trust: the pulls API silently ignores an *empty* `head` filter and answers with the
+  // newest open pull request rather than with none, so an unusable input would otherwise aim this
+  // at whichever pull request happened to be last.
+  const rawNumber = (process.env.PR_NUMBER || '').trim()
+  const headBranch = (process.env.HEAD_BRANCH || '').trim()
+  if (rawNumber && !/^[0-9]+$/.test(rawNumber)) {
+    core.setFailed(`Refusing to proceed: pr is not a plain integer (${JSON.stringify(rawNumber)}).`)
+    return
+  }
+  if (!rawNumber && !headBranch) {
+    core.setFailed('Refusing to proceed: neither a pull request number nor a head branch was given.')
+    return
+  }
+  const prNumber = Number(rawNumber || '0')
+
+  // Resolved from the branch rather than from workflow_run.pull_requests, which is empty whenever
+  // the triggering run's head commit is no longer the head of an open pull request.
+  let pr
+  if (prNumber) {
+    pr = (await github.rest.pulls.get({ owner, repo, pull_number: prNumber })).data
+  } else {
+    const { data: matches } = await github.rest.pulls.list({
+      owner,
+      repo,
+      head: `${owner}:${headBranch}`,
+      state: 'open',
+      per_page: 1,
+    })
+    pr = matches[0]
+  }
+
+  if (!pr || pr.state !== 'open') {
+    core.info(`No open pull request for ${headBranch || `#${prNumber}`}; nothing to mark ready.`)
+    return
+  }
+  if (!pr.draft) {
+    core.info(`#${pr.number} is already ready for review.`)
+    return
+  }
+  if (pr.user.login !== COPILOT || pr.user.type !== 'Bot') {
+    core.info(`#${pr.number} is authored by ${pr.user.login}, not ${COPILOT}; leaving its draft status alone.`)
+    return
+  }
+
+  // The agent pushes several commits over a session and each one runs the full suite, so green
+  // checks alone would undraft a pull request the agent is still working on. `copilot_work_started`
+  // and `copilot_work_finished` bracket each session: the newest of the two says whether one is
+  // running right now, which a plain "has it ever finished" test would miss on a second session.
+  const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  })
+  const work = timeline.filter(event => WORK_EVENTS.has(event.event))
+  const latest = work[work.length - 1]
+  if (!latest || latest.event !== 'copilot_work_finished') {
+    core.info(`#${pr.number}: the agent is still working (${latest ? latest.event : 'no session recorded'}).`)
+    return
+  }
+
+  const headSha = pr.head.sha
+
+  // filter=latest collapses re-runs to the check that is actually reported on the pull request.
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: headSha,
+    filter: 'latest',
+    per_page: 100,
+  })
+
+  if (checkRuns.length === 0) {
+    core.info(`#${pr.number}: no checks have reported on ${headSha.slice(0, 7)} yet.`)
+    return
+  }
+
+  const pending = checkRuns.filter(check => check.status !== 'completed')
+  if (pending.length > 0) {
+    core.info(`#${pr.number}: still running — ${pending.map(check => check.name).join(', ')}. Not the last one out.`)
+    return
+  }
+
+  const failed = checkRuns.filter(check => FAILED_CONCLUSIONS.has(check.conclusion))
+  if (failed.length > 0) {
+    core.info(
+      `#${pr.number}: ${failed.map(check => check.name).join(', ')} failed on ${headSha.slice(0, 7)}. ` +
+        'A draft is the correct state for a pull request whose checks are red.',
+    )
+    return
+  }
+
+  // No REST equivalent exists; this is the only way to undraft a pull request. It needs
+  // `contents: write` as well as `pull-requests: write` — see cli/cli#6924.
+  await github.graphql(
+    `mutation ($id: ID!) {
+      markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+        pullRequest {
+          number
+        }
+      }
+    }`,
+    { id: pr.node_id },
+  )
+
+  core.info(`#${pr.number}: all ${checkRuns.length} checks passed on ${headSha.slice(0, 7)}; marked ready for review.`)
+  core.summary.addRaw(`Marked [#${pr.number}](${pr.html_url}) ready for review — all checks green.`)
+  await core.summary.write()
+}
+
+module.exports = markCopilotPrReady


### PR DESCRIPTION
Copilot opens its pull requests as a draft and never leaves one: at the end of a session it requests a review and stops. Nothing else moves it either, so the pull request waits in draft — invisible to reviewers, ineligible for auto-merge — until someone notices. Every non-draft Copilot pull request in this repository was undrafted by hand, and 26 are sitting in draft right now.

## Why not an instruction in the prompt files

That was the first attempt and it was reverted. The agent would have to run `gh pr ready` itself, its token cannot be relied on to carry `contents: write`, and no Copilot session in this repository has ever undrafted its own pull request. An instruction that silently fails is worse than none. `PR Ready` reacts to the checks instead, which this repository owns outright.

## Changes

- **`.github/workflows/pr-ready.yml`** — fires on every check completion across the seven CI workflows, in the base-repo context, with `checks: read`, `contents: write`, and `pull-requests: write`. The same `workflow_run` arrangement `dependabot-fix.yml` uses, and for the same reason: a pull request's checks finish at different times, so triggering on `success` would fire while others were still running.
- **`scripts/ci/mark-copilot-pr-ready.cjs`** — the guards, in order. The pull request must still be a draft **authored by the agent**, since a human's draft is deliberate and the `copilot/` branch prefix is not proof of authorship. Its newest `copilot_work_*` timeline event must be `copilot_work_finished`, because the agent pushes several commits per session and each runs the full suite, so green checks alone would undraft work still in progress. Every check must have completed, so only the last one out proceeds. And none may have failed — a draft is the correct state for a pull request that is red.
- **`docs/agents/readme.md`** — the lifecycle diagram gains the undraft step, and the list of workflows that belong to the agent system rather than to ordinary CI goes from two to three.

`GITHUB_TOKEN` is sufficient; no PAT is involved. `markPullRequestReadyForReview` needs `contents: write` alongside `pull-requests: write` ([cli/cli#6924](https://github.com/cli/cli/discussions/6924)), both declared in the workflow. The usual reason to reach for a PAT does not apply: a `GITHUB_TOKEN` mutation raises no further workflow runs, and nothing here triggers on `ready_for_review`.

## Verification

The gating logic was run against live pull requests with only the mutation stubbed:

| PR | State | Decision |
| --- | --- | --- |
| #5234, #5004 | human drafts | skipped — not Copilot |
| #4184 | Copilot, newest event `copilot_work_started` | skipped — agent still working |
| #4031 | Copilot, Puppeteer red | skipped — draft is correct for red |
| #5230, #5190, #5088, #5129, #4930 | Copilot, finished, 11/11 green | would undraft |

The session guard is not hypothetical: #4184 is genuinely mid-session with green checks and would have been undrafted without it.

Two further facts were checked rather than assumed. The mutation's name and its `pullRequestId: ID!` input match the live GraphQL schema. And `pull_request_target` runs — BrowserStack, Vercel Preview — do carry `head_branch=copilot/…`, so the branch pre-filter matches all seven trigger workflows; had it not, a pull request whose last check was BrowserStack would never have fired.

## For the reviewer

- **It does nothing until merged.** `workflow_run` reads this file from the default branch. After merge, `gh workflow run pr-ready.yml -f pr=<number>` exercises it against a real pull request on demand. Executing the mutation under `GITHUB_TOKEN` is the one step that cannot be rehearsed beforehand.
- **The backlog stays put.** Only new check completions trigger this, so the 26 open drafts are unaffected unless something re-runs their checks.
- **`[WIP]`-titled pull requests are not exempt.** #5129 and #4930 would be undrafted. The agent's own exit checklist requires the title to describe what landed, so `[WIP]` on a finished session reads as a stale title — #4996 was `[WIP]` and merged. Easy to add a title guard if you disagree.
- **`contents: write` is broader than the job needs**, and there is no narrower grant for this mutation. Mitigated by `persist-credentials: false` and a single step running base-repo code only. The standing risk is future edits: any step added to this workflow inherits that token.
- **`actions/checkout@v6` is a moving tag** in a job holding that token — the weakest supply-chain link here, though `actions/github-script` is SHA-pinned. It matches `dependabot-fix.yml` and `puppeteer-diff-comment.yml`, so pinning it would be worth doing across all three or not at all.
