### PR TITLE
Give each AI service its own OpenAI API key

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -19,7 +19,7 @@ Install dependencies from the repository root:
 yarn
 ```
 
-Create `packages/ai/.env.local` with an OpenAI API key for development. This file is ignored by git.
+Create `packages/ai/.env.local` with an OpenAI API key for development. This file is ignored by git. `OPENAI_API_KEY` is the fallback for every service, so a single key is all that local development needs. See [API keys](#api-keys) for the per-service keys used in deployment.
 
 ```dotenv
 OPENAI_API_KEY=your-development-key
@@ -69,10 +69,12 @@ In the Vercel project settings (Settings → Build and Deployment):
 - **Framework Settings** — leave Build Command and Output Directory overrides off. The Install Command may be overridden with `yarn`.
 - **Deployment Protection** — Vercel Authentication must be disabled so em clients can reach the service.
 
-Set `OPENAI_API_KEY` in both the `em-ai` Production and Preview environments. Use a dedicated, tightly
-budgeted key for Preview: the preview workflow runs pull request code, including approved fork code, so provider
-limits are an additional safeguard against accidental or malicious use. The key is a server secret and must never
-be added to the repository or exposed through a `VITE_*` variable.
+Set the keys described under [API keys](#api-keys) in both the `em-ai` Production and Preview environments. Give
+Preview its own OpenAI project rather than only its own keys: the preview workflow runs pull request code, including
+approved fork code, and budgets, rate limits, and model allowlists are project settings, so the project is the boundary
+that bounds the blast radius. A project budget only sends a notification and does not stop requests once it is reached;
+the only hard stop OpenAI provides is prepaid credits with auto-recharge disabled, which applies to the whole
+organization. Keys are server secrets and must never be added to the repository or exposed through a `VITE_*` variable.
 
 Production is deployed by the `Vercel Production` GitHub Actions workflow on every push to `main`. The workflow selects `em-ai` with `VERCEL_PROJECT_ID_EM_AI`, runs `vercel pull`, `vercel build --prod`, and `vercel deploy --prebuilt --prod`.
 
@@ -82,6 +84,26 @@ GitHub deployment links to the user-facing `em` preview, while the workflow summ
 diagnostics. Vercel Authentication must remain disabled for preview deployments so the browser can call the API.
 
 Vercel's own Git deployment is disabled in `vercel.json` to prevent duplicate deployments. The repository's `.env.production` sets the AI service base URL to `https://ai.emthought.space/ai`.
+
+### API keys
+
+Each service authenticates with its own OpenAI API key so that its usage and spend can be read separately.
+`completeChat` looks up `OPENAI_API_KEY_{SERVICE}` for the `Service` it is passed and falls back to `OPENAI_API_KEY`.
+
+| Service          | Environment variable              |
+| ---------------- | --------------------------------- |
+| Generate Thought | `OPENAI_API_KEY_GENERATE_THOUGHT` |
+
+Adding a service means adding a member to [`src/@types/Service.ts`](src/@types/Service.ts), passing it to
+`completeChat`, and creating a key of the same name in the OpenAI dashboard. The fallback keeps a deployment that sets
+only `OPENAI_API_KEY` working, at the cost of merging that service into the shared key's total.
+
+API key is a reporting dimension in the OpenAI dashboard: the Usage and Spend views filter and group by key, and the
+Usage and Costs APIs accept `api_key_ids` and `group_by=api_key_id`. The Costs API identifies a key by its ID rather
+than its name, so match the ID against the key list in the dashboard when reading a report.
+
+Keys segment reporting only. Two keys in the same project draw on the same budget and the same rate limits, and there
+is no per-key spend cap.
 
 ### Rate limiting
 
@@ -114,6 +136,7 @@ Function metrics (invocations, duration percentiles, error rate, cold starts, me
 
 ## Environment variables
 
-- `OPENAI_API_KEY` — required by the AI server locally and in the `em-ai` Vercel Production and Preview environments.
+- `OPENAI_API_KEY` — fallback OpenAI API key for any service that has no key of its own. Required by the AI server locally, and in the `em-ai` Vercel Production and Preview environments for as long as any service relies on the fallback.
+- `OPENAI_API_KEY_GENERATE_THOUGHT` — optional per-service key for Generate Thought in the `em-ai` Vercel Production and Preview environments. See [API keys](#api-keys).
 - `PORT` — optional local server port. Defaults to `3111`.
 - `VITE_AI_URL` — public, build-time client base URL. Development uses `http://localhost:3111/ai`, production uses `https://ai.emthought.space/ai`, and pull request builds receive their matching `em-ai` preview URL from the workflow.

--- a/packages/ai/src/@types/Service.ts
+++ b/packages/ai/src/@types/Service.ts
@@ -1,0 +1,10 @@
+/**
+ * An AI service exposed by this server. Each service authenticates with its own OpenAI API key so that the OpenAI
+ * dashboard and the Usage and Costs APIs can attribute tokens and spend to it. The value is the suffix of the service's
+ * `OPENAI_API_KEY_{SERVICE}` environment variable.
+ */
+enum Service {
+    GENERATE_THOUGHT = 'GENERATE_THOUGHT',
+}
+
+export default Service

--- a/packages/ai/src/__tests__/completeChat.ts
+++ b/packages/ai/src/__tests__/completeChat.ts
@@ -1,0 +1,81 @@
+import { vi } from 'vitest'
+import { z } from 'zod'
+import Model from '../@types/Model'
+import ReasoningEffort from '../@types/ReasoningEffort'
+import Service from '../@types/Service'
+import completeChat from '../completeChat'
+
+/** Records the options that the OpenAI client is constructed with. Hoisted so that it is defined before vi.mock runs. */
+const { constructOpenAI } = vi.hoisted(() => ({ constructOpenAI: vi.fn() }))
+
+vi.mock('openai', async importOriginal => {
+  const actual = await importOriginal<typeof import('openai')>()
+  return {
+    ...actual,
+    /** A stand-in for the OpenAI client that records the key it is constructed with and returns a fixed completion. */
+    default: class {
+      chat = {
+        completions: {
+          parse: async () => ({ choices: [{ message: { parsed: { thought: 'California' } } }] }),
+        },
+      }
+
+      /** Records the client options so that the test can assert on the API key. */
+      constructor(options: { apiKey?: string }) {
+        constructOpenAI(options)
+      }
+    },
+  }
+})
+
+afterEach(() => {
+  constructOpenAI.mockClear()
+  vi.unstubAllEnvs()
+})
+
+it('authenticates with the key of the service the request is made for', async () => {
+  vi.stubEnv('OPENAI_API_KEY_GENERATE_THOUGHT', 'generate-thought-key')
+  vi.stubEnv('OPENAI_API_KEY', 'shared-key')
+
+  await completeChat({
+    messages: [{ role: 'user', content: 'The state after Arkansas alphabetically.' }],
+    model: Model.GPT_5_6_LUNA,
+    reasoningEffort: ReasoningEffort.NONE,
+    schema: z.object({ thought: z.string() }),
+    service: Service.GENERATE_THOUGHT,
+  })
+
+  expect(constructOpenAI).toHaveBeenCalledWith({ apiKey: 'generate-thought-key' })
+})
+
+it('falls back to the shared key when the service has no key of its own', async () => {
+  vi.stubEnv('OPENAI_API_KEY_GENERATE_THOUGHT', undefined)
+  vi.stubEnv('OPENAI_API_KEY', 'shared-key')
+
+  await completeChat({
+    messages: [{ role: 'user', content: 'The state after Arkansas alphabetically.' }],
+    model: Model.GPT_5_6_LUNA,
+    reasoningEffort: ReasoningEffort.NONE,
+    schema: z.object({ thought: z.string() }),
+    service: Service.GENERATE_THOUGHT,
+  })
+
+  expect(constructOpenAI).toHaveBeenCalledWith({ apiKey: 'shared-key' })
+})
+
+it('throws when neither the service key nor the shared key is set', async () => {
+  vi.stubEnv('OPENAI_API_KEY_GENERATE_THOUGHT', undefined)
+  vi.stubEnv('OPENAI_API_KEY', undefined)
+
+  await expect(
+    completeChat({
+      messages: [{ role: 'user', content: 'The state after Arkansas alphabetically.' }],
+      model: Model.GPT_5_6_LUNA,
+      reasoningEffort: ReasoningEffort.NONE,
+      schema: z.object({ thought: z.string() }),
+      service: Service.GENERATE_THOUGHT,
+    }),
+  ).rejects.toThrow('Missing OPENAI_API_KEY_GENERATE_THOUGHT and OPENAI_API_KEY')
+
+  expect(constructOpenAI).not.toHaveBeenCalled()
+})

--- a/packages/ai/src/completeChat.ts
+++ b/packages/ai/src/completeChat.ts
@@ -4,10 +4,7 @@ import { zodResponseFormat } from 'openai/helpers/zod'
 import { ZodType } from 'zod'
 import Model from './@types/Model'
 import ReasoningEffort from './@types/ReasoningEffort'
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
+import Service from './@types/Service'
 
 /** Completes a chat and parses its structured response. */
 const completeChat = async <T>({
@@ -15,12 +12,23 @@ const completeChat = async <T>({
   model,
   reasoningEffort,
   schema,
+  service,
 }: {
   messages: ChatCompletionMessageParam[]
   model: Model
   schema: ZodType<T>
   reasoningEffort: ReasoningEffort
+  /** The service the request is made on behalf of, which selects the API key it is billed to. */
+  service: Service
 }): Promise<T> => {
+  // Authenticate as the service so that the OpenAI dashboard and the Usage and Costs APIs can group tokens and spend by
+  // API key. Fall back to the shared key, which is all that local development and a single-key deployment need.
+  const apiKey = process.env[`OPENAI_API_KEY_${service}`] || process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error(`Missing OPENAI_API_KEY_${service} and OPENAI_API_KEY`)
+  }
+  const openai = new OpenAI({ apiKey })
+
   const response = await openai.chat.completions.parse({
     messages,
     model,

--- a/packages/ai/src/prompts/generateThought.ts
+++ b/packages/ai/src/prompts/generateThought.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import Model from '../@types/Model'
 import ReasoningEffort from '../@types/ReasoningEffort'
+import Service from '../@types/Service'
 import completeChat from '../completeChat'
 
 /** Prompts the LLM to generate a thought. */
@@ -51,6 +52,7 @@ ${input}
     ],
     model: Model.GPT_5_6_LUNA,
     reasoningEffort: ReasoningEffort.NONE,
+    service: Service.GENERATE_THOUGHT,
     schema: z.object({
       thought: z.string().trim().min(1).describe('The complete replacement for the target thought'),
     }),


### PR DESCRIPTION
Every request from this server authenticated with the same `OPENAI_API_KEY`, so the OpenAI dashboard reported the whole service as one line. API key became a reporting dimension in the August 4, 2026 changelog — the Usage and Spend views filter and group by key, and the Usage and Costs APIs accept `api_key_ids` and `group_by=api_key_id` — so a key per service is now all it takes to separate one service's spend from another's.

Metadata tags are not an alternative. They require `store: true`, which retains the prompt and completion — here the user's own thought outline — and they carry no cost aggregation at all; attribution stops at project and key.

## Changes

- **`src/@types/Service.ts`** — new enum, one member per service. The value is the suffix of that service's `OPENAI_API_KEY_{SERVICE}` variable. `GENERATE_EMOJI` arrives with #5085.
- **`src/completeChat.ts`** — takes the `Service` the request is made for and constructs the client with that service's key, falling back to `OPENAI_API_KEY`. The client moves from module scope into the call, since a module-level client cannot vary by service.
- **`src/prompts/generateThought.ts`** — passes `Service.GENERATE_THOUGHT`.
- **`src/__tests__/completeChat.ts`** — service key, fallback, and the throw when neither variable is set.
- **`README.md`** — an API keys section, plus a correction. The old text told the reader to use a "dedicated, tightly budgeted key" for Preview. OpenAI has no per-key budget: budgets, rate limits, and model allowlists are project settings, so Preview needs its own project. The section also now says that a project budget only sends a notification rather than stopping requests, since that was the property the old advice was relying on.

## Verification

- `yarn --cwd packages/ai typecheck` and `eslint` are clean.
- The three unit tests pass, and the first fails for the right reason: reverting the resolution to `process.env.OPENAI_API_KEY` alone turns *authenticates with the key of the service the request is made for* red while the other two stay green.

## For the reviewer

- **`OPENAI_API_KEY_GENERATE_THOUGHT` must exist in the `em-ai` Vercel project**, Production and Preview, for this to do anything. It has been added. GitHub repository secrets are not involved — the deploy workflows pass only `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID*`.
- **It fails soft.** A missing or mistyped variable falls back to `OPENAI_API_KEY` and Generate Thought keeps working, with its spend back in the shared total. Checking Usage grouped by API key after deploy is the only thing that proves the new key is live.
- **Keys segment reporting only.** Two keys in one project draw on the same budget and the same rate limits, and there is no per-key spend cap. Bounding what a fork PR can spend still needs a separate OpenAI project for Preview.
- **#5085 follow-up.** Generate Emoji adds its own enum member and `service:` argument once this is on `main`; noted in a comment there.
- **#5242** covers the same split for `scripts/issue-classifier` and `scripts/estimate`, which share one `OPENAI_API_KEY` repository secret today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
