### PR TITLE
Give the issue classifier and estimate scripts their own OpenAI API keys

### DIFF
--- a/.github/workflows/estimate-backfill.yml
+++ b/.github/workflows/estimate-backfill.yml
@@ -57,7 +57,9 @@ jobs:
         run: node scripts/estimate/src/backfill.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # OpenAI API key used for issue estimation inference (backfill.ts).
+          # OpenAI API key used for issue estimation inference (backfill.ts). The estimate key bills this
+          # workflow separately in the OpenAI dashboard; the shared key is the fallback.
+          OPENAI_API_KEY_ESTIMATE: ${{ secrets.OPENAI_API_KEY_ESTIMATE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}
           # An EVERHOUR_PROJECT_ID secret must be configured in repo settings.

--- a/.github/workflows/estimate-issue-opened.yml
+++ b/.github/workflows/estimate-issue-opened.yml
@@ -33,7 +33,9 @@ jobs:
         run: node scripts/estimate/src/issue.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # OpenAI API key used for issue estimation inference (issue.ts).
+          # OpenAI API key used for issue estimation inference (issue.ts). The estimate key bills this
+          # workflow separately in the OpenAI dashboard; the shared key is the fallback.
+          OPENAI_API_KEY_ESTIMATE: ${{ secrets.OPENAI_API_KEY_ESTIMATE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           EVERHOUR_API_KEY: ${{ secrets.EVERHOUR_API_KEY }}
           EVERHOUR_PROJECT_ID: ${{ secrets.EVERHOUR_PROJECT_ID }}

--- a/.github/workflows/issue-classifier.yml
+++ b/.github/workflows/issue-classifier.yml
@@ -55,7 +55,9 @@ jobs:
         run: node scripts/issue-classifier/src/issue.ts ${{ inputs.dry && '--dry' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # OpenAI API key used for the milestone selection inference call (issue.ts).
+          # OpenAI API key used for the milestone selection inference call (issue.ts). The classifier key
+          # bills this workflow separately in the OpenAI dashboard; the shared key is the fallback.
+          OPENAI_API_KEY_ISSUE_CLASSIFIER: ${{ secrets.OPENAI_API_KEY_ISSUE_CLASSIFIER }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # Empty for the issues event, where the issue number comes from the event payload instead.
           ISSUE_NUMBER: ${{ inputs.issue }}

--- a/docs/agents/readme.md
+++ b/docs/agents/readme.md
@@ -189,7 +189,7 @@ Worth knowing about, because nothing here will tell you when one of them breaks:
 
 - **[MCP server configuration](mcp.md).** An MCP server is an external tool the agent can call. Three matter here: [`chrome-devtools`](mcp.md#chrome-devtools) for driving Chrome, [`wdio`](mcp.md#wdio) for driving iOS, and [the GitHub server](mcp.md#the-github-server) for reading issues and CI runs. They are configured in Copilot's own settings, not in this repository. In particular, `chrome-devtools` must be given `--browser-url=http://127.0.0.1:9222` so that it joins the browser the setup step already started instead of launching a second one.
 - **The pre-built iOS app.** iOS work runs against an app binary uploaded to BrowserStack under the name `em-server-mode`. BrowserStack deletes uploads 30 days after they were last used, and if it lapses, iOS reproduction stops working until someone rebuilds it. Rebuilding is one command on a Mac with Xcode signing set up — `yarn build:ios:browserstack` — and nothing warns you before it expires.
-- **Secrets.** `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`, and `OPENAI_API_KEY` are repository secrets.
+- **Secrets.** `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`, and `OPENAI_API_KEY` are repository secrets. `OPENAI_API_KEY_ISSUE_CLASSIFIER` and `OPENAI_API_KEY_ESTIMATE` are too: each script prefers its own key so that its spend is reported separately, and falls back to `OPENAI_API_KEY`.
 - **Network allowances.** The agent runs behind a firewall that blocks outbound traffic by default. Hosts it needs are listed in `COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS` in the setup workflow. A new external dependency needs adding there or it will fail in a way that looks like a hang.
 
 ## Changing any of this

--- a/scripts/estimate/.env.example
+++ b/scripts/estimate/.env.example
@@ -5,7 +5,10 @@
 # API Token can be refreshed at https://app.everhour.com/#/account/profile
 EVERHOUR_API_KEY=
 EVERHOUR_PROJECT_ID=
-# OpenAI API key used for the estimation inference call.
+# OpenAI API key used for the estimation inference call. OPENAI_API_KEY_ESTIMATE takes precedence when
+# set, which is how this script's spend is reported separately in the OpenAI dashboard. One shared key
+# is all a local run needs.
+# OPENAI_API_KEY_ESTIMATE=
 OPENAI_API_KEY=
 # Inference tuning (all optional; defaults shown):
 # ESTIMATE_MODEL=gpt-5.6-terra          # OpenAI model used for estimation. Must support Structured Outputs.

--- a/scripts/estimate/README.md
+++ b/scripts/estimate/README.md
@@ -12,6 +12,10 @@ EVERHOUR_PROJECT_ID=
 OPENAI_API_KEY=
 ```
 
+Every script here reads `OPENAI_API_KEY_ESTIMATE` first and falls back to `OPENAI_API_KEY`. The separate
+name is what lets estimation spend be read on its own in the OpenAI dashboard, which reports by API key;
+one shared key in `.env` is all a local run needs.
+
 ## Usage
 
 ```bash
@@ -45,7 +49,7 @@ Valid estimate values: `1h` (XXS), `2h` (XS), `4h` (S), `8h` (M), `16h` (L), `24
 
 ## Workflows
 
-Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings. The Issue Opened and Backfill workflows additionally require an `OPENAI_API_KEY` secret for the estimation inference call.
+Three GitHub Action workflows in `.github/workflows/` drive the estimation scripts. All require the `EVERHOUR_API_KEY` and `EVERHOUR_PROJECT_ID` secrets to be configured in the repository settings. The Issue Opened and Backfill workflows additionally require an `OPENAI_API_KEY_ESTIMATE` secret for the estimation inference call, or `OPENAI_API_KEY` as the fallback.
 
 | Workflow                                                                     | Script            | Trigger                                  | Description                                                                                                                                     |
 | ---------------------------------------------------------------------------- | ----------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/scripts/estimate/src/backfill.ts
+++ b/scripts/estimate/src/backfill.ts
@@ -152,8 +152,8 @@ const main = async () => {
   const githubToken = process.env.GITHUB_TOKEN
   if (!githubToken) throw new Error('GITHUB_TOKEN is required')
 
-  const openaiApiKey = process.env.OPENAI_API_KEY
-  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+  const openaiApiKey = process.env.OPENAI_API_KEY_ESTIMATE || process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY_ESTIMATE or OPENAI_API_KEY is required')
 
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')

--- a/scripts/estimate/src/evaluate.ts
+++ b/scripts/estimate/src/evaluate.ts
@@ -147,8 +147,8 @@ const formatReport = (metrics: EvalMetrics): string => {
 
 /** Runs the leave-one-out evaluation over every labeled sample and prints the accuracy report. */
 const main = async () => {
-  const openaiApiKey = process.env.OPENAI_API_KEY
-  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+  const openaiApiKey = process.env.OPENAI_API_KEY_ESTIMATE || process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY_ESTIMATE or OPENAI_API_KEY is required')
 
   // Resolve the repo root from this file's location (scripts/estimate/src/evaluate.ts → repo root)
   // so instructions/samples load correctly regardless of the current working directory.

--- a/scripts/estimate/src/issue.ts
+++ b/scripts/estimate/src/issue.ts
@@ -26,8 +26,8 @@ const main = async () => {
   const githubToken = process.env.GITHUB_TOKEN
   if (!githubToken) throw new Error('GITHUB_TOKEN is required')
 
-  const openaiApiKey = process.env.OPENAI_API_KEY
-  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+  const openaiApiKey = process.env.OPENAI_API_KEY_ESTIMATE || process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY_ESTIMATE or OPENAI_API_KEY is required')
 
   const everhourApiKey = process.env.EVERHOUR_API_KEY
   if (!everhourApiKey) throw new Error('EVERHOUR_API_KEY is required')

--- a/scripts/issue-classifier/.env.example
+++ b/scripts/issue-classifier/.env.example
@@ -2,7 +2,10 @@
 # GITHUB_TOKEN is required to assign a milestone or post a comment. Reading milestones and issues
 # from a public repository works without it, so --dry runs need no token at all.
 GITHUB_TOKEN=
-# OpenAI API key used for the milestone selection inference call.
+# OpenAI API key used for the milestone selection inference call. OPENAI_API_KEY_ISSUE_CLASSIFIER takes
+# precedence when set, which is how this script's spend is reported separately in the OpenAI dashboard.
+# One shared key is all a local run needs.
+# OPENAI_API_KEY_ISSUE_CLASSIFIER=
 OPENAI_API_KEY=
 # Repository to operate on. Defaults to cybersemics/em; in Actions it comes from GITHUB_REPOSITORY.
 # ISSUE_CLASSIFIER_REPO=cybersemics/em

--- a/scripts/issue-classifier/README.md
+++ b/scripts/issue-classifier/README.md
@@ -15,6 +15,10 @@ OPENAI_API_KEY=
 
 `GITHUB_TOKEN` is only needed to write. Reading milestones and issues from a public repository works without one, so `--dry` runs and `yarn evaluate` need nothing but an OpenAI key.
 
+Every script here reads `OPENAI_API_KEY_ISSUE_CLASSIFIER` first and falls back to `OPENAI_API_KEY`. The
+separate name is what lets this classifier's spend be read on its own in the OpenAI dashboard, which
+reports by API key; one shared key in `.env` is all a local run needs.
+
 ## Usage
 
 ```bash
@@ -176,7 +180,7 @@ Full results are [a comment on #5098](https://github.com/cybersemics/em/pull/509
 | ---------------------------------------------------------------- | -------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Issue Classifier](../../.github/workflows/issue-classifier.yml) | `src/issue.ts` | Issue opened, or manual `workflow_dispatch` | Assigns the best-matching open milestone and labels what kind of work the issue is, or comments asking for a category when no milestone fits. |
 
-It needs the `OPENAI_API_KEY` repository secret; the `GITHUB_TOKEN` is supplied by Actions. The manual dispatch takes an `issue` number, which is also how an existing unclassified issue gets a milestone, plus an optional `dry` toggle that runs the inference and prints the decision without assigning anything.
+It needs the `OPENAI_API_KEY_ISSUE_CLASSIFIER` repository secret, or `OPENAI_API_KEY` as the fallback; the `GITHUB_TOKEN` is supplied by Actions. The manual dispatch takes an `issue` number, which is also how an existing unclassified issue gets a milestone, plus an optional `dry` toggle that runs the inference and prints the decision without assigning anything.
 
 ```sh
 gh workflow run issue-classifier.yml -f issue=5092 -f dry=true

--- a/scripts/issue-classifier/src/compare.ts
+++ b/scripts/issue-classifier/src/compare.ts
@@ -281,8 +281,8 @@ export const mapConcurrent = async <T, R>(items: T[], limit: number, fn: (item: 
 /** Runs every model over every sample, `runs` times, and appends the graded rows to the output file. */
 const main = async () => {
   const { models, runs, samples: samplesFile, split, out, votes } = parseArgs(process.argv.slice(2))
-  const apiKey = process.env.OPENAI_API_KEY
-  if (!apiKey) throw new Error('OPENAI_API_KEY is required')
+  const apiKey = process.env.OPENAI_API_KEY_ISSUE_CLASSIFIER || process.env.OPENAI_API_KEY
+  if (!apiKey) throw new Error('OPENAI_API_KEY_ISSUE_CLASSIFIER or OPENAI_API_KEY is required')
 
   const repo = process.env.GITHUB_REPOSITORY ?? process.env.ISSUE_CLASSIFIER_REPO ?? DEFAULT_REPO
   const instructions = loadInstructions()

--- a/scripts/issue-classifier/src/evaluate.ts
+++ b/scripts/issue-classifier/src/evaluate.ts
@@ -433,8 +433,8 @@ export const grade = async (
 
 /** Evaluates the classifier over every labeled sample and prints the accuracy report. */
 const main = async () => {
-  const openaiApiKey = process.env.OPENAI_API_KEY
-  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+  const openaiApiKey = process.env.OPENAI_API_KEY_ISSUE_CLASSIFIER || process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY_ISSUE_CLASSIFIER or OPENAI_API_KEY is required')
 
   const minAccuracy = resolveMinAccuracy()
   const repo = process.env.GITHUB_REPOSITORY ?? process.env.ISSUE_CLASSIFIER_REPO ?? DEFAULT_REPO

--- a/scripts/issue-classifier/src/issue.ts
+++ b/scripts/issue-classifier/src/issue.ts
@@ -47,8 +47,8 @@ const resolveIssueNumber = (): number => {
 const main = async () => {
   const dryRun = process.argv.includes('--dry')
 
-  const openaiApiKey = process.env.OPENAI_API_KEY
-  if (!openaiApiKey) throw new Error('OPENAI_API_KEY is required')
+  const openaiApiKey = process.env.OPENAI_API_KEY_ISSUE_CLASSIFIER || process.env.OPENAI_API_KEY
+  if (!openaiApiKey) throw new Error('OPENAI_API_KEY_ISSUE_CLASSIFIER or OPENAI_API_KEY is required')
 
   // Reads work unauthenticated against a public repository, so only a run that actually writes
   // needs a token. That is what lets --dry be exercised locally with nothing but an OpenAI key.


### PR DESCRIPTION
`scripts/issue-classifier` and `scripts/estimate` authenticated with the same `OPENAI_API_KEY` repository secret, so in the OpenAI dashboard the two were one line, and neither could be told apart from product traffic. Each script now reads its own key and falls back to the shared one.

`OPENAI_API_KEY_ISSUE_CLASSIFIER` and `OPENAI_API_KEY_ESTIMATE` are already configured as repository secrets.

Closes #5242.

## Changes

- **Six entry points** — `issue.ts`, `evaluate.ts`, and `compare.ts` under `scripts/issue-classifier/src`, and `issue.ts`, `backfill.ts`, and `evaluate.ts` under `scripts/estimate/src` — read `OPENAI_API_KEY_{CONSUMER} || OPENAI_API_KEY`, and the error names both. The read stays inline rather than moving behind a helper, to match the `GITHUB_TOKEN` and `EVERHOUR_API_KEY` reads sitting beside it in the same functions.
- **`issue-classifier.yml`, `estimate-issue-opened.yml`, `estimate-backfill.yml`** — pass the new secret alongside the old one. An unset secret arrives as an empty string, which is falsy, so the fallback holds if a secret is ever removed.
- **Both `.env.example` files, both script READMEs, and `docs/agents/readme.md`** — name the new variable and say a single shared key is all a local run needs.

## Naming

#5242 left this open: the scripts prefix their own settings (`ISSUE_CLASSIFIER_MODEL`, `ESTIMATE_MODEL`), which argued for `ISSUE_CLASSIFIER_OPENAI_API_KEY`. This uses `OPENAI_API_KEY_{CONSUMER}` instead, matching #5243, so that the repository has one convention for OpenAI keys rather than each package matching its immediate neighbors.

## Verification

Key resolution exercised directly on `scripts/estimate/src/issue.ts`, which checks `GITHUB_TOKEN` first and `EVERHOUR_API_KEY` after, so advancing to the Everhour error is the proof that the OpenAI key resolved:

| Environment | Result |
| --- | --- |
| neither key | `OPENAI_API_KEY_ESTIMATE or OPENAI_API_KEY is required` |
| `OPENAI_API_KEY` only | advances — fallback resolves |
| `OPENAI_API_KEY_ESTIMATE` only | advances — own key resolves |

`tsc --noEmit` for both packages, `eslint`, and `prettier --check` are clean; the three workflow files parse.

## For the reviewer

- **Nothing proves the split until a workflow actually runs.** The next classified issue and the next estimate are the first real requests through the new names; Usage grouped by API key is where that shows up.
- **It fails soft, like #5243.** A mistyped secret name falls back to `OPENAI_API_KEY` and the workflow still succeeds, with its spend back in the shared total.
- **No test added.** The reads live in script `main()` entry points that have no existing coverage — the adjacent `GITHUB_TOKEN` and `EVERHOUR_API_KEY` checks are untested for the same reason. The table above was run by hand instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
