### PR TITLE
Label the Puppeteer snapshot diff panels with a table header

### DIFF
--- a/scripts/ci/upsert-diff-comment.cjs
+++ b/scripts/ci/upsert-diff-comment.cjs
@@ -16,13 +16,36 @@ const HEADING = '### 🖼️ Puppeteer snapshot diffs'
 const esc = s =>
   String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c])
 
+/**
+ * Renders one diff image as a table whose header labels the three panels of jest-image-snapshot's
+ * composite. The image spans all three columns, so the percentage widths — which GitHub's sanitizer
+ * preserves, unlike `style` — keep the labels aligned over their panels as the image scales down.
+ */
+const diffTable = ({ label, url }) =>
+  [
+    '<table width="100%">',
+    '  <tr>',
+    `    <th colspan="3" align="left">${label}</th>`,
+    '  </tr>',
+    '  <tr>',
+    '    <th width="34%">Expected (base branch)</th>',
+    '    <th width="32%">Diff</th>',
+    '    <th width="34%">Actual (PR branch)</th>',
+    '  </tr>',
+    '  <tr>',
+    `    <td colspan="3"><img src="${url}" alt="${label}" width="900" /></td>`,
+    '  </tr>',
+    '</table>',
+  ].join('\n')
+
 /** Comment body listing every diff image inline, with the command to update the affected snapshots. */
 const diffBody = ({ rels, base, author, runUrl }) => {
   const blocks = rels
     .map(rel => {
       const url = `${base}/${rel.split('/').map(encodeURIComponent).join('/')}`
-      const label = esc(rel.replace('/__diff_output__/', ' / '))
-      return `**${label}**\n\n<img src="${url}" alt="${label}" width="900" />`
+      // ui/__diff_output__/thought-1-diff.png -> ui / thought-1, matching the snapshot's own name.
+      const label = esc(rel.replace('/__diff_output__/', ' / ').replace(/-diff\.png$/, ''))
+      return diffTable({ label, url })
     })
     .join('\n\n')
   const authorMention = author ? `@${esc(author)}` : ''
@@ -35,18 +58,19 @@ const diffBody = ({ rels, base, author, runUrl }) => {
     MARKER,
     HEADING,
     '',
-    `${authorMention}: These snapshot tests failed, which indicates a visual regression. Please review your changes. If the visual changes are intentional, update the snapshots for the affected test files:`,
-    '',
-    `\`\`\`\n${updateCommand}\n\`\`\``,
+    `${authorMention}: These snapshot tests failed, which indicates a visual regression. Please review your changes.`,
     '',
     `<details open><summary>${rels.length} broken snapshot${rels.length === 1 ? '' : 's'}</summary>`,
     '',
-    `Left: Expected (base branch) | Right: Actual (PR branch)`,
     blocks,
     '',
     '</details>',
     '',
-    `[View workflow run](${runUrl})`,
+    `[Workflow run](${runUrl})`,
+    '',
+    'If the visual changes are intentional, update the snapshots for the affected test files:',
+    '',
+    `\`\`\`\n${updateCommand}\n\`\`\``,
   ].join('\n')
 }
 
@@ -58,7 +82,7 @@ const resolvedBody = ({ runId, runUrl }) =>
     '',
     `✅ No snapshot diffs in the latest run (${runId}). Any previously reported diffs have been cleared.`,
     '',
-    `[View workflow run](${runUrl})`,
+    `[Workflow run](${runUrl})`,
   ].join('\n')
 
 /** Creates or updates the single marked snapshot-diff comment on the PR. */


### PR DESCRIPTION
The diff image posted by `Puppeteer Diff Comment` is jest-image-snapshot's three-panel composite — expected | diff | actual, each panel an exact third of the image. The comment introduced it with a two-panel caption (`Left: Expected (base branch) | Right: Actual (PR branch)`), which left the middle panel unlabelled.

Each image is now wrapped in a table whose header names all three panels. The image spans the row with `colspan="3"`, so it is still a single composite, not three files. The columns use percentage widths rather than inline CSS because GitHub's HTML sanitizer preserves the `width` attribute and strips `style` — that keeps each label over its panel as the image scales down to the comment width.

The body is also reordered so the images come first: the update instructions and the targeted `yarn test:puppeteer -u ...` command now follow the workflow run link. Per-image labels drop the `-diff.png` suffix to match the snapshot's own name under `__image_snapshots__/`.


<details><summary>Generated comment body</summary>

````markdown
<!-- puppeteer-diff -->
### 🖼️ Puppeteer snapshot diffs

@cindmichelle: These snapshot tests failed, which indicates a visual regression. Please review your changes.

<details open><summary>1 broken snapshot</summary>

<table width="100%">
  <tr>
    <th colspan="3" align="left">ui / mobile-command-center-1</th>
  </tr>
  <tr>
    <th width="34%">Expected (base branch)</th>
    <th width="32%">Diff</th>
    <th width="34%">Actual (PR branch)</th>
  </tr>
  <tr>
    <td colspan="3"><img src="https://raw.githubusercontent.com/cybersemics/em/snapshot-diffs/pr-5263/33491634519/ui/__diff_output__/mobile-command-center-1-diff.png" alt="ui / mobile-command-center-1" width="900" /></td>
  </tr>
</table>

</details>

[Workflow run](https://github.com/cybersemics/em/actions/runs/33491634519)

If the visual changes are intentional, update the snapshots for the affected test files:

```
yarn test:puppeteer -u ui
```
````

</details>

Verified by running `upsert-diff-comment.cjs` against a stub GitHub client with the manifest from [#5263](https://github.com/cybersemics/em/pull/5263)'s failing run; the emitted body matches the target format byte for byte. The multi-snapshot path emits one table per image and still collapses the update command to the unique set of test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
