### PR TITLE
Ignore span-carried colors when sorting thoughts

### DIFF
--- a/src/util/__tests__/compareThought.ts
+++ b/src/util/__tests__/compareThought.ts
@@ -273,6 +273,45 @@ describe('compareReasonable', () => {
     expect(compareReasonable('élan', 'élan')).toBe(0)
     expect(compareReasonable('every', 'élan')).toBe(1)
   })
+
+  it('sort a colored thought by its text, whether the color is on a font or a span tag', () => {
+    // <font color> and <font style="background-color"> are written by the formatting commands
+    expect(compareReasonable('<font color="#ff573d">apple</font>', 'apple')).toBe(0)
+    expect(
+      compareReasonable('<font color="#000000" style="background-color: rgb(0, 214, 136);">apple</font>', 'apple'),
+    ).toBe(0)
+    expect(compareReasonable('<font style="background-color: rgb(0, 128, 255);">apple</font>', 'apple')).toBe(0)
+
+    // <span style="color"> is written when a colored thought is pasted or split
+    expect(compareReasonable('<span style="color: rgb(255, 87, 61);">apple</span>', 'apple')).toBe(0)
+    expect(compareReasonable('<span style="background-color: rgb(0, 214, 136);">apple</span>', 'apple')).toBe(0)
+    expect(
+      compareReasonable('<span style="color: #000000;background-color: rgb(0, 214, 136);">apple</span>', 'apple'),
+    ).toBe(0)
+
+    // the two markups sort together, so re-coloring or pasting a thought does not move it
+    expect(compareReasonable('<span style="color: pink;">apple</span>', '<font color="#ff573d">apple</font>')).toBe(0)
+    expect(compareReasonable('<span style="color: pink;">apple</span>', 'banana')).toBe(-1)
+    expect(compareReasonable('<span style="color: pink;">banana</span>', 'apple')).toBe(1)
+
+    // a color does not hide the leading emoji or the empty value that the earlier comparators sort on
+    expect(compareReasonable('<span style="color: pink;">🍍 apple</span>', 'banana')).toBe(-1)
+    expect(compareReasonable('<span style="color: pink;"></span>', 'apple')).toBe(-1)
+    expect(compareReasonable('<font color="#ff573d"></font>', 'apple')).toBe(-1)
+  })
+
+  it('sort a formatted thought by its formatting, even when a color is applied to it', () => {
+    // the color is ignored, but the bold it wraps still sorts above plain text
+    expect(compareReasonable('<font color="#ff573d"><b>apple</b></font>', '<b>apple</b>')).toBe(0)
+    expect(compareReasonable('<font color="#ff573d"><b>apple</b></font>', 'apple')).toBe(-1)
+    expect(compareReasonable('<span style="color: pink;"><b>apple</b></span>', 'apple')).toBe(-1)
+    // the inner tag's closing tag is not consumed along with the color wrapper's
+    expect(compareReasonable('<b><span style="color: pink;">apple</span></b>', '<b>apple</b>')).toBe(0)
+
+    // a span that carries formatting rather than a color is left in place, so it still sorts as formatted
+    expect(compareReasonable('<span style="font-weight: 700;">apple</span>', 'apple')).toBe(-1)
+    expect(compareReasonable('<span style="color: pink;font-weight: 700;">apple</span>', 'apple')).toBe(-1)
+  })
 })
 
 describe('compareThought', () => {
@@ -316,6 +355,13 @@ describe('compareThought', () => {
     it('sort equally-formatted thoughts by their visible text, ignoring formatting markup (#3977)', () => {
       expect(compareThoughtDescending(thought('<b><i>E</b>'), thought('<i><b>D</b></i>'))).toBe(-1)
       expect(compareThoughtDescending(thought('<b><i>C</b>'), thought('<i><b>D</b></i>'))).toBe(1)
+    })
+
+    it('sort a colored thought by its text in descending order, whether the color is on a font or a span tag', () => {
+      expect(compareThoughtDescending(thought('<font color="#ff573d">apple</font>'), thought('apple'))).toBe(0)
+      expect(compareThoughtDescending(thought('<span style="color: pink;">apple</span>'), thought('apple'))).toBe(0)
+      expect(compareThoughtDescending(thought('<span style="color: pink;">apple</span>'), thought('banana'))).toBe(1)
+      expect(compareThoughtDescending(thought('<span style="color: pink;">banana</span>'), thought('apple'))).toBe(-1)
     })
 
     it('sort empty thought above formatted thoughts in descending order', () => {

--- a/src/util/compareThought.ts
+++ b/src/util/compareThought.ts
@@ -57,9 +57,47 @@ const REGEX_DATE_COMBINED = new RegExp(
 // Allows mixed separators since it's only for parsing, not validation
 const REGEX_SHORT_DATE_PARSE = new RegExp(`^(\\d{1,2}[\\/-]\\d{1,2}|(${MONTH_NAMES})\\s+\\d{1,2})$`, 'i')
 
-// Match fonts tags for color and background color
-// can be used to strip font tags before sorting (#3782)
-const FONT_TAG_REGEX = /<font color="[^"]+"\s*(?:style="[^"]+")?>|<\/font>/gm
+// Match an opening or closing font or span tag, capturing the slash of a closing tag and the attributes of an opening
+// tag. These are the only two elements that can carry a color.
+const REGEX_COLOR_WRAPPER = /<(\/?)(?:font|span)\b([^>]*)>/gi
+
+// Match the color attribute of an opening font tag, e.g. <font color="#ff573d">
+const REGEX_COLOR_ATTRIBUTE = /(^|\s)color\s*=\s*"[^"]*"/gi
+
+// Match the style attribute of an opening tag, capturing its declarations
+const REGEX_STYLE_ATTRIBUTE = /style\s*=\s*"([^"]*)"/i
+
+// Match a color or background-color style declaration, i.e. both declarations of
+// <span style="color: #000000;background-color: rgb(0, 214, 136);">
+const REGEX_COLOR_DECLARATION = /^\s*(?:background-)?color\s*:/i
+
+/** Returns true if a font or span opening tag's attributes consist of nothing but a text or background color, i.e. the element exists only to color its contents. */
+const isColorOnlyWrapper = (attributes: string): boolean =>
+  attributes
+    .replace(REGEX_COLOR_ATTRIBUTE, '')
+    .replace(REGEX_STYLE_ATTRIBUTE, (styleAttribute, declarations: string) =>
+      declarations.split(';').every(declaration => !declaration.trim() || REGEX_COLOR_DECLARATION.test(declaration))
+        ? ''
+        : styleAttribute,
+    )
+    .trim() === ''
+
+/** Removes the font and span elements that carry nothing but a color, so that coloring a thought does not change where
+ * it sorts (#3927). Both tags occur: formatSelectionHtml writes a single <font color> for a text or background color,
+ * while a thought that has been pasted or split passes through formattingNodeToHtml, which rewrites <font> as
+ * <span style>. A wrapper that carries anything else, such as the font-weight of a pasted <span>, is left in place,
+ * since compareFormatting and compareFormattingTagPriority sort on it. */
+const stripColorWrappers = (value: string): string => {
+  // whether each font/span wrapper that is currently open was removed, so that its closing tag is removed with it
+  const removed: boolean[] = []
+  return value.replace(REGEX_COLOR_WRAPPER, (tag, closingSlash: string, attributes: string) => {
+    // a closing tag is removed only if its opening tag was; an unmatched closing tag has no opening tag to pair with
+    if (closingSlash) return removed.pop() ? '' : tag
+    const isColorOnly = isColorOnlyWrapper(attributes)
+    removed.push(isColorOnly)
+    return isColorOnly ? '' : tag
+  })
+}
 
 // removeDiacritics borrowed from modern-diacritics package
 // modern-diacritics does not currently import so it is copied here
@@ -281,8 +319,8 @@ export const compareReasonable: ComparatorFunction<string> = (a: string, b: stri
     compareStringsWithEmoji,
     (a, b) => compareReadableText(normalizeCharacters(a), normalizeCharacters(b)),
   ])
-  // Ignore font tags when sorting thoughts (#3782)
-  return comparator(a.replaceAll(FONT_TAG_REGEX, ''), b.replaceAll(FONT_TAG_REGEX, ''))
+  // Ignore color markup when sorting thoughts (#3927)
+  return comparator(stripColorWrappers(a), stripColorWrappers(b))
 }
 
 /** A comparator that sorts anything in descending order. Not a strict reversal of compareReasonable, as empty strings, formatting, punctuation, and meta attributes are still sorted above plain text.
@@ -304,8 +342,8 @@ export const compareReasonableDescending: ComparatorFunction<string> = (a: strin
     _.flip(compareStringsWithEmoji),
     (a, b) => compareReadableText(normalizeCharacters(b), normalizeCharacters(a)),
   ])
-  // Ignore font tags when sorting thoughts (#3782)
-  return comparator(a.replaceAll(FONT_TAG_REGEX, ''), b.replaceAll(FONT_TAG_REGEX, ''))
+  // Ignore color markup when sorting thoughts (#3927)
+  return comparator(stripColorWrappers(a), stripColorWrappers(b))
 }
 
 /** Compare the value of two thoughts. */


### PR DESCRIPTION
Coloring a thought is not supposed to move it in a sorted context ([#3927](https://github.com/cybersemics/em/pull/3927)), but the strip that makes that true only matched `<font color="…">`.

Since the execCommand refactor ([#4657](https://github.com/cybersemics/em/pull/4657)), a color reaches a thought's value on either tag:

- `formatSelectionHtml` writes a single `<font color="#ff573d">` (or `<font color="#000000" style="background-color: …">` for a highlight).
- A thought that is **pasted or split** passes through `formattingNodeToHtml`, which deliberately rewrites `<font>` as `<span style="color: …">`. (`splitThought` reaches it via `strip(…, { preserveFormatting: true })`.)
- External HTML supplies `<span style="color: …">` directly.

So a span-carried color survived into the comparator:

```
compareReasonable('<span style="color: pink;">apple</span>', 'apple')
  before:  -1   ← the leading "<" sorts it as punctuation, and the <span> gives it a formatting priority
  after:    0
```

The same red thought sorted in two different places depending on how it was colored. A legacy `<font style="background-color: …">` (style but no `color` attribute) fared worse — the opening tag was kept and the closing tag stripped, leaving mangled markup to sort on:

```
'<font style="background-color: rgb(0, 128, 255);">apple</font>'
  →  '<font style="background-color: rgb(0, 128, 255);">apple'
```

### Changes

- **`src/util/compareThought.ts`** — `FONT_TAG_REGEX` → `stripColorWrappers`: removes a `font` or `span` element only when its attributes carry nothing but a text or background color, pairing each opening tag with its own closing tag rather than stripping every `</font>` it finds.

  A wrapper that carries anything else — such as the `font-weight` of a pasted `<span>` — is left in place, since `compareFormatting` and `compareFormattingTagPriority` deliberately sort on it. It stays a single linear scan of the value, so there is no added cost per comparison.

- **`src/util/__tests__/compareThought.ts`** — covers both markups sorting by their text and together, colors not hiding the leading emoji or the empty value that the earlier comparators sort on, formatting inside a color wrapper still sorting as formatted, and a formatting-carrying `<span>` being left alone. All three new tests fail on `main`.

The existing `SortPicker` re-ranking tests already cover the `<font>` case at the JSDOM level and are unchanged.
