### PR TITLE
Install the Vercel CLI once per run instead of per call

### DIFF
--- a/.github/actions/vercel-cli/action.yml
+++ b/.github/actions/vercel-cli/action.yml
@@ -1,0 +1,49 @@
+name: Install Vercel CLI
+description: >
+  Install the Vercel CLI once per run and put it on PATH, so the pull, build, and deploy steps
+  invoke a plain `vercel`.
+
+  This replaces a `yarn dlx vercel` at every call site, which reinstalls the CLI each time it is
+  used — six times in Vercel Preview, three in Vercel Production. Yarn caches the download but
+  relinks and rebuilds (esbuild) on every invocation, so each repeat costs roughly 17 seconds for a
+  binary the run already has. Installing once is around a minute and a half faster per preview run.
+
+  It also fixes one CLI version for the whole run. The version is still whatever `latest` is when
+  the run starts — the CLI is deliberately unpinned so deploys track Vercel's tooling — but a
+  release landing mid-run can no longer leave one step on a different build than the next.
+
+  The retry is for Vercel's publish order. The CLI pins each of its own workspace packages exactly
+  (`"@vercel/go": "9.0.0"`) and normally publishes them first; when that order inverts, `latest` is
+  unresolvable until the missing package lands and the install fails with `ETARGET` (`YN0082` under
+  Yarn) — a red deploy caused by nothing but the minute the run started in. It is rare: in the six
+  releases before it, `@vercel/go` reached npm between 46 seconds and 4 minutes *ahead* of the CLI.
+  59.11.0 inverted the order and left a seven-minute hole on 2026-09-01 that a preview run fell
+  into, failing 26 seconds before the missing package was published.
+
+runs:
+  using: composite
+  steps:
+    # Installed under RUNNER_TEMP rather than the workspace so `vercel build` never sees it.
+    #
+    # Six attempts a minute apart. Nothing in this repository bounds the window — it lasts as long
+    # as the missing package takes to publish — so the ceiling is a judgement call: five minutes
+    # covers the one occurrence observed, and a `latest` that is genuinely broken is only delayed by
+    # it, never hidden.
+    - name: Install Vercel CLI
+      shell: bash
+      run: |
+        prefix="$RUNNER_TEMP/vercel-cli"
+        attempts=6
+        for attempt in $(seq 1 $attempts); do
+          if npm install --no-save --no-audit --no-fund --prefix "$prefix" vercel; then
+            echo "$prefix/node_modules/.bin" >> "$GITHUB_PATH"
+            "$prefix/node_modules/.bin/vercel" --version
+            exit 0
+          fi
+          if [ "$attempt" -eq "$attempts" ]; then
+            echo "vercel@latest was still uninstallable after $attempts attempts over $((attempts - 1)) minutes."
+            exit 1
+          fi
+          echo "Attempt $attempt/$attempts failed; retrying in 60s in case npm is missing a just-published dependency."
+          sleep 60
+        done

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/install
 
+      # Installs the CLI once onto PATH, so the steps below invoke a plain `vercel` rather than
+      # reinstalling it per call. See .github/actions/vercel-cli/action.yml.
+      - name: Install Vercel CLI
+        uses: ./.github/actions/vercel-cli
+
       # Create a GitHub deployment so the preview URL appears in the PR's deployment
       # box (and under repo Environments) rather than as a bot comment. Superseded
       # deployments are automatically marked inactive, so stale preview URLs on older
@@ -127,21 +132,21 @@ jobs:
       - name: Pull em-ai Vercel environment
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM_AI }}
-        run: yarn dlx vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
       - name: Build em-ai
         env:
           # Bundle the TypeScript module graph so ordinary extensionless imports work at runtime.
           VERCEL_EXPERIMENTAL_BACKENDS: '1'
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM_AI }}
-        run: yarn dlx vercel build --token="$VERCEL_TOKEN"
+        run: vercel build --token="$VERCEL_TOKEN"
 
       - name: Deploy em-ai
         id: deploy-ai
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM_AI }}
         run: |
-          url="$(yarn dlx vercel deploy --prebuilt --token="$VERCEL_TOKEN" | grep -Eo 'https://[^[:space:]]+' | tail -n 1)"
+          url="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN" | grep -Eo 'https://[^[:space:]]+' | tail -n 1)"
           test -n "$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "- em-ai preview: $url" >> "$GITHUB_STEP_SUMMARY"
@@ -157,21 +162,21 @@ jobs:
       - name: Pull em Vercel environment
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM }}
-        run: yarn dlx vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
       - name: Build em
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM }}
           # Vite gives an existing process variable precedence over .env.production.
           VITE_AI_URL: ${{ steps.deploy-ai.outputs.url }}/ai
-        run: yarn dlx vercel build --token="$VERCEL_TOKEN"
+        run: vercel build --token="$VERCEL_TOKEN"
 
       - name: Deploy em
         id: deploy
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EM }}
         run: |
-          url="$(yarn dlx vercel deploy --prebuilt --token="$VERCEL_TOKEN" | grep -Eo 'https://[^[:space:]]+' | tail -n 1)"
+          url="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN" | grep -Eo 'https://[^[:space:]]+' | tail -n 1)"
           test -n "$url"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -58,14 +58,19 @@ jobs:
       - name: Install npm dependencies
         uses: ./.github/actions/install
 
+      # Installs the CLI once onto PATH, so the steps below invoke a plain `vercel` rather than
+      # reinstalling it per call. See .github/actions/vercel-cli/action.yml.
+      - name: Install Vercel CLI
+        uses: ./.github/actions/vercel-cli
+
       - name: Pull Vercel environment
-        run: yarn dlx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build
         env:
           # The AI service uses the unified backend builder so its TypeScript module graph is bundled.
           VERCEL_EXPERIMENTAL_BACKENDS: ${{ matrix.project == 'em-ai' && '1' || '0' }}
-        run: yarn dlx vercel build --prod --token="$VERCEL_TOKEN"
+        run: vercel build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy
-        run: yarn dlx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -653,6 +653,10 @@ The primary Test, Puppeteer, and BrowserStack workflows run on pushes to `main` 
 
 Vercel Preview runs on pull requests separately from the test workflows. It deploys the pull request's `em-ai` service first, verifies its health route, then supplies that deployment's URL as `VITE_AI_URL` while building the matching `em` web preview. The GitHub `Preview` deployment links to the user-facing web app; the workflow summary includes the paired AI service URL for diagnostics. Both deploys run sequentially in one job so the GitHub deployment status represents the entire pair.
 
+Both it and [`Vercel Production`](../.github/workflows/vercel-production.yml) install the CLI once per run through [`.github/actions/vercel-cli`](../.github/actions/vercel-cli/action.yml) and call a plain `vercel` thereafter. The obvious `yarn dlx vercel` at each call site reinstalls it every time — six times in Preview, three in Production — and Yarn relinks and rebuilds on each one even with the download cached, so that costs about a minute and a half per preview run for a binary the run already has. Installing once also fixes one CLI version across every step of a run.
+
+The version is still whatever `latest` is when the run starts; the CLI is deliberately unpinned so deploys track Vercel's tooling. That leaves the install exposed to Vercel's own publish order: the CLI pins each of its workspace packages exactly, and if one is published *after* the CLI depending on it, `latest` is unresolvable until it lands and the install fails with `ETARGET` (`YN0082` under Yarn). It is rare — across the six releases before it the package reached npm 46 seconds to 4 minutes *ahead* of the CLI — but `vercel@59.11.0` inverted the order and left a seven-minute hole on 2026-09-01 that a preview run fell into, failing 26 seconds before the missing package was published. The install therefore retries for five minutes before giving up; the `pull`, `build`, and `deploy` steps that follow are left to fail fast on genuine errors.
+
 #### Path filtering
 
 Test, Puppeteer, BrowserStack, and Vercel Preview each carry the same `paths-ignore` filter, covering two groups:


### PR DESCRIPTION
## Why

[Run 33522683538](https://github.com/cybersemics/em/actions/runs/33522683538/job/99905616406) failed its `Pull em-ai Vercel environment` step on a Vercel publish race, not on anything in the pull request:

```
YN0082: @vercel/go@npm:9.0.0: No candidates found
```

`vercel@59.11.0` reached npm at 14:50:43Z pinning `@vercel/go` at exactly `9.0.0`; that package was not published until 14:58:02Z. Any run resolving `vercel@latest` inside that seven-minute window died in Yarn's Resolution step before the CLI ran at all. This one missed by 26 seconds.

It is rare — across the six releases before it, `@vercel/go` reached npm 46 seconds to 4 minutes *ahead* of the CLI — but both workflows call `yarn dlx vercel`, so every run installs whatever `latest` is at that moment and any window like this reddens a deploy for no reason but the minute the run started in.

## What changed

- **New `vercel-cli` composite action.** Installs the CLI once per run (`npm install --prefix "$RUNNER_TEMP/vercel-cli" vercel`) and appends its `.bin` to `$GITHUB_PATH`. Installed under `RUNNER_TEMP` rather than the workspace so `vercel build` never sees it.
- **Retries six times, a minute apart.** Five minutes of coverage. A `latest` that is genuinely broken is delayed by it, never hidden.
- **Nine call sites now invoke a plain `vercel`** — six in Vercel Preview, three in Vercel Production.
- **`docs/testing.md`** gains the rationale under CI workflows.

Retrying the install rather than each `vercel` invocation is deliberate: the failure happens while the CLI is being installed, before it runs, so the `pull`, `build`, and `deploy` steps keep failing fast on genuine errors instead of repeating a real build break for minutes.

## Why install once rather than just wrap `yarn dlx` in a retry

Installing once is faster than what it replaces, so the fix costs less than the status quo:

| | cost |
|---|---|
| `yarn dlx vercel`, cold | 29s |
| `yarn dlx vercel`, warm | 17s |
| `npm install … vercel` | ~14s |

`yarn dlx` caches the download but relinks and rebuilds esbuild on every invocation, so Preview paid that six times per run and Production three. One install saves roughly a minute and a half per preview run.

It also fixes a single CLI version across every step of a run. A release landing mid-run can no longer leave one step on a different build than the next — the gap a per-invocation retry would have left open.

## Reviewer notes

- **The CLI stays unpinned.** `latest` at run start, so deploys keep tracking Vercel's tooling. Pinning a version was the alternative considered; it trades this class of failure for a manual bump and was not chosen.
- **The deploy steps' URL grep is unaffected.** Removing `yarn dlx` only drops Yarn's own progress lines from stdout; `vercel deploy`'s URL is still the last `https://` line, and `Inspect:` goes to stderr as before.
- **Verified locally**, with `RUNNER_TEMP` and `GITHUB_PATH` stubbed: the install succeeds, the PATH line is written, and `vercel --version` resolves through it. The retry loop's exhaust and success paths were stub-tested separately.
- **This pull request's own CI cannot exercise the change.** `Vercel Preview` is `pull_request_target`, so GitHub runs the workflow definition from `main` rather than from the branch — confirmed on [this branch's run](https://github.com/cybersemics/em/actions/runs/33544454330), which has no `Install Vercel CLI` step. `Vercel Production` only triggers on push to `main`. The first real exercise is therefore the production deploy on the merge commit, and the first preview run after that. A failure there stalls a deploy rather than breaking the live site: Vercel's own git auto-deploy for `main` is disabled in `vercel.json`, so the previous production deployment stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

