### PR TITLE
docs(write-issue): ask clarifying questions before posting

### DIFF
--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -8,6 +8,21 @@ allowed-tools:
 
 Issues reporting broken behaviour in this repo follow a fixed format.
 
+## Ask before posting
+
+The issue is read by someone who cannot ask you anything. Every gap in it becomes a question in a comment thread, or a guess by whoever picks it up.
+
+So put your open questions to the reporter first, and post once the answers are in. Ask about anything whose answer changes what the issue says:
+
+- A step you would otherwise have to guess at — which setting, which value, which platform, what the thought tree was.
+- Whether what you are describing is one bug or two.
+- Expected Behavior, where the correct behaviour is a decision rather than an observation.
+- Evidence you believe exists and do not have — a screenshot, a video, a debug log.
+
+Ask them in one pass rather than one at a time, and only where the answer is the reporter's to give: a question you can settle by reproducing the bug or by reading the code is yours to settle.
+
+What you post is then succinct and free of loose ends — no "possibly", no "I think this is related to", no alternative left unruled-out. Where an answer genuinely cannot be had, name it as a known unknown in the preamble rather than leaving it implied.
+
 ## The template
 
 Exactly these headings, at `##`, in this order:
@@ -143,9 +158,10 @@ New issues often originate in a comment thread on another issue or PR.
 - A paragraph of preamble establishing what you did and did not reproduce, where a clause would do.
 - A screenshot with no steps.
 - A `Blocked by` line in the body with no relationship configured on GitHub.
+- A loose end left for the reader — an unruled-out alternative, a missing value, an unnamed platform — that the reporter could have answered before posting.
 
 ## When something is unknown
 
-State the uncertainty in the preamble rather than omitting the issue.
+Ask, as above. State whatever survives the answers in the preamble rather than omitting the issue.
 
 Do not guess Expected Behavior. Apply `design-needed` and leave the decision to a maintainer, since a guess there becomes a regression test asserting behaviour nobody chose.


### PR DESCRIPTION
Adds a rule to the `write-issue` skill: put open questions to the reporter before posting, and post an issue that is succinct with no loose ends left in it.

An issue is read by someone who cannot ask the reporter anything, so every gap in it becomes a question in a comment thread or a guess by whoever picks it up. The skill already said what a good issue looks like; it did not say when to stop and ask.

## Changes

- **New `## Ask before posting` section**, placed before the template since it governs the order of operations. It names what is worth asking — a step you would otherwise guess at, whether this is one bug or two, an Expected Behavior that is a decision rather than an observation, evidence you believe exists and do not have — and bounds it: ask in one pass, and only where the answer is the reporter's to give, since a question you can settle by reproducing the bug or reading the code is yours to settle.
- **`## When something is unknown` now points at that step first.** What survives the answers still goes in the preamble; `design-needed` and the rule against guessing Expected Behavior are unchanged.
- **A new entry under `## Common defects`** for a loose end the reporter could have answered before posting.

## Notes

Documentation-only change to `.github/skills/write-issue/SKILL.md`, which `.claude/skills/write-issue` symlinks to, so the rule applies to every harness that loads the skill. It is phrased harness-neutrally ("ask the reporter") rather than naming any one tool.

`docs/agents/skills.md` describes `write-issue` in a single table row and `AGENTS.md` in a sentence about the template and its conventions; both remain accurate, so no doc updates were needed. `.github/skills` is prettier-ignored, so `yarn lint` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHVcnqxaE5ZeKDC7P4wzTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHVcnqxaE5ZeKDC7P4wzTR)_