### PR TITLE
Remove the unused setSelection test helper

### DIFF
--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -13,7 +13,6 @@ import { setCursorActionCreator as setCursor } from './actions/setCursor'
 import { updateThoughtsActionCreator } from './actions/updateThoughts'
 import { commandById, executeCommand } from './commands'
 import db, { type ThoughtspaceStorage, thoughtspaceRuntime } from './data-providers/thoughtspace'
-import * as selection from './device/selection'
 import testFlags from './e2e/testFlags'
 import contextToThoughtId from './selectors/contextToThoughtId'
 import decodeThoughtsUrl from './selectors/decodeThoughtsUrl'
@@ -158,7 +157,6 @@ const testHelpers = {
   dropThoughtspace: thoughtspaceRuntime.drop,
   waitForInitialized,
   waitForThoughtspaceRuntimeIdle: thoughtspaceRuntime.waitForIdle,
-  setSelection: selection.set,
   importToContext: withDispatch(importToContext),
   getLexemeFromThoughtspace: (value: string) => db.getLexemeById(hashThought(value)),
   getState: store.getState,


### PR DESCRIPTION
Removes `setSelection` from `window.em.testHelpers`.

## Why

`testHelpers.setSelection` exposed `selection.set` from `src/device/selection` to the e2e suites, but nothing calls it. Every `setSelection` under `src/e2e` is the Puppeteer or iOS helper of that name, which places a DOM Range through the page's own Selection API (the same state a user's click-drag produces) and never reaches for `window.em`. Those helpers are unchanged and remain listed under *Browser/driver limitation* in `docs/testing.md`.

An unused entry on the backdoor object is one more internal a test could quietly start reaching for, so it goes.

## Changes

- `src/initialize.ts`: drop the `setSelection` member and the `selection` import that existed only to feed it.

No test behaviour changes; no doc described this member.

## Stack

This is the first of a series of stacked pull requests that each remove one `testHelpers` member. Merge order: `1-setselection` → `2-lodash` → `3-getstate` → `4-getlexeme` → `5-waitforinitialized` → `6-dropthoughtspace` → `7-executecommandbyid`. Each PR's base is the previous branch, so they merge top-down without conflicts.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
