### PR TITLE
Rely on browser-context isolation instead of dropping the thoughtspace after each Puppeteer test

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -206,6 +206,6 @@ Device permissions live in [`permissionsStore.ts`](../src/data-providers/permiss
 
 ## Cleanup
 
-`db.clear` is the runtime's `drop`. It detaches the data provider (rejecting any writes still waiting on initialization), stops WebSocket sync, unsubscribes the materialization listener, and calls `client.drop()`, which closes SQLite and — for OPFS storage — deletes the thoughtspace's database file. Used by the device-removal flow above, and by e2e tests through `em.testHelpers.dropThoughtspace`.
+`db.clear` is the runtime's `drop`. It detaches the data provider (rejecting any writes still waiting on initialization), stops WebSocket sync, unsubscribes the materialization listener, and calls `client.drop()`, which closes SQLite and — for OPFS storage — deletes the thoughtspace's database file. Used by the device-removal flow above, and by the unit-test helpers [`initStore`](../src/test-helpers/initStore.ts) (as `thoughtspaceRuntime.drop`) and [`cleanupTestApp`](../src/test-helpers/createTestApp.tsx) (as `db.clear`) to reset the in-memory thoughtspace between tests.
 
-Unit tests and most e2e runs initialize with `storage: 'memory'`, so they never touch OPFS; persistence-specific Puppeteer suites opt into OPFS explicitly. See [testing.md](testing.md).
+Unit tests and most e2e runs initialize with `storage: 'memory'`, so they never touch OPFS; persistence-specific Puppeteer suites opt into OPFS explicitly. Puppeteer tests do not drop the thoughtspace themselves: each test runs in its own incognito browser context under a fresh `tsid`, and closing the context discards its OPFS database along with the rest of its storage. See [testing.md](testing.md).

--- a/src/e2e/puppeteer/setup.ts
+++ b/src/e2e/puppeteer/setup.ts
@@ -133,18 +133,11 @@ const setup = async ({
 
 beforeEach(setup, 60000)
 
-// TreeCRDT teardown can drain OPFS writes from import-heavy tests before dropping storage.
+// Closing the browser context is the whole teardown. Every test runs in its own incognito context whose storage
+// (localStorage and the OPFS database alike) is discarded with it, and names its thoughtspace with a fresh tsid, so
+// nothing a test wrote can be seen by the next one and there is no need to drop the thoughtspace from inside the page.
 afterEach(async () => {
   if (page) {
-    await page
-      .evaluate(async () => {
-        await window.em?.testHelpers?.waitForThoughtspaceRuntimeIdle?.()
-        await window.em?.testHelpers?.dropThoughtspace?.()
-      })
-      .catch(() => {
-        // Ignore teardown errors when a failing test has already closed or navigated the page.
-      })
-
     await page.close().catch(() => {
       // Ignore errors when closing the page.
     })

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -156,7 +156,6 @@ const testHelpers = {
   executeCommandById: (id: CommandId) => {
     executeCommand(commandById(id))
   },
-  dropThoughtspace: thoughtspaceRuntime.drop,
   waitForInitialized,
   waitForThoughtspaceRuntimeIdle: thoughtspaceRuntime.waitForIdle,
   importToContext: withDispatch(importToContext),


### PR DESCRIPTION
Removes `dropThoughtspace` from `window.em.testHelpers` and the Puppeteer `afterEach` step that used it.

## Why

The `afterEach` in `src/e2e/puppeteer/setup.ts` asked the page to wait for the TreeCRDT runtime to go idle and then drop the thoughtspace before closing the page and its browser context. That step is redundant:

- `setup()` creates a fresh `createBrowserContext()` per test. In Chrome every non-default context is incognito, with its own storage partition that is discarded when `context.close()` runs: localStorage, sessionStorage, and the OPFS directory the wa-sqlite worker writes to alike (`docs/testing.md` already notes that Chromium Incognito keeps OPFS only until the private session ends).
- Each test also seeds a unique `tsid`, and the TreeCRDT client names its OPFS file `/treecrdt-em-<tsid>.db`, so even a file that outlived its context could never be opened by another test.

Nothing a test writes can therefore be observed by a later test, which is all teardown has to guarantee. Unflushed writes are discarded with the context; tests that need durability before a reload already wait for idle inside `refresh`.

The drop arrived with the TreeCRDT migration (#4325). The fork history behind that squash shows it was introduced without a stated reason, then tuned for its own cost (a 60 s hook timeout, a reverted no-wait experiment, timing diagnostics added and removed, bounded vitest workers because "OPFS cleanup" was a load source). No commit, PR comment, or issue names a cross-test failure it fixed. The full commit body has the details.

## Changes

- `src/e2e/puppeteer/setup.ts`: teardown is `page.close()` and `context.close()`; the comment above it states why that suffices. The idle wait went with the drop since it only existed so the drop did not race in-flight writes.
- `src/initialize.ts`: drop the `dropThoughtspace` member.
- `docs/persistence.md`: no longer claims e2e tests reach `drop` through `em.testHelpers.dropThoughtspace`; names the unit-test helpers that do use it and why Puppeteer tests do not.

## Stack

Based on `main`: #5290, #5291, #5292, and #5300 are merged, and #5294 (`waitForInitialized`) was closed by decision to keep that helper. Remaining merge order: `6-dropthoughtspace` → `7-executecommandbyid` (#5296 is based on this branch).
## Beyond CI

Because this changes teardown for every Puppeteer test, the persistent-storage suites (`ContextView`, `caret`, `caret-multiline`, `cursor`, `scroll`, `treecrdt-single-tab`, `treecrdt-memory-fallback`, `startup`) were run locally three times in a row against Browserless at this commit, and 13 memory-storage suites once, watching the forwarded browser console for `sqlite3_open_v2|SQL logic error|database is locked|Thoughtspace persistence failed|TreeCRDT`. No such line appeared, no `afterEach` hook timed out, and total time was in line with the earlier runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
