### PR TITLE
Show the background glow opacity value next to its slider

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useEffect, useRef, useState } from 'react'
+import React, { FC, PropsWithChildren, useEffect, useId, useRef, useState } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import pkg from '../../package.json'
 import { css, cx } from '../../styled-system/css'
@@ -141,6 +141,7 @@ const glowSwatchClass = css({
 const BackgroundGlowPicker = () => {
   const [showPicker, setShowPicker] = useState(false)
   const { image, opacity } = backgroundGlowStore.useState()
+  const opacityId = useId()
 
   return (
     <div className={css({ display: 'inline-block', position: 'relative' })}>
@@ -211,8 +212,11 @@ const BackgroundGlowPicker = () => {
             })}
           </div>
           <div className={css({ display: 'flex', alignItems: 'center', gap: '0.5em', marginTop: '0.75em' })}>
-            <span className={css({ color: 'dim' })}>Opacity</span>
+            <label htmlFor={opacityId} className={css({ color: 'dim' })}>
+              Opacity
+            </label>
             <input
+              id={opacityId}
               type='range'
               min={0}
               max={1}
@@ -222,6 +226,10 @@ const BackgroundGlowPicker = () => {
               // prevent the browser from scrolling the page while dragging the slider handle
               className={css({ flexGrow: 1, touchAction: 'none' })}
             />
+            {/* The exact value, so the opacity that looks best on a device can be read off and hard-coded as the default. Two decimals and tabular digits keep the label a fixed width, so the slider does not shift under the finger while it is dragged. */}
+            <output htmlFor={opacityId} className={css({ fontVariantNumeric: 'tabular-nums' })}>
+              {opacity.toFixed(2)}
+            </output>
           </div>
         </div>
       )}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -220,7 +220,7 @@ const BackgroundGlowPicker = () => {
               type='range'
               min={0}
               max={1}
-              step={0.05}
+              step={0.01}
               value={opacity}
               onChange={e => backgroundGlowStore.update({ opacity: +e.target.value })}
               // prevent the browser from scrolling the page while dragging the slider handle

--- a/src/components/__tests__/Footer.ts
+++ b/src/components/__tests__/Footer.ts
@@ -1,0 +1,32 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { act } from 'react'
+import backgroundGlowStore from '../../stores/backgroundGlowStore'
+import click from '../../test-helpers/click'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+describe('background glow picker', () => {
+  it('show the current opacity next to the slider when the picker is opened', async () => {
+    // an opacity chosen earlier, as restored from local storage on a later visit
+    await act(async () => {
+      backgroundGlowStore.update({ opacity: 0.25 })
+    })
+
+    await click('[data-testid=background-glow]')
+
+    expect(screen.getByRole('status').textContent).toBe('0.25')
+  })
+
+  it('update the opacity label as the slider is moved', async () => {
+    await click('[data-testid=background-glow]')
+
+    // user-event has no slider interaction, so set the value and fire the change event that dragging produces
+    await act(async () => {
+      fireEvent.change(screen.getByRole('slider', { name: 'Opacity' }), { target: { value: '0.35' } })
+    })
+
+    expect(screen.getByRole('status').textContent).toBe('0.35')
+  })
+})


### PR DESCRIPTION
## Summary

- The background glow picker in the Footer now shows the current opacity next to the slider, so the value that looks best on a device can be read off and hard-coded as the default.
- The readout is an output element bound to the slider and rendered from `backgroundGlowStore`, so it updates live as the slider is dragged and shows the persisted value when the picker is opened.
- The value is fixed to two decimals with tabular digits so the label keeps a constant width and the slider does not shift under the finger while it is dragged.
- The slider steps by 0.01 instead of 0.05, the same precision the readout displays, so the best-looking value can be found exactly.
- The "Opacity" text is now a real label element for the slider.

## Tests

New JSDOM tests in `src/components/__tests__/Footer.ts`: the readout shows the stored opacity when the picker opens, and updates when the slider is moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBcYtDyPg41QmWt3xuAiWR