### PR TITLE
Install page-lifecycle from npm and declare its types locally

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -5,8 +5,9 @@ See: https://github.com/raineorshine/npm-check-updates
 Dependency notes:
   - html-escaper     Replace 'he' with 'html-escaper' due to bundle size.
                      Other small HTML entity encoder/decoders: entities, html-entities
-  - page-lifecycle   Use https://github.com/magic-akari/page-lifecycle/tree/feat/add-types
-                     to get Typescript types.
+  - page-lifecycle   The npm package ships no TypeScript types. They are declared locally in
+                     src/@types/page-lifecycle.d.ts, so check that the declaration still matches
+                     the library's API after upgrading.
 
 */
 

--- a/README.md
+++ b/README.md
@@ -175,27 +175,9 @@ See: https://panda-css.com/docs/concepts/writing-styles
 
 ## Custom Dependencies
 
-This project uses some custom dependencies that are overridden via `resolutions` in `package.json`. The actual versions used are specified in the `resolutions` section.
+Every dependency resolves to the npm registry, which `yarn lint:lockfile` enforces, so `yarn install` needs no other host. Two mechanisms in `package.json` customize what gets installed:
 
-### Tarball URL Format
+- `resolutions` overrides the version of a transitive dependency.
+- `yarn patch` applies the patches in [`.yarn/patches`](.yarn/patches) to a package after it is fetched. [`.yarn/patches/README.md`](.yarn/patches/README.md) describes each patch and how to add another.
 
-GitHub tarball URLs follow this format:
-
-```
-https://codeload.github.com/[owner]/[repo]/tar.gz/[commit-hash]
-```
-
-Example:
-
-- Repository: `https://github.com/magic-akari/page-lifecycle`
-- Commit hash: `50b50421bdeab3d211a57e81a277f699638373b0`
-- Tarball URL: `https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0`
-
-### Updating Dependencies
-
-To update these custom dependencies:
-
-1. Check the source repository for new commits
-2. Get the new commit hash
-3. Update the tarball URL in the `resolutions` section of `package.json`
-4. Test thoroughly as these are custom forks
+A package that ships without TypeScript types gets its declarations in [`src/@types`](src/@types), e.g. [`page-lifecycle.d.ts`](src/@types/page-lifecycle.d.ts), rather than being replaced by a typed fork.

--- a/package.json
+++ b/package.json
@@ -72,8 +72,6 @@
       "workspace:"
     ],
     "allowed-hosts": [
-      "codeload.github.com",
-      "github.com",
       "npm",
       "yarn"
     ],
@@ -84,7 +82,6 @@
   },
   "resolutions": {
     "@pandacss/node@npm:0.47.0": "patch:@pandacss/node@npm%3A0.47.0#~/.yarn/patches/@pandacss-node-npm-0.47.0.patch",
-    "page-lifecycle": "https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0",
     "use-latest": "^1.3.0",
     "use-isomorphic-layout-effect": "^1.2.1"
   },
@@ -138,7 +135,7 @@
     "murmurhash3js": "^3.0.1",
     "nanoid": "^6.0.1",
     "openai": "^7.7.0",
-    "page-lifecycle": "⚠️ OVERRIDDEN BY 'resolutions' - Source: https://github.com/magic-akari/page-lifecycle#feat/add-types | Tarball: https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0 | Configured in: package.json#resolutions",
+    "page-lifecycle": "^0.1.2",
     "pluralize": "^8.0.0",
     "qrcode.react": "^4.2.0",
     "rc-slider": "^11.1.9",

--- a/src/@types/page-lifecycle.d.ts
+++ b/src/@types/page-lifecycle.d.ts
@@ -1,0 +1,44 @@
+/** Ambient module declaration for page-lifecycle, whose npm package ships no TypeScript types.
+ *
+ * Describes the public API of https://github.com/GoogleChromeLabs/page-lifecycle. Only the statechange event is
+ * typed, since the library dispatches no other event.
+ */
+declare module 'page-lifecycle' {
+  /** The lifecycle states that the library reports. The Page Lifecycle API also defines a discarded state, but a discarded page runs no script, so the library never reports it. */
+  type PageState = 'active' | 'passive' | 'hidden' | 'frozen' | 'terminated'
+
+  /** The event dispatched on every lifecycle state change. */
+  interface StateChangeEvent extends Event {
+    /** The state the page transitioned to. */
+    readonly newState: PageState
+    /** The state the page transitioned from. */
+    readonly oldState: PageState
+    /** The browser event that triggered the transition, e.g. visibilitychange or blur. */
+    readonly originalEvent: Event
+  }
+
+  /** The singleton that observes the page lifecycle. */
+  interface Lifecycle extends EventTarget {
+    /** The current lifecycle state. */
+    readonly state: PageState
+    /** Whether the browser discarded the page and later reloaded it, i.e. `document.wasDiscarded`. */
+    readonly pageWasDiscarded: boolean
+    addEventListener(
+      type: 'statechange',
+      listener: (event: StateChangeEvent) => void,
+      options?: boolean | AddEventListenerOptions,
+    ): void
+    removeEventListener(
+      type: 'statechange',
+      listener: (event: StateChangeEvent) => void,
+      options?: boolean | EventListenerOptions,
+    ): void
+    /** Registers unsaved changes under a unique id. The user is prompted before the page unloads until every id has been removed. */
+    addUnsavedChanges(id: symbol | object): void
+    /** Removes the unsaved changes registered under the id. */
+    removeUnsavedChanges(id: symbol | object): void
+  }
+
+  const lifecycle: Lifecycle
+  export default lifecycle
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11972,7 +11972,7 @@ __metadata:
     nanoid: "npm:^6.0.1"
     npm-run-all2: "npm:^9.0.3"
     openai: "npm:^7.7.0"
-    page-lifecycle: "⚠️ OVERRIDDEN BY 'resolutions' - Source: https://github.com/magic-akari/page-lifecycle#feat/add-types | Tarball: https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0 | Configured in: package.json#resolutions"
+    page-lifecycle: "npm:^0.1.2"
     pluralize: "npm:^8.0.0"
     postinstall-postinstall: "npm:^2.1.0"
     prettier: "npm:^3.9.6"
@@ -19219,10 +19219,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"page-lifecycle@https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0":
+"page-lifecycle@npm:^0.1.2":
   version: 0.1.2
-  resolution: "page-lifecycle@https://codeload.github.com/magic-akari/page-lifecycle/tar.gz/50b50421bdeab3d211a57e81a277f699638373b0"
-  checksum: 10c0/ddf01b57da4e67db36aa00085476caa7291918e83baab5501443441125b106231b447a143eed786e3bffab1ea3556146f9ab15ce40d0512244ea2778c310972d
+  resolution: "page-lifecycle@npm:0.1.2"
+  checksum: 10c0/509dbbc2ad2000dffcf591f66ab13d80fb1dba9337d85c76269173f7a5c3959b5a876e3bfb1e4494f6b932c1dc02a0b5824ebd452ab1a7204d4abdf498cb27c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`page-lifecycle` was pinned through `resolutions` to a GitHub tarball of the `magic-akari/page-lifecycle#feat/add-types` fork. That fork's only change over the published 0.1.2 release is a set of TypeScript declarations: its `dist/` and `src/` are byte-identical to the npm package. Fetching the tarball needs `codeload.github.com`, which agent sandboxes with a restricted egress policy block, so `yarn install` failed there and eslint, tsc, and vitest could not run locally.

This resolves `page-lifecycle` from the npm registry and declares the library's API in `src/@types/page-lifecycle.d.ts`, following the existing `react-contenteditable.d.ts` precedent. With it, `yarn install` completes in a sandbox that can reach only the registry.

## Changes

- `package.json`: `page-lifecycle` becomes an ordinary `^0.1.2` dependency and the `resolutions` override is removed. `codeload.github.com` and `github.com` are dropped from the `lockfile-lint` allowed hosts, so every dependency must now resolve to the registry.
- `yarn.lock`: only the `page-lifecycle` entries change.
- `src/@types/page-lifecycle.d.ts`: ambient module declaration covering the singleton, the `statechange` event, and the unsaved-changes API.
- `README.md`: the Custom Dependencies section no longer documents the tarball workflow; it describes `resolutions`, `yarn patch`, and local declarations for untyped packages.
- `.ncurc.js`: the dependency note points at the local declaration instead of the fork.

No application code changes. `import lifecycle from 'page-lifecycle'` and the `vi.mock('page-lifecycle', …)` in `initEvents.lifecycle.ts` are untouched, and the installed package's `dist/` was diffed against the fork's at the pinned commit and is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3QyJBb2gxeNrzd7x892rX

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3QyJBb2gxeNrzd7x892rX)_