### PR TITLE
Migrate Export dropdown and Dialog to useOnClickOutside

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren, useEffect, useRef } from 'react'
 import { dialogRecipe } from '../../../styled-system/recipes'
+import useOnClickOutside from '../../hooks/useOnClickOutside'
 
 interface DialogProps {
   onClose: () => void
@@ -13,26 +14,8 @@ const Dialog: React.FC<PropsWithChildren<DialogProps>> = ({ children, onClose, n
   const dialogRef = useRef<HTMLDivElement | null>(null)
   const dialog = dialogRecipe()
 
-  /**
-   * Calls the onClose function when the user clicks outside the dialog.
-   */
-  useEffect(() => {
-    const currentDialogRef = dialogRef.current
-
-    /** When the user clicks outside the dialog, close the dialog. */
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node
-      if (currentDialogRef && !currentDialogRef.contains(target)) {
-        onClose()
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [onClose])
+  // Close the dialog when the user clicks or taps outside of it.
+  useOnClickOutside(dialogRef, onClose)
 
   /**
    * Disable swipe-to-go-back.

--- a/src/components/modals/Export.tsx
+++ b/src/components/modals/Export.tsx
@@ -30,6 +30,7 @@ import download from '../../device/download'
 import * as selection from '../../device/selection'
 import share from '../../device/share'
 import globals from '../../globals'
+import useOnClickOutside from '../../hooks/useOnClickOutside'
 import documentSort from '../../selectors/documentSort'
 import exportContext, { exportFilter } from '../../selectors/exportContext'
 import { getChildrenRanked } from '../../selectors/getChildren'
@@ -267,20 +268,8 @@ const ExportDropdown: FC<ExportDropdownProps> = ({ selected, onSelect }) => {
 
   const dropDownRef = React.useRef<HTMLDivElement>(null)
 
-  // Close the dropdown when clicking outside of it. Inlined from the unmaintained use-onclickoutside package.
-  useEffect(() => {
-    /** Closes the dropdown on mousedown/touchstart outside the dropdown element. */
-    const listener = (e: MouseEvent | TouchEvent) => {
-      if (!dropDownRef.current || dropDownRef.current.contains(e.target as Node)) return
-      closeDropdown()
-    }
-    document.addEventListener('mousedown', listener)
-    document.addEventListener('touchstart', listener, { passive: true })
-    return () => {
-      document.removeEventListener('mousedown', listener)
-      document.removeEventListener('touchstart', listener)
-    }
-  }, [closeDropdown])
+  // Close the dropdown when clicking outside of it.
+  useOnClickOutside(dropDownRef, closeDropdown)
 
   return (
     <span ref={dropDownRef} className={css({ position: 'relative', whiteSpace: 'nowrap', userSelect: 'none' })}>


### PR DESCRIPTION
#4332

Stacked on #4338, which introduces `useOnClickOutside` and fixes sorting dropdown dismissal on Command Universe, Customize Toolbar, and Command Library.

**What I did**

Replace the inline outside-click handlers in Export and Dialog with the shared hook. Export retains its mouse and touch handling. Dialog also gains `touchstart` dismissal on its overlay.

**What I verified**

Validation covers the existing ModalExport tests and the inherited sort-dropdown tests. The restacked tree is compared with the previously verified combined tree, and this PR's diff is restricted to Export and Dialog.

**How to test**

Open the Export dropdown and press outside it; it should close. Open a dialog and tap the overlay; the dialog should close. Presses inside the dialog should leave it open.

<details>
<summary>Architectural plan</summary>

### 1. Existing surface area

Export and Dialog already have inline outside-click subscriptions. The shared hook supplied by #4338 subscribes in `src/hooks/useOnClickOutside.ts:15`:
```tsx
document.addEventListener('mousedown', listener)
document.addEventListener('touchstart', listener, { passive: true })
```

### 2. Build versus extend

Replace those effects with the existing hook at the component's current ref boundary, as in `src/components/modals/Export.tsx:271`:
```tsx
useOnClickOutside(dropDownRef, closeDropdown)
```
Reuse the original migration commit; the hook definition, sort integrations, and regression tests belong to the parent PR.

### 3. Adjacent behavior

The containment guard in `src/hooks/useOnClickOutside.ts:11` preserves inside presses:
```tsx
if (!ref.current || ref.current.contains(e.target as Node)) return
```
Export already handles both event types. Dialog formerly handled only mousedown, so earlier touch dismissal is intentional. The remaining touchmove effect still prevents swipe-to-go-back outside the dialog. No editor action, selection, caret, undo/redo, clipboard, IME, or multicursor handling changes.

### 4. Approaches

Replay only the original migration atop the completed fix PR. Keeping the sort fix here would split the original issue across two PRs and make the parent incomplete.

### 5. Diff sketch and critique

Only `src/components/modals/Export.tsx` and `src/components/dialog/Dialog.tsx` change. Confirm that exact file list and compare the full combined tree to the previously verified version. Critique passed: the existing ref boundaries match the hook's containment contract, and the only migration behavior change is Dialog's documented touchstart handling. Documentation remains accurate.

</details>

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"12926b11ab00366a43f32d4fd348efe0a53b5364","createdAt":"2026-09-10T00:39:43Z","url":"https://em-keofaeg38-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview · Sep 10, 2026 · <code>12926b1</code></summary>

[![Preview deployment](https://github.com/user-attachments/assets/70727d6c-42c8-4820-8650-9c365afd8313)](https://em-keofaeg38-cybersemics.vercel.app)

[Open preview](https://em-keofaeg38-cybersemics.vercel.app)

</details>
<!-- preview-qr:end -->