### PR TITLE
Add explicit test coverage for existing cursor autoscroll behavior

### DIFF
--- a/src/device/__tests__/scrollCursorIntoView.ts
+++ b/src/device/__tests__/scrollCursorIntoView.ts
@@ -1,0 +1,92 @@
+import viewportStore from '../../stores/viewport'
+import scrollCursorIntoView from '../scrollCursorIntoView'
+
+vi.mock('../../browser', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../browser')>()
+  return { ...actual, isCapacitor: () => true, isSafari: () => true, isTouch: true }
+})
+
+/** Creates a DOMRect with the given vertical measurements. */
+const createRect = ({ top, height }: { top: number; height: number }): DOMRect =>
+  ({
+    x: 0,
+    y: top,
+    top,
+    right: 0,
+    bottom: top + height,
+    left: 0,
+    width: 0,
+    height,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: 10 })
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: { height: 800 },
+  })
+
+  viewportStore.update({
+    innerHeight: 800,
+    layoutTreeTop: 0,
+    virtualKeyboardHeight: 0,
+  })
+
+  const toolbar = document.createElement('div')
+  toolbar.id = 'toolbar'
+  toolbar.getBoundingClientRect = () => createRect({ top: 50, height: 50 })
+  document.body.appendChild(toolbar)
+
+  const navbar = document.createElement('nav')
+  navbar.setAttribute('aria-label', 'nav')
+  navbar.getBoundingClientRect = () => createRect({ top: 750, height: 50 })
+  document.body.appendChild(navbar)
+
+  window.scrollTo = vi.fn()
+})
+
+it('does not scroll while the cursor is inside the existing viewport bounds', () => {
+  scrollCursorIntoView(200, 30)
+
+  expect(window.scrollTo).not.toHaveBeenCalled()
+})
+
+it('preserves the existing top landing calculation', () => {
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: 300 })
+
+  scrollCursorIntoView(350, 30)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 285, behavior: 'smooth' })
+})
+
+it('preserves the existing bottom landing calculation', () => {
+  scrollCursorIntoView(780, 30)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 75, behavior: 'smooth' })
+})
+
+it('preserves the existing keyboard-open bottom landing calculation', () => {
+  Object.defineProperty(window, 'visualViewport', {
+    configurable: true,
+    value: { height: 500 },
+  })
+
+  scrollCursorIntoView(600, 30)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 195, behavior: 'smooth' })
+})
+
+it('preserves the existing multiline bottom landing calculation', () => {
+  scrollCursorIntoView(760, 60)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 100, behavior: 'smooth' })
+})
+
+it('preserves the existing instant behavior for a target more than one visible viewport away', () => {
+  scrollCursorIntoView(1800, 30)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 1095, behavior: 'auto' })
+})

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests iOS Safari autoscroll.
+ * Uses WDIO with Appium so the software keyboard and WebKit scrolling behavior are real.
+ */
+import series from '../../../util/series.js'
+import clickThought from '../helpers/clickThought.js'
+import isKeyboardShown from '../helpers/isKeyboardShown.js'
+import paste from '../helpers/paste.js'
+import tapReturnKey from '../helpers/tapReturnKey.js'
+import waitForEditable from '../helpers/waitForEditable.js'
+
+interface CursorViewportGeometry {
+  /** Bottom edge of the cursor editable. */
+  bottom: number
+  /** Bottom edge of the visible viewport above fixed navigation. */
+  bottomEdge: number
+  /** Current document scroll position. */
+  scrollY: number
+  /** Top edge of the cursor editable. */
+  top: number
+  /** Bottom edge of the toolbar. */
+  topEdge: number
+}
+
+/** Reads the cursor and visible viewport geometry from Mobile Safari. */
+const getCursorViewportGeometry = async (): Promise<CursorViewportGeometry> => {
+  const value = await browser.execute(() => {
+    const cursor = document.querySelector('[data-editing=true] [data-editable]')?.getBoundingClientRect()
+    if (!cursor) throw new Error('Cursor editable is not rendered.')
+
+    const toolbar = document.querySelector('[data-testid="toolbar"]')?.getBoundingClientRect()
+    const navbar = document.querySelector('[aria-label="nav"]')?.getBoundingClientRect()
+    const viewportTop = window.visualViewport?.offsetTop ?? 0
+    const viewportBottom = viewportTop + (window.visualViewport?.height ?? window.innerHeight)
+
+    return JSON.stringify({
+      bottom: cursor.bottom,
+      bottomEdge: Math.min(viewportBottom, navbar?.top ?? viewportBottom),
+      scrollY: window.scrollY,
+      top: cursor.top,
+      topEdge: toolbar?.bottom ?? 0,
+    })
+  })
+
+  return JSON.parse(value) as CursorViewportGeometry
+}
+
+/** Waits until Mobile Safari's viewport and scroll animations are both quiet. */
+const waitForViewportSettled = () =>
+  browser.execute(
+    settleTime =>
+      new Promise<void>(resolve => {
+        let timeout: number
+        const controller = new AbortController()
+
+        /** Stops observing viewport events and resolves the wait. */
+        function finish() {
+          controller.abort()
+          resolve()
+        }
+
+        /** Restarts the quiet-period timer after each viewport event. */
+        function onScroll() {
+          window.clearTimeout(timeout)
+          timeout = window.setTimeout(finish, settleTime)
+        }
+
+        window.addEventListener('scroll', onScroll, { passive: true, signal: controller.signal })
+        window.visualViewport?.addEventListener('resize', onScroll, { passive: true, signal: controller.signal })
+        onScroll()
+      }),
+    500,
+  )
+
+/** Asserts that the cursor is fully visible between the toolbar and software keyboard. */
+const expectCursorVisible = async (): Promise<CursorViewportGeometry> => {
+  const geometry = await getCursorViewportGeometry()
+  expect(geometry.top).toBeGreaterThanOrEqual(geometry.topEdge)
+  expect(geometry.bottom).toBeLessThanOrEqual(geometry.bottomEdge)
+  return geometry
+}
+
+/** Asserts that the cursor is not covered by the software keyboard. */
+const expectCursorAboveKeyboard = async (): Promise<CursorViewportGeometry> => {
+  const geometry = await getCursorViewportGeometry()
+  expect(geometry.bottom).toBeLessThanOrEqual(geometry.bottomEdge)
+  return geometry
+}
+
+/** Selects a thought, opens the software keyboard, and waits for scrolling to settle. */
+const openKeyboardAt = async (value: string) => {
+  await waitForEditable(value)
+  await clickThought(value)
+  await browser.waitUntil(
+    async () =>
+      browser.execute(
+        value => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML === value,
+        value,
+      ),
+    { timeoutMsg: `cursor did not move to ${value}` },
+  )
+  await waitForViewportSettled()
+  if (!(await isKeyboardShown())) await clickThought(value)
+  await browser.waitUntil(isKeyboardShown, { timeoutMsg: 'software keyboard did not open' })
+  await waitForViewportSettled()
+}
+
+describe('Autoscroll', () => {
+  // https://github.com/cybersemics/em/issues/3765
+  it('keeps a tapped thought above the software keyboard when it opens', async () => {
+    await paste(Array.from({ length: 20 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    const editable = await waitForEditable('Thought 20')
+    await browser.execute((editable: HTMLElement) => editable.scrollIntoView({ block: 'center' }), editable)
+    await waitForViewportSettled()
+    await openKeyboardAt('Thought 20')
+
+    await expectCursorAboveKeyboard()
+  })
+
+  it('keeps each new thought visible while Return is pressed repeatedly above the software keyboard', async () => {
+    await paste(Array.from({ length: 8 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    await waitForEditable('Thought 8')
+    await openKeyboardAt('Thought 4')
+    const { scrollY: initialScrollY } = await expectCursorVisible()
+
+    const geometries = await series(
+      Array.from({ length: 12 }, () => async () => {
+        await tapReturnKey()
+        await waitForViewportSettled()
+        return expectCursorVisible()
+      }),
+    )
+
+    expect(Math.max(...geometries.map(geometry => geometry.scrollY))).toBeGreaterThan(initialScrollY)
+  })
+})

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -122,7 +122,7 @@ describe('Autoscroll', () => {
     await paste(Array.from({ length: 8 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
     await waitForEditable('Thought 8')
     await openKeyboardAt('Thought 4')
-    const { scrollY: initialScrollY } = await expectCursorVisible()
+    const { scrollY: initialScrollY } = await expectCursorAboveKeyboard()
 
     const geometries = await series(
       Array.from({ length: 12 }, () => async () => {

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -98,7 +98,7 @@ const openKeyboardAt = async (value: string) => {
     { timeoutMsg: `cursor did not move to ${value}` },
   )
   await waitForViewportSettled()
-  if (!(await isKeyboardShown())) await tap(await waitForEditable(value), { y: 60 })
+  if (!(await isKeyboardShown())) await tap(await waitForEditable(value), { pointerType: 'touch', y: 60 })
   await browser.waitUntil(isKeyboardShown, { timeoutMsg: 'software keyboard did not open' })
   await waitForViewportSettled()
 }

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -115,6 +115,28 @@ describe('Autoscroll', () => {
     await expectCursorAboveKeyboard()
   })
 
+  // https://github.com/cybersemics/em/issues/3765
+  it('keeps the keyboard open and the cursor visible when focus moves to a lower thought', async () => {
+    await paste(Array.from({ length: 20 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    await openKeyboardAt('Thought 4')
+
+    const editable = await waitForEditable('Thought 20')
+    await browser.execute((editable: HTMLElement) => editable.scrollIntoView({ block: 'center' }), editable)
+    await waitForViewportSettled()
+    await tap(await waitForEditable('Thought 20'), { pointerType: 'touch', y: 60 })
+    await browser.waitUntil(
+      async () =>
+        browser.execute(
+          () => document.querySelector('[data-editing=true] [data-editable]')?.innerHTML === 'Thought 20',
+        ),
+      { timeoutMsg: 'cursor did not move to Thought 20' },
+    )
+    await browser.waitUntil(isKeyboardShown, { timeoutMsg: 'software keyboard closed while focus moved' })
+    await waitForViewportSettled()
+
+    await expectCursorAboveKeyboard()
+  })
+
   it('keeps each new thought visible while Return is pressed repeatedly above the software keyboard', async () => {
     await paste(Array.from({ length: 8 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
     await waitForEditable('Thought 8')

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -15,8 +15,6 @@ interface CursorViewportGeometry {
   bottom: number
   /** Bottom edge of the visible viewport above fixed navigation. */
   bottomEdge: number
-  /** Current document scroll position. */
-  scrollY: number
   /** Top edge of the cursor editable. */
   top: number
   /** Bottom edge of the toolbar. */
@@ -37,7 +35,6 @@ const getCursorViewportGeometry = async (): Promise<CursorViewportGeometry> => {
     return JSON.stringify({
       bottom: cursor.bottom,
       bottomEdge: Math.min(viewportBottom, navbar?.top ?? viewportBottom),
-      scrollY: window.scrollY,
       top: cursor.top,
       topEdge: toolbar?.bottom ?? 0,
     })
@@ -122,16 +119,18 @@ describe('Autoscroll', () => {
     await paste(Array.from({ length: 8 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
     await waitForEditable('Thought 8')
     await openKeyboardAt('Thought 4')
-    const { scrollY: initialScrollY } = await expectCursorAboveKeyboard()
+    await expectCursorAboveKeyboard()
+    const initialThoughtCount = await browser.execute(() => document.querySelectorAll('[data-editable]').length)
 
-    const geometries = await series(
-      Array.from({ length: 12 }, () => async () => {
+    await series(
+      Array.from({ length: 12 }, (_, index) => async () => {
         await tapReturnKey()
         await waitForViewportSettled()
-        return expectCursorVisible()
+        expect(await browser.execute(() => document.querySelectorAll('[data-editable]').length)).toBe(
+          initialThoughtCount + index + 1,
+        )
+        await expectCursorVisible()
       }),
     )
-
-    expect(Math.max(...geometries.map(geometry => geometry.scrollY))).toBeGreaterThan(initialScrollY)
   })
 })

--- a/src/e2e/iOS/__tests__/scroll.ts
+++ b/src/e2e/iOS/__tests__/scroll.ts
@@ -6,6 +6,7 @@ import series from '../../../util/series.js'
 import clickThought from '../helpers/clickThought.js'
 import isKeyboardShown from '../helpers/isKeyboardShown.js'
 import paste from '../helpers/paste.js'
+import tap from '../helpers/tap.js'
 import tapReturnKey from '../helpers/tapReturnKey.js'
 import waitForEditable from '../helpers/waitForEditable.js'
 
@@ -100,7 +101,7 @@ const openKeyboardAt = async (value: string) => {
     { timeoutMsg: `cursor did not move to ${value}` },
   )
   await waitForViewportSettled()
-  if (!(await isKeyboardShown())) await clickThought(value)
+  if (!(await isKeyboardShown())) await tap(await waitForEditable(value), { y: 60 })
   await browser.waitUntil(isKeyboardShown, { timeoutMsg: 'software keyboard did not open' })
   await waitForViewportSettled()
 }

--- a/src/e2e/puppeteer/__tests__/scroll.ts
+++ b/src/e2e/puppeteer/__tests__/scroll.ts
@@ -1,4 +1,5 @@
 import type { PreloadedEmWindow } from '../../../@types'
+import series from '../../../util/series'
 import clickThought from '../helpers/clickThought'
 import getEditingText from '../helpers/getEditingText'
 import paste from '../helpers/paste'
@@ -15,6 +16,87 @@ import { usePersistentTreecrdtStorage } from '../setup'
 
 const MOCK_REPLICATION_DELAY = 100
 
+interface CursorViewportGeometry {
+  /** Bottom edge of the cursor editable. */
+  bottom: number
+  /** Bottom edge of the visible viewport above the navbar. */
+  bottomEdge: number
+  /** Current document scroll position. */
+  scrollY: number
+  /** Top edge of the positioned cursor overlay. */
+  positionTop: number
+  /** Top edge of the cursor editable. */
+  top: number
+  /** Bottom edge of the toolbar. */
+  topEdge: number
+}
+
+interface ThoughtViewportGeometry {
+  /** Bottom edge of the thought editable. */
+  bottom: number
+  /** Height of the thought editable. */
+  height: number
+  /** Top edge of the thought editable. */
+  top: number
+  /** Top edge of the positioned tree node. */
+  positionTop: number | null
+}
+
+/** Reads the cursor and fixed-chrome geometry that is visible to the user. */
+const getCursorViewportGeometry = async (): Promise<CursorViewportGeometry> =>
+  page.evaluate(() => {
+    const cursor = document.querySelector('[data-editing=true] [data-editable]')?.getBoundingClientRect()
+    if (!cursor) throw new Error('Cursor editable is not rendered.')
+
+    const toolbar = document.querySelector('[data-testid="toolbar"]')?.getBoundingClientRect()
+    const navbar = document.querySelector('[aria-label="nav"]')?.getBoundingClientRect()
+    const positionTop = document.querySelector('[aria-label="cursor-overlay-tree-node"]')?.getBoundingClientRect().top
+    if (positionTop == null) throw new Error('Cursor positioner is not rendered.')
+
+    return {
+      bottom: cursor.bottom,
+      bottomEdge: window.innerHeight - (navbar?.height ?? 0),
+      positionTop,
+      scrollY: window.scrollY,
+      top: cursor.top,
+      topEdge: toolbar?.bottom ?? 0,
+    }
+  })
+
+/** Asserts that the cursor is fully visible between the toolbar and navbar. */
+const expectCursorVisible = async (): Promise<CursorViewportGeometry> => {
+  const geometry = await getCursorViewportGeometry()
+  expect(geometry.top).toBeGreaterThanOrEqual(geometry.topEdge)
+  expect(geometry.bottom).toBeLessThanOrEqual(geometry.bottomEdge)
+  return geometry
+}
+
+/** Waits until no scroll event has fired for a short interval. */
+const waitForScrollSettled = () =>
+  page.evaluate(
+    settleTime =>
+      new Promise<void>(resolve => {
+        let timeout: number
+        const controller = new AbortController()
+
+        /** Stops observing scroll events and resolves the wait. */
+        function finish() {
+          controller.abort()
+          resolve()
+        }
+
+        /** Restarts the quiet-period timer after each scroll event. */
+        function onScroll() {
+          window.clearTimeout(timeout)
+          timeout = window.setTimeout(finish, settleTime)
+        }
+
+        window.addEventListener('scroll', onScroll, { passive: true, signal: controller.signal })
+        onScroll()
+      }),
+    150,
+  )
+
 /** Gets the y position of a thought relative to the viewport. Throws if the thought is not rendered. */
 const getThoughtTop = async (value: string): Promise<number> => {
   const top = await page.evaluate(value => {
@@ -27,10 +109,132 @@ const getThoughtTop = async (value: string): Promise<number> => {
   return top
 }
 
+/** Reads the rendered viewport geometry of a thought. Throws if the thought is not rendered. */
+const getThoughtViewportGeometry = async (value: string): Promise<ThoughtViewportGeometry> => {
+  const geometry = await page.evaluate(value => {
+    const thought = Array.from(document.querySelectorAll('[data-editable]')).find(
+      element => element.innerHTML === value,
+    )
+    if (!thought) return null
+    const rect = thought.getBoundingClientRect()
+    const treeRect = thought.closest('[aria-label="tree-node"]')?.getBoundingClientRect()
+    return {
+      bottom: rect.bottom,
+      height: rect.height,
+      positionTop: treeRect?.top ?? null,
+      top: rect.top,
+    }
+  }, value)
+  if (!geometry) throw new Error(`Thought "${value}" is not rendered.`)
+  return geometry
+}
+
 vi.setConfig({ testTimeout: 60000, hookTimeout: 20000 })
 usePersistentTreecrdtStorage()
 
 describe('scrollCursorIntoView', () => {
+  it('does not scroll when keyboard navigation keeps the cursor inside the visible viewport', async () => {
+    await paste(Array.from({ length: 12 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    await clickThought('Thought 5')
+    await waitForBrowserSettled()
+    const { scrollY: scrollYBefore } = await getCursorViewportGeometry()
+
+    await press('ArrowDown')
+    await waitForCursor('Thought 6')
+    await waitForBrowserSettled()
+
+    const { scrollY: scrollYAfter } = await expectCursorVisible()
+    expect(scrollYAfter).toBe(scrollYBefore)
+  })
+
+  it('keeps the cursor visible while navigating repeatedly across both viewport edges', async () => {
+    await paste(Array.from({ length: 24 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    await waitForEditable('Thought 24')
+    await clickThought('Thought 1')
+    await waitForBrowserSettled()
+    await waitForScrollSettled()
+    const { scrollY: initialScrollY } = await getCursorViewportGeometry()
+
+    const downward = await series(
+      Array.from({ length: 19 }, (_, i) => async () => {
+        await press('ArrowDown')
+        await waitForCursor(`Thought ${i + 2}`)
+        await waitForBrowserSettled()
+        await waitForScrollSettled()
+        return expectCursorVisible()
+      }),
+    )
+
+    const upward = await series(
+      Array.from({ length: 19 }, (_, i) => async () => {
+        await press('ArrowUp')
+        await waitForCursor(`Thought ${19 - i}`)
+        await waitForBrowserSettled()
+        await waitForScrollSettled()
+        return expectCursorVisible()
+      }),
+    )
+
+    const peakScrollY = Math.max(...downward.map(geometry => geometry.scrollY))
+    expect(peakScrollY).toBeGreaterThan(initialScrollY)
+    expect(upward.at(-1)!.scrollY).toBeLessThan(peakScrollY)
+  })
+
+  it('preserves the exact bottom landing delta for a multiline thought', async () => {
+    const multiline = Array.from({ length: 30 }, () => 'multiline').join(' ')
+    const shortThoughts = Array.from({ length: 18 }, (_, i) => `- Thought ${i + 1}`)
+    await paste([...shortThoughts, `- ${multiline}`, '- After multiline'].join('\n'))
+    await waitForEditable('After multiline')
+    await clickThought('Thought 1')
+
+    await series(
+      Array.from({ length: 17 }, (_, i) => async () => {
+        await press('ArrowDown')
+        await waitForCursor(`Thought ${i + 2}`)
+        await waitForBrowserSettled()
+        await waitForScrollSettled()
+      }),
+    )
+
+    const before = await getCursorViewportGeometry()
+    const multilineBefore = await getThoughtViewportGeometry(multiline)
+    const afterMultilineBefore = await getThoughtViewportGeometry('After multiline')
+    if (multilineBefore.positionTop == null || afterMultilineBefore.positionTop == null) {
+      throw new Error('Multiline thought positioners are not rendered.')
+    }
+    const multilineLayoutHeight = afterMultilineBefore.positionTop - multilineBefore.positionTop
+    const expectedScrollDelta = multilineBefore.positionTop + multilineLayoutHeight * 1.5 - before.bottomEdge
+    expect(multilineBefore.height).toBeGreaterThan(before.bottom - before.top)
+    expect(expectedScrollDelta).toBeGreaterThan(0)
+
+    await press('ArrowDown')
+    await waitForCursor(multiline)
+    await waitForBrowserSettled()
+    await waitForScrollSettled()
+
+    const after = await expectCursorVisible()
+    const actualScrollDelta = after.scrollY - before.scrollY
+    expect(actualScrollDelta).toBeCloseTo(expectedScrollDelta, 0)
+    expect(after.bottomEdge - (after.positionTop + multilineLayoutHeight)).toBeCloseTo(multilineLayoutHeight / 2, 0)
+  })
+
+  it('keeps each new thought visible while Enter is pressed repeatedly', async () => {
+    await paste(Array.from({ length: 20 }, (_, i) => `- Thought ${i + 1}`).join('\n'))
+    await clickThought('Thought 20')
+    await press('End')
+
+    const geometries = await series(
+      Array.from({ length: 8 }, () => async () => {
+        await press('Enter')
+        await waitForBrowserSettled()
+        await waitForScrollSettled()
+        return expectCursorVisible()
+      }),
+    )
+
+    expect(geometries.every((geometry, i) => i === 0 || geometry.scrollY > geometries[i - 1].scrollY)).toBe(true)
+  })
+
   it('should scroll cursor into view after page refresh with delayed replicateChildren', async () => {
     const importText = `
 - a


### PR DESCRIPTION
<!-- Suggested title: Add explicit test coverage for existing cursor autoscroll behavior -->

Add explicit test coverage for cursor autoscroll behaviour before landing any implementation changes.

## Background

Cursor autoscroll currently has very little test coverage. This makes it a very fragile part of the codebase, and difficult to make any substantial changes to without risking breaking the current, accepted behaviour.

To fix #3765, a series of changes need to be made to the autoscroll system. Before doing so, establish a set of robust and *specific* tests for the current behaviour.

This will help us have more confidence that the current behaviour does not regress following the changes. It also makes any potential future changes to the autoscroll system much less risky.

The new tests cover: unit tests, Chromium, and Mobile Safari.

## New tests

In the unit fixtures, `y` is the cursor overlay's destination coordinate relative to the layout tree — the argument supplied to `scrollCursorIntoView(y, height)`.

These tests set `viewport.layoutTreeTop = 0`, so `y` is also the cursor's document coordinate.

In the assertions below, `top` is the absolute document scroll position passed to `window.scrollTo({ top })`. It is not the cursor's top coordinate.

| Level | Test and fixture | Behavior asserted |
| --- | --- | --- |
| Unit | `y=200`, `height=30`, `scrollY=10`, 800px viewport | A cursor already inside the current comfort zone makes no `scrollTo` call. |
| Unit | `y=350`, `height=30`, `scrollY=300`, 50px toolbar | Crossing the top edge calls `window.scrollTo` with an absolute document scroll position of `285px` and smooth behavior. |
| Unit | `y=780`, `height=30`, 800px viewport, 50px navbar | Keyboard-closed bottom landing calls `window.scrollTo` with an absolute document scroll position of `75px` and smooth behavior. |
| Unit | `y=600`, `height=30`, `visualViewport.height=500` | Existing keyboard-open bottom landing calls `window.scrollTo` with an absolute document scroll position of `195px` and smooth behavior. This works on `main` because Mobile Safari shrinks `visualViewport`. |
| Unit | `y=760`, multiline `height=60` | Existing multiline landing calls `window.scrollTo` with an absolute document scroll position of `100px`; the larger half-height landing margin is therefore part of the contract. |
| Unit | `y=1800`, `height=30`, 800px viewport | A cursor more than one visible viewport away calls `window.scrollTo` with an absolute document scroll position of `1095px` and instant behavior. |
| Puppeteer | Import 12 thoughts, select Thought 5, ArrowDown once | Thought 6 is fully visible and `scrollY` is exactly unchanged. |
| Puppeteer | Import 24 thoughts, navigate Thought 1 → 20 → 1 | Every intermediate cursor is fully between toolbar/navbar; scroll crosses the bottom and then returns upward. |
| Puppeteer | Import 18 single-line thoughts followed by a real wrapped multiline thought | Before navigation, read the multiline thought's positioned height and overflow. The resulting `scrollY` delta must equal overflow plus half the positioned height within 0.5 CSS px, and the final gap inside the bottom edge must equal half its height within 0.5 CSS px. |
| Puppeteer | Import 20 thoughts, select Thought 20, press Enter eight times | Every new cursor stays visible and every subsequent Enter increases `scrollY`; scrolling cannot skip an entered line. |
| Appium | Import 20 thoughts, position Thought 20 onscreen, open the real iOS keyboard | The cursor bottom remains above the software-keyboard boundary. |
| Appium | Open the keyboard on Thought 4, then move focus to Thought 20 | The keyboard stays open and the lower cursor remains above the software-keyboard boundary. |
| Appium | Import 8 thoughts, edit Thought 4, press Return twelve times | Each Return creates exactly one thought, and every new thought remains fully between toolbar and keyboard. |

## Notes

- The tests define only behavior observed working on `main`.
- iPad, Android, portrait/landscape orientation changes, and alternative font sizes currently remain outside test coverage.
