### PR TITLE
Make cursor autoscroll respect the virtual keyboard

### DIFF
--- a/src/@types/VirtualKeyboardState.ts
+++ b/src/@types/VirtualKeyboardState.ts
@@ -4,4 +4,6 @@ export default interface VirtualKeyboardState {
   open: boolean
   /** The height of the virtual keyboard in pixels. */
   height: number
+  /** The final height that the virtual keyboard is animating toward. */
+  targetHeight: number
 }

--- a/src/device/__tests__/scrollCursorIntoView.ts
+++ b/src/device/__tests__/scrollCursorIntoView.ts
@@ -1,4 +1,5 @@
 import viewportStore from '../../stores/viewport'
+import virtualKeyboardStore from '../../stores/virtualKeyboardStore'
 import scrollCursorIntoView from '../scrollCursorIntoView'
 
 vi.mock('../../browser', async importOriginal => {
@@ -34,6 +35,7 @@ beforeEach(() => {
     layoutTreeTop: 0,
     virtualKeyboardHeight: 0,
   })
+  virtualKeyboardStore.update({ open: false, height: 0, ...{ targetHeight: 0 } })
 
   const toolbar = document.createElement('div')
   toolbar.id = 'toolbar'
@@ -89,4 +91,14 @@ it('preserves the existing instant behavior for a target more than one visible v
   scrollCursorIntoView(1800, 30)
 
   expect(window.scrollTo).toHaveBeenCalledWith({ top: 1095, behavior: 'auto' })
+})
+
+// https://github.com/cybersemics/em/issues/3765
+it('scrolls the cursor above the Capacitor keyboard when visualViewport does not resize', () => {
+  // The spread keeps this regression test source-compatible with the pre-fix VirtualKeyboardState.
+  virtualKeyboardStore.update({ open: true, height: 300, ...{ targetHeight: 300 } })
+
+  scrollCursorIntoView(600, 30)
+
+  expect(window.scrollTo).toHaveBeenCalledWith({ top: 195, behavior: 'smooth' })
 })

--- a/src/device/scrollCursorIntoView.ts
+++ b/src/device/scrollCursorIntoView.ts
@@ -1,6 +1,7 @@
 import { isSafari, isTouch } from '../browser'
 import { PREVENT_AUTOSCROLL_TIMEOUT, isPreventAutoscrollInProgress } from '../device/preventAutoscroll'
 import viewportStore from '../stores/viewport'
+import virtualKeyboardStore from '../stores/virtualKeyboardStore'
 
 /** Scrolls the minimum amount necessary to move the viewport so that it includes the element. */
 const scrollIntoViewIfNeeded = (y: number, height: number) => {
@@ -18,10 +19,13 @@ const scrollIntoViewIfNeeded = (y: number, height: number) => {
   // toolbar element is not present when distractionFreeTyping is activated
   const viewport = viewportStore.getState()
 
-  // window.visualViewport.height excludes the virtual keyboard height (i.e. it changes when the keyboard is open/closed).
-  // It changes in a single step (before the virtual keyboard animation completes), so we can use it to determine if the element will be below the visible area.
-  // On desktop or when the virtual keyboard is down, it is equivalent to window.innerHeight.
-  const visualViewportHeight = window.visualViewport?.height ?? window.innerHeight
+  // Use the keyboard's destination rather than the animated height so the cursor is placed against
+  // the final visible area as soon as the keyboard starts moving. On Capacitor, visualViewport does
+  // not resize because the Keyboard plugin uses resize: 'none'.
+  const keyboardTargetHeight = virtualKeyboardStore.getState().targetHeight
+  const visibleViewportHeight = keyboardTargetHeight
+    ? window.innerHeight - keyboardTargetHeight
+    : (window.visualViewport?.height ?? window.innerHeight)
 
   /** The y position of the element relative to the document. */
   const yDocument = viewport.layoutTreeTop + y
@@ -33,7 +37,7 @@ const scrollIntoViewIfNeeded = (y: number, height: number) => {
   const toolbarBottom = toolbarRect ? toolbarRect.bottom : 0
   const navbarRect = document.querySelector('[aria-label="nav"]')?.getBoundingClientRect()
   const isAboveViewport = yViewport < toolbarBottom
-  const isBelowViewport = yViewport + height > visualViewportHeight - (navbarRect?.height ?? 0)
+  const isBelowViewport = yViewport + height > visibleViewportHeight - (navbarRect?.height ?? 0)
 
   if (!isAboveViewport && !isBelowViewport) return
 
@@ -44,7 +48,7 @@ const scrollIntoViewIfNeeded = (y: number, height: number) => {
   // add offset to account for the navbar height and prevent scrolled to elements from being hidden below
   const scrollYNew = isAboveViewport
     ? yDocument - (toolbarRect?.height ?? 0) - height / 2
-    : yDocument - visualViewportHeight + height * 1.5 + (navbarRect?.height ?? 0)
+    : yDocument - visibleViewportHeight + height * 1.5 + (navbarRect?.height ?? 0)
 
   // scroll to 1 instead of 0
   // otherwise Mobile Safari scrolls to the top after MultiGesture
@@ -52,7 +56,7 @@ const scrollIntoViewIfNeeded = (y: number, height: number) => {
   const top = Math.max(1, scrollYNew)
 
   const scrollDistance = Math.abs(scrollYNew - window.scrollY)
-  const behavior: ScrollBehavior = scrollDistance < visualViewportHeight ? 'smooth' : 'auto'
+  const behavior: ScrollBehavior = scrollDistance < visibleViewportHeight ? 'smooth' : 'auto'
 
   window.scrollTo({
     top,

--- a/src/device/virtual-keyboard/handlers/iOSCapacitorHandler.ts
+++ b/src/device/virtual-keyboard/handlers/iOSCapacitorHandler.ts
@@ -33,7 +33,7 @@ const iOSCapacitorHandler: VirtualKeyboardHandler = {
       // is the value we actually need. Consider this an additional 'safe area inset' that applies only when the keyboard is open.
       const targetHeight = rawHeight - getSafeAreaBottom()
       viewportStore.update({ virtualKeyboardHeight: targetHeight })
-      virtualKeyboardStore.update({ open: true })
+      virtualKeyboardStore.update({ open: true, targetHeight })
 
       // Stop any existing animation to prevent conflicts
       controls?.stop()
@@ -53,7 +53,7 @@ const iOSCapacitorHandler: VirtualKeyboardHandler = {
 
     Keyboard.addListener('keyboardWillHide', () => {
       // note: leave open: true until the keyboard has fully hidden
-      virtualKeyboardStore.update({ open: true })
+      virtualKeyboardStore.update({ open: true, targetHeight: 0 })
 
       // Stop any existing animation to prevent conflict.
       controls?.stop()

--- a/src/device/virtual-keyboard/handlers/iOSSafariHandler.ts
+++ b/src/device/virtual-keyboard/handlers/iOSSafariHandler.ts
@@ -40,7 +40,7 @@ const updateIOSSafariKeyboardState = () => {
       if (targetHeight === currentTargetHeight) return
 
       controls?.stop()
-      virtualKeyboardStore.update({ open: true })
+      virtualKeyboardStore.update({ open: true, targetHeight })
       currentTargetHeight = targetHeight
 
       // Approximate iOS' keyboard spring animation (same curve as iOSCapacitorHandler)
@@ -59,7 +59,7 @@ const updateIOSSafariKeyboardState = () => {
       controls?.stop()
 
       // Keep open: true during the closing animation so consumers still account for the keyboard
-      virtualKeyboardStore.update({ open: true })
+      virtualKeyboardStore.update({ open: true, targetHeight: 0 })
       currentTargetHeight = 0
 
       controls = animate(virtualKeyboardStore.getState().height, 0, {

--- a/src/hooks/__tests__/useScrollCursorIntoView.ts
+++ b/src/hooks/__tests__/useScrollCursorIntoView.ts
@@ -1,0 +1,27 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import virtualKeyboardStore from '../../stores/virtualKeyboardStore'
+import useScrollCursorIntoView from '../useScrollCursorIntoView'
+
+const scrollCursorIntoView = vi.hoisted(() => vi.fn())
+
+vi.mock('../../device/scrollCursorIntoView', () => ({ default: scrollCursorIntoView }))
+
+beforeEach(() => {
+  scrollCursorIntoView.mockReset()
+  virtualKeyboardStore.update({ open: false, height: 0, ...{ targetHeight: 0 } })
+})
+
+// https://github.com/cybersemics/em/issues/3765
+it('rechecks cursor visibility when the keyboard target height changes', async () => {
+  const { unmount } = renderHook(() => useScrollCursorIntoView(600, 30))
+  scrollCursorIntoView.mockClear()
+
+  act(() => {
+    // The spread keeps this regression test source-compatible with the pre-fix VirtualKeyboardState.
+    virtualKeyboardStore.update({ open: true, height: 0, ...{ targetHeight: 300 } })
+  })
+
+  await waitFor(() => expect(scrollCursorIntoView).toHaveBeenCalledOnce())
+  expect(scrollCursorIntoView).toHaveBeenCalledWith(600, 30)
+  unmount()
+})

--- a/src/hooks/useScrollCursorIntoView.ts
+++ b/src/hooks/useScrollCursorIntoView.ts
@@ -1,8 +1,13 @@
 import { throttle } from 'lodash'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import VirtualKeyboardState from '../@types/VirtualKeyboardState'
 import scrollCursorIntoView from '../device/scrollCursorIntoView'
 import testFlags from '../e2e/testFlags'
 import editingValueStore from '../stores/editingValue'
+import virtualKeyboardStore from '../stores/virtualKeyboardStore'
+
+/** Selects the final height that the keyboard is animating toward. */
+const selectKeyboardTargetHeight = (state: VirtualKeyboardState) => state.targetHeight
 
 const throttledScrollCursorIntoView = throttle((y: number, height: number) => scrollCursorIntoView(y, height), 400)
 
@@ -29,6 +34,13 @@ const useScrollCursorIntoView = (y: number, height: number) => {
      */
     setTimeout(() => throttledScrollCursorIntoView(sizeRef.current.y, sizeRef.current.height))
   })
+
+  /** Re-evaluates cursor visibility when the keyboard's destination changes. */
+  const onKeyboardTargetChange = useCallback(() => {
+    scrollCursorIntoView(sizeRef.current.y, sizeRef.current.height)
+  }, [])
+
+  virtualKeyboardStore.useSelectorEffect(onKeyboardTargetChange, selectKeyboardTargetHeight)
 
   useEffect(() => scrollCursorIntoView(y, height), [height, y])
 }

--- a/src/stores/virtualKeyboardStore.ts
+++ b/src/stores/virtualKeyboardStore.ts
@@ -6,6 +6,7 @@ import reactMinistore from './react-ministore'
 const virtualKeyboardStore = reactMinistore<VirtualKeyboardState>({
   open: false,
   height: 0,
+  targetHeight: 0,
 })
 
 export default virtualKeyboardStore


### PR DESCRIPTION
<!-- Suggested title: Make cursor autoscroll respect the virtual keyboard -->

Make cursor autoscroll respect the virtual keyboard – scoping the "view" area to just the visible portion of the screen that is unoccluded by the keyboard.

This change was specifically made for iOS Capacitor, where the "viewport" technically does not change size with the virtual keyboard due to the `resize: none` configuration.

## Changes

### VirtualKeyboardStore

`VirtualKeyboardStore` now distinguishes:

- `height`: the animated value used by UI that moves with the keyboard (changes along with the keyboard animation)
- `targetHeight`: the final height the keyboard is opening or closing toward

The iOS Capacitor handler publishes `targetHeight` from the native `keyboardWillShow`/`keyboardWillHide` events. The iOS Safari handler publishes the same destination using an estimated value, because there is no robust API to get the exact value.

### `scrollCursorIntoView`

`scrollCursorIntoView` uses `window.innerHeight - targetHeight` whenever a nonzero destination is known. In other words, `scrollCursorIntoView` now respects the virtual keyboard and scopes the "view" area to just the visible portion of the screen that is unoccluded by the keyboard.

`useScrollCursorIntoView` also subscribes to changes in `targetHeight` (i.e. at the moment the keyboard begins to open and close). This is necessary because the usable viewport changes if the virtual keyboard opens.

## Tests

Two regression cases are added in this PR:

- ensure the cursor moves above a simulated keyboard
- ensure a stationary cursor is rechecked when `targetHeight` changes

All other autoscroll-related tests from the last PR remain green.

## Notes

- Native iOS autoscroll still runs in this PR, so #3765's fixed-toolbar compositor jitter is not expected to be resolved yet. That fix comes in a later PR.
