### PR TITLE
Suppress native iOS autoscroll using JavaScript

### DIFF
--- a/docs/cursor-and-caret.md
+++ b/docs/cursor-and-caret.md
@@ -234,7 +234,7 @@ Because the temporary CSS inflates the editable's padding, any height measured d
 
 ### `focusWithoutAutoscroll.ts`
 
-[`src/device/focusWithoutAutoscroll.ts`](../src/device/focusWithoutAutoscroll.ts) transfers ordinary thought and note focus on iOS without WebKit's native reveal. The initiating mousedown is canceled, the editable is focused with `preventScroll`, and any synchronous scroll caused by setting the browser selection is restored before paint. [`scrollCursorIntoView`](#scrollcursorintoviewts) is then the only code that deliberately moves the viewport for these focus changes.
+[`src/device/focusWithoutAutoscroll.ts`](../src/device/focusWithoutAutoscroll.ts) transfers ordinary thought and note focus on iOS without WebKit's native reveal. When a selected thought is tapped with the keyboard closed, focus is transferred during the real `touchend`, while iOS still considers it user-initiated and can open the keyboard. The later synthesized `mousedown` is canceled, the editable is focused with `preventScroll`, and any synchronous scroll caused by setting the browser selection is restored before paint. [`scrollCursorIntoView`](#scrollcursorintoviewts) is then the only code that deliberately moves the viewport for these focus changes.
 
 Autocomplete retargeting and cleared multicursor editing retain `preventAutoscroll`. Both have additional blur and focus-timing invariants, so they are not part of the ordinary-focus ownership transfer.
 

--- a/docs/cursor-and-caret.md
+++ b/docs/cursor-and-caret.md
@@ -228,9 +228,15 @@ When the cursor crosses an edge, it lands half its own height back inside the co
 
 [`src/device/preventAutoscroll.ts`](../src/device/preventAutoscroll.ts).
 
-When `selection.set` runs on a thought that's near the bottom of the viewport, the browser will sometimes scroll the editable into view. This is fine in theory but can fight with em's own viewport autocrop logic and produce a jumpy keyboard. `preventAutoscroll` temporarily applies CSS that puts the element near the viewport center (so the browser thinks no scroll is needed), restores the original styles after a 10 ms timeout, and is invoked by `useEditMode` before `selection.set`.
+When `selection.set` runs on a thought that's near the bottom of the viewport, the browser will sometimes scroll the editable into view. This is fine in theory but can fight with em's own viewport autocrop logic and produce a jumpy keyboard. `preventAutoscroll` temporarily applies CSS that puts the element near the viewport center (so the browser thinks no scroll is needed), restores the original styles after a 10 ms timeout, and is invoked before legacy selection writes.
 
 Because the temporary CSS inflates the editable's padding, any height measured during the autoscroll window is too large. `getAutoscrollPadding(el)` returns the number of pixels of padding currently added to an element so that `VirtualThought.updateSize` can subtract it and record the thought's true height even during the window. Without this, a height change that occurs during the window — e.g. a note added by Swap Note — would be recorded with an inflated height or skipped entirely, leaving the next thought overlapping the note ([#4279](https://github.com/cybersemics/em/issues/4279)).
+
+### `focusWithoutAutoscroll.ts`
+
+[`src/device/focusWithoutAutoscroll.ts`](../src/device/focusWithoutAutoscroll.ts) transfers ordinary thought and note focus on iOS without WebKit's native reveal. The initiating mousedown is canceled, the editable is focused with `preventScroll`, and any synchronous scroll caused by setting the browser selection is restored before paint. [`scrollCursorIntoView`](#scrollcursorintoviewts) is then the only code that deliberately moves the viewport for these focus changes.
+
+Autocomplete retargeting and cleared multicursor editing retain `preventAutoscroll`. Both have additional blur and focus-timing invariants, so they are not part of the ordinary-focus ownership transfer.
 
 ## Testing
 

--- a/src/components/Editable/__tests__/useEditMode.iosSafari.ts
+++ b/src/components/Editable/__tests__/useEditMode.iosSafari.ts
@@ -88,3 +88,35 @@ it('blocks native focus before placing the caret on the cursor thought', () => {
   expect(document.activeElement).toBe(editable)
   expect(store.getState().cursorOffset).toBe(0)
 })
+
+// https://github.com/cybersemics/em/issues/3765
+it('focuses a keyboard-closed cursor during touchend before blocking the synthesized mousedown', () => {
+  store.dispatch([importText({ text: '- a' }), setCursor(['a'])])
+
+  const editable = document.createElement('div')
+  editable.setAttribute('contenteditable', 'true')
+  editable.textContent = 'a'
+  document.body.appendChild(editable)
+  const focus = vi.spyOn(editable, 'focus')
+
+  renderHook(
+    () =>
+      useEditMode({
+        contentRef: { current: editable as unknown as HTMLInputElement },
+        isEditing: true,
+        path: store.getState().cursor!,
+        style: undefined,
+        transient: undefined,
+      }),
+    { wrapper: ({ children }) => createElement(Provider, { store, children }) },
+  )
+
+  const touchend = new Event('touchend', { bubbles: true, cancelable: true }) as TouchEvent
+  Object.defineProperty(touchend, 'changedTouches', { value: [{ clientX: 0, clientY: 0 }] })
+
+  act(() => {
+    editable.dispatchEvent(touchend)
+  })
+
+  expect(focus).toHaveBeenCalledWith({ preventScroll: true })
+})

--- a/src/components/Editable/__tests__/useEditMode.iosSafari.ts
+++ b/src/components/Editable/__tests__/useEditMode.iosSafari.ts
@@ -59,7 +59,8 @@ it('suppress the synthesized mousedown of a tap that already moved the cursor wi
   expect(mousedown.defaultPrevented).toBe(true)
 })
 
-it('allow mousedown on the cursor thought when no cursor-moving tap preceded it', () => {
+// https://github.com/cybersemics/em/issues/3765
+it('blocks native focus before placing the caret on the cursor thought', () => {
   store.dispatch([importText({ text: '- a' }), setCursor(['a'])])
 
   const editable = document.createElement('div')
@@ -83,5 +84,7 @@ it('allow mousedown on the cursor thought when no cursor-moving tap preceded it'
     editable.dispatchEvent(mousedown)
   })
 
-  expect(mousedown.defaultPrevented).toBe(false)
+  expect(mousedown.defaultPrevented).toBe(true)
+  expect(document.activeElement).toBe(editable)
+  expect(store.getState().cursorOffset).toBe(0)
 })

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -7,6 +7,7 @@ import { setCursorActionCreator as setCursor } from '../../actions/setCursor'
 import { isSafari, isTouch } from '../../browser'
 import { LongPressState } from '../../constants'
 import asyncFocus from '../../device/asyncFocus'
+import focusWithoutAutoscroll from '../../device/focusWithoutAutoscroll'
 import getCaretOffset from '../../device/getCaretOffset'
 import preventAutoscroll, { preventAutoscrollEnd } from '../../device/preventAutoscroll'
 import * as selection from '../../device/selection'
@@ -83,6 +84,7 @@ const useEditMode = ({
       // Get the cursorOffset directly from the store rather than subscribing to it reactively with useSelector.
       // Otherwise, it will try to set the selection while typing.
       const { cursorOffset, lastUndoableActionType } = store.getState()
+      const preventNativeAutoscroll = isTouch && isSafari() && !isCursorCleared
 
       /** Set the selection to the current Editable at the cursor offset. */
       const setSelectionToCursorOffset = () => {
@@ -106,10 +108,14 @@ const useEditMode = ({
           // transition into the cleared state; focusing on any other run blurs the previously focused editable
           // before the selection is set, which recomputes the cursor offset and ends the editing session.
           if (isCursorCleared && wasCursorCleared === false && contentRef.current) {
-            contentRef.current.focus()
+            contentRef.current.focus({ preventScroll: true })
           }
 
-          selection.set(contentRef.current, { offset: cursorOffset ?? 0 })
+          if (preventNativeAutoscroll) {
+            focusWithoutAutoscroll(contentRef.current, { offset: cursorOffset ?? 0 })
+          } else {
+            selection.set(contentRef.current, { offset: cursorOffset ?? 0 })
+          }
         }
       }
 
@@ -130,7 +136,7 @@ const useEditMode = ({
           !disabledRef.current)
 
       if (shouldSetSelection) {
-        preventAutoscroll(contentRef.current)
+        if (!preventNativeAutoscroll) preventAutoscroll(contentRef.current)
 
         /*
         When a new thought is created, the Shift key should be on when Auto-Capitalization is enabled.
@@ -164,7 +170,7 @@ const useEditMode = ({
           // Not in the cleared state, which setSelectionToCursorOffset focuses itself on the transition into it
           // (#4519). Focusing on its later runs would leave the editable focused for the next run's asyncFocus to
           // blur, which ends the editing session and closes the keyboard mid-edit.
-          if (!isCursorCleared) contentRef.current?.focus()
+          if (!isCursorCleared) contentRef.current?.focus({ preventScroll: true })
         }
 
         setSelectionToCursorOffset()
@@ -313,7 +319,28 @@ const useEditMode = ({
           clientY: e.clientY,
         })
 
-        if (offset !== null) {
+        const preventNativeAutoscroll = isTouch && isSafari() && !multiEditing
+        if (preventNativeAutoscroll) e.preventDefault()
+
+        if (offset !== null || preventNativeAutoscroll) {
+          const targetOffset = offset ?? 0
+
+          if (preventNativeAutoscroll) {
+            // Move Redux first so Editable.onFocus recognizes this as the current thought and does
+            // not replace the coordinate-derived offset while focus is being transferred.
+            dispatch(
+              setCursor({
+                path,
+                offset: targetOffset,
+                isKeyboardOpen: true,
+                cursorHistoryClear: true,
+                preserveMulticursor,
+              }),
+            )
+            focusWithoutAutoscroll(editable, { offset: targetOffset })
+            return
+          }
+
           // Prevent the browser from autoscrolling to this editable element.
           // For some reason doesn't work on touchend.
           preventAutoscroll(editable, {
@@ -324,7 +351,7 @@ const useEditMode = ({
           // Setting the caret offset will activate the declarative shouldSetSelection effect, which will call preventAutoscroll and selection.set
           // all over again. Since the selection is managed imperatively in this handler, this duplicate behavior is undesirable.
           allowDefaultSelection()
-          setCaretOffset(offset, { preserveMulticursor })
+          setCaretOffset(targetOffset, { preserveMulticursor })
 
           // It's important to avoid preventDefault when the tap is somewhere that can be handled by native browser selection behavior.
           // If the tap is prevented, it will interfere with functionality like double tap or the context menu. If the selection is

--- a/src/components/Editable/useEditMode.ts
+++ b/src/components/Editable/useEditMode.ts
@@ -233,6 +233,29 @@ const useEditMode = ({
       lastTouchEndTime = performance.now()
       lastTouchEndTarget = editable
 
+      // When the cursor is selected but the keyboard is closed, focus must be transferred during the real
+      // touch event. The synthesized mousedown arrives too late for iOS to reliably raise the keyboard, and its
+      // native focus is deliberately blocked below to prevent WebKit autoscroll (#3765).
+      if (editingOrOnCursor && !editing && !isMulticursor && style?.visibility !== 'hidden') {
+        const { offset } = getCaretOffset(editable, {
+          clientX: e.changedTouches[0].clientX,
+          clientY: e.changedTouches[0].clientY,
+        })
+        const targetOffset = offset ?? 0
+
+        dispatch(
+          setCursor({
+            path,
+            offset: targetOffset,
+            isKeyboardOpen: true,
+            cursorHistoryClear: true,
+          }),
+        )
+        asyncFocus({ force: true })
+        focusWithoutAutoscroll(editable, { offset: targetOffset })
+        return
+      }
+
       // #4173: touchend is the only event iOS reliably delivers to the tapped thought — on a rapid tap it
       // retargets the synthesized mousedown/focus to the previously-focused thought (onMouseDown suppresses
       // that ghost), so onFocus cannot be relied on to move the cursor. Set the cursor here.

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -14,7 +14,9 @@ import { setCursorActionCreator as setCursor } from '../actions/setCursor'
 import { setDescendantActionCreator as setDescendant } from '../actions/setDescendant'
 import { setNoteFocusActionCreator as setNoteFocus } from '../actions/setNoteFocus'
 import { toggleNoteActionCreator as toggleNote } from '../actions/toggleNote'
-import { isTouch } from '../browser'
+import { isSafari, isTouch } from '../browser'
+import focusWithoutAutoscroll from '../device/focusWithoutAutoscroll'
+import getCaretOffset from '../device/getCaretOffset'
 import preventAutoscroll, { preventAutoscrollEnd } from '../device/preventAutoscroll'
 import * as selection from '../device/selection'
 import globals from '../globals'
@@ -78,7 +80,7 @@ const Note = React.memo(
       const { noteOffset } = store.getState()
       // cursor must be true if note is focused
       if (hasFocus && noteOffset !== null) {
-        selection.set(noteRef.current!, { offset: noteOffset })
+        focusWithoutAutoscroll(noteRef.current, { offset: noteOffset })
         // Clear noteOffset after placing the caret so it acts as a one-shot request. Otherwise repeatedly
         // restoring the caret to the same offset (e.g. applying a font color over a background color multiple
         // times) would set noteOffset to an unchanged value, the effect would not re-run, and the caret would
@@ -207,7 +209,19 @@ const Note = React.memo(
       [dispatch],
     )
 
-    const onMouseDown = useCallback(() => preventAutoscroll(noteRef.current), [noteRef])
+    const onMouseDown = useCallback((e: React.MouseEvent) => {
+      const note = noteRef.current
+      if (!note) return
+
+      if (!isTouch || !isSafari()) {
+        preventAutoscroll(note)
+        return
+      }
+
+      const { offset } = getCaretOffset(note, { clientX: e.clientX, clientY: e.clientY })
+      e.preventDefault()
+      focusWithoutAutoscroll(note, { offset: offset ?? 0 })
+    }, [])
 
     const onCopy = useCallback((e: React.ClipboardEvent) => {
       const html = selection.html()

--- a/src/device/__tests__/focusWithoutAutoscroll.ts
+++ b/src/device/__tests__/focusWithoutAutoscroll.ts
@@ -1,0 +1,36 @@
+import focusWithoutAutoscroll from '../focusWithoutAutoscroll'
+import * as selection from '../selection'
+
+vi.mock('../../browser', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../browser')>()
+  return { ...actual, isSafari: () => true, isTouch: true }
+})
+
+vi.mock('../selection', () => ({
+  isThought: vi.fn(),
+  offsetThought: vi.fn(() => null),
+  set: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.mocked(selection.set).mockReset()
+  Object.defineProperty(window, 'scrollX', { configurable: true, value: 0 })
+  Object.defineProperty(window, 'scrollY', { configurable: true, writable: true, value: 100 })
+  window.scrollTo = vi.fn()
+})
+
+// https://github.com/cybersemics/em/issues/3765
+it('prevents focus and selection from changing the iOS scroll position', () => {
+  const editable = document.createElement('div')
+  editable.setAttribute('contenteditable', 'true')
+  const focus = vi.spyOn(editable, 'focus')
+  vi.mocked(selection.set).mockImplementation(() => {
+    window.scrollY = 400
+  })
+
+  focusWithoutAutoscroll(editable, { offset: 3 })
+
+  expect(focus).toHaveBeenCalledWith({ preventScroll: true })
+  expect(selection.set).toHaveBeenCalledWith(editable, { offset: 3 })
+  expect(window.scrollTo).toHaveBeenCalledWith(0, 100)
+})

--- a/src/device/asyncFocus.ts
+++ b/src/device/asyncFocus.ts
@@ -36,7 +36,7 @@ export const AsyncFocus: () => (options?: { force?: boolean }) => void = () => {
     // provide the option to force the focus in order to retarget focus and prevent an iOS Safari bug (#4222)
     if (options.force || !selection.isThought()) {
       hiddenInput.disabled = false
-      hiddenInput.focus()
+      hiddenInput.focus({ preventScroll: true })
       // the hidden input should not be a valid focus target unless this function was invoked
       hiddenInput.disabled = true
     }

--- a/src/device/focusWithoutAutoscroll.ts
+++ b/src/device/focusWithoutAutoscroll.ts
@@ -1,0 +1,28 @@
+import { isSafari, isTouch } from '../browser'
+import * as selection from './selection'
+
+/** Focuses an editable and places the caret without allowing iOS WebKit to change the scroll position. */
+const focusWithoutAutoscroll = (el: HTMLElement | null | undefined, { offset }: { offset: number }): void => {
+  if (!el) return
+
+  // Keep the existing implicit-focus selection behavior on other platforms. iOS is the only platform
+  // switching from native autoscroll to em's scrollCursorIntoView policy.
+  if (!isTouch || !isSafari()) {
+    selection.set(el, { offset })
+    return
+  }
+
+  const wasFocused = el === document.activeElement
+  const currentOffset = wasFocused ? selection.offsetThought() : null
+  if (wasFocused && currentOffset === offset) return
+
+  if (!wasFocused) el.focus({ preventScroll: true })
+
+  // Setting a Range inside a contenteditable can trigger a second native reveal independently of
+  // focus. Selection has no preventScroll option, so restore any synchronous movement before paint.
+  const scrollY = window.scrollY
+  selection.set(el, { offset })
+  if (window.scrollY !== scrollY) window.scrollTo(window.scrollX, scrollY)
+}
+
+export default focusWithoutAutoscroll

--- a/src/device/virtual-keyboard/handlers/iOSCapacitorHandler.ts
+++ b/src/device/virtual-keyboard/handlers/iOSCapacitorHandler.ts
@@ -82,7 +82,7 @@ const iOSCapacitorHandler: VirtualKeyboardHandler = {
     // thought. The selection is then applied without focus and is wiped again as soon as the hidden asyncFocus
     // input blurs, leaving the new thought with no caret and no keyboard (#4869). A script-initiated focus
     // restores both. Keyboard.show() is not an option: the Capacitor plugin only implements it on Android.
-    editable.focus()
+    editable.focus({ preventScroll: true })
   },
 }
 


### PR DESCRIPTION
<!-- Suggested title: Suppress native iOS autoscroll using JavaScript -->

Suppress WebKit's native autoscroll using JavaScript, rather than a CSS trick. Fixes #3765.

## Changes

Rather than "counteracting" autoscroll with a CSS centering trick, prevent it outright using the (relatively) new `preventScroll: true` prop when focussing an editable.

This issue directly benefits from the work done in #3410, which replaced iOS' native caret placement with a fully custom implementation.

A new `focusWithoutAutoscroll` method is called when ordinary focus is transferred to an editable. It:

- focusses the editable with `focus({ preventScroll: true })` when necessary (preventing native autoscroll);
- place the browser selection at the requested offset (per #3410); and
- restore any synchronous selection-driven scroll before paint

When a selected thought is tapped with the keyboard closed, `useEditMode` transfers focus during the real `touchend`, while iOS still considers it user-initiated and can open the keyboard. It then cancels the synthesized mousedown before native autofocus can reveal the editable. The Redux cursor is updated first so focus handlers immediately see the correct thought and offset.

A unit regression test verifies that the keyboard-closed cursor receives focus during `touchend`, before the synthesized mousedown is blocked. The Appium tests verify that the keyboard still opens and the cursor remains visible near the bottom of the viewport.

`Note` uses the same route for ordinary note focus. `asyncFocus` also focuses its hidden input with `preventScroll: true`, so priming the iOS selection cannot produce its own scroll-to-top movement.

Note that the scope is deliberately narrower than the original submission:

- ordinary thought focus is transferred
- ordinary note focus is transferred
- autocomplete retargeting remains on legacy `preventAutoscroll`
- cleared multicursor editing remains on legacy `preventAutoscroll`

The last two flows carry additional blur/focus and multiselection invariants. Keeping them unchanged avoids repeating the multi-edit/autocomplete regressions uncovered during the original broad cutover.

The existing `preventAutoscroll` implementation is not deleted. It remains available for those explicitly retained legacy paths.

All tests continue to pass.
