### PR TITLE
Separate GestureDiagram rendering responsibilities

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -5,10 +5,11 @@ import { token } from '../../styled-system/tokens'
 import { SystemStyleObject } from '../../styled-system/types'
 import Gesture from '../@types/Gesture'
 import { GESTURE_GLOW_BLUR, GESTURE_GLOW_COLOR } from '../constants'
+import ArrowheadMarker from './GestureDiagram/ArrowheadMarker'
+import SegmentedGradientGestureRenderer from './GestureDiagram/SegmentedGradientGestureRenderer'
+import SolidGestureRenderer from './GestureDiagram/SolidGestureRenderer'
 import getGestureGeometry from './GestureDiagram/getGestureGeometry'
 import GestureArrowhead from './GestureDiagram/types/GestureArrowhead'
-import GestureGeometry from './GestureDiagram/types/GestureGeometry'
-import GestureSegment from './GestureDiagram/types/GestureSegment'
 
 interface GestureDiagramProps {
   /** Length of the SVG arrowhead marker. */
@@ -51,239 +52,6 @@ interface GestureDiagramProps {
   highlightColor?: string
 }
 
-type ArcGestureSegment = Extract<GestureSegment, { kind: 'arc' }>
-
-/** Generate a list of pre-computed gradients for the special case of the mobile command universe question mark diagram. */
-const MobileCommandUniverseGradients = () => (
-  <>
-    <radialGradient
-      cx={29.7}
-      cy={13.5}
-      r={33.3}
-      id={`rdld-gradient-0`}
-      key={`rdld-gradient-0`}
-      gradientUnits='userSpaceOnUse'
-    >
-      <stop offset='0%' className={`rdld-gradient-0-start`} />
-      <stop offset='100%' className={`rdld-gradient-0-stop`} />
-    </radialGradient>
-    <linearGradient id={`rdld-gradient-1`} key={`rdld-gradient-1`} gradientUnits='userSpaceOnUse'>
-      <stop offset='0%' className={`rdld-gradient-1-start`} />
-      <stop offset='100%' className={`rdld-gradient-1-stop`} />
-    </linearGradient>
-    <radialGradient
-      cx={54}
-      cy={40.5}
-      r={18.5}
-      id={`rdld-gradient-2`}
-      key={`rdld-gradient-2`}
-      gradientUnits='userSpaceOnUse'
-    >
-      <stop offset='0%' className={`rdld-gradient-2-start`} />
-      <stop offset='100%' className={`rdld-gradient-2-stop`} />
-    </radialGradient>
-    <linearGradient
-      x1={45}
-      y1={58.5}
-      x2={45}
-      y2={72}
-      id={`rdld-gradient-3`}
-      key={`rdld-gradient-3`}
-      gradientUnits='userSpaceOnUse'
-    >
-      <stop offset='0%' className={`rdld-gradient-3-start`} />
-      <stop offset='100%' className={`rdld-gradient-3-stop`} />
-    </linearGradient>
-  </>
-)
-
-/** Generates radial gradients for curved segments of the gesture. */
-const ArcGradient = ({
-  index,
-  extendedPath,
-  segment,
-}: {
-  index: number
-  extendedPath: Gesture
-  segment: ArcGestureSegment
-}) => {
-  return (
-    <radialGradient
-      cx={segment.from.x}
-      cy={segment.from.y}
-      r={segment.radius}
-      id={`${extendedPath}-gradient-${index}`}
-      key={`${extendedPath}-gradient-${index}`}
-      gradientUnits='userSpaceOnUse'
-    >
-      <stop offset='0%' className={`${extendedPath}-gradient-${index}-start`} />
-      <stop offset='100%' className={`${extendedPath}-gradient-${index}-stop`} />
-    </radialGradient>
-  )
-}
-
-/** Generate CSS rules defining the colors for the gradients that are applied to gesture diagram path segments. */
-const GradientStyleBlock = ({ color, highlight, path }: { color?: string; highlight?: number; path: Gesture }) => {
-  const index = path === 'rdl' ? 3 : path === 'ldr' ? 2 : undefined
-  // The initial path segment should start at 25% opacity. Subsequent path segmenets should start at 50% opacity.
-  // The final path segment should start at 75% opacity.
-  const stopColors = Array.from(path).map((_, i) => (i === 0 ? 25 : path.length > 2 && i === path.length - 1 ? 75 : 50))
-
-  return (
-    <style>
-      {stopColors.map((startPercent, i) => {
-        const stopPercent = i === path.length - 1 ? 100 : stopColors[i + 1]
-
-        // Highlight the segment if its index is less than the highlight index.
-        // Special Case: Highlight the extended segment and all segments after it.
-        const stopColor =
-          highlight != null && (i < highlight || highlight === path.length || (highlight === index && i === index))
-            ? token('colors.vividHighlight')
-            : color || token('colors.fg')
-
-        return `
-            .${path}-gradient-${i}-start { stop-color: color-mix(in srgb, ${stopColor} ${startPercent}%, ${token('colors.bg')}) }
-            .${path}-gradient-${i}-stop { stop-color: color-mix(in srgb, ${stopColor} ${stopPercent}%, ${token('colors.bg')}) }
-          `
-      })}
-    </style>
-  )
-}
-
-/** Serializes one canonical segment as an independently renderable SVG path. */
-const segmentPathData = (segment: GestureSegment, path: Gesture) =>
-  segment.kind === 'line'
-    ? path === 'rdld'
-      ? `M ${segment.from.x},${segment.from.y} L ${segment.to.x},${segment.to.y}`
-      : `M ${segment.from.x} ${segment.from.y} l ${segment.to.x - segment.from.x} ${segment.to.y - segment.from.y}`
-    : segment.kind === 'arc'
-      ? `M ${segment.from.x} ${segment.from.y} A ${segment.radius} ${segment.radius} 0 0 ${segment.sweepFlag} ${segment.to.x} ${segment.to.y}`
-      : `M ${segment.from.x},${segment.from.y} Q ${segment.control.x},${segment.control.y} ${segment.to.x},${segment.to.y}`
-
-/** Serializes consecutive canonical segments as one continuous SVG path. */
-const gesturePathData = (segments: readonly GestureSegment[]) =>
-  segments.reduce((pathData, segment, i) => {
-    const rdld = segments[0]?.kind === 'quadratic'
-    return `${pathData}${i === 0 ? `M ${segment.from.x}${rdld ? ',' : ' '}${segment.from.y} ` : ' '}${
-      segment.kind === 'line'
-        ? `L ${segment.to.x}${rdld ? ',' : ' '}${segment.to.y}`
-        : segment.kind === 'arc'
-          ? `A ${segment.radius} ${segment.radius} 0 0 ${segment.sweepFlag} ${segment.to.x} ${segment.to.y}`
-          : `Q ${segment.control.x},${segment.control.y} ${segment.to.x},${segment.to.y}`
-    }`
-  }, '')
-
-type GesturePathProps = {
-  arrowhead: 'filled' | 'outlined' | 'none'
-  color?: string
-  dropShadow?: string
-  geometry: GestureGeometry
-  highlight?: number
-  highlightColor?: string
-  id: string
-  strokeWidth: number
-  useGradient: boolean
-}
-
-/** Renders the gesture path as SVG path element(s). */
-const GesturePath = ({
-  arrowhead,
-  color,
-  dropShadow,
-  geometry,
-  highlight,
-  highlightColor,
-  id,
-  strokeWidth,
-  useGradient,
-}: GesturePathProps) => {
-  const { path, segments } = geometry
-  const commonPathProps = {
-    strokeWidth: strokeWidth * 1.5,
-    strokeLinecap: 'round' as const,
-    strokeLinejoin: 'round' as const,
-    fill: 'none' as const,
-    style: dropShadow ? { filter: dropShadow } : undefined,
-  }
-  const allHighlighted = highlight != null && highlight >= path.length
-  const noneHighlighted = highlight == null || highlight === 0
-  const markerEnd = arrowhead !== 'none' ? `url(#${id})` : undefined
-  const activeColor = highlightColor ?? token('colors.vividHighlight')
-  const inactiveColor = color ?? token('colors.fg')
-
-  // Combined-path rendering for straight, solid-color paths. Using a single <path>
-  // with strokeLinejoin='round' avoids overlapping round caps at joints, which
-  // become visible as blobs/beads when strokeWidth is large relative to segment length.
-  if (!useGradient && segments[0]?.kind === 'line' && path !== 'rdld') {
-    if (allHighlighted || noneHighlighted) {
-      return (
-        <path
-          d={gesturePathData(segments)}
-          stroke={allHighlighted ? activeColor : inactiveColor}
-          markerEnd={markerEnd}
-          {...commonPathProps}
-        />
-      )
-    }
-
-    return (
-      <>
-        <path d={gesturePathData(segments.slice(0, highlight))} stroke={activeColor} {...commonPathProps} />
-        <path
-          d={gesturePathData(segments.slice(highlight))}
-          stroke={inactiveColor}
-          markerEnd={markerEnd}
-          {...commonPathProps}
-        />
-      </>
-    )
-  }
-
-  // Combined-path rendering for the rdld (Command Universe) solid-color special case.
-  if (!useGradient && path === 'rdld') {
-    if (allHighlighted || noneHighlighted) {
-      return (
-        <path
-          d={gesturePathData(segments)}
-          stroke={allHighlighted ? activeColor : inactiveColor}
-          {...commonPathProps}
-        />
-      )
-    }
-
-    return (
-      <>
-        {highlight! > 0 && (
-          <path d={gesturePathData(segments.slice(0, highlight))} stroke={activeColor} {...commonPathProps} />
-        )}
-        <path d={gesturePathData(segments.slice(highlight))} stroke={inactiveColor} {...commonPathProps} />
-      </>
-    )
-  }
-
-  // Per-segment rendering for gradient or rounded paths.
-  return (
-    <>
-      {segments.map((segment, i) => {
-        const stroke = useGradient
-          ? `url(#${geometry.extendedPath}-gradient-${i})`
-          : highlight != null && (i < highlight || highlight === path.length)
-            ? activeColor
-            : inactiveColor
-        return (
-          <path
-            d={segmentPathData(segment, path)}
-            key={i}
-            stroke={stroke}
-            {...commonPathProps}
-            markerEnd={i === segments.length - 1 && path !== 'rdld' && arrowhead !== 'none' ? markerEnd : undefined}
-          />
-        )
-      })}
-    </>
-  )
-}
-
 /** Renders an SVG representation of a gesture.
  *
  * @param path Any combination of l/r/u/d,or null for a cancel gesture (X).
@@ -312,7 +80,8 @@ const GestureDiagram = ({
   useGradient = true,
   highlightColor,
 }: GestureDiagramProps) => {
-  const [id] = useState(nanoid())
+  // One stable prefix keeps this diagram's marker, masks, and gradients unique in the document.
+  const [instanceId] = useState(nanoid)
 
   // match signaturePad shadow in TraceGesture component
   // TODO: Why isn't this working?
@@ -368,8 +137,6 @@ const GestureDiagram = ({
     )
   }
 
-  const { extendedPath, segments } = geometry!
-
   /** Crop the viewbox to the diagram and adjust the svg element's height when first rendered. */
   const onRef = (el: SVGGraphicsElement | null) => {
     if (!el) return
@@ -409,84 +176,41 @@ const GestureDiagram = ({
         viewBox={viewBox}
       >
         <defs>
-          {arrowhead !== 'none' && (
-            <marker
-              id={id}
-              viewBox='0 0 10 10'
-              refX={rounded ? '0' : '5'}
-              refY='5'
-              markerWidth={arrowSize! * (arrowhead === 'outlined' ? 2 : 1)}
-              markerHeight={arrowSize! * (arrowhead === 'outlined' ? 3 : 1)}
-              markerUnits='userSpaceOnUse'
-              orient='auto-start-reverse'
-            >
-              <path
-                d={
-                  arrowhead === 'filled'
-                    ? 'M 0 0 L 10 5 L 0 10 z'
-                    : arrowhead === 'outlined'
-                      ? 'M 0 0 L 5 5 L 0 10'
-                      : undefined
-                }
-                fill={
-                  arrowhead === 'outlined'
-                    ? 'none'
-                    : highlight != null && highlight >= path.length
-                      ? (highlightColor ?? token('colors.vividHighlight'))
-                      : (color ?? token('colors.fg'))
-                }
-                stroke={arrowhead === 'outlined' ? (color ?? token('colors.fg')) : 'none'}
-                strokeWidth={arrowhead === 'outlined' ? strokeWidth / 3 : 0}
-                style={dropShadow ? { filter: dropShadow } : undefined}
-              />
-            </marker>
-          )}
-          {useGradient && (
-            <>
-              {extendedPath === 'rdld' ? (
-                <MobileCommandUniverseGradients />
-              ) : (
-                segments.map((segment, i) => {
-                  return segment.kind === 'arc' ? (
-                    <ArcGradient
-                      key={`${extendedPath}-gradient-${i}`}
-                      index={i}
-                      extendedPath={extendedPath}
-                      segment={segment}
-                    />
-                  ) : (
-                    <linearGradient
-                      id={`${extendedPath}-gradient-${i}`}
-                      key={`${extendedPath}-gradient-${i}`}
-                      gradientUnits='userSpaceOnUse'
-                      x1={segment.from.x}
-                      x2={segment.to.x}
-                      y1={segment.from.y}
-                      y2={segment.to.y}
-                    >
-                      <stop offset='0%' className={`${extendedPath}-gradient-${i}-start`} />
-                      <stop offset='100%' className={`${extendedPath}-gradient-${i}-stop`} />
-                    </linearGradient>
-                  )
-                })
-              )}
-            </>
-          )}
+          <ArrowheadMarker
+            arrowSize={arrowSize!}
+            color={color}
+            dropShadow={dropShadow}
+            highlightColor={highlightColor}
+            highlighted={highlight != null && highlight >= path.length}
+            instanceId={instanceId}
+            kind={arrowhead}
+            rounded={rounded}
+            strokeWidth={strokeWidth}
+          />
         </defs>
 
-        {useGradient && <GradientStyleBlock color={color} highlight={highlight} path={extendedPath} />}
-
-        <GesturePath
-          arrowhead={arrowhead}
-          color={color}
-          dropShadow={dropShadow}
-          geometry={geometry!}
-          highlight={highlight}
-          highlightColor={highlightColor}
-          id={id}
-          strokeWidth={strokeWidth}
-          useGradient={useGradient}
-        />
+        {useGradient ? (
+          <SegmentedGradientGestureRenderer
+            arrowhead={arrowhead}
+            color={color}
+            dropShadow={dropShadow}
+            geometry={geometry!}
+            highlight={highlight}
+            instanceId={instanceId}
+            strokeWidth={strokeWidth}
+          />
+        ) : (
+          <SolidGestureRenderer
+            arrowhead={arrowhead}
+            color={color}
+            dropShadow={dropShadow}
+            geometry={geometry!}
+            highlight={highlight}
+            highlightColor={highlightColor}
+            instanceId={instanceId}
+            strokeWidth={strokeWidth}
+          />
+        )}
       </svg>
     </span>
   )

--- a/src/components/GestureDiagram/ArrowheadMarker.tsx
+++ b/src/components/GestureDiagram/ArrowheadMarker.tsx
@@ -1,0 +1,64 @@
+import { token } from '../../../styled-system/tokens'
+import GestureArrowhead from './types/GestureArrowhead'
+
+interface ArrowheadMarkerProps {
+  /** Length of the marker in SVG user units. */
+  arrowSize: number
+  /** Solid fallback color for the marker. */
+  color?: string
+  /** Drop-shadow filter shared with the gesture stroke. */
+  dropShadow?: string
+  /** Color used when the complete gesture is highlighted. */
+  highlightColor?: string
+  /** Whether the complete gesture is highlighted. */
+  highlighted: boolean
+  /** Stable identifier shared by one GestureDiagram instance. */
+  instanceId: string
+  /** Marker shape to define, or none to omit it. */
+  kind: GestureArrowhead
+  /** Whether the gesture uses the legacy rounded-arc topology. */
+  rounded?: boolean
+  /** Base gesture stroke width. */
+  strokeWidth: number
+}
+
+/** Defines the conventional SVG marker referenced by a gesture renderer. */
+const ArrowheadMarker = ({
+  arrowSize,
+  color,
+  dropShadow,
+  highlightColor,
+  highlighted,
+  instanceId,
+  kind,
+  rounded,
+  strokeWidth,
+}: ArrowheadMarkerProps) => {
+  if (kind === 'none') return null
+
+  const outlined = kind === 'outlined'
+  const markerColor = highlighted ? (highlightColor ?? token('colors.vividHighlight')) : (color ?? token('colors.fg'))
+
+  return (
+    <marker
+      id={`${instanceId}-arrowhead`}
+      viewBox='0 0 10 10'
+      refX={rounded ? '0' : '5'}
+      refY='5'
+      markerWidth={arrowSize * (outlined ? 2 : 1)}
+      markerHeight={arrowSize * (outlined ? 3 : 1)}
+      markerUnits='userSpaceOnUse'
+      orient='auto-start-reverse'
+    >
+      <path
+        d={outlined ? 'M 0 0 L 5 5 L 0 10' : 'M 0 0 L 10 5 L 0 10 z'}
+        fill={outlined ? 'none' : markerColor}
+        stroke={outlined ? markerColor : 'none'}
+        strokeWidth={outlined ? strokeWidth / 3 : 0}
+        style={dropShadow ? { filter: dropShadow } : undefined}
+      />
+    </marker>
+  )
+}
+
+export default ArrowheadMarker

--- a/src/components/GestureDiagram/SegmentedGradientGestureRenderer.tsx
+++ b/src/components/GestureDiagram/SegmentedGradientGestureRenderer.tsx
@@ -1,0 +1,187 @@
+import { token } from '../../../styled-system/tokens'
+import Gesture from '../../@types/Gesture'
+import GestureArrowhead from './types/GestureArrowhead'
+import GestureGeometry from './types/GestureGeometry'
+import GestureSegment from './types/GestureSegment'
+
+type ArcGestureSegment = Extract<GestureSegment, { kind: 'arc' }>
+
+interface SegmentedGradientGestureRendererProps {
+  /** Marker style attached to the final rendered segment. */
+  arrowhead: GestureArrowhead
+  /** Gradient endpoint and highlighted marker fallback. */
+  color?: string
+  /** Drop-shadow filter applied to the gesture segments. */
+  dropShadow?: string
+  /** Canonical shape to paint. */
+  geometry: GestureGeometry
+  /** Number of semantic directions to highlight. */
+  highlight?: number
+  /** Stable identifier shared by one GestureDiagram instance. */
+  instanceId: string
+  /** Base gesture stroke width. */
+  strokeWidth: number
+}
+
+/** Defines the four historical gradients used by the rdld question-mark glyph. */
+const MobileCommandUniverseGradients = () => (
+  <>
+    <radialGradient cx={29.7} cy={13.5} r={33.3} id='rdld-gradient-0' gradientUnits='userSpaceOnUse'>
+      <stop offset='0%' className='rdld-gradient-0-start' />
+      <stop offset='100%' className='rdld-gradient-0-stop' />
+    </radialGradient>
+    <linearGradient id='rdld-gradient-1' gradientUnits='userSpaceOnUse'>
+      <stop offset='0%' className='rdld-gradient-1-start' />
+      <stop offset='100%' className='rdld-gradient-1-stop' />
+    </linearGradient>
+    <radialGradient cx={54} cy={40.5} r={18.5} id='rdld-gradient-2' gradientUnits='userSpaceOnUse'>
+      <stop offset='0%' className='rdld-gradient-2-start' />
+      <stop offset='100%' className='rdld-gradient-2-stop' />
+    </radialGradient>
+    <linearGradient x1={45} y1={58.5} x2={45} y2={72} id='rdld-gradient-3' gradientUnits='userSpaceOnUse'>
+      <stop offset='0%' className='rdld-gradient-3-start' />
+      <stop offset='100%' className='rdld-gradient-3-stop' />
+    </linearGradient>
+  </>
+)
+
+/** Defines the historical radial gradient used for one rounded arc. */
+const ArcGradient = ({
+  extendedPath,
+  index,
+  segment,
+}: {
+  /** Gesture string used to namespace the legacy gradient. */
+  extendedPath: Gesture
+  /** Index of this gradient within the gesture. */
+  index: number
+  /** Circular arc painted by the gradient. */
+  segment: ArcGestureSegment
+}) => (
+  <radialGradient
+    cx={segment.from.x}
+    cy={segment.from.y}
+    r={segment.radius}
+    id={`${extendedPath}-gradient-${index}`}
+    gradientUnits='userSpaceOnUse'
+  >
+    <stop offset='0%' className={`${extendedPath}-gradient-${index}-start`} />
+    <stop offset='100%' className={`${extendedPath}-gradient-${index}-stop`} />
+  </radialGradient>
+)
+
+/** Defines the legacy per-segment gradient colors and highlight overrides. */
+const GradientStyleBlock = ({
+  color,
+  highlight,
+  path,
+}: {
+  /** Gradient endpoint. */
+  color?: string
+  /** Number of semantic directions to highlight. */
+  highlight?: number
+  /** Extended gesture used to identify each gradient. */
+  path: Gesture
+}) => {
+  const extendedSegmentIndex = path === 'rdl' ? 3 : path === 'ldr' ? 2 : undefined
+  // The first segment starts faint, intermediate segments continue at half opacity, and the final segment reaches full opacity.
+  const stopColors = Array.from(path).map((_, index) =>
+    index === 0 ? 25 : path.length > 2 && index === path.length - 1 ? 75 : 50,
+  )
+
+  return (
+    <style>
+      {stopColors.map((startPercent, index) => {
+        const stopPercent = index === path.length - 1 ? 100 : stopColors[index + 1]
+        // The synthetic rdl/ldr segment inherits the highlight state of its semantic direction.
+        const stopColor =
+          highlight != null &&
+          (index < highlight ||
+            highlight === path.length ||
+            (highlight === extendedSegmentIndex && index === extendedSegmentIndex))
+            ? token('colors.vividHighlight')
+            : color || token('colors.fg')
+
+        return `
+          .${path}-gradient-${index}-start { stop-color: color-mix(in srgb, ${stopColor} ${startPercent}%, ${token('colors.bg')}) }
+          .${path}-gradient-${index}-stop { stop-color: color-mix(in srgb, ${stopColor} ${stopPercent}%, ${token('colors.bg')}) }
+        `
+      })}
+    </style>
+  )
+}
+
+/** Serializes one canonical segment as an independently paintable SVG path. */
+const serializeSegment = (segment: GestureSegment, path: Gesture) =>
+  segment.kind === 'line'
+    ? path === 'rdld'
+      ? `M ${segment.from.x},${segment.from.y} L ${segment.to.x},${segment.to.y}`
+      : `M ${segment.from.x} ${segment.from.y} l ${segment.to.x - segment.from.x} ${segment.to.y - segment.from.y}`
+    : segment.kind === 'arc'
+      ? `M ${segment.from.x} ${segment.from.y} A ${segment.radius} ${segment.radius} 0 0 ${segment.sweepFlag} ${segment.to.x} ${segment.to.y}`
+      : `M ${segment.from.x},${segment.from.y} Q ${segment.control.x},${segment.control.y} ${segment.to.x},${segment.to.y}`
+
+/** Paints the existing gradient mode, restarting a gradient on every geometry segment. */
+const SegmentedGradientGestureRenderer = ({
+  arrowhead,
+  color,
+  dropShadow,
+  geometry,
+  highlight,
+  instanceId,
+  strokeWidth,
+}: SegmentedGradientGestureRendererProps) => {
+  const { extendedPath, path, segments } = geometry
+  const commonPathProps = {
+    strokeWidth: strokeWidth * 1.5,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    fill: 'none' as const,
+    style: dropShadow ? { filter: dropShadow } : undefined,
+  }
+
+  return (
+    <>
+      <defs>
+        {extendedPath === 'rdld' ? (
+          <MobileCommandUniverseGradients />
+        ) : (
+          segments.map((segment, index) =>
+            segment.kind === 'arc' ? (
+              <ArcGradient key={index} index={index} extendedPath={extendedPath} segment={segment} />
+            ) : (
+              <linearGradient
+                id={`${extendedPath}-gradient-${index}`}
+                key={index}
+                gradientUnits='userSpaceOnUse'
+                x1={segment.from.x}
+                x2={segment.to.x}
+                y1={segment.from.y}
+                y2={segment.to.y}
+              >
+                <stop offset='0%' className={`${extendedPath}-gradient-${index}-start`} />
+                <stop offset='100%' className={`${extendedPath}-gradient-${index}-stop`} />
+              </linearGradient>
+            ),
+          )
+        )}
+      </defs>
+      <GradientStyleBlock color={color} highlight={highlight} path={extendedPath} />
+      {segments.map((segment, index) => (
+        <path
+          d={serializeSegment(segment, path)}
+          key={index}
+          stroke={`url(#${extendedPath}-gradient-${index})`}
+          {...commonPathProps}
+          markerEnd={
+            index === segments.length - 1 && path !== 'rdld' && arrowhead !== 'none'
+              ? `url(#${instanceId}-arrowhead)`
+              : undefined
+          }
+        />
+      ))}
+    </>
+  )
+}
+
+export default SegmentedGradientGestureRenderer

--- a/src/components/GestureDiagram/SolidGestureRenderer.tsx
+++ b/src/components/GestureDiagram/SolidGestureRenderer.tsx
@@ -1,0 +1,133 @@
+import { token } from '../../../styled-system/tokens'
+import GestureArrowhead from './types/GestureArrowhead'
+import GestureGeometry from './types/GestureGeometry'
+import GestureSegment from './types/GestureSegment'
+
+type ArcGestureSegment = Extract<GestureSegment, { kind: 'arc' }>
+
+interface SolidGestureRendererProps {
+  /** Marker style attached to the final rendered path. */
+  arrowhead: GestureArrowhead
+  /** Color of the unhighlighted gesture. */
+  color?: string
+  /** Drop-shadow filter applied to the gesture paths. */
+  dropShadow?: string
+  /** Canonical shape to paint. */
+  geometry: GestureGeometry
+  /** Number of semantic directions to paint with the highlight color. */
+  highlight?: number
+  /** Color of highlighted directions. */
+  highlightColor?: string
+  /** Stable identifier shared by one GestureDiagram instance. */
+  instanceId: string
+  /** Base gesture stroke width. */
+  strokeWidth: number
+}
+
+/** Serializes consecutive canonical segments as one continuous SVG path. */
+const serializeGesturePath = (segments: readonly GestureSegment[]) =>
+  segments.reduce((pathData, segment, index) => {
+    const commaSeparated = segments[0]?.kind === 'quadratic'
+    return `${pathData}${index === 0 ? `M ${segment.from.x}${commaSeparated ? ',' : ' '}${segment.from.y} ` : ' '}${
+      segment.kind === 'line'
+        ? `L ${segment.to.x}${commaSeparated ? ',' : ' '}${segment.to.y}`
+        : segment.kind === 'arc'
+          ? `A ${segment.radius} ${segment.radius} 0 0 ${segment.sweepFlag} ${segment.to.x} ${segment.to.y}`
+          : `Q ${segment.control.x},${segment.control.y} ${segment.to.x},${segment.to.y}`
+    }`
+  }, '')
+
+/** Serializes a legacy rounded segment, which is always a circular arc. */
+const serializeArc = (segment: ArcGestureSegment) =>
+  `M ${segment.from.x} ${segment.from.y} A ${segment.radius} ${segment.radius} 0 0 ${segment.sweepFlag} ${segment.to.x} ${segment.to.y}`
+
+/** Paints canonical gesture geometry with binary solid colors. */
+const SolidGestureRenderer = ({
+  arrowhead,
+  color,
+  dropShadow,
+  geometry,
+  highlight,
+  highlightColor,
+  instanceId,
+  strokeWidth,
+}: SolidGestureRendererProps) => {
+  const { path, segments } = geometry
+  const commonPathProps = {
+    strokeWidth: strokeWidth * 1.5,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    fill: 'none' as const,
+    style: dropShadow ? { filter: dropShadow } : undefined,
+  }
+  const allHighlighted = highlight != null && highlight >= path.length
+  const noneHighlighted = highlight == null || highlight === 0
+  const markerEnd = arrowhead === 'none' ? undefined : `url(#${instanceId}-arrowhead)`
+  const activeColor = highlightColor ?? token('colors.vividHighlight')
+  const inactiveColor = color ?? token('colors.fg')
+
+  // A single path prevents rounded caps from overlapping into visible beads at joins.
+  if (segments[0]?.kind === 'line' && path !== 'rdld') {
+    if (allHighlighted || noneHighlighted) {
+      return (
+        <path
+          d={serializeGesturePath(segments)}
+          stroke={allHighlighted ? activeColor : inactiveColor}
+          markerEnd={markerEnd}
+          {...commonPathProps}
+        />
+      )
+    }
+
+    // Extended geometry such as rdl → rddl still belongs to three semantic directions.
+    const highlighted = segments.filter(segment => segment.gestureIndex < highlight!)
+    const remaining = segments.slice(highlighted.length)
+    return (
+      <>
+        <path d={serializeGesturePath(highlighted)} stroke={activeColor} {...commonPathProps} />
+        <path d={serializeGesturePath(remaining)} stroke={inactiveColor} markerEnd={markerEnd} {...commonPathProps} />
+      </>
+    )
+  }
+
+  // The Command Universe question mark combines its quadratic and line segments into one path.
+  if (path === 'rdld') {
+    if (allHighlighted || noneHighlighted) {
+      return (
+        <path
+          d={serializeGesturePath(segments)}
+          stroke={allHighlighted ? activeColor : inactiveColor}
+          {...commonPathProps}
+        />
+      )
+    }
+
+    const highlighted = segments.filter(segment => segment.gestureIndex < highlight!)
+    const remaining = segments.slice(highlighted.length)
+    return (
+      <>
+        {highlighted.length > 0 && (
+          <path d={serializeGesturePath(highlighted)} stroke={activeColor} {...commonPathProps} />
+        )}
+        <path d={serializeGesturePath(remaining)} stroke={inactiveColor} {...commonPathProps} />
+      </>
+    )
+  }
+
+  // Legacy rounded gestures are independent arcs and cannot use the continuous line serializer.
+  return (
+    <>
+      {(segments as readonly ArcGestureSegment[]).map((segment, index) => (
+        <path
+          d={serializeArc(segment)}
+          key={index}
+          stroke={highlight != null && segment.gestureIndex < highlight ? activeColor : inactiveColor}
+          {...commonPathProps}
+          markerEnd={index === segments.length - 1 ? markerEnd : undefined}
+        />
+      ))}
+    </>
+  )
+}
+
+export default SolidGestureRenderer

--- a/src/components/__tests__/GestureDiagram.ts
+++ b/src/components/__tests__/GestureDiagram.ts
@@ -23,6 +23,12 @@ describe('GestureDiagram rendering modes', () => {
     expect(renderedPathData(markup)).toEqual(['M 0 0 L 50 0', 'M 50 0 L 50 50 L 100 50'])
   })
 
+  it('keeps synthetic geometry with the semantic direction it extends', () => {
+    const markup = render({ path: 'rdl', size: 100, arrowhead: 'none', useGradient: false, highlight: 2 })
+
+    expect(renderedPathData(markup)).toEqual(['M 0 0 L 50 0 L 50 50 L 50 100', 'M 50 100 L 0 100'])
+  })
+
   it('preserves the rdld Bezier geometry in solid mode', () => {
     const markup = render({ path: 'rdld', arrowhead: 'none', useGradient: false })
 


### PR DESCRIPTION
#4186

Extract the existing SVG rendering from `GestureDiagram` into three components local to `GestureDiagram`. Based on #5315; followed by #5317.

`GestureDiagram` builds geometry and selects the renderer. Both paint renderers receive `GestureGeometry`; the marker component receives the arrowhead options:

- `SolidGestureRenderer` handles `useGradient={false}` and binary active/inactive colors. It preserves @cindmichelle's combined-path technique, which avoids overlapping round caps at joins.
- `SegmentedGradientGestureRenderer` keeps the default per-segment gradients, progressive brightness, and bespoke `rdld` treatment.
- `ArrowheadMarker` defines the conventional filled and outlined SVG markers.

The shared `instanceId` is initialized once per diagram and prefixes its marker ID. Legacy segmented-gradient IDs still use `extendedPath`; this PR does not make those IDs unique per instance.

## Behavior changes to review

The extraction includes two highlighting changes:

- For `rdl` and `ldr`, the solid renderer selects segments by `gestureIndex`. With `rdl` and `highlight={2}`, both generated down segments now highlight together, matching the two directions the user completed.
- A fully highlighted outlined marker now uses `highlightColor`, like the filled marker. Previously its outline retained `color` even when the gesture was fully highlighted.

The geometry builder is unchanged. The new components stay local to `GestureDiagram`; they do not introduce an application-wide rendering API.

## Validation

The existing four rendering tests remain, and one new test covers the synthetic-segment highlight boundary. That test covers the `rdl` case; the outlined-marker color change has no dedicated assertion yet. The gesture-diagram snapshot file is unchanged.

For manual review, compare partially highlighted `rdl`/`ldr` gestures in solid mode, and compare an outlined marker before and after the whole gesture is highlighted.
