### PR TITLE
Add corners and chevrons to GestureGeometry

### DIFF
--- a/src/components/GestureDiagram.tsx
+++ b/src/components/GestureDiagram.tsx
@@ -48,6 +48,12 @@ interface GestureDiagramBaseProps {
   arrowhead?: GestureArrowhead
   /** When true, renders a drop-shadow glow filter on all path segments. Default: true. */
   glow?: boolean
+  /** Radius used to soften corners in line-based gradient gestures. */
+  cornerRadius?: number
+  /** Interior angle of the geometry-based wide chevron. Default 80. */
+  chevronApexAngle?: number
+  /** Chevron half-span as a multiple of the rendered stroke width. Default 2.2. */
+  chevronSize?: number
   /** Stroke color for highlighted directions. Default: token('colors.vividHighlight'). */
   highlightColor?: string
 }
@@ -95,6 +101,9 @@ const GestureDiagram = ({
   glow = true,
   useGradient = true,
   gradient,
+  cornerRadius = 0,
+  chevronApexAngle = 80,
+  chevronSize = 2.2,
   highlightColor,
 }: GestureDiagramProps) => {
   // One stable prefix keeps this diagram's marker, masks, and gradients unique in the document.
@@ -114,11 +123,27 @@ const GestureDiagram = ({
       path === null
         ? null
         : getGestureGeometry(path, {
+            chevron:
+              gradient && arrowhead === 'outlined-wide'
+                ? { apexAngle: chevronApexAngle, halfSpan: strokeWidth * 1.5 * chevronSize }
+                : undefined,
+            cornerRadius: gradient ? cornerRadius : 0,
             reversalOffset: reversalOffset!,
             rounded,
             size,
           }),
-    [path, reversalOffset, rounded, size],
+    [
+      arrowhead,
+      chevronApexAngle,
+      chevronSize,
+      cornerRadius,
+      path,
+      reversalOffset,
+      rounded,
+      size,
+      gradient,
+      strokeWidth,
+    ],
   )
 
   // If path is null, render a cancel gesture svg
@@ -200,7 +225,7 @@ const GestureDiagram = ({
             highlightColor={highlightColor}
             highlighted={highlight != null && highlight >= path.length}
             instanceId={instanceId}
-            kind={arrowhead}
+            kind={geometry!.chevron ? 'none' : arrowhead}
             rounded={rounded}
             strokeWidth={strokeWidth}
           />

--- a/src/components/GestureDiagram/ArrowheadMarker.tsx
+++ b/src/components/GestureDiagram/ArrowheadMarker.tsx
@@ -36,7 +36,8 @@ const ArrowheadMarker = ({
 }: ArrowheadMarkerProps) => {
   if (kind === 'none') return null
 
-  const outlined = kind === 'outlined'
+  // A solid outlined-wide arrow falls back to the conventional marker; gradient-wide arrows use geometry and omit this component.
+  const outlined = kind === 'outlined' || kind === 'outlined-wide'
   const markerColor = highlighted ? (highlightColor ?? token('colors.vividHighlight')) : (color ?? token('colors.fg'))
 
   return (

--- a/src/components/GestureDiagram/ContinuousGradientGestureRenderer.tsx
+++ b/src/components/GestureDiagram/ContinuousGradientGestureRenderer.tsx
@@ -88,7 +88,7 @@ const serializePiece = (points: readonly GesturePoint[]) =>
   points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ')
 
 /** Divides a polyline into pieces annotated with cumulative path distance. */
-const measureStrokePieces = (samples: readonly GesturePoint[]): StrokePiece[] => {
+const measureStrokePieces = (samples: readonly GesturePoint[]): { pieces: StrokePiece[]; length: number } => {
   // Repeated points have zero length and cannot define a useful linear gradient direction.
   const points = samples.filter(
     (point, index) => index === 0 || point.x !== samples[index - 1].x || point.y !== samples[index - 1].y,
@@ -101,13 +101,17 @@ const measureStrokePieces = (samples: readonly GesturePoint[]): StrokePiece[] =>
     [],
   )
   const length = cumulative.at(-1) ?? 0
-  return length === 0
-    ? []
-    : points.slice(1).map((point, index) => ({
-        points: [points[index], point],
-        start: cumulative[index] / length,
-        end: cumulative[index + 1] / length,
-      }))
+  return {
+    pieces:
+      length === 0
+        ? []
+        : points.slice(1).map((point, index) => ({
+            points: [points[index], point],
+            start: cumulative[index] / length,
+            end: cumulative[index + 1] / length,
+          })),
+    length,
+  }
 }
 
 /** Returns the percentage of the end color at one normalized path distance. */
@@ -150,7 +154,7 @@ const ContinuousGradientGestureRenderer = ({
   instanceId,
   strokeWidth,
 }: ContinuousGradientGestureRendererProps) => {
-  const pieces = measureStrokePieces(flattenGestureGeometry(geometry))
+  const { pieces, length } = measureStrokePieces(flattenGestureGeometry(geometry))
   const ramp: StrokeRamp = {
     from: gradient.from,
     to: gradient.to,
@@ -164,16 +168,34 @@ const ContinuousGradientGestureRenderer = ({
     fill: 'none' as const,
   }
   const markerEnd =
-    geometry.path !== 'rdld' && arrowhead !== 'none' && pieces.length ? `url(#${instanceId}-arrowhead)` : undefined
+    geometry.path !== 'rdld' && arrowhead !== 'none' && !geometry.chevron && pieces.length
+      ? `url(#${instanceId}-arrowhead)`
+      : undefined
+  const chevronMouth = geometry.chevron
+    ? {
+        x: (geometry.chevron[0].x + geometry.chevron[2].x) / 2,
+        y: (geometry.chevron[0].y + geometry.chevron[2].y) / 2,
+      }
+    : null
+  // The chevron uses the final portion of the same ramp rather than starting a new gradient.
+  const chevronPiece =
+    geometry.chevron && chevronMouth
+      ? {
+          points: [chevronMouth, geometry.chevron[1]] as const,
+          start:
+            1 - Math.hypot(geometry.chevron[1].x - chevronMouth.x, geometry.chevron[1].y - chevronMouth.y) / length,
+          end: 1,
+        }
+      : null
 
   /** Defines one local gradient along a short stroke piece. */
-  const renderGradient = (piece: StrokePiece, index: number, form: 'color' | 'alpha') => {
+  const renderGradient = (piece: StrokePiece, key: string, form: 'color' | 'alpha') => {
     const [first, last] = piece.points
     const [start, end] = getRampStops(ramp, piece, form)
     return (
       <linearGradient
-        key={`${form}-${index}`}
-        id={`${instanceId}-piece-${index}-${form}`}
+        key={`${form}-${key}`}
+        id={`${instanceId}-${key}-${form}`}
         gradientUnits='userSpaceOnUse'
         x1={first.x}
         y1={first.y}
@@ -197,6 +219,9 @@ const ContinuousGradientGestureRenderer = ({
           {...pathProps}
         />
       ))}
+      {geometry.chevron && (
+        <path d={serializePiece(geometry.chevron)} stroke={`url(#${instanceId}-chevron-${form})`} {...pathProps} />
+      )}
     </>
   )
 
@@ -207,8 +232,10 @@ const ContinuousGradientGestureRenderer = ({
   return (
     <g style={dropShadow ? { filter: dropShadow } : undefined}>
       <defs>
-        {pieces.map((piece, index) => renderGradient(piece, index, 'color'))}
-        {pieces.map((piece, index) => renderGradient(piece, index, 'alpha'))}
+        {pieces.map((piece, index) => renderGradient(piece, `piece-${index}`, 'color'))}
+        {chevronPiece && renderGradient(chevronPiece, 'chevron', 'color')}
+        {pieces.map((piece, index) => renderGradient(piece, `piece-${index}`, 'alpha'))}
+        {chevronPiece && renderGradient(chevronPiece, 'chevron', 'alpha')}
         {/* The mask preserves the requested alpha where rounded piece caps overlap. */}
         <mask
           id={`${instanceId}-alpha`}
@@ -228,6 +255,13 @@ const ContinuousGradientGestureRenderer = ({
       )}
       {/* Conventional markers have their own color and must not be clipped by the shaft's alpha mask. */}
       {markerEnd && <path d={serializePiece(pieces.at(-1)!.points)} fill='none' stroke='none' markerEnd={markerEnd} />}
+      {geometry.chevron && highlight != null && highlight >= geometry.path.length && (
+        <path
+          d={serializePiece(geometry.chevron)}
+          stroke={highlightColor ?? token('colors.vividHighlight')}
+          {...pathProps}
+        />
+      )}
     </g>
   )
 }

--- a/src/components/GestureDiagram/getGestureGeometry.ts
+++ b/src/components/GestureDiagram/getGestureGeometry.ts
@@ -87,8 +87,10 @@ const RDLD_SEGMENTS: readonly GestureSegment[] = [
   { kind: 'line', from: { x: 45, y: 58.5 }, to: { x: 45, y: 72 }, gestureIndex: 3 },
 ]
 
-/** Converts a gesture into the canonical line, arc, or quadratic segments used by every renderer. */
-const getGestureGeometry = (
+type BaseGestureGeometry = Omit<GestureGeometry, 'chevron'>
+
+/** Converts a gesture into its unadorned line, arc, or quadratic segments. */
+const getBaseGestureGeometry = (
   path: Gesture,
   {
     reversalOffset,
@@ -99,7 +101,7 @@ const getGestureGeometry = (
     rounded?: boolean
     size: number
   },
-): GestureGeometry => {
+): BaseGestureGeometry => {
   if (path === 'rdld') return { path, extendedPath: path, segments: RDLD_SEGMENTS }
 
   if (rounded) {
@@ -184,6 +186,121 @@ const getGestureGeometry = (
     gestureIndex: gestureIndexes[i],
   }))
   return { path, extendedPath, segments }
+}
+
+/** Returns a point a limited distance from the first point toward the second. */
+const pointTowards = (from: GesturePoint, to: GesturePoint, distance: number): GesturePoint => {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const length = Math.hypot(dx, dy) || 1
+  // Limiting the offset to half the segment prevents neighboring corners from crossing.
+  const offset = Math.min(distance, length / 2)
+  return { x: from.x + (dx / length) * offset, y: from.y + (dy / length) * offset }
+}
+
+/** Replaces each interior vertex of line geometry with a quadratic corner. */
+const softenCorners = (geometry: BaseGestureGeometry, cornerRadius: number): BaseGestureGeometry => {
+  if (cornerRadius <= 0 || geometry.segments.length < 2 || geometry.segments.some(segment => segment.kind !== 'line')) {
+    return geometry
+  }
+
+  const lines = geometry.segments as readonly LineGestureSegment[]
+  const points = [lines[0].from, ...lines.map(segment => segment.to)]
+  const segments = points.slice(1, -1).reduce<GestureSegment[]>((softened, vertex, index) => {
+    const before = pointTowards(vertex, points[index], cornerRadius)
+    const after = pointTowards(vertex, points[index + 2], cornerRadius)
+    const from = softened.at(-1)?.to ?? points[0]
+    return [
+      ...softened,
+      { kind: 'line', from, to: before, gestureIndex: lines[index].gestureIndex },
+      {
+        kind: 'quadratic',
+        from: before,
+        control: vertex,
+        to: after,
+        gestureIndex: lines[index].gestureIndex,
+      },
+    ]
+  }, [])
+  const from = segments.at(-1)?.to ?? points[0]
+  return {
+    ...geometry,
+    segments: [...segments, { kind: 'line', from, to: points.at(-1)!, gestureIndex: lines.at(-1)!.gestureIndex }],
+  }
+}
+
+/** Returns the final direction vector of a canonical segment. */
+const getEndTangent = (segment: GestureSegment): GesturePoint => {
+  if (segment.kind === 'line') return { x: segment.to.x - segment.from.x, y: segment.to.y - segment.from.y }
+  if (segment.kind === 'quadratic') return { x: segment.to.x - segment.control.x, y: segment.to.y - segment.control.y }
+
+  const radians = (segment.endAngle * Math.PI) / 180
+  const radial = { x: Math.cos(radians), y: Math.sin(radians) }
+  return segment.sweepFlag === 1 ? { x: -radial.y, y: radial.x } : { x: radial.y, y: -radial.x }
+}
+
+/** Constructs a chevron whose apex follows the final gesture tangent. */
+const getChevron = (
+  tip: GesturePoint,
+  tangent: GesturePoint,
+  {
+    apexAngle,
+    halfSpan,
+  }: {
+    /** Interior angle at the chevron apex. */
+    apexAngle: number
+    /** Perpendicular distance from the centerline to either leg. */
+    halfSpan: number
+  },
+): readonly [GesturePoint, GesturePoint, GesturePoint] => {
+  const length = Math.hypot(tangent.x, tangent.y) || 1
+  const forwardX = tangent.x / length
+  const forwardY = tangent.y / length
+  const sideX = -forwardY
+  const sideY = forwardX
+  const depth = halfSpan / Math.max(Math.tan((apexAngle / 2) * (Math.PI / 180)), 0.01)
+  const legsX = tip.x - (forwardX * depth) / 2
+  const legsY = tip.y - (forwardY * depth) / 2
+  return [
+    { x: legsX + sideX * halfSpan, y: legsY + sideY * halfSpan },
+    { x: legsX + forwardX * depth, y: legsY + forwardY * depth },
+    { x: legsX - sideX * halfSpan, y: legsY - sideY * halfSpan },
+  ]
+}
+
+/** Builds the complete canonical shape consumed by paint and framing. */
+const getGestureGeometry = (
+  path: Gesture,
+  {
+    chevron,
+    cornerRadius = 0,
+    reversalOffset,
+    rounded,
+    size,
+  }: {
+    /** Dimensions of a geometry-based chevron, or undefined for an SVG marker. */
+    chevron?: { apexAngle: number; halfSpan: number }
+    /** Radius used to soften vertices in line geometry. */
+    cornerRadius?: number
+    /** Orthogonal offset used to separate reversing directions. */
+    reversalOffset: number
+    /** Whether to construct the legacy circular-arc topology. */
+    rounded?: boolean
+    /** Nominal gesture extent in SVG user units. */
+    size: number
+  },
+): GestureGeometry => {
+  const geometry = softenCorners(getBaseGestureGeometry(path, { reversalOffset, rounded, size }), cornerRadius)
+  if (!chevron || path === 'rdld') return { ...geometry, chevron: null }
+
+  const finalSegment = geometry.segments.at(-1)!
+  const chevronPoints = getChevron(finalSegment.to, getEndTangent(finalSegment), chevron)
+  return {
+    ...geometry,
+    // Extending the centerline to the apex lets the gradient finish at the gesture's visual tip.
+    segments: [...geometry.segments.slice(0, -1), { ...finalSegment, to: chevronPoints[1] }] as GestureSegment[],
+    chevron: chevronPoints,
+  }
 }
 
 export default getGestureGeometry

--- a/src/components/GestureDiagram/getGestureGeometry.ts
+++ b/src/components/GestureDiagram/getGestureGeometry.ts
@@ -297,8 +297,15 @@ const getGestureGeometry = (
   const chevronPoints = getChevron(finalSegment.to, getEndTangent(finalSegment), chevron)
   return {
     ...geometry,
-    // Extending the centerline to the apex lets the gradient finish at the gesture's visual tip.
-    segments: [...geometry.segments.slice(0, -1), { ...finalSegment, to: chevronPoints[1] }] as GestureSegment[],
+    // An arc's endpoint is fixed by its circle and angles. Add a tangent line so the
+    // centerline and its gradient reach the apex without changing the circular shape.
+    segments:
+      finalSegment.kind === 'arc'
+        ? [
+            ...geometry.segments,
+            { kind: 'line', from: finalSegment.to, to: chevronPoints[1], gestureIndex: finalSegment.gestureIndex },
+          ]
+        : [...geometry.segments.slice(0, -1), { ...finalSegment, to: chevronPoints[1] }],
     chevron: chevronPoints,
   }
 }

--- a/src/components/GestureDiagram/types/GestureArrowhead.ts
+++ b/src/components/GestureDiagram/types/GestureArrowhead.ts
@@ -1,4 +1,4 @@
 /** Arrowhead style rendered at the end of a gesture. */
-type GestureArrowhead = 'filled' | 'outlined' | 'none'
+type GestureArrowhead = 'filled' | 'outlined' | 'outlined-wide' | 'none'
 
 export default GestureArrowhead

--- a/src/components/GestureDiagram/types/GestureGeometry.ts
+++ b/src/components/GestureDiagram/types/GestureGeometry.ts
@@ -1,4 +1,5 @@
 import Gesture from '../../../@types/Gesture'
+import GesturePoint from './GesturePoint'
 import GestureSegment from './GestureSegment'
 
 /** Canonical gesture geometry before paint or framing is applied. */
@@ -9,6 +10,8 @@ interface GestureGeometry {
   extendedPath: Gesture
   /** Ordered geometric segments associated with their semantic directions. */
   segments: readonly GestureSegment[]
+  /** Wide chevron points, or null when the arrowhead uses an SVG marker. */
+  chevron: readonly [GesturePoint, GesturePoint, GesturePoint] | null
 }
 
 export default GestureGeometry

--- a/src/components/__tests__/GestureDiagram.ts
+++ b/src/components/__tests__/GestureDiagram.ts
@@ -108,3 +108,49 @@ describe('continuous path-length gradient', () => {
     expect(glyphStops.length).toBeGreaterThan(20)
   })
 })
+
+describe('gesture shape', () => {
+  const gradient = { from: '#111', to: '#eee' }
+
+  /** Parses the coordinates from a path containing only move and line commands. */
+  const pointsOf = (pathData: string) => {
+    const values = pathData.match(/-?[\d.]+/g)!.map(Number)
+    return Array.from({ length: values.length / 2 }, (_, index) => ({
+      x: values[index * 2],
+      y: values[index * 2 + 1],
+    }))
+  }
+
+  it('samples softened corners into additional gradient pieces', () => {
+    const sharp = render({ path: 'rdr', gradient, arrowhead: 'none' })
+    const soft = render({ path: 'rdr', gradient, arrowhead: 'none', cornerRadius: 5 })
+
+    expect(soft.match(/-piece-\d+-color/g)!.length).toBeGreaterThan(sharp.match(/-piece-\d+-color/g)!.length)
+  })
+
+  it('draws an outlined-wide chevron at the requested apex angle', () => {
+    const markup = render({
+      path: 'rdr',
+      gradient,
+      arrowhead: 'outlined-wide',
+      chevronApexAngle: 60,
+      chevronSize: 2.2,
+    })
+    const chevron = pointsOf(renderedPathData(markup).at(-1)!)
+    const [leg1, apex, leg2] = chevron
+    const a = { x: leg1.x - apex.x, y: leg1.y - apex.y }
+    const b = { x: leg2.x - apex.x, y: leg2.y - apex.y }
+    const cosine = (a.x * b.x + a.y * b.y) / (Math.hypot(a.x, a.y) * Math.hypot(b.x, b.y))
+
+    expect(markup).not.toContain('marker-end')
+    expect((Math.acos(cosine) * 180) / Math.PI).toBeCloseTo(60)
+  })
+
+  it('keeps the rdld glyph arrowhead-free', () => {
+    const markup = render({ path: 'rdld', gradient, arrowhead: 'outlined-wide' })
+    const gradientPieceCount = [...markup.matchAll(/<linearGradient id="[^"]+-piece-\d+-color"/g)].length
+
+    expect(markup).not.toContain('marker-end')
+    expect(renderedPathData(markup)).toHaveLength(gradientPieceCount)
+  })
+})

--- a/src/components/__tests__/GestureDiagram.ts
+++ b/src/components/__tests__/GestureDiagram.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import GestureDiagram from '../GestureDiagram'
+import getGestureGeometry from '../GestureDiagram/getGestureGeometry'
 
 /** Renders a gesture diagram to static SVG markup. */
 const render = (props: Parameters<typeof GestureDiagram>[0]) =>
@@ -9,6 +10,15 @@ const render = (props: Parameters<typeof GestureDiagram>[0]) =>
 /** Returns the path data rendered outside the defs block. */
 const renderedPathData = (markup: string) =>
   [...markup.replace(/<defs>.*?<\/defs>/gs, '').matchAll(/ d="([^"]+)"/g)].map(([, pathData]) => pathData)
+
+/** Parses the coordinates from a path containing only move and line commands. */
+const pointsOf = (pathData: string) => {
+  const values = pathData.match(/-?[\d.]+/g)!.map(Number)
+  return Array.from({ length: values.length / 2 }, (_, index) => ({
+    x: values[index * 2],
+    y: values[index * 2 + 1],
+  }))
+}
 
 describe('GestureDiagram rendering modes', () => {
   it('renders a solid gesture as one combined path', () => {
@@ -107,19 +117,34 @@ describe('continuous path-length gradient', () => {
     expect(roundedStops.length).toBeGreaterThan(20)
     expect(glyphStops.length).toBeGreaterThan(20)
   })
+
+  // https://github.com/cybersemics/em/pull/5318
+  it('matches the circular shaft and chevron colors where they join', () => {
+    const markup = render({ ...props, path: 'rul', rounded: true, arrowhead: 'outlined-wide', gradient })
+    const arcEnd = getGestureGeometry('rul', { rounded: true, size: props.size, reversalOffset: 45 }).segments.at(
+      -1,
+    )!.to
+    const shaftPaths = renderedPathData(markup).slice(0, -1)
+    const joinIndex = shaftPaths.findIndex(pathData => {
+      const end = pointsOf(pathData).at(-1)!
+      return Math.hypot(end.x - arcEnd.x, end.y - arcEnd.y) < 1e-6
+    })
+    const document = new DOMParser().parseFromString(markup, 'text/html')
+    const chevronStops = Array.from(document.querySelectorAll('linearGradient[id$="-chevron-color"] stop')).map(stop =>
+      mixOf(stop.getAttribute('style')!),
+    )
+    const shaftStops = gradientStops(markup)
+
+    expect(joinIndex).toBeGreaterThanOrEqual(0)
+    expect(chevronStops).toHaveLength(2)
+    // The original arc endpoint is halfway between the chevron's mouth and apex.
+    expect(mixOf(shaftStops[joinIndex].end)).toBeCloseTo((chevronStops[0] + chevronStops[1]) / 2, 1)
+    expect(mixOf(shaftStops.at(-1)!.end)).toBe(100)
+  })
 })
 
 describe('gesture shape', () => {
   const gradient = { from: '#111', to: '#eee' }
-
-  /** Parses the coordinates from a path containing only move and line commands. */
-  const pointsOf = (pathData: string) => {
-    const values = pathData.match(/-?[\d.]+/g)!.map(Number)
-    return Array.from({ length: values.length / 2 }, (_, index) => ({
-      x: values[index * 2],
-      y: values[index * 2 + 1],
-    }))
-  }
 
   it('samples softened corners into additional gradient pieces', () => {
     const sharp = render({ path: 'rdr', gradient, arrowhead: 'none' })
@@ -152,5 +177,20 @@ describe('gesture shape', () => {
 
     expect(markup).not.toContain('marker-end')
     expect(renderedPathData(markup)).toHaveLength(gradientPieceCount)
+  })
+
+  // https://github.com/cybersemics/em/pull/5318
+  it('preserves circular arcs and connects their endpoint to the chevron apex', () => {
+    const options = { rounded: true, size: 150, reversalOffset: 45 }
+    const circular = getGestureGeometry('rul', options)
+    const geometry = getGestureGeometry('rul', { ...options, chevron: { apexAngle: 80, halfSpan: 39.6 } })
+
+    expect(geometry.segments.slice(0, -1)).toEqual(circular.segments)
+    expect(geometry.segments.at(-1)).toEqual({
+      kind: 'line',
+      from: circular.segments.at(-1)!.to,
+      to: geometry.chevron![1],
+      gestureIndex: 2,
+    })
   })
 })


### PR DESCRIPTION
#4186

Add corner softening and a wide chevron to the geometry used by continuous-gradient gestures. Based on #5317; followed by #5319.

`getGestureGeometry` calculates the new points. `ContinuousGradientGestureRenderer` paints them, including a chevron ramp drawn from the final portion of the gesture's gradient.

## Shape options

| Prop | Behavior |
| --- | --- |
| `cornerRadius` | Shortens the lines on either side of each interior vertex and joins them with a quadratic Bézier. Defaults to `0`. |
| `arrowhead='outlined-wide'` | Requests a geometry-based chevron. |
| `chevronApexAngle` | Interior angle at the tip, in degrees. Defaults to `80`. |
| `chevronSize` | Half-span as a multiple of rendered stroke width. Defaults to `2.2`. |

Corner shortening is capped at half each neighboring line's length. It applies only to all-line geometry; the existing circular gestures and `rdld` quadratics are not softened again.

The chevron follows the final segment's tangent. A circular arc's endpoint is determined by its circle and angles, so circular gestures retain that endpoint and add a short tangent line to the chevron apex. That line belongs to the final semantic direction and contributes to the measured path length, so the shaft and chevron use the same gradient position where they meet. The chevron points are stored on `GestureGeometry` and use the last portion of the same ramp. A fully highlighted gesture paints the chevron in the highlight color. `rdld` remains arrowhead-free. Conventional filled and outlined arrowheads remain SVG markers.

These options currently take effect only when `gradient` is supplied. Without it, `cornerRadius` is ignored and `outlined-wide` falls back to the conventional outlined marker. The public types still permit those ignored combinations.

## Validation

Five tests cover additional sampling for softened corners, the requested chevron angle without `marker-end`, the arrowhead-free `rdld` glyph, preserved circular arcs with a connected tip, and matching shaft/chevron colors at the join. The gesture-diagram snapshot file is unchanged; visual fixtures arrive in #5320.

The TDD control below is the original shape commit, which reproduces both the missing connection and the color discontinuity.

/tdd 3a761c454831e36a5b4b9c6499cd0083f77f4891
