### PR TITLE
Scope WebdriverIO's global types to the iOS tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -432,6 +432,12 @@ WebdriverIO tests provide automated test coverage of actual iOS devices (among o
 
 The configuration files live in [src/e2e/iOS/config](../src/e2e/iOS/config). [wdio.base.conf.ts](../src/e2e/iOS/config/wdio.base.conf.ts) contains common iOS Safari settings and lifecycle hooks. [wdio.browserstack.conf.ts](../src/e2e/iOS/config/wdio.browserstack.conf.ts) loads credentials, starts the Cloudflare tunnel, and configures `@wdio/browserstack-service`. [wdio.local.conf.ts](../src/e2e/iOS/config/wdio.local.conf.ts) configures local Appium and the iOS Simulator.
 
+#### TypeScript for the iOS tests
+
+The iOS tests are typechecked by their own [`src/e2e/iOS/tsconfig.json`](../src/e2e/iOS/tsconfig.json), which is the only program that declares WebdriverIO's globals — `browser`, `$`, `$$`, and `expect` from `@wdio/globals/types`, mocha's `describe`/`it` via `@wdio/mocha-framework`, and `@wdio/browserstack-service`'s global interfaces (`State`, `GRRUrls`, …). The root `tsconfig.json` excludes `src/e2e/iOS`, so none of those exist for app code: a file that forgets to import the app's own `State` fails to compile instead of silently binding to BrowserStack's. `yarn lint` runs both programs (`lint:tsc`), and editors pick the nearest `tsconfig.json`, so each file sees the globals of the runtime it targets.
+
+A module shared with the app is checked by both programs and therefore cannot reference `browser`. The console proxy is split along that line: [`src/util/consoleProxy.ts`](../src/util/consoleProxy.ts) is the app side and owns the storage key and record shape, while draining the buffer and waiting for the proxy to install live in [`wdio.base.conf.ts`](../src/e2e/iOS/config/wdio.base.conf.ts).
+
 #### Origin health check
 
 An iOS run is only as good as the origin it loads, and a wrong origin is indistinguishable from a working one to a naive check: a Cloudflare edge error page (502, 1033, "can't reach origin") and the Vite token gate's `403` are both well-formed HTML documents with a `<body>`. Two hooks in [`wdio.base.conf.ts`](../src/e2e/iOS/config/wdio.base.conf.ts) assert the page is actually em:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -215,6 +215,21 @@ export default [
       },
     },
   },
+  // The iOS WebdriverIO tests are typechecked by their own tsconfig, the only program that declares
+  // WebdriverIO's globals (browser, $, expect) and @wdio/browserstack-service's global interfaces. The root
+  // tsconfig excludes src/e2e/iOS, so type-aware linting of those files has to use theirs.
+  {
+    files: ['./src/e2e/iOS/**/*.ts'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        project: './src/e2e/iOS/tsconfig.json',
+      },
+    },
+  },
   {
     files: ['./src/e2e/**/*.ts'],
     rules: {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:no-npm": "node ./scripts/no-files.js package-lock.json",
     "lint:prettier": "FORCE_COLOR=1 prettier --check .",
     "lint:src": "FORCE_COLOR=1 NODE_OPTIONS=--max-old-space-size=4096 eslint . --cache --rule 'no-console: [2, { allow: [error, info, warn] }]'",
-    "lint:tsc": "tsc",
+    "lint:tsc": "tsc && tsc -p src/e2e/iOS/tsconfig.json",
     "lint": "FORCE_COLOR=1 npm-run-all --serial \"lint:*\"",
     "postinstall": "yarn build:packages && git config core.hooksPath .hooks && yarn build:styles",
     "servebuild": "vite preview --port 3000",

--- a/src/e2e/iOS/config/wdio.base.conf.ts
+++ b/src/e2e/iOS/config/wdio.base.conf.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 import https from 'https'
 import path from 'path'
-import { drainConsoleProxy, waitForConsoleProxy } from '../../../util/consoleProxy'
+import { CONSOLE_PROXY_STORAGE_KEY, type CapturedLog } from '../../../util/consoleProxy'
 import resetApp from '../helpers/resetApp'
 
 const LOCAL_URL = 'https://localhost:3000'
@@ -70,6 +70,45 @@ export const checkAppRunning = async (url: string = LOCAL_URL): Promise<void> =>
         ? 'Start the app locally (yarn start) before running tests.'
         : 'The origin is wrong or unreachable — check that the tunnel points at the protocol and port the app is served on.'),
   )
+}
+
+/**
+ * Atomically reads and clears the console proxy buffer for `key`. Runs IN THE REMOTE BROWSER:
+ * drainConsoleProxy ships this via browser.execute, which serializes the function source and drops
+ * all closure scope, so it must reference only its `key` param and browser globals (no module-scope
+ * helpers, no CONSOLE_PROXY_STORAGE_KEY capture). The buffer is written by the app side of the proxy,
+ * src/util/consoleProxy.ts, which owns the key and the record shape.
+ */
+const drainBuffer = (key: string): CapturedLog[] => {
+  try {
+    const logs = JSON.parse(sessionStorage.getItem(key) ?? '[]') as CapturedLog[]
+    sessionStorage.setItem(key, '[]')
+    return logs
+  } catch {
+    return []
+  }
+}
+
+/** Readiness probe for waitForConsoleProxy. Self-contained for the same browser.execute serialization reason as drainBuffer. The buffer key exists iff installConsoleProxy has run. */
+const isProxyInstalled = (key: string): boolean => sessionStorage.getItem(key) !== null
+
+/** Atomically reads and clears the console proxy buffer in the remote browser. Returns [] when capture is not enabled or nothing has been captured. */
+const drainConsoleProxy = async (): Promise<CapturedLog[]> => {
+  if (!process.env.VITE_BROWSER_CONSOLE_CAPTURE) return []
+  return browser.execute(drainBuffer, CONSOLE_PROXY_STORAGE_KEY)
+}
+
+/**
+ * Resolves once the console proxy has installed in the remote browser, or rejects after `timeout` ms.
+ *
+ * No-op when VITE_BROWSER_CONSOLE_CAPTURE is unset – this env var must be set both at build time (so the served bundle includes the proxy) and at runtime (so this helper waits for it).
+ */
+const waitForConsoleProxy = async (timeout = 30000): Promise<void> => {
+  if (!process.env.VITE_BROWSER_CONSOLE_CAPTURE) return
+  await browser.waitUntil(async () => browser.execute(isProxyInstalled, CONSOLE_PROXY_STORAGE_KEY), {
+    timeout,
+    timeoutMsg: `Console proxy did not install within ${timeout}ms — VITE_BROWSER_CONSOLE_CAPTURE is set on the WDIO process but the served bundle was likely built without it. Rebuild with \`VITE_BROWSER_CONSOLE_CAPTURE=1 yarn build\` and re-serve.`,
+  })
 }
 
 /**

--- a/src/e2e/iOS/tsconfig.json
+++ b/src/e2e/iOS/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // Typechecks the WebdriverIO (iOS Safari) tests. This is the only program that declares WebdriverIO's
+  // globals — browser, $, $$, and expect from @wdio/globals/types, mocha's describe/it via
+  // @wdio/mocha-framework — and @wdio/browserstack-service's global interfaces (State, GRRUrls, …).
+  // The root tsconfig excludes this directory so that none of those leak into app code. Modules shared
+  // with the app (e.g. src/util/consoleProxy.ts) are pulled in here by import and are therefore checked
+  // by both programs; the root one is what stops them from depending on these globals.
+  "extends": "../../../tsconfig.json",
+  // The app modules pulled in by import rely on the app's ambient declarations (vite-env.d.ts, @types/*.d.ts)
+  // and on the global augmentations in src/@types/index.ts (Window.em, the redux Dispatch overloads, …),
+  // which the root program gets from its src/**/*.ts include and this one has to name.
+  "include": ["**/*.ts", "../../@types/index.ts", "../../**/*.d.ts"],
+  // The root excludes this directory; exclude is inherited, so it must be reset here.
+  "exclude": [],
+  "compilerOptions": {
+    "types": ["node", "@wdio/globals/types", "@wdio/mocha-framework", "@wdio/browserstack-service"]
+  }
+}

--- a/src/util/consoleProxy.ts
+++ b/src/util/consoleProxy.ts
@@ -3,41 +3,26 @@
  * sessionStorage when the VITE_BROWSER_CONSOLE_CAPTURE build-time env var is set.
  * BrowserStack does not provide native access to console logs from iOS runs;
  * this proxy lets us work around those limitations.
+ *
+ * This is the app side, imported first by src/index.tsx. The WebdriverIO side — draining the buffer
+ * and waiting for the proxy to install — lives in src/e2e/iOS/config/wdio.base.conf.ts, because it
+ * needs WebdriverIO's global `browser`, whose types are declared only for src/e2e/iOS. The two sides
+ * share nothing but the storage key and the record shape exported here.
  */
 
 export type CapturedLog = { level: string; message: string }
 
 /** SessionStorage key under which captured logs are buffered. Using sessionStorage rather than an in-memory array means the buffer survives same-tab page reloads, which iOS Safari occasionally does mid-test. */
-const STORAGE_KEY = '__capturedConsoleLogs__'
+export const CONSOLE_PROXY_STORAGE_KEY = '__capturedConsoleLogs__'
 
 /** Reads the buffer from sessionStorage. Returns [] on parse failure or missing buffer. */
 const read = (): CapturedLog[] => {
   try {
-    return JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? '[]') as CapturedLog[]
+    return JSON.parse(sessionStorage.getItem(CONSOLE_PROXY_STORAGE_KEY) ?? '[]') as CapturedLog[]
   } catch {
     return []
   }
 }
-
-/**
- * Atomically reads and clears the buffer for `key`. Runs IN THE REMOTE BROWSER:
- * drainConsoleProxy ships this via browser.execute, which serializes the function
- * source and drops all closure scope, so it must reference only its `key` param and
- * browser globals (no module-scope helpers, no STORAGE_KEY capture). Single source of
- * truth for the drain wire format.
- */
-const drainBuffer = (key: string): CapturedLog[] => {
-  try {
-    const logs = JSON.parse(sessionStorage.getItem(key) ?? '[]') as CapturedLog[]
-    sessionStorage.setItem(key, '[]')
-    return logs
-  } catch {
-    return []
-  }
-}
-
-/** Readiness probe for waitForConsoleProxy. Self-contained for the same browser.execute serialization reason as drainBuffer. The buffer key exists iff installConsoleProxy has run. */
-const isProxyInstalled = (key: string): boolean => sessionStorage.getItem(key) !== null
 
 let installed = false
 
@@ -54,9 +39,9 @@ const installConsoleProxy = (): void => {
   if (installed) return
   installed = true
 
-  // Create the storage key if it doesn't exist. drainConsoleProxy / waitForConsoleProxy use this as a readiness signal.
-  if (sessionStorage.getItem(STORAGE_KEY) === null) {
-    sessionStorage.setItem(STORAGE_KEY, '[]')
+  // Create the storage key if it doesn't exist. The WebdriverIO side uses its existence as the readiness signal.
+  if (sessionStorage.getItem(CONSOLE_PROXY_STORAGE_KEY) === null) {
+    sessionStorage.setItem(CONSOLE_PROXY_STORAGE_KEY, '[]')
   }
 
   const c = console as unknown as Record<string, (...args: unknown[]) => void>
@@ -67,32 +52,13 @@ const installConsoleProxy = (): void => {
         const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
         const buf = read()
         buf.push({ level: method, message })
-        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(buf))
+        sessionStorage.setItem(CONSOLE_PROXY_STORAGE_KEY, JSON.stringify(buf))
       } catch {
         // Serialization or storage failure (e.g. circular refs, quota) — drop this entry.
       }
       orig(...args)
     }
   }
-}
-
-/** Atomically reads and clears the console-proxy buffer in the remote browser. Returns [] when capture is not enabled or nothing has been captured. */
-export const drainConsoleProxy = async (): Promise<CapturedLog[]> => {
-  if (!process.env.VITE_BROWSER_CONSOLE_CAPTURE) return []
-  return browser.execute(drainBuffer, STORAGE_KEY)
-}
-
-/**
- * Resolves once the console proxy has installed in the remote browser, or rejects after `timeout` ms.
- *
- * No-op when VITE_BROWSER_CONSOLE_CAPTURE is unset – this env var must be set both at build time (so the served bundle includes the proxy) and at runtime (so this helper waits for it).
- */
-export const waitForConsoleProxy = async (timeout = 30000): Promise<void> => {
-  if (!process.env.VITE_BROWSER_CONSOLE_CAPTURE) return
-  await browser.waitUntil(async () => browser.execute(isProxyInstalled, STORAGE_KEY), {
-    timeout,
-    timeoutMsg: `Console proxy did not install within ${timeout}ms — VITE_BROWSER_CONSOLE_CAPTURE is set on the WDIO process but the served bundle was likely built without it. Rebuild with \`VITE_BROWSER_CONSOLE_CAPTURE=1 yarn build\` and re-serve.`,
-  })
 }
 
 export default installConsoleProxy

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "styled-system"],
+  // The iOS WebdriverIO tests are typechecked by src/e2e/iOS/tsconfig.json, the only program that declares
+  // WebdriverIO's globals. Excluding them here keeps browser, $, expect, and @wdio/browserstack-service's
+  // global interfaces (State, GRRUrls, …) out of app code.
+  "exclude": ["src/e2e/iOS"],
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
@@ -31,6 +35,6 @@
       "@treecrdt/wa-sqlite/client": ["./node_modules/@treecrdt/wa-sqlite/dist/client.d.ts"],
       "@treecrdt/wa-sqlite/vite-plugin": ["./node_modules/@treecrdt/wa-sqlite/dist/vite-plugin.d.ts"]
     },
-    "types": ["node", "vitest/globals", "@wdio/globals/types", "@wdio/mocha-framework", "@wdio/browserstack-service"]
+    "types": ["node", "vitest/globals"]
   }
 }


### PR DESCRIPTION
## What

- Root `tsconfig.json` now excludes `src/e2e/iOS` and keeps only `node` and `vitest/globals` in `types`.
- New `src/e2e/iOS/tsconfig.json` extends the root, resets `exclude`, and is the only program that declares WebdriverIO's globals (`browser`, `$`, `$$`, `expect`), mocha's `describe`/`it`, and `@wdio/browserstack-service`'s global interfaces. It also includes `src/@types/index.ts` and the app's `.d.ts` files, because the iOS graph pulls in half the app through `constants.ts` and needs the `Window.em` and redux `Dispatch` augmentations.
- The WebdriverIO half of the console proxy (`drainConsoleProxy`, `waitForConsoleProxy` and the two remote functions they ship) moved from `src/util/consoleProxy.ts` into `wdio.base.conf.ts`, its only consumer. The app side now exports just the storage key and record type. Function bodies are unchanged.
- `eslint.config.js` routes `src/e2e/iOS/**` to the new project for type-aware rules.
- `lint:tsc` runs both programs. The second adds about seven seconds.
- `docs/testing.md` gains a short section on the split.

## Why

`compilerOptions.types` entries are ambient for every file in the program, and the program was all of `src/`. `@wdio/browserstack-service` declares `interface State { value: number; toString: () => string }` inside `declare global`, so every app file could see a global `State`; a file that forgot to import the app's own `State` compiled silently against BrowserStack's, and editors offered that definition on hover. The wdio packages were added to the root `types` wholesale in #3537, which tried a separate iOS tsconfig and dropped it minutes later without explanation.

`src/util/consoleProxy.ts` was the one app module that referenced the `browser` global, which is why the split of the console proxy is part of this change: a module imported by both `src/index.tsx` and the wdio config is checked by both programs, and the root one now rejects any wdio global.

## Verification

- Both `tsc` programs pass; the root program loads zero wdio, mocha, or expect-webdriverio declaration files.
- A scratch file in `src/` referencing `State` and `browser` fails with `Cannot find name` under the root program.
- Both wdio configs load under tsx with all four hooks present.
- Full `yarn lint` passes.

## Reviewer notes

- The iOS suite was not run locally (needs BrowserStack or Appium). The runtime change is limited to moving four functions between modules with identical bodies; the BrowserStack workflow on this PR is the real proof.
- Side effect: `src/e2e/puppeteer/setup.ts` declares its own global `browser` (Puppeteer's), which previously collided with WebdriverIO's declaration and was masked by `skipLibCheck`. The root program now has a single `browser` declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
