### PR TITLE
New Grandchild: create a thought in the first root thought when there is no cursor

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -400,7 +400,7 @@ https://github.com/user-attachments/assets/e7077d5d-2387-48b5-8a60-c944d38889ec
 
 ### New Grandchild
 
-Create a thought within the first subthought. With a multiselect, a new grandchild is created in every selected thought; the new grandchildren are then selected, with the cursor on the last of them. The command is disabled when any selected thought has no subthought to create the grandchild in.
+Create a thought within the first subthought. With a multiselect, a new grandchild is created in every selected thought; the new grandchildren are then selected, with the cursor on the last of them. With no cursor, the root stands in for it, so the new thought is created within the first visible thought in the root. The command is disabled when any selected thought — or the root, when nothing is selected — has no subthought to create the grandchild in.
 
 ### Categorize
 

--- a/src/actions/newGrandChild.ts
+++ b/src/actions/newGrandChild.ts
@@ -3,29 +3,29 @@ import Thunk from '../@types/Thunk'
 import newThought from '../actions/newThought'
 import { TUTORIAL_STEP_START } from '../constants'
 import { firstVisibleChild } from '../selectors/getChildren'
+import getRootPath from '../selectors/getRootPath'
 import getSetting from '../selectors/getSetting'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import appendToPath from '../util/appendToPath'
 import head from '../util/head'
 
 /**
- * Creates a new grandchild at first visible subthought.
+ * Creates a new grandchild at the first visible subthought of the cursor. When there is no cursor, the root stands in for it, so the new thought is created in the first visible child of the root.
  */
 const newGrandChild = (state: State): State => {
-  const { cursor } = state
-
   const tutorial = getSetting(state, 'Tutorial') !== 'Off'
   const tutorialStep = +!getSetting(state, 'Tutorial Step')
 
-  // cancel if cursor is not available or tutorial has just started
-  if (!cursor || (tutorial && tutorialStep === TUTORIAL_STEP_START)) return state
+  // cancel if the tutorial has just started
+  if (tutorial && tutorialStep === TUTORIAL_STEP_START) return state
 
-  const firstChild = firstVisibleChild(state, head(cursor))
+  const path = state.cursor || getRootPath(state)
+  const firstChild = firstVisibleChild(state, head(path))
 
   // stop if there is no visible children
   if (!firstChild) return state
 
-  return newThought(state, { insertNewSubthought: true, at: appendToPath(cursor, firstChild.id) })
+  return newThought(state, { insertNewSubthought: true, at: appendToPath(path, firstChild.id) })
 }
 
 /** Action-creator for newGrandChild. */

--- a/src/commands/__tests__/newGrandChild.ts
+++ b/src/commands/__tests__/newGrandChild.ts
@@ -50,6 +50,52 @@ describe('canExecute', () => {
 
     expect(newGrandChildCommand.canExecute(store.getState())).toBe(true)
   })
+
+  it('requires the root to have a visible child when there is no cursor', () => {
+    store.dispatch(setCursor(null))
+
+    expect(newGrandChildCommand.canExecute(store.getState())).toBe(false)
+
+    store.dispatch([
+      importText({
+        text: `
+          - a
+          - b
+        `,
+      }),
+      setCursor(null),
+    ])
+
+    expect(newGrandChildCommand.canExecute(store.getState())).toBe(true)
+  })
+})
+
+describe('no cursor', () => {
+  it('creates a new empty thought in the first visible child of the root', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - x
+          - b
+        `,
+      }),
+      setCursor(null),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const state = store.getState()
+
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - x
+    - ${''}
+  - b`)
+
+    // the cursor must end in the new empty thought, ready to type
+    expectPathToEqual(state, state.cursor, ['a', ''])
+  })
 })
 
 describe('multicursor', () => {

--- a/src/commands/newGrandChild.ts
+++ b/src/commands/newGrandChild.ts
@@ -3,6 +3,7 @@ import State from '../@types/State'
 import { newGrandChildActionCreator as newGrandChild } from '../actions/newGrandChild'
 import SettingsIcon from '../components/icons/SettingsIcon'
 import { hasChildren } from '../selectors/getChildren'
+import getRootPath from '../selectors/getRootPath'
 import selectedPaths from '../selectors/selectedPaths'
 import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
@@ -10,7 +11,8 @@ import isDocumentEditable from '../util/isDocumentEditable'
 const newGrandChildCommand = {
   id: 'newGrandChild',
   label: 'New Grandchild' as const,
-  description: 'Create a thought within the first subthought.',
+  description:
+    'Create a thought within the first subthought. With no cursor, creates a thought within the first thought in the root.',
   gesture: 'rdrd',
   multicursor: {
     // The action sets the cursor to the new empty grandchild with the keyboard open, ready to type. The default restore would move the caret back to the originally selected thought.
@@ -21,8 +23,10 @@ const newGrandChildCommand = {
   // TODO: Create unique icon
   svg: SettingsIcon,
   canExecute: (state: State) => {
-    const paths = selectedPaths(state)
-    return isDocumentEditable() && paths.length > 0 && paths.every(path => hasChildren(state, head(path)))
+    const selected = selectedPaths(state)
+    // Without a selection, the root stands in for the cursor: the new thought is created in the first visible child of the root, so the root must have a visible child.
+    const paths = selected.length > 0 ? selected : [getRootPath(state)]
+    return isDocumentEditable() && paths.every(path => hasChildren(state, head(path)))
   },
   exec: dispatch => dispatch(newGrandChild()),
 } satisfies Command


### PR DESCRIPTION
## Summary

When the cursor is null, the New Grandchild command now creates a new thought beneath the first visible child in the root. Previously the reducer returned the state unchanged and the command's `canExecute` was disabled without a selection.

- `src/actions/newGrandChild.ts`: the root path stands in for a missing cursor, so the new thought is inserted as a subthought of the first visible child of the root. The tutorial-start guard is unchanged.
- `src/commands/newGrandChild.ts`: `canExecute` falls back to the root path when nothing is selected, so the command is enabled only when the root has a visible child. Multicursor behaviour is unchanged since `selectedPaths` still prefers the multicursors.
- `docs/commands.md`: describes the null-cursor behaviour.

## Tests

Added store tests in `src/commands/__tests__/newGrandChild.ts`, both observed failing before the fix:

- `canExecute` is false with no cursor and an empty root, and true once the root has a child.
- With no cursor, executing the command creates an empty thought in the first root thought and leaves the cursor in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMRCJ9Rd3U4UGocDGo8jMu