### PR TITLE
Rename write-issue skill to create-issue

### DIFF
--- a/.agents/skills/create-issue
+++ b/.agents/skills/create-issue
@@ -1,0 +1,1 @@
+../../.github/skills/create-issue

--- a/.agents/skills/write-issue
+++ b/.agents/skills/write-issue
@@ -1,1 +1,0 @@
-../../.github/skills/write-issue

--- a/.github/skills/create-issue/SKILL.md
+++ b/.github/skills/create-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: write-issue
+name: create-issue
 description: >-
-  ALWAYS USE THIS SKILL when creating or editing a GitHub issue in this repo — filing a new bug, splitting one out of a comment thread, adding reproduction steps to an issue that lacks them, or marking one blocked by another.
+  ALWAYS USE THIS SKILL when creating or editing a GitHub issue in this repo — filing a new bug, splitting one out of a comment thread, adding reproduction steps to an issue that lacks them, or marking one blocked by another. Triggers on "create issue", "write issue", "file an issue", "open an issue", "make an issue", "report a bug", and any request to draft or edit issue text.
 allowed-tools:
   - bash
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 **1. Reproduce before theorising.** If you are fixing reported behaviour, try observing the failure yourself before making assumptions. An agent that starts from the code builds a theory and then finds evidence for it; one that has watched the thing fail is working from an observation.
 
-**2. Use `write-issue` when you file one.** Issues reporting broken behaviour here follow a fixed format — "Steps to Reproduce", "Current Behavior", "Expected Behavior". The skill has the template and the conventions around it; run it whenever you create an issue, split one out of a comment thread, or add steps to one that lacks them.
+**2. Use `create-issue` when you file one.** Issues reporting broken behaviour here follow a fixed format — "Steps to Reproduce", "Current Behavior", "Expected Behavior". The skill has the template and the conventions around it; run it whenever you create an issue, split one out of a comment thread, or add steps to one that lacks them.
 
 **3. Suggest `end-session` when the work is wrapping up.** As the user starts to finish — pushing, opening a pull request, handing the change on — offer executing `end-session` to the user. It checks that documentation still describes reality, that nothing is uncommitted or unpushed, that no test was left switched off, and that anything claimed was actually observed.
 

--- a/docs/agents/external-agents.md
+++ b/docs/agents/external-agents.md
@@ -79,11 +79,11 @@ The skill states *what* must be true and lets a single clause carry *how* per en
 
 ## What is shared, and what is not
 
-**Shared** — [`write-issue`](skills.md#write-issue), [`plan`](skills.md#plan), [`tdd-write-failing-test`](skills.md#tdd-write-failing-test), [`test-diagnosis`](skills.md#test-diagnosis), [`puppeteer-update-snapshots`](skills.md#puppeteer-update-snapshots), [`ci-monitor`](skills.md#ci-monitor), [`docs-sync`](skills.md#docs-sync), [`end-session`](skills.md#end-session).
+**Shared** — [`create-issue`](skills.md#create-issue), [`plan`](skills.md#plan), [`tdd-write-failing-test`](skills.md#tdd-write-failing-test), [`test-diagnosis`](skills.md#test-diagnosis), [`puppeteer-update-snapshots`](skills.md#puppeteer-update-snapshots), [`ci-monitor`](skills.md#ci-monitor), [`docs-sync`](skills.md#docs-sync), [`end-session`](skills.md#end-session).
 
 Three of those needed a per-harness clause. `end-session` and `ci-monitor` name a Copilot tool that has no local equivalent — opening a pull request, listing workflow runs — and now name the `gh` command alongside it. `test-diagnosis` was written as though a failure could only arrive from CI; its trigger now covers a suite run locally, where the output is already on screen rather than in a log to be fetched.
 
-`write-issue` needed nothing — it shells out to `gh` and names no provisioned resource.
+`create-issue` needed nothing — it shells out to `gh` and names no provisioned resource.
 
 The rest of it was portable untouched. `puppeteer-update-snapshots` turned out to be the *most* local skill in the set — its command explicitly unsets `GITHUB_ACTIONS` so that the Docker and Vite setup runs, which is exactly the local path.
 

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -68,7 +68,7 @@ The two green boxes are the gates — the agent must run them before it is allow
 | [`puppeteer-update-snapshots`](#puppeteer-update-snapshots) | Regenerate screenshot comparisons after an intended visual change | [SKILL.md](../../.github/skills/puppeteer-update-snapshots/SKILL.md) |
 | [`end-session`](#end-session) | Work through the exit checklist before stopping for any reason | [SKILL.md](../../.github/skills/end-session/SKILL.md) |
 | [`docs-sync`](#docs-sync) | Repair the documentation your change made untrue, in the same commit | [SKILL.md](../../.github/skills/docs-sync/SKILL.md) |
-| `write-issue` | Write a GitHub issue in the format this repo uses | [SKILL.md](../../.github/skills/write-issue/SKILL.md) |
+| `create-issue` | Write a GitHub issue in the format this repo uses | [SKILL.md](../../.github/skills/create-issue/SKILL.md) |
 
 ## The gates
 


### PR DESCRIPTION
Renames the `write-issue` skill to `create-issue` and broadens its description so it triggers on the phrasings people actually use.

## Changes

- `git mv .github/skills/write-issue` → `.github/skills/create-issue`, and repointed the `.agents/skills` symlink (which `.claude/skills` links to).
- Frontmatter `name: write-issue` → `create-issue`.
- Appended trigger phrasings to the description so the skill fires automatically: "create issue", "write issue", "file an issue", "open an issue", "make an issue", "report a bug", and any request to draft or edit issue text.
- Updated the references in `AGENTS.md`, `docs/agents/skills.md`, and `docs/agents/external-agents.md` (including the `skills.md#write-issue` anchors).

The skill body itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGuNckGq6nC839Hf1A7fdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGuNckGq6nC839Hf1A7fdn)_