### PR TITLE
Stop Dependabot from labeling its pull requests `javascript`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       time: '22:00'
       timezone: 'America/New_York'
     open-pull-requests-limit: 10
+    # Replaces Dependabot's default labels, which are `dependencies` plus an ecosystem label.
+    # npm is the only ecosystem configured here, so the `javascript` label it adds distinguishes
+    # nothing and is dropped by omitting it. `dependencies` must be listed to be kept.
+    labels:
+      - 'dependencies'
     # Group related deps into single PR
     groups:
       babel:


### PR DESCRIPTION
Every Dependabot pull request here lands with two labels, `dependencies` and `javascript` — [#5385](https://github.com/cybersemics/em/pull/5385), [#5386](https://github.com/cybersemics/em/pull/5386), [#5390](https://github.com/cybersemics/em/pull/5390) and the rest of the last batch all carry both. Neither is set by `dependabot.yml`; they are Dependabot's defaults, which are `dependencies` plus a label for the ecosystem that produced the bump.

npm is the only ecosystem configured in `.github/dependabot.yml`, so `javascript` is on every bump Dependabot opens and distinguishes none of them.

The `labels` key replaces the default set rather than adding to it, so naming `dependencies` alone keeps the label that carries meaning and drops the one that does not:

```yaml
labels:
  - 'dependencies'
```

`dependencies` already exists in the repository, which is what it needs to be applied — Dependabot silently ignores a configured label that does not exist.

### Scope

- No workflow reads either label. `dependabot-automerge.yml` and `dependabot-fix.yml` gate on the pull request author and the `dependabot/` branch prefix; the only label-driven workflow is `tdd.yml`, on its `skip-tdd*` labels.
- The one open Dependabot pull request, [#4242](https://github.com/cybersemics/em/pull/4242), already carries `dependencies` alone, so no existing pull request needs relabeling.
- The `javascript` label itself is left in place — this only stops Dependabot from applying it.
- Nothing in `docs/` describes Dependabot's labels. `docs/testing.md` covers the auto-merge and fix workflows, neither of which depends on them.

### Verification

- `prettier --check .github/dependabot.yml` passes (run with a plugin-free config; the repo's `@trivago/prettier-plugin-sort-imports` applies to imports, not YAML).
- Parsed the file to confirm it still reads as one npm ecosystem with all 16 groups, the Saturday schedule, and the limit of 10 intact, now with `labels: ["dependencies"]`.

The change takes effect on the next batch of bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2ysFgMRt1P5NPnxyNG97S

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2ysFgMRt1P5NPnxyNG97S)_