### PR TITLE
Do not close the Alert while text is selected on it

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -8,6 +8,7 @@ import { alertActionCreator } from '../actions/alert'
 import { clearMulticursorsActionCreator as clearMulticursors } from '../actions/clearMulticursors'
 import { deleteResumableFile } from '../actions/importFiles'
 import { AlertType } from '../constants'
+import * as selection from '../device/selection'
 import alertStore from '../stores/alert'
 import syncStatusStore from '../stores/syncStatus'
 import fastClick from '../util/fastClick'
@@ -58,19 +59,47 @@ const Alert: FC = () => {
   const iconSize = useSelector(state => 0.78 * state.fontSize)
   const multicursor = useSelector(state => state.alert?.alertType === AlertType.MulticursorActive)
   const dispatch = useDispatch()
+  const popupRef = useRef<HTMLDivElement>(null)
 
   /** Dismiss the alert on close. */
   const onClose = useCallback(() => {
     dispatch(alertActionCreator(null))
   }, [dispatch])
 
-  const { startTimer, clearTimer } = useDelayedEffect(onClose, alert?.clearDelay)
+  /** Auto-dismiss the alert, unless the user is selecting its text. Closing would tear down the selection mid-copy. */
+  const onCloseAuto = useCallback(() => {
+    if (selection.isSelectedWithin(popupRef.current)) return
+    onClose()
+  }, [onClose])
+
+  const { startTimer, clearTimer } = useDelayedEffect(onCloseAuto, alert?.clearDelay)
+
+  // Suspend the auto-dismiss timer while text is selected on the alert, and restart it once the selection is
+  // released. Only the transitions are acted on, otherwise selection changes elsewhere (e.g. typing in a thought)
+  // would keep restarting the timer and the alert would never be dismissed.
+  const isSelectedRef = useRef(false)
+  useEffect(() => {
+    /** Starts or stops the auto-dismiss timer as the selection enters or leaves the alert. */
+    const onSelectionChange = () => {
+      const isSelected = selection.isSelectedWithin(popupRef.current)
+      if (isSelected === isSelectedRef.current) return
+      isSelectedRef.current = isSelected
+      if (isSelected) {
+        clearTimer()
+      } else {
+        startTimer()
+      }
+    }
+    document.addEventListener('selectionchange', onSelectionChange)
+    return () => document.removeEventListener('selectionchange', onSelectionChange)
+  }, [clearTimer, startTimer])
 
   const Icon = alert?.alertType === AlertType.Undo ? UndoIcon : alert?.alertType === AlertType.Redo ? RedoIcon : null
 
   // if dismissed, set timeout to 0 to remove alert component immediately. Otherwise it will block toolbar interactions until the timeout completes.
   return (
     <Notification
+      ref={popupRef}
       transitionKey={transitionKey}
       onClose={alert?.clearDelay != null ? onClose : undefined}
       value={alert ? value : null}

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -1,13 +1,15 @@
-import React, { ComponentProps, FC, ReactNode, useCallback, useRef, useState } from 'react'
+import React, { ComponentProps, ReactNode, useCallback, useRef, useState } from 'react'
 import { TransitionGroup } from 'react-transition-group'
 import { css } from '../../styled-system/css'
 import { token } from '../../styled-system/tokens'
 import { isTouch } from '../browser'
+import useCombinedRefs from '../hooks/useCombinedRefs'
 import FadeTransition from './FadeTransition'
 import PopupBase from './PopupBase'
 
 /** A popup component in which you can customize what is rendered. Used for Alerts + Tips. */
-const Notification: FC<
+const Notification = React.forwardRef<
+  HTMLDivElement,
   {
     icon?: ReactNode
     /** The content rendered with padding in the center of the notification. */
@@ -17,13 +19,14 @@ const Notification: FC<
     /** Optional content rendered after the value without padding or alignment. Must be positioned independently. */
     children?: ReactNode
   } & Pick<ComponentProps<typeof PopupBase>, 'onClose' | 'textAlign' | 'onMouseOver' | 'onMouseLeave'>
-> = ({ icon, onClose, value, transitionKey, children, ...props }) => {
+>(({ icon, onClose, value, transitionKey, children, ...props }, ref) => {
   const [isDismissed, setIsDismissed] = useState(false)
   // Share this ref between FadeTransition and PopupBase so the fade opacity is applied directly to the
   // positioned zIndex: 'popup' element rather than to an intermediate static <span>. Without a nodeRef,
   // FadeTransition's span becomes a z-index: auto stacking context while opacity < 1, trapping the popup's
   // z-index behind #content and causing the toast to fade in behind full-screen thoughts.
   const popupRef = useRef<HTMLDivElement>(null)
+  const combinedRef = useCombinedRefs([ref, popupRef])
 
   /** Dismiss the alert on close. */
   const handleClose = useCallback(() => {
@@ -50,7 +53,7 @@ const Notification: FC<
       {value ? (
         <FadeTransition type='slow' nodeRef={popupRef} onEntering={() => setIsDismissed(false)}>
           <PopupBase
-            ref={popupRef}
+            ref={combinedRef}
             anchorFromBottom
             anchorOffset={36}
             key={transitionKey}
@@ -83,6 +86,8 @@ const Notification: FC<
       ) : null}
     </TransitionGroup>
   )
-}
+})
+
+Notification.displayName = 'Notification'
 
 export default Notification

--- a/src/components/__tests__/Alert.ts
+++ b/src/components/__tests__/Alert.ts
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/dom'
+import { act } from 'react'
+import { alertActionCreator as alert } from '../../actions/alert'
+import store from '../../stores/app'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+/** Selects all of the text in the alert. */
+const selectAlertText = () => {
+  const range = document.createRange()
+  range.selectNodeContents(screen.getByTestId('alert-content'))
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+it('auto-dismisses after clearDelay', async () => {
+  await dispatch(alert('Hello', { clearDelay: 1000 }))
+  // Do not flush all pending timers, or the auto-dismiss timer under test fires immediately.
+  await act(async () => {})
+
+  expect(screen.queryByTestId('alert-content')).toBeTruthy()
+
+  await act(async () => {
+    vi.advanceTimersByTime(1000)
+  })
+
+  expect(store.getState().alert).toBeNull()
+})
+
+it('does not auto-dismiss while text is selected on the alert', async () => {
+  await dispatch(alert('Hello', { clearDelay: 1000 }))
+  // Do not flush all pending timers, or the auto-dismiss timer under test fires immediately.
+  await act(async () => {})
+
+  await act(async () => {
+    selectAlertText()
+  })
+
+  await act(async () => {
+    vi.advanceTimersByTime(1000)
+  })
+
+  expect(store.getState().alert).not.toBeNull()
+
+  // dismisses once the selection is released
+  await act(async () => {
+    window.getSelection()!.removeAllRanges()
+  })
+  await act(async () => {
+    vi.advanceTimersByTime(1000)
+  })
+
+  expect(store.getState().alert).toBeNull()
+})

--- a/src/device/selection.ts
+++ b/src/device/selection.ts
@@ -102,6 +102,14 @@ export const isCollapsed = (): boolean => !!window.getSelection()?.isCollapsed
 /** Returns true if there is an active selection. */
 export const isActive = (): boolean => !!window.getSelection()?.focusNode
 
+/** Returns true if a non-collapsed selection is contained within the given element. */
+export const isSelectedWithin = (element: Element | null | undefined): boolean => {
+  if (!element) return false
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false
+  return element.contains(selection.getRangeAt(0).commonAncestorContainer)
+}
+
 /** Traverses a node's parents until it finds an element node that is not a formatting tag. Returns null if a suitable parent cannot be found. */
 const getEditableCandidate = (node?: EventTarget | null) => {
   if (!isHTMLElement(node)) return null


### PR DESCRIPTION
The alert's `clearDelay` timer dismissed the toast while the user was selecting its text, tearing down the selection mid-copy.

- `Alert` suspends the auto-dismiss timer while a non-collapsed selection is inside the alert, and restarts it once the selection is released (`selectionchange`).
- The timer callback also re-checks the selection, so a timer already in flight cannot close the alert out from under a selection.
- New `selection.isSelectedWithin(element)` in `src/device/selection.ts`; `Notification` forwards a ref to the popup element so `Alert` can scope the check to itself.
- Manual dismissal (the X, swipe-to-dismiss) is unaffected.

Covered by `src/components/__tests__/Alert.ts` — verified failing without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)