### PR TITLE
Settle cursor scrolling before long-list snapshots

### DIFF
--- a/src/e2e/puppeteer/__tests__/render-thoughts.ts
+++ b/src/e2e/puppeteer/__tests__/render-thoughts.ts
@@ -15,6 +15,7 @@ import screenshot from '../helpers/screenshot'
 import scroll from '../helpers/scroll'
 import scrollTo from '../helpers/scrollTo'
 import setTheme from '../helpers/setTheme'
+import waitForBrowserSettled from '../helpers/waitForBrowserSettled'
 import { page } from '../session'
 
 expect.extend({
@@ -93,6 +94,9 @@ const testSuite = () => {
 
     // set the cursor to null
     await press('Escape')
+
+    // Let input-deferred cursor-scroll timers run before scrollTo cancels their trailing throttle.
+    await waitForBrowserSettled()
 
     // scroll to top
     await scrollTo(0, 0)


### PR DESCRIPTION
#5298

Makes the long-list snapshot tests establish their intended scroll position reliably in newer Chrome, without changing the snapshots or application behavior.

Stack: **#5398 → #5463 → #5305**.

**What I did**

Added one call to the existing `waitForBrowserSettled()` helper after Escape and before `scrollTo(0, 0)` in `src/e2e/puppeteer/__tests__/render-thoughts.ts`. The diff contains only the import, explanatory comment, and awaited call.

### Why this must precede #5305

#5305 upgrades the test browser from Browserless v1/Chrome 121 to Browserless v2/Chrome 151. The newer browser exposed a race in how these tests prepare a screenshot:

1. Typing schedules an outer timer in `useScrollCursorIntoView`. That timer later calls a throttled scroll function.
2. The test clears the cursor with Escape, then calls `scrollTo(0, 0)`. That helper cancels the throttle before setting the scroll position.
3. If the outer timer has not run yet, cancelling the throttle cannot cancel it. The timer can subsequently schedule another scroll, moving the page away from the position the test just established.

Chrome 134 enabled `DeferRendererTasksAfterInput` by default, making this ordering visible in the newer browser. See the [feature's introduction](https://chromium.googlesource.com/chromium/src/+/29ff47d3f212fae17310a613844f36d214cd9400) and [CL 6175333 enabling it by default](https://chromium-review.googlesource.com/c/chromium/src/+/6175333).

`waitForBrowserSettled()` crosses two animation frames and then a timer task. In the observed sequence, this lets the deferred work reach the throttle **before** `scrollTo` cancels it and establishes the screenshot position.

Separating this fix from #5305 lets reviewers verify the test's setup independently of the browser upgrade and its rendering differences. Otherwise, an incorrectly scrolled screenshot could be mistaken for a baseline that needs regeneration.

### Does this change the test's meaning?

It changes setup timing, not the visual state being asserted. These tests check rendering at an explicitly chosen scroll position; they do not test how quickly scrolling settles after Escape.

The input content, Escape action, target position `(0, 0)`, assertions, baselines, and image thresholds are unchanged. No production code or browser flags change in this PR.

**What I verified**

- The original setup worked in Chrome 121 but exhibited the race in Chrome 151.
- Disabling only `DeferRendererTasksAfterInput` in Chrome 151 removed the failure, linking it to the scheduling change.
- Exercised the helper-based setup in both browsers against the original baselines and assertions, with the browser feature left enabled where it is normally enabled.

**How to test**

Run `yarn test:puppeteer render-thoughts` without updating snapshots. The test must retain its intended top-of-page framing and satisfy the existing image assertions.

**Known limits & follow-ups**

This fixes the observed test-setup ordering; it does not change production cursor-scroll cancellation or claim that the helper drains every possible future task. The separate gesture-coordinate bug exposed by the migration is addressed in #5463.
