### PR TITLE
fix(middleware): dispatch closeDropdowns instead of argless toggleDropdown

### DIFF
--- a/src/redux-middleware/closeDropdownsWhenCursorNull.ts
+++ b/src/redux-middleware/closeDropdownsWhenCursorNull.ts
@@ -1,6 +1,6 @@
 import { ThunkMiddleware } from 'redux-thunk'
 import State from '../@types/State'
-import { toggleDropdownActionCreator as toggleDropdown } from '../actions/toggleDropdown'
+import { closeDropdownsActionCreator as closeDropdowns } from '../actions/closeDropdowns'
 
 /** A middleware that closes any open toolbar dropdowns (e.g. Text Color, Letter Case) when the cursor is set to null. This handles cases where cursor becomes null without going through setCursor, such as when the last thought is deleted. */
 const closeDropdownsWhenCursorNull: ThunkMiddleware<State> = ({ getState, dispatch }) => {
@@ -14,7 +14,7 @@ const closeDropdownsWhenCursorNull: ThunkMiddleware<State> = ({ getState, dispat
     // Close all open dropdowns when cursor transitions from non-null to null.
     // setCursor already handles this for direct cursor navigation, but other reducers (e.g. deleteThought) may set cursor to null directly.
     if (prevCursor !== null && state.cursor === null) {
-      dispatch(toggleDropdown())
+      dispatch(closeDropdowns())
     }
   }
 }


### PR DESCRIPTION
Two PRs merged into main in sequence created a semantic conflict that broke every build job on main.

- #4232 added `closeDropdownsWhenCursorNull` middleware calling `toggleDropdownActionCreator()` with no argument.
- #3991 (merged just before) made the payload required, and added a dedicated `closeDropdownsActionCreator`.

Result: `TS2554: Expected 1 arguments, but got 0` failing Lint, Test build, Puppeteer, BrowserStack, Vercel Production, and Tauri Release.

Switched the middleware to the intended `closeDropdownsActionCreator`, which is exactly what the middleware wants (close all dropdowns, no toggle semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)