### PR TITLE
test(undo): a command that changes nothing does not split a typing run

### DIFF
--- a/src/commands/__tests__/undo-typing-run.ts
+++ b/src/commands/__tests__/undo-typing-run.ts
@@ -1,0 +1,31 @@
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { executeCommand } from '../../commands'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import { editThoughtByContextActionCreator as editThought } from '../../test-helpers/editThoughtByContext'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import exportContextCommand from '../exportContext'
+
+beforeEach(initStore)
+
+it('a command that changes nothing does not break a contiguous run of typing into two undo steps', () => {
+  store.dispatch([
+    importText({
+      text: `
+      - a`,
+    }),
+    setCursor(['a']),
+    editThought(['a'], 'ab'),
+  ])
+
+  // Export only opens a modal, so it makes no undoable change to the thoughtspace and should not interrupt the run of typing.
+  executeCommand(exportContextCommand, { store, type: 'keyboard' })
+
+  store.dispatch([editThought(['ab'], 'abc'), undo()])
+
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a`)
+})


### PR DESCRIPTION
Pins that a contiguous run of typing stays one undo step when a command that makes no undoable change runs in the middle of it. Export only opens a modal, so it should not interrupt the run.

Passes on `main` as of `6e420d9cc8`. Fails on #5165, where the command boundary actions reset the enhancer's edit-direction tracking unconditionally, so one undo reverts only the last edit.

Merge `main` into #5165 to see it fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
