### PR TITLE
test(undo): a trailing cursor move is undone with the navigation before it

### DIFF
--- a/src/commands/__tests__/undo-navigation-grouping.ts
+++ b/src/commands/__tests__/undo-navigation-grouping.ts
@@ -1,0 +1,56 @@
+import { cursorDownActionCreator as cursorDown } from '../../actions/cursorDown'
+import { importTextActionCreator as importText } from '../../actions/importText'
+import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { undoActionCreator as undo } from '../../actions/undo'
+import { HOME_TOKEN } from '../../constants'
+import exportContext from '../../selectors/exportContext'
+import store from '../../stores/app'
+import { editThoughtByContextActionCreator as editThought } from '../../test-helpers/editThoughtByContext'
+import initStore from '../../test-helpers/initStore'
+import { setCursorFirstMatchActionCreator as setCursor } from '../../test-helpers/setCursorFirstMatch'
+import headValue from '../../util/headValue'
+
+beforeEach(initStore)
+
+it('undoes a trailing navigation action together with the navigation action before it', () => {
+  store.dispatch([
+    importText({
+      text: `
+        - a
+        - b
+        - c`,
+    }),
+    setCursor(['a']),
+    // create a thought and type its value, so that the navigation that follows has a non-navigation action to attach to
+    newThought({ value: '' }),
+    editThought([''], 'x'),
+    cursorDown(),
+    // create a second thought and type its value
+    newThought({ value: '' }),
+    editThought([''], 'y'),
+  ])
+
+  expect(headValue(store.getState(), store.getState().cursor!)).toBe('y')
+
+  // undo the second thought and its value in one step. This also resets the merge tracking, so the next navigation
+  // starts its own history entry instead of merging with the cursorDown before it.
+  store.dispatch(undo())
+
+  expect(headValue(store.getState(), store.getState().cursor!)).toBe('b')
+
+  // move the cursor again, leaving the two newest history entries both navigation-only
+  store.dispatch(cursorDown())
+
+  expect(headValue(store.getState(), store.getState().cursor!)).toBe('c')
+
+  // undo reverts both navigation entries, restoring the cursor to the thought that was edited before them
+  store.dispatch(undo())
+
+  expect(headValue(store.getState(), store.getState().cursor!)).toBe('x')
+
+  expect(exportContext(store.getState(), [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+  - x
+  - b
+  - c`)
+})


### PR DESCRIPTION
Pins the grouping rule for two adjacent navigation-only history entries, reachable once an undo clears the enhancer's merge tracking.

Passes on `main` as of `6e420d9cc8`. Fails on #5165, where the predicate was narrowed from `isPatchUndoable` to `!isNavigation`, so undo reverts one entry instead of two.

Merge `main` into #5165 to see it fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
