### PR TITLE
docs: note that fresh checkouts and worktrees need their own yarn install

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@
 
 ## Quick Start
 
-The project requires Node.js 22.13 or newer. Install dependencies with `yarn` before running tests.
+The project requires Node.js 22.13 or newer. Install dependencies with `yarn` before running tests. A fresh checkout — including every agent worktree under `.claude/worktrees/` — needs its own `yarn install`: the local Capacitor plugins in `packages/` are linked as workspace dependencies and are only compiled by the `postinstall` → `build:packages` step, so without it any test that reaches production code importing one fails to collect with `Failed to resolve import "webview-background" from "src/device/nativeHistory.ts"`. Run `yarn` (or just `yarn build:packages` if the rest of `node_modules` is already present) and re-run the tests.
 
 ```sh
 yarn test            # unit and jsdom tests


### PR DESCRIPTION
## What

Adds a line to the Quick Start in `docs/testing.md`: a fresh checkout — including every agent worktree under `.claude/worktrees/` — needs its own `yarn install` before tests will run.

## Why

Running tests in a worktree without installing fails at collection with:

```
Failed to resolve import "webview-background" from "src/device/nativeHistory.ts"
```

`webview-background` is the local Capacitor plugin in `packages/webview`, linked as a workspace dependency; its `dist/` only exists after `postinstall` → `build:packages`. The error names a missing package, which reads like a broken import rather than a missing install step, so the note records the symptom verbatim to make it greppable.

## Notes for the reviewer

Docs only. `yarn build:packages` alone is not always sufficient (other deps can be missing too), which the note reflects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)