### PR TITLE
docs(skills): no em dashes or semicolons in prose

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -104,6 +104,7 @@ Close with what is **out of scope**, as bare bullets: issues split out, preexist
 ## Words
 
 - **No em dashes in prose.**
+- **No semicolons in prose.** Two sentences, or a comma and a conjunction.
 - **No invented terms.** Every one of these was rewritten: "re-announce" became "open another one", "the recorded value" became "the patch should store undefined", "pinned by #5433" became "now covered by #5433". If a phrase is not in [`docs/glossary.md`](../../../docs/glossary.md) or plain English, it is jargon.
 - **Use the project's vocabulary.** em has thoughts and a thoughtspace. It has no documents. Resolve an unfamiliar term in the glossary before using it, including in a review.
 

--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -132,6 +132,7 @@ Word count is not the measure — a bug needing eight steps gets eight steps. Wh
 ## Words
 
 - **No em dashes in prose.** This applies to what you post: the issue body, the title, and comments on it.
+- **No semicolons in prose.** Two sentences, or a comma and a conjunction.
 
 ## Title
 

--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -129,6 +129,10 @@ Say the thing and stop. An issue is a report, not a write-up — the reader need
 
 Word count is not the measure — a bug needing eight steps gets eight steps. What gets cut is the writing that is about your investigation rather than about the bug.
 
+## Words
+
+- **No em dashes in prose.** This applies to what you post: the issue body, the title, and comments on it.
+
 ## Title
 
 Describe the symptom rather than the suspected cause: `Gesture Diagrams misaligned at larger font sizes`, not `GestureDiagram flex-align bug`.


### PR DESCRIPTION
Adds the "no em dashes in prose" rule from review-pr to write-issue, scoped to what gets posted: the issue body, the title, and comments on it.

Adds a matching "no semicolons in prose" rule to both skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)