### PR TITLE
fix(hooks): remove the lint log in an EXIT trap so set -e cannot skip it

### DIFF
--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -44,4 +44,8 @@ fi
 # Lint in the background, not blocking the terminal and piping all output to a file.
 # If the lint fails, trigger a notification (on supported platforms) with at least the first error shown.
 # We pipe output so that the terminal (tmux, vim, emacs etc.) isn't borked by stray output.
-(yarn lint:src 2>&1 | strip >"${LINT_LOG}" 2>&1 || notify "Lint Error"; rm -f -- "${LINT_LOG}") &
+# The EXIT trap removes the log even when notify fails, which set -e would otherwise skip.
+(
+  trap 'rm -f -- "${LINT_LOG}"' EXIT
+  yarn lint:src 2>&1 | strip >"${LINT_LOG}" 2>&1 || notify "Lint Error"
+) &


### PR DESCRIPTION
Follow-up to #4537.

`set -Eeuo pipefail` aborts the background subshell as soon as `notify` returns non-zero, so the trailing `rm -f` is skipped. The "`rm -f` moved into background subshell so it always runs" guarantee does not hold in the one case that needs it, and `main` before #4537 — having no `set -e` — did clean up there.

The failing branch is reachable, not theoretical: `notify` interpolates `$ERRORS` into AppleScript unescaped, so `osascript` exits 1 whenever a lint message contains a double quote. `react/no-unescaped-entities` emits exactly that.

    $ /usr/bin/osascript -e "display notification \"JSX has unescaped \` \" \` ...\" with title \"Lint Error\""
    41:43: syntax error: A unknown token can’t go after this “"”. (-2740)
    $ echo $?
    1

An `EXIT` trap makes the cleanup unconditional.

## Verified locally

Ran the hook with `core.hooksPath` pointed at each version against a deliberate `no-console` violation, with `/usr/bin/osascript` swapped for a shim recording its argv (and a variant exiting 1).

| case | before | after |
| --- | --- | --- |
| lint fails, `osascript` exits 1 | 298B `lint.<sha>.log` left in `$TMPDIR` | cleaned up |
| lint fails, notification shown | cleaned up | cleaned up |
| lint passes | cleaned up | cleaned up |

Notification still fires (confirmed on screen, title `Lint Error`), and `git commit` still returns in ~0.3s with the lint continuing in the background.

Not addressed here, and worth its own PR: `sed 1,4d` was tuned for Yarn 1's two-line banner, which Yarn 4 does not print, so it deletes the filename and the error itself — every notification body is just `✖ 1 problem (1 error, 0 warnings)`. The unescaped `$ERRORS` interpolation above belongs with that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
