### PR TITLE
fix(hooks): show the actual lint error in the post-commit notification

### DIFF
--- a/.hooks/post-commit
+++ b/.hooks/post-commit
@@ -17,13 +17,19 @@ strip() {
 
 # Display a notification
 notify() {
-  # read back in the lint errors
+  # Read back the lint errors, dropping blank lines and any package manager preamble so
+  # that the first real errors are what get shown. Done in one awk pass rather than piping
+  # into head, which can leave the pipeline with a SIGPIPE status under pipefail.
   local ERRORS
-  ERRORS=$(sed 1,4d "${LINT_LOG}")
+  ERRORS=$(awk '/^[[:space:]]*$/ || /^yarn run v/ || /^\$ / { next } { print; if (++n == 4) exit }' "${LINT_LOG}")
 
   # macOS via osascript, Linux via notify-send; do nothing if neither exists
   if [[ -x /usr/bin/osascript ]]; then
-    /usr/bin/osascript -e "display notification \"${ERRORS}\" with title \"$*\""
+    # A backslash or double quote in a lint message is a syntax error in AppleScript, so
+    # escape both before interpolating. eslint emits them, e.g. react/no-unescaped-entities.
+    local ESCAPED=${ERRORS//\\/\\\\}
+    ESCAPED=${ESCAPED//\"/\\\"}
+    /usr/bin/osascript -e "display notification \"${ESCAPED}\" with title \"$*\""
   elif command -v notify-send >/dev/null; then
     notify-send "$*" "${ERRORS}"
   fi


### PR DESCRIPTION
Split out of #5456, which fixes the cleanup leak in the same file. The two touch different hunks and merge cleanly in either order (`git merge-tree` reports no conflict).

## `sed 1,4d` deletes the error

It was tuned for Yarn 1's two-line banner. This repo is on `yarn@4.17.0`, which prints no banner, so the four lines it drops are the blank line, the filename, and the first errors. The body that survives is only the summary — you're told something broke, never what.

Actual `$LINT_LOG` for a single `no-console` violation:

    1 | (blank)
    2 | /Users/raine/projects/em/src/thing.ts
    3 |   3:3  error  Unexpected console statement...  no-console
    4 | (blank)
    5 | ✖ 1 problem (1 error, 0 warnings)

Selecting the first real error lines in a single `awk` pass — rather than piping into `head`, which can leave the pipeline with a SIGPIPE status under `pipefail` — gives the filename and errors instead.

## Unescaped interpolation into AppleScript

`$ERRORS` goes into the script source unquoted, so a backslash or double quote in a lint message is a syntax error and `osascript` exits 1 — no notification at all. `react/no-unescaped-entities` emits exactly that.

## Verified locally

Driving `notify()` against a log holding a `` `"` can be escaped `` message and a backslash:

| | before | after |
| --- | --- | --- |
| `osascript` | `syntax error … (-2741)`, exit 1, no notification | exit 0, notification shown |
| body | first two errors missing | filename + all three errors |

And end-to-end, committing a real `no-console` violation with `core.hooksPath` pointed at this version, the notification body is now:

    /Users/raine/.../src/lintTestBad.ts
      3:3  error  Unexpected console statement. Only these console methods are allowed: error, info, warn  no-console
    ✖ 1 problem (1 error, 0 warnings)

where on `main` it is just `✖ 1 problem (1 error, 0 warnings)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
