### PR TITLE
end-session: report in the turn that did the work, and let a cloud runner go idle

### DIFF
--- a/.github/skills/end-session/SKILL.md
+++ b/.github/skills/end-session/SKILL.md
@@ -121,7 +121,7 @@ Use `ci-monitor`. Wait for every run on the branch to complete; do not report on
 
 ## Step 7: Report
 
-Your final message is the entire record for whoever picks this up. It must contain:
+Your final message is the entire record for whoever picks this up. Write it **in the turn that did the work**, before you yield — never on a later wake, which may arrive hours after the fact or not at all. It must contain:
 
 - **What you did**, step by step — branch created, commits made, PR opened, CI status, fixes applied.
 - **The PR URL and its status.**
@@ -129,6 +129,17 @@ Your final message is the entire record for whoever picks this up. It must conta
 - **A concise diagnosis of any CI failure** you hit along the way, and what you did about it.
 - **What you did not do.** Anything out of scope, deferred, or left broken. A test still skipped, a file you left alone in Step 2, a second reproduction path you did not get to. Silence here reads as "everything is handled."
 - **If escalating:** what you tried, what you observed each time, and the specific question or decision you need from the user. "It didn't work" is not an escalation.
+
+---
+
+## Step 8: How to wait for whatever comes next
+
+A cloud session's runner is reclaimed once it goes idle, and that is the correct end state rather than a failure: an idle session costs nothing, while every wake costs a full turn — a fresh runner, and the whole conversation re-read. So end deliberately instead of leaving the session alive to watch.
+
+- **Subscribe; do not poll.** A pull request subscription delivers CI results, review comments, and the merge itself as events, and costs nothing in between. Ending your turn *is* how you wait for them.
+- **Do not put a timer on top of it.** A scheduled check-in fires whether or not anything happened, re-provisions the runner that was correctly reclaimed, and spends a turn reporting that nothing changed. Left overnight on a quiet pull request, that is one wake an hour for no information.
+- **Never wake to narrate a finished outcome.** A merged pull request needs nothing further, so the wake that announces it is pure cost — and it is the report you owed in Step 7 arriving late. Report the merge in the turn that performed it, and let the session go.
+- The one thing a subscription genuinely misses is a conflict created when the base branch advances, which GitHub emits no webhook for. That belongs in CI, not in a timer: [`copilot-conflicts.yml`](../../workflows/copilot-conflicts.yml) already scans for it on every push to `main`.
 
 ---
 
@@ -154,3 +165,5 @@ Unlike the `issue-repro` and `plan` gate lines, this one **is** a stopping point
 - **Cleaning the tree by deleting.** `git checkout .` makes Step 3's command print nothing and destroys the session's work doing it. Account for files; never discard them.
 - **Escalating without pushing.** The most expensive ending available: the investigation is gone and the user restarts from zero. Escalation runs the full checklist.
 - **Reporting CI you did not watch.** Ending while runs are in flight and describing the ones that happened to finish.
+- **Yielding first and reporting on the next wake.** Finishing a merge or a green run, ending the turn silently, and planning to summarise when something wakes you. The runner is reclaimed in the meantime, so the report arrives hours later from a fresh one — or never, because nothing wakes a session whose work is already done. The report belongs in the turn that did the work.
+- **Keeping the session alive to watch.** Scheduling a check-in so the session stays warm. The subscription already covers every event worth waking for, and the timer only pays to rebuild what idling correctly tore down.

--- a/docs/agents/external-agents.md
+++ b/docs/agents/external-agents.md
@@ -93,6 +93,14 @@ These depend on things the runner provides: Chrome already listening on a debugg
 
 One idea inside `browser-control` is worth knowing wherever you drive this app, because it is a property of **em** rather than of any harness: *observing is free, but actuating goes through the project's own e2e helpers*, since some of em's controls (the toolbar buttons and color swatches) are bound to touch events only when `isTouch`, so a raw mouse click silently no-ops under touch emulation. It has not been extracted into a shared skill — do that if it starts causing trouble locally.
 
+## Claude Code in the cloud
+
+"Local" above means *not the Copilot cloud agent*, which is not quite the same as *on a laptop*: a Claude Code session started from [claude.ai/code](https://claude.ai/code) reads `AGENTS.md` through the same `CLAUDE.md` symlink and the same `.agents/skills/`, but runs on a disposable Anthropic-managed runner rather than on a developer's machine. Everything above still applies to it. Two properties of that runner do not apply to either of the others, and [`end-session`](skills.md#end-session) Step 8 is where they turn into rules.
+
+The runner is **reclaimed once the session goes idle**, and reopening the session provisions a fresh one. That makes idling the cheap state and waking the expensive one, which inverts the usual instinct to keep a session running: there is no compute charge for the runner, but every wake re-reads the whole conversation. A session whose work is finished should be allowed to end.
+
+The session can also be **woken by pull request activity**, which it subscribes to per pull request. Subscription is the right way to wait, because it costs nothing until GitHub actually emits something. A scheduled check-in on top of it is not, because it fires on a clock rather than on an event and pays to rebuild the runner that idling correctly released. The one blind spot is a conflict created when the base branch advances, which GitHub emits no webhook for at all — [`copilot-conflicts.yml`](../../.github/workflows/copilot-conflicts.yml) covers that from CI on every push to `main`, though it scans only pull requests authored by the Copilot account.
+
 ## Changing any of this
 
 **Adding a skill to the shared set** is one symlink:


### PR DESCRIPTION
A Claude Code session started from [claude.ai/code](https://claude.ai/code) reads `AGENTS.md` through the same `CLAUDE.md` symlink and the same `.agents/skills/` as a local one, so every existing rule already applies to it. But it runs on a disposable Anthropic-managed runner, and that runner has two properties neither a laptop nor the Copilot runner has. Nothing in the repository said what to do about them, so this session got both wrong.

## What went wrong

On #5394 I merged the PR at 18:46 UTC and ended the turn without reporting. The runner was then reclaimed for inactivity. The GitHub events queued at 18:46 had nowhere to land, and sat there until the session was reopened at 01:30 the next morning, which provisioned a fresh runner and flushed them. The merge summary arrived just under three hours late, from a runner that had to be rebuilt to deliver it.

I then proposed fixing that with a scheduled hourly check-in, which is worse. A timer fires on a clock rather than on an event, so on a quiet PR it is one wake an hour for no information, each one re-provisioning the runner that idling had correctly released, and each one re-reading the whole conversation. The report was the fix; the timer only pays to rebuild what should have been allowed to end.

## The rules

**Step 7** now says the report belongs in the turn that did the work, never on a later wake.

**Step 8** is new, and states how to wait:

- Subscribe, do not poll. The subscription delivers CI results, review comments, and the merge as events, and costs nothing in between. Ending the turn *is* how you wait for them.
- Do not put a timer on top of it.
- Never wake to narrate a finished outcome. A merged PR needs nothing further, and that wake is the Step 7 report arriving late.

Two entries join **Failure modes to avoid**: yielding first and reporting on the next wake, and keeping a session alive to watch.

## The one real exception

A subscription genuinely misses a conflict created when the base branch advances, because [GitHub emits no webhook for it](https://code.claude.com/docs/en/claude-code-on-the-web#how-claude-responds-to-pr-activity). That is what left #5394 conflicted until it was pointed out. Step 8 does not carve out an exception for it, because the right trigger is `push` to `main`, which is CI's job and not a timer's — `copilot-conflicts.yml` already does exactly that.

Worth knowing separately: `collect-copilot-conflicts.cjs:57` filters on `pr.user.login === 'Copilot'`, and cloud-session PRs are authored by the connected account, so #5394 was ineligible and the scan skipped it. Not changed here; noted in the docs and worth deciding on its own.

## Where it went, and where it didn't

`docs/agents/external-agents.md` currently frames everything non-Copilot as "agents running on a developer's own machine", which no longer covers a cloud session. It gains a short section describing the runner and the reasoning, keeping the procedure in the skill and the rationale in `docs/`, as elsewhere in this repo.

Not `AGENTS.md`. That file is ingested on every run by every agent, Copilot included, where neither PR subscriptions nor runner reclamation exist — it would be standing attention spent on something only one harness can act on. `end-session` is read at exactly the moment these rules apply and costs nothing until then.

Both files are covered by `.prettierignore`, so there is no formatting check on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JoqGxqEoiaWJhpLnSUV8w

---
_Generated by [Claude Code](https://claude.ai/code/session_013JoqGxqEoiaWJhpLnSUV8w)_