### PR TITLE
fix(gestures): measure finger movement in viewport coordinates

### DIFF
--- a/src/components/MultiGesture.tsx
+++ b/src/components/MultiGesture.tsx
@@ -278,6 +278,13 @@ class MultiGesture extends React.Component<MultiGestureProps> {
           return
         }
 
+        // React Native Web reports page coordinates. Measure finger movement in the viewport so
+        // momentum scrolling cannot turn an upward swipe into a downward or stationary gesture.
+        const clientPoint = {
+          x: gestureState.moveX - window.scrollX,
+          y: gestureState.moveY - window.scrollY,
+        }
+
         // initialize this.currentStart on the the first trigger of the move event
         // TODO: Why doesn't onPanResponderStart work?
         if (!this.currentStart) {
@@ -298,10 +305,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             this.disableScroll = false
           }
 
-          this.currentStart = {
-            x: gestureState.moveX,
-            y: gestureState.moveY,
-          }
+          this.currentStart = clientPoint
           this.scrollYStart = window.scrollY
           if (this.props.onStart) {
             this.props.onStart({ clientStart: this.clientStart!, e })
@@ -311,10 +315,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
 
         const g = gesture(
           this.currentStart,
-          {
-            x: gestureState.moveX,
-            y: gestureState.moveY,
-          },
+          clientPoint,
           this.minDistanceSquared,
           // The new sequence will be appended as soon as it is detected, so we need to base the bias on the second-to-last letter in the sequence
           this.sequence.length > 1
@@ -326,10 +327,7 @@ class MultiGesture extends React.Component<MultiGestureProps> {
 
         if (g) {
           this.disableScroll = true
-          this.currentStart = {
-            x: gestureState.moveX,
-            y: gestureState.moveY,
-          }
+          this.currentStart = clientPoint
 
           if (g !== this.sequence[this.sequence.length - 1]) {
             // append the gesture to the sequence and call the onGesture handler
@@ -349,22 +347,22 @@ class MultiGesture extends React.Component<MultiGestureProps> {
             abandon: this.abandon,
           })
         }
+        const clientEnd = {
+          x: gestureState.moveX - window.scrollX,
+          y: gestureState.moveY - window.scrollY,
+        }
         // Log the start and end coordinates so that a false gesture, such as an OS app switcher swipe misread as a command gesture, can be diagnosed from the debug log. innerHeight and safeAreaBottom determine the bottom system-gesture exclusion that was in effect (see isInGestureZone), so the log also reveals if the exclusion was inert because the safe area inset read as zero.
         debugLog.log('gesture', {
           sequence: this.sequence,
           x: this.clientStart && Math.round(this.clientStart.x),
           y: this.clientStart && Math.round(this.clientStart.y),
-          endX: Math.round(gestureState.moveX),
-          endY: Math.round(gestureState.moveY),
+          endX: Math.round(clientEnd.x),
+          endY: Math.round(clientEnd.y),
           abandon: this.abandon,
           innerHeight: viewportStore.getState().innerHeight,
           safeAreaBottom: getSafeAreaBottom(),
         })
         if (!this.abandon) {
-          const clientEnd = {
-            x: gestureState.moveX,
-            y: gestureState.moveY,
-          }
           this.props.onEnd?.({ sequence: this.sequence, clientStart: this.clientStart!, clientEnd, e })
         }
         this.reset()


### PR DESCRIPTION
#5298

Makes gesture recognition follow the finger's movement on screen, rather than mixing it with document scrolling. This preserves the existing same-document gesture test when upgrading Chrome.

Stack: **#5398 → #5463 → #5305**.

**What I did**

Changed `src/components/MultiGesture.tsx` to subtract `window.scrollX` and `window.scrollY` from React Native Web's page-relative coordinates before measuring gesture segments. End coordinates supplied to callbacks and debug logging use the same viewport-relative convention.

**This is a production behavior fix, not a test-only adjustment.** When the page is stationary, gesture recognition is unchanged. When the document scrolls during a gesture, recognition now follows the finger instead of including that scroll movement. Thresholds, direction bias, and excluded gesture zones are unchanged.

### Why this must precede #5305

#5305 upgrades Browserless v1/Chrome 121 to Browserless v2/Chrome 151. That upgrade exposed an existing coordinate assumption in the app through the Command Center bottom-edge test.

The test deliberately checks two actions in the **same document**, without a pause or reload between them:

1. An upward swipe starting in the excluded bottom-system-gesture strip must **not** open Command Center.
2. An immediate upward swipe starting inside the valid gesture area **must** open it.

In Chrome's mobile emulation, the uncanceled first swipe starts native scrolling and momentum. The second swipe arrives while the document is still moving. Page coordinates include the scroll offset, so comparing them can make an upward finger movement appear stationary or downward.

### Why older Chrome hid the problem

[Chromium CL 7239269](https://chromium-review.googlesource.com/c/chromium/src/+/7239269), “Fix first touch move to correctly track if event is blocking,” corrected first-move bookkeeping during Chrome 145 development. It landed on December 16, 2025: commit [`42c8b2a872`](https://chromium.googlesource.com/chromium/src/+/42c8b2a872d3c9322dba3eacbcc090618e923979), linked to [crbug 467963553](https://issues.chromium.org/issues/467963553).

Our helper moves the finger in 10px steps. Chromium suppresses the first small move before JavaScript receives it. Previously, that suppressed event used up the internal “first move” designation. The next, DOM-visible move remained cancelable, letting the app stop the scrolling and masking the coordinate bug.

The CL extends the designation through the first move beyond the small-motion threshold. That DOM-visible move now inherits Chromium's existing “nonblocking due to fling” policy: the app cannot cancel it, scrolling continues, and the incorrect coordinate comparison is exposed. **The fling policy itself is not new.**

### Why not just change the test?

Waiting for momentum to stop or reloading between swipes would stop testing immediate same-document recovery. This PR instead preserves the original test **without any test-file change**. Both assertions, input steps, and timing remain intact. The rejected `resetApp` workaround is absent from #5305 as well.

Keeping this production fix separate lets reviewers assess its behavior and validation before #5305 changes the browser environment or regenerates snapshots. The stack therefore resolves the exposed app bug first, then performs the migration.

**What I verified**

- With the original app code and test, official Chromium build **1559151** produced the expected result twice; build **1559167** timed out on the second assertion twice. One run of each included tracing and one did not.
- Both builds reported “NonBlocking due to fling.” The traces differ in precisely the first-move designation changed by the CL and the resulting cancelability of the first DOM-visible move.
- These available builds span 16 commits, not a custom compilation of the exact parent and child. The interval was inspected; CL 7239269 is its only touch-input change. Provenance: [before](https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1559151/REVISIONS), [after](https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1559167/REVISIONS).
- Temporarily using 20px input steps, avoiding the suppressed initial move, made the pre-change browser exhibit the same failure. This was a diagnostic control; the helper still uses 10px steps.
- Exercised the fix against the original test and all 12 neighboring Command Center, gesture, and scroll cases in Chrome 121 and 151. Also ran the full Chrome 151 browser suite, unit suite, and lint on the combined migration tree.
- Temporarily removing the bottom-edge exclusion made the first assertion fail, confirming that the original test still detects that regression. The exclusion was restored.
- Faiz manually validated the suggested interactions and reported no perceived behavioral difference. Exact device/browser coverage was not recorded.

**How to test**

Use a long, scrollable document with a thought selected, on a touch device:

1. Check ordinary directional and multi-direction command gestures with the page stationary.
2. Fling using the scroll zone, then immediately swipe up in the valid gesture area while the document is moving. Command Center should open without an unintended command. Repeat after scrolling in either direction.
3. Start a swipe in the scroll zone and move into the gesture area. It must remain scrolling, not become a command.
4. On iOS, open the app switcher from the bottom edge, return, then perform a valid Command Center gesture. Only the valid app gesture should open Command Center.
5. Repeat the relevant checks with the keyboard visible and, if used, left-handed mode.

**Known limits & follow-ups**

This makes direction detection independent of document scrolling; it **does not stop native momentum scrolling**. A command may therefore be recognized while scrolling continues. That production behavior was part of the manual validation, not something the browser test alone could approve. Existing intermittent suite failures are outside this fix; no assertions, timeouts, or skip markers were changed to accommodate them.
