### PR TITLE
debug: record why a keystroke edited nothing on iOS Safari

### DIFF
--- a/docs/cursor-and-caret.md
+++ b/docs/cursor-and-caret.md
@@ -126,6 +126,17 @@ Both cases return early, before any of the end-of-editing resets (`editingValueS
 
 There is also a small effect that re-focuses the editable when the sidebar closes on desktop, so editing resumes seamlessly.
 
+### `deadKey`: a keystroke that edits nothing
+
+On iOS Safari the editable can stop accepting edits while still looking and behaving like a focused, editable thought: `keydown` fires on it, but no `beforeinput` follows and nothing changes. Every key is affected, not just deletion, and the state persists across backgrounding the app. Two causes produce that same signature, and neither leaves any other trace:
+
+- **The caret has nowhere editable to act on**, e.g. the selection is in a different thought's editable than the focus, or the editable has no layout box.
+- **iOS's native text-input layer has wedged**, the freeze that the deferred autocomplete retarget in `Editable` guards against ([issue #4607](https://github.com/cybersemics/em/issues/4607)).
+
+The Safari-only debug effect in [`Editable`](../src/components/Editable.tsx) records both the caret state on every `keydown` and a `deadKey` entry when a key that should have edited the text produced no `beforeinput` by the next animation frame. Keys the command layer claims are excluded by checking `defaultPrevented`, so `deadKey` marks a real failure rather than a handled command. The layout reads that separate the two causes are deferred to the failure case, so a healthy session pays nothing for them.
+
+`focus` and `blur` entries record the `aria-label` of the active element (`editable-<thoughtId>`) alongside the label of the editable whose listener fired. Thought editables are otherwise indistinguishable in the log — every one is a bare `DIV` with no `data-testid` — so without the labels a focus retargeted onto a neighbouring thought reads exactly like the focus staying put.
+
 **Prefer `useEditMode` over manually calling `selection.set`.** The hook handles ordering, edge cases, and platform quirks; manual calls tend to introduce subtle inconsistencies. There are still cases where manual selection is unavoidable (e.g. after a programmatic content edit), but those are minimized.
 
 ## Philosophy

--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -500,13 +500,73 @@ const Editable = ({
     // platforms. Each is a no-op when debug logging is disabled. They capture the raw event stream around autocomplete,
     // which React's synthetic onChange does not fully expose (e.g. beforeinput, composition, and focus retargeting).
 
-    /** Logs the key sequence leading into an autocomplete freeze. */
-    const onEditableKeyDown = (e: KeyboardEvent) => debugLog.log('keydown', { key: e.key, isComposing: e.isComposing })
+    // Counts beforeinput events on this editable so that a keystroke can be checked against it a frame later. A
+    // keystroke that leaves this unchanged produced no mutation attempt at all (see onEditableKeyDown).
+    let beforeInputCount = 0
+
+    /** Returns true if the key is one that must produce a beforeinput when it reaches a healthy editable: a printable
+     * character, or a deletion or newline key. Modifier chords are excluded, since they invoke commands rather than
+     * editing the text. */
+    const isMutatingKey = (e: KeyboardEvent) =>
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      (e.key.length === 1 || e.key === 'Backspace' || e.key === 'Delete' || e.key === 'Enter')
+
+    /** Describes where the browser thinks the caret is relative to this editable, which is what determines whether a
+     * keystroke can mutate anything. Reads no layout, so it is cheap enough to record on every keystroke. */
+    const describeCaret = () => {
+      // Read the thought id back off the editable rather than closing over the path, which is not a dependency of this
+      // effect and so could be stale by the time a key is pressed.
+      const thoughtId = editable.getAttribute('aria-label')?.replace(/^editable-/, '') ?? ''
+      return {
+        isActiveElement: document.activeElement === editable,
+        isContentEditable: editable.isContentEditable,
+        selInEditable: selection.isOnEditable(thoughtId),
+        selActive: selection.isActive(),
+        selIsText: selection.isText(),
+        selCollapsed: selection.isCollapsed(),
+        offset: selection.offset(),
+      }
+    }
+
+    /** Logs the key sequence leading into an autocomplete freeze, along with the caret state that determines whether
+     * the key can edit anything, and flags a key that silently did nothing (see below). */
+    const onEditableKeyDown = (e: KeyboardEvent) => {
+      // Guard on isEnabled so that the DOM reads below, and the animation frame scheduled per keystroke, do not run at
+      // all in a normal session. debugLog.log is already a no-op when disabled, but its arguments are not.
+      if (!debugLog.isEnabled()) return
+
+      debugLog.log('keydown', { key: e.key, isComposing: e.isComposing, ...describeCaret() })
+
+      /* A key that should edit the text, that em did not claim as a command, must reach the editable as a beforeinput.
+         When none arrives by the next frame, no mutation was even attempted: the caret has nowhere editable to act on,
+         or iOS's native text-input layer has stopped accepting edits altogether (the freeze described in #4607).
+         Either way the failure is completely silent — the log otherwise shows a keydown and nothing after it — so
+         record the caret state at the moment the key died, which is what distinguishes the two causes. */
+      if (!isMutatingKey(e)) return
+      const beforeInputCountAtKeyDown = beforeInputCount
+      requestAnimationFrame(() => {
+        // The command layer calls preventDefault when it handles the key (see keyDown in commands.ts), in which case
+        // the absence of a beforeinput is expected rather than a failure.
+        if (beforeInputCount !== beforeInputCountAtKeyDown || e.defaultPrevented) return
+        debugLog.log('deadKey', {
+          key: e.key,
+          ...describeCaret(),
+          // Layout reads, deferred to the failure case: an editable with no layout box accepts no input, which is the
+          // one condition that reproduces this signature outside of a native freeze.
+          rects: editable.getClientRects().length,
+          height: Math.round(editable.getBoundingClientRect().height),
+        })
+      })
+    }
 
     /** Logs beforeinput, which precedes each mutation and reveals intent (e.g. insertReplacementText) even if input never fires. */
-    const onEditableBeforeInput = (e: Event) =>
-      e instanceof InputEvent &&
+    const onEditableBeforeInput = (e: Event) => {
+      if (!(e instanceof InputEvent)) return
+      beforeInputCount++
       debugLog.log('beforeinput', { inputType: e.inputType, data: e.data, isComposing: e.isComposing })
+    }
 
     /** Logs IME composition boundaries; iOS autocorrect runs inside a composition and a hang may straddle these. */
     const onEditableCompositionStart = () => debugLog.log('composition', { phase: 'start' })
@@ -514,10 +574,19 @@ const Editable = ({
     const onEditableCompositionEnd = (e: CompositionEvent) =>
       debugLog.log('composition', { phase: 'end', data: e.data })
 
-    /** Describes the currently focused element (tag + data-testid) so focus retargeting during autocomplete can be traced. */
+    /** Describes the currently focused element so focus retargeting during autocomplete can be traced. Every thought
+     * editable is a bare DIV with no data-testid, so the aria-label (`editable-<thoughtId>`) is what identifies which
+     * thought the focus landed on. Without it a retarget onto a neighbouring thought is indistinguishable from the
+     * focus staying put. */
     const describeActiveElement = () => {
       const el = document.activeElement
-      return { tag: el?.tagName ?? null, testid: el?.getAttribute?.('data-testid') ?? null }
+      return {
+        tag: el?.tagName ?? null,
+        testid: el?.getAttribute?.('data-testid') ?? null,
+        label: el?.getAttribute?.('aria-label') ?? null,
+        // The editable whose listener fired, which is not necessarily the one that is now active.
+        editable: editable.getAttribute('aria-label'),
+      }
     }
     /** Logs when the editable gains focus, recording which element is now active. */
     const onEditableFocus = () => debugLog.log('focus', describeActiveElement())


### PR DESCRIPTION
Reported as "cannot delete the clock emoji from `📅🕰️` on mobile Safari", with a debug log attached. Analysis of that log shows the bug is not about emoji, and not about deletion: **once it starts, no edit of any kind works**, and it survives backgrounding the app.

This PR does not fix it. It makes the next capture conclusive, because the current log cannot distinguish the remaining causes or even mark where the failure began.

## What the attached log proves

The 13 dead `Backspace` presses on `📅🕰️` are the **only** dead keydowns in the session (491 keydowns, 13 with no follow-up).

1. **em is not swallowing the key.** `debugLog.log('command', …)` fires in `executeCommand` only after `canExecute` passes, and no `command` entry follows any of the 13 — so `deleteEmptyThoughtOrOutdent.canExecute` returned `false` and `keyDown` never called `preventDefault`. Working Backspaces elsewhere in the same session *do* log `command`.
2. **The browser then did nothing at all.** The editable's `beforeinput` listener logs unconditionally and never fired. No `beforeinput`, no `input`, no mutation. WebKit gave up before dispatching anything.
3. **The editable was focused and mounted** — the `keydown` listener is bound to the editable itself.
4. The last successful `beforeinput` in the whole log is at `09:47:22.949`. Nothing edits for the remaining 42s.

Reproducing the signature in Chromium: an editable that has lost its layout box swallows *both* typing and Backspace with no `beforeinput`, matching the report exactly. Every other configuration tried (caret anchored on the element vs. inside the text node, emoji vs. plain text, focus/selection mismatch, stale node, no selection) still dispatches `deleteContentBackward`. So the emoji and the end-of-thought caret are not the cause.

## Why the log cannot go further

- A dead keystroke logs a `keydown` and nothing after it, which is exactly what a key claimed by the command layer looks like.
- Every thought editable logs as a bare `DIV` with no `data-testid`, so a focus retargeted onto a neighbouring thought is indistinguishable from the focus staying put. The log contains one such spontaneous retarget onto the previous thought 1.1s after the last touch, outside the 700ms `GHOST_MOUSE_WINDOW_MS` guard (#4173), and there is no way to confirm which editable held focus afterwards.

## Changes

All inside the existing Safari-touch-only debug effect in `Editable`:

- **Caret state on every `keydown`** — active element, `isContentEditable`, whether the selection is in this editable, offset, collapsed. No layout reads.
- **A `deadKey` entry** when a key that should have edited the text produced no `beforeinput` by the next animation frame. Keys the command layer claimed are excluded via `defaultPrevented`, so `deadKey` marks a real failure rather than a handled command. The layout reads that separate "caret has nowhere editable to act on" from "native text-input layer wedged" (#4607) are deferred to the failure case.
- **Focus attribution** — `focus`/`blur` now record the `aria-label` of the active element (`editable-<thoughtId>`) alongside the label of the editable whose listener fired.

The handler is guarded on `debugLog.isEnabled()`, so a normal session performs none of the DOM reads and schedules no animation frame per keystroke.

## Testing

Verified the watchdog in Chromium against a harness mirroring the handler:

| case | keys | `deadKey` |
| --- | --- | --- |
| healthy editable | `x`, `Backspace` | none |
| healthy editable | `ArrowLeft`, `ArrowRight` | none (not mutating keys) |
| editable that lost its layout box while focused | `x`, `Backspace` | **both flagged** |
| key claimed by the command layer (`preventDefault`) | `Enter` | none |

No false positives on normal editing. `yarn lint:src`, `yarn lint:tsc`, prettier, and the unit suite (523 passed, 4 skipped) all pass.

`docs/cursor-and-caret.md` gains a short section describing the `deadKey` entry and the focus labels.

## Next step

One reproduction on the affected device with this build attached to the issue should identify the cause outright. Deliberately no behavioural change here: the repo's own note on #4607 warns that blurring and refocusing inside an input event can deadlock the native text-input layer, so a self-healing retarget would risk causing the very freeze it is meant to clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXP8AXosk12VpT2XxJuytn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXP8AXosk12VpT2XxJuytn)_