### PR TITLE
Document the sub-issue relationship in write-issue

### DIFF
--- a/.github/skills/write-issue/SKILL.md
+++ b/.github/skills/write-issue/SKILL.md
@@ -150,9 +150,43 @@ Add `design-needed` when the correct behaviour has not been decided.
 
 Leave priority and triage labels — `hold`, `low-priority`, `unable-to-reproduce`, `human` — to the maintainers.
 
+## Sub-issues
+
+Work that only makes sense as part of a larger piece belongs to that piece as a sub-issue, not beside it as a sibling with a reference in the body. GitHub tracks the hierarchy: the parent shows its children and a completion count, closing a child advances it, and the children stay findable from the parent long after the thread that created them has scrolled away.
+
+Use it where one issue is a part of another — a feature broken into the pieces that build it, as [#5481](https://github.com/cybersemics/em/issues/5481) is by #5482 through #5488. Do not use it for two issues that merely touch the same code.
+
+Sub-issues and `Blocked by` are different relationships, and an issue can have both. Sub-issue is composition: this is *part of* that. `Blocked by` is sequencing: this cannot start until that is done. Siblings under one parent are frequently also blocked by each other, and that ordering has to be set separately.
+
+Set the relationship from the parent, with the child's numeric database id rather than its issue number:
+
+```bash
+gh api repos/cybersemics/em/issues/5482 --jq .id
+```
+
+```bash
+gh api --method POST repos/cybersemics/em/issues/5481/sub_issues -f sub_issue_id=<id>
+```
+
+`gh` may also expose this as a flag on `gh issue edit` depending on the version installed — check `gh issue edit --help` before falling back to the endpoint.
+
+Verify it landed, since a body reference and a relationship look alike once rendered:
+
+```bash
+gh issue view 5481 --repo cybersemics/em --json subIssuesSummary
+```
+
+A parent holds up to 100 sub-issues and the hierarchy nests up to 8 levels, neither of which any issue here is close to.
+
+The relationship is also what makes the backlog readable. `no:parent-issue` filters an issue list down to top-level work, and `parent-issue:cybersemics/em#5481` gives one feature's pieces:
+
+```bash
+gh issue list --repo cybersemics/em --search "is:open no:parent-issue"
+```
+
 ## Blocked by
 
-"Blocked by" is a GitHub relationship, not a line of body text. `Blocked by #5228` in the body renders as a plain reference: the issue is not marked blocked, it does not show as blocked in issue lists or projects, and #5228 does not show what it is holding up.
+"Blocked by" is a GitHub relationship, not a line of body text, and it is not the sub-issue relationship above — it orders two issues rather than nesting one inside the other. `Blocked by #5228` in the body renders as a plain reference: the issue is not marked blocked, it does not show as blocked in issue lists or projects, and #5228 does not show what it is holding up.
 
 Set the relationship with `gh`, at creation or after:
 
@@ -208,6 +242,7 @@ New issues often originate in a comment thread on another issue or PR.
 - A paragraph of preamble establishing what you did and did not reproduce, where a clause would do.
 - A screenshot with no steps.
 - A `Blocked by` line in the body with no relationship configured on GitHub.
+- A piece of a larger feature opened as a sibling with `Part of #5481` in the body, where a sub-issue relationship is what tracks it.
 - A loose end left for the reader — an unruled-out alternative, a missing value, an unnamed platform — that the reporter could have answered before posting.
 
 ## When something is unknown


### PR DESCRIPTION
`write-issue` covered `Blocked by` in detail — what the relationship is, why a body reference is not a substitute, how to set and verify it — and said nothing about sub-issues. An agent breaking a feature into its pieces therefore reached for a body reference or a `- [ ]` checklist, neither of which GitHub tracks, and the pieces stopped being findable from the parent once the thread scrolled away.

Adds a `## Sub-issues` section before `## Blocked by`, covering:

- When the relationship applies — one issue is *part of* another, as #5481 is composed of #5482–#5488 — and when it does not.
- How it differs from `Blocked by`: composition versus sequencing, and that an issue often has both.
- How to set it, using the child's numeric database id rather than its issue number, mirroring the pattern the skill already documents for dependencies.
- How to verify it landed, since a body reference and a relationship look alike once rendered.
- The `no:parent-issue` and `parent-issue:` filters, which are what make a backlog this size readable.

Also cross-references the two relationships from the `Blocked by` section, and adds the missing-relationship case to `## Common defects`.

The `gh` flags for sub-issues could not be verified from this environment, so the section documents the API endpoint and points the reader at `gh issue edit --help` rather than asserting a flag that may not exist in their version.

No documentation drift: `docs/agents/skills.md` describes `write-issue` in one table row, which is still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMSc1LpXWbMmGkWWyisTbw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMSc1LpXWbMmGkWWyisTbw)_