### PR TITLE
Open a command detail page from the grid

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -125,15 +125,18 @@ The Toolbar renders a configurable subset of commands as buttons. The user's cus
 The **Command Universe** is the searchable command palette. Two flavors:
 
 - **`DesktopCommandUniverse`** (`Cmd/Ctrl + P`) — desktop palette opened by `openCommandCenter` / `openDesktopCommandUniverse`.
-- **`MobileCommandUniverse`** — mobile drawer opened by `openMobileCommandUniverse`, also reachable by gesture.
+- **`MobileCommandUniverse`** — dialog opened by `openMobileCommandUniverse`, also reachable by gesture. Clicking a grid cell opens its command detail page, including when the command cannot currently execute. Cells are native buttons, so Enter and Space also open details. Back/Forward in `DialogHeader` navigate the dialog history. Search stays above the grid scroller, and changing search or sort resets the results to the top.
 
 The Command Universe has one session owner and separate routing and presentation layers:
 
 - [`CommandUniverseProvider`](../src/components/CommandUniverse/CommandUniverseProvider.tsx) owns one [`CommandUniversePageNavigator`](../src/@types/CommandUniversePageNavigator.ts), keeping its reducer and lifecycle logic inside the provider. Consumers read that same instance through [`useCommandUniverseNavigator`](../src/hooks/useCommandUniverseNavigator.ts). The consumer hook never creates a second history and throws when no provider is present. The provider sits outside the modal's fade/unmount boundary. Its `isOpen` describes the entire Command Universe session, not whether one particular presentation is visible.
 - [`commandUniversePages`](../src/components/CommandUniverse/commandUniversePages.ts) maps page ids to components. [`CommandUniversePage`](../src/@types/CommandUniversePage.ts) derives both the ids and the corresponding props from that registry. A history entry wraps a page with its own `entryId`, so two visits to the same page remain distinct. The navigator stores opaque page props and has no command-specific fields.
 - [`CommandUniversePageRouter`](../src/components/CommandUniverse/CommandUniversePageRouter.tsx) selects the registered component and forwards its props. It does not own history, read command data, or size the dialog. The modal composition sizes the outer non-scrolling viewport. Each page uses [`DialogContent`](../src/components/dialog/DialogContent.tsx) for its independent scroller, padding, and custom scrollbar.
+- [`CommandUniversePageTransitions`](../src/components/CommandUniverse/CommandUniversePageTransitions.tsx) coordinates the retained page surfaces. Inactive pages are inert and hidden by whole-page opacity, which also hides descendants that override visibility themselves. After navigation, the view restores the destination's last focused element or focuses its designated heading without changing scroll position.
 
-Starting a new branch discards its abandoned redo entries. Closing and reopening starts a fresh session. This history is independent of browser history and the editor's undo/redo.
+Reachable history entries remain mounted with their independent scroll positions. Starting a new branch discards its abandoned redo pages. Closing and reopening starts a fresh session. This history is independent of browser history and the editor's undo/redo.
+
+For a future docked presentation, keep the provider and the router's rendered page tree mounted in the same React position while changing the shell's layout. Keep `isOpen` true when docking. Sharing the provider preserves history, but replacing the router subtree would still remount page-local state and scroll containers. The current app renders the modal presentation; docking controls are separate work.
 
 #### Adding a Command Universe page
 

--- a/src/components/CommandUniverse/CommandUniverseDetailPage.tsx
+++ b/src/components/CommandUniverse/CommandUniverseDetailPage.tsx
@@ -1,0 +1,136 @@
+import { FC, useRef } from 'react'
+import { useSelector } from 'react-redux'
+import { css } from '../../../styled-system/css'
+import { token } from '../../../styled-system/tokens'
+import Command from '../../@types/Command'
+import { gestureString } from '../../commands'
+import GestureDiagram from '../GestureDiagram'
+import DialogContent from '../dialog/DialogContent'
+import SettingsIcon from '../icons/SettingsIcon'
+
+interface CommandUniverseDetailPageProps {
+  command: Command
+}
+
+/**
+ * Resolves the user-facing label and description strings, mirroring the logic in
+ * `CommandUniverseGridItem`. Honors `labelInverse` / `descriptionInverse` when the
+ * command's `isActive` selector is true.
+ */
+const useCommandLabels = (command: Command) => {
+  const isActive = useSelector(state => command.isActive?.(state))
+  const label = command.labelInverse && isActive ? command.labelInverse : command.label
+  const description = useSelector(state => {
+    const value = (isActive && command.descriptionInverse) || command.description
+    return typeof value === 'function' ? value(state) : value
+  })
+  return { label, description }
+}
+
+/**
+ * Level 1 of the Command Universe — the per-command detail page reached by tapping a
+ * grid cell. Layout: icon + title + subtitle row, and an optional gesture row showing
+ * the diagram with a short caption to its right.
+ *
+ * This page owns its content and scroller. Navigation, focus, and motion live outside it.
+ */
+const CommandUniverseDetailPage: FC<CommandUniverseDetailPageProps> = ({ command }) => {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const { label, description } = useCommandLabels(command)
+  const Icon = command.svg ?? SettingsIcon
+  const iconFill = token('colors.fg')
+
+  return (
+    <DialogContent scrollRef={scrollRef}>
+      <div className={css({ paddingInline: '1.25rem', paddingTop: '0.5rem', paddingBottom: '1.5rem' })}>
+        <header
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '1rem',
+            paddingTop: '0.5rem',
+            paddingBottom: '1.25rem',
+          })}
+        >
+          <div
+            className={css({
+              flex: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '36px',
+              height: '36px',
+            })}
+          >
+            <Icon cssRaw={css.raw({ flex: 'none' })} size={36} fill={iconFill} />
+          </div>
+          <div className={css({ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 })}>
+            <h3
+              tabIndex={-1}
+              data-page-focus
+              className={css({
+                margin: 0,
+                color: 'fg',
+                fontSize: '1.1rem',
+                fontWeight: 400,
+                lineHeight: 1.2,
+                outline: 'none',
+              })}
+            >
+              {label}
+            </h3>
+            {description ? (
+              <p
+                className={css({
+                  margin: 0,
+                  color: 'fgOverlay75',
+                  marginTop: '0.25rem',
+                  fontSize: '0.8rem',
+                  fontWeight: 300,
+                  opacity: 0.85,
+                  lineHeight: 1.35,
+                })}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+        </header>
+
+        {command.gesture ? (
+          <div
+            className={css({
+              display: 'flex',
+              alignItems: 'center',
+              gap: '1.25rem',
+              paddingTop: 0,
+              paddingBottom: '1.5rem',
+            })}
+          >
+            <div className={css({ flex: 'none', width: '130px', aspectRatio: '1 / 1' })}>
+              <GestureDiagram
+                path={gestureString(command)}
+                cssRaw={css.raw({ width: '100%', height: '100%' })}
+                size={150}
+                arrowSize={1}
+                strokeWidth={12}
+                arrowhead='outlined-wide'
+                chevronApexAngle={80}
+                chevronSize={2.2}
+                cornerRadius={12}
+                color='#ffffff'
+                gradient={{ from: 'rgba(88, 181, 212, 0.45)', to: 'rgba(255, 255, 255, 1)' }}
+                glow={false}
+              />
+            </div>
+            <p className={css({ margin: 0, color: 'fg', flex: 1, fontSize: '0.75rem', lineHeight: 1.4 })}>
+              Use this gesture in <b>em</b> to quickly activate the command.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </DialogContent>
+  )
+}
+
+export default CommandUniverseDetailPage

--- a/src/components/CommandUniverse/CommandUniversePageRouter.tsx
+++ b/src/components/CommandUniverse/CommandUniversePageRouter.tsx
@@ -1,14 +1,24 @@
-import { ComponentType } from 'react'
+import { ComponentType, Fragment } from 'react'
 import useCommandUniverseNavigator from '../../hooks/useCommandUniverseNavigator'
+import CommandUniversePageTransitions from './CommandUniversePageTransitions'
 import commandUniversePages from './commandUniversePages'
 
-/** Resolves the active page id and forwards its props. Layout and navigation ownership live outside the router. */
+/** Resolves registered page ids and forwards their props. Layout and navigation ownership live outside the router. */
 const CommandUniversePageRouter = () => {
-  const { entries, activeEntryId } = useCommandUniverseNavigator()
-  const { page } = entries.find(entry => entry.entryId === activeEntryId)!
-  // open() checks this correlation. TypeScript loses it when indexing a heterogeneous component registry.
-  const Page = commandUniversePages[page.pageId] as ComponentType<typeof page.props>
-  return <Page {...page.props} />
+  const navigator = useCommandUniverseNavigator()
+  return (
+    <CommandUniversePageTransitions>
+      {navigator.entries.map(({ entryId, page }) => {
+        // open() checks this correlation. TypeScript loses it when indexing a heterogeneous component registry.
+        const Page = commandUniversePages[page.pageId] as ComponentType<typeof page.props>
+        return (
+          <Fragment key={entryId}>
+            <Page {...page.props} />
+          </Fragment>
+        )
+      })}
+    </CommandUniversePageTransitions>
+  )
 }
 
 export default CommandUniversePageRouter

--- a/src/components/CommandUniverse/CommandUniversePageTransitions.tsx
+++ b/src/components/CommandUniverse/CommandUniversePageTransitions.tsx
@@ -1,0 +1,68 @@
+import { ReactElement, useEffect, useLayoutEffect, useRef } from 'react'
+import { css } from '../../../styled-system/css'
+import useCommandUniverseNavigator from '../../hooks/useCommandUniverseNavigator'
+
+/** Coordinates retained page surfaces. The router supplies keyed content; the provider owns history. */
+const CommandUniversePageTransitions = ({ children }: { children: ReactElement[] }) => {
+  const { entries, activeEntryId, isOpen } = useCommandUniverseNavigator()
+  const pages = useRef(new Map<string, HTMLDivElement>())
+  const focusTargets = useRef(new Map<string, HTMLElement>())
+  const previousActiveEntryId = useRef(activeEntryId)
+
+  useLayoutEffect(() => {
+    const previous = previousActiveEntryId.current
+    previousActiveEntryId.current = activeEntryId
+    if (!isOpen || previous === activeEntryId) return
+    const page = pages.current.get(activeEntryId)
+    if (!page) return
+    const saved = focusTargets.current.get(activeEntryId)
+    const target =
+      saved && page.contains(saved) ? saved : (page.querySelector<HTMLElement>('[data-page-focus]') ?? page)
+    target.focus({ preventScroll: true })
+  }, [activeEntryId, isOpen])
+
+  useEffect(() => {
+    const retained = new Set(entries.map(entry => entry.entryId))
+    focusTargets.current.forEach((_, entryId) => {
+      if (!retained.has(entryId)) focusTargets.current.delete(entryId)
+    })
+  }, [entries])
+
+  return (
+    <div className={css({ position: 'relative', width: '100%', height: '100%', minHeight: 0, overflow: 'hidden' })}>
+      {children.map(child => {
+        const entryId = String(child.key)
+        const active = entryId === activeEntryId
+        return (
+          <div
+            key={entryId}
+            ref={element => {
+              if (element) pages.current.set(entryId, element)
+              else pages.current.delete(entryId)
+            }}
+            data-testid={active ? 'active-page' : 'inactive-page'}
+            tabIndex={-1}
+            inert={!isOpen || !active}
+            aria-hidden={!active}
+            onFocusCapture={event => focusTargets.current.set(entryId, event.target)}
+            className={css({
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0,
+              overflow: 'hidden',
+              outline: 'none',
+            })}
+            // Whole-page opacity also hides descendants that explicitly override visibility.
+            style={{ visibility: active ? 'visible' : 'hidden', opacity: active ? 1 : 0 }}
+          >
+            {child}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default CommandUniversePageTransitions

--- a/src/components/CommandUniverse/commandUniversePages.ts
+++ b/src/components/CommandUniverse/commandUniversePages.ts
@@ -1,8 +1,10 @@
+import CommandUniverseDetailPage from './CommandUniverseDetailPage'
 import CommandUniverseGridPage from './CommandUniverseGridPage'
 
 /** Register pages here. Registry keys define page ids; component props define their navigation arguments. */
 const commandUniversePages = {
   grid: CommandUniverseGridPage,
+  detail: CommandUniverseDetailPage,
 }
 
 export default commandUniversePages

--- a/src/components/CommandUniverseGridItem.tsx
+++ b/src/components/CommandUniverseGridItem.tsx
@@ -6,9 +6,10 @@ import Command from '../@types/Command'
 import State from '../@types/State'
 import { isTouch } from '../browser'
 import { gestureString } from '../commands'
-import store from '../stores/app'
+import useCommandUniverseNavigator from '../hooks/useCommandUniverseNavigator'
 import GestureDiagram from './GestureDiagram'
 import HighlightedText from './HighlightedText'
+import CircleEllipsisIcon from './icons/CircleEllipsisIcon'
 import SettingsIcon from './icons/SettingsIcon'
 
 const GESTURE_GRADIENT = {
@@ -29,7 +30,8 @@ interface CommandUniverseGridItemProps {
 
 /** Renders a single command as a cell in CommandUniverseGrid. */
 const CommandUniverseGridItem: FC<CommandUniverseGridItemProps> = ({ command, search = '' }) => {
-  const isActive = command.isActive?.(store.getState())
+  const navigator = useCommandUniverseNavigator()
+  const isActive = useSelector(state => command.isActive?.(state))
   const disabled = useSelector(state => !isExecutable(state, command))
   const label = command.labelInverse && isActive ? command.labelInverse : command.label
   const description = useSelector(state => {
@@ -42,109 +44,146 @@ const CommandUniverseGridItem: FC<CommandUniverseGridItemProps> = ({ command, se
   const Icon = command.svg ?? SettingsIcon
 
   return (
-    <tr
-      className={css({
-        position: 'relative',
-        textAlign: 'left',
-        borderRadius: '8px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.533rem',
-        justifyContent: 'flex-start',
-        alignItems: 'flex-start',
-        marginInline: '0.2rem',
-      })}
-    >
-      {/* Gesture diagram container. */}
-      {isTouch ? (
-        <td
+    <tr>
+      <td className={css({ display: 'block', height: '100%' })}>
+        <button
+          type='button'
+          aria-label={label}
+          onClick={() => navigator.open('detail', { command })}
           className={css({
-            boxSizing: 'border-box',
-            minWidth: 0,
+            position: 'relative',
+            cursor: 'pointer',
             width: '100%',
-            textAlign: 'center',
-          })}
-        >
-          <div
-            className={css({
-              width: '100%',
-              aspectRatio: '1 / 1',
-              maxWidth: '130px',
-              margin: '0 auto',
-            })}
-          >
-            <GestureDiagram
-              path={gestureString(command)}
-              cssRaw={css.raw({ display: 'block' })}
-              size={150}
-              arrowSize={1}
-              strokeWidth={12}
-              arrowhead='outlined-wide'
-              cornerRadius={12}
-              rounded={command.rounded}
-              gradient={GESTURE_GRADIENT}
-              glow={false}
-            />
-          </div>
-        </td>
-      ) : null}
-
-      <td
-        className={css({
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          gap: '0.25em',
-          flexWrap: 'wrap',
-          fontWeight: 'normal',
-          width: '100%',
-        })}
-      >
-        {/* Command icon inline with the title. */}
-        <div
-          className={css({
+            height: '100%',
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+            color: 'inherit',
+            font: 'inherit',
+            _focusVisible: { outline: '2px solid {colors.fg}', outlineOffset: '2px' },
+            textAlign: 'left',
+            borderRadius: '8px',
             display: 'flex',
-            alignItems: 'center',
+            flexDirection: 'column',
+            gap: '0.533rem',
             justifyContent: 'flex-start',
-            width: '100%',
-            gap: '0.75rem',
+            alignItems: 'flex-start',
+            marginInline: '0.2rem',
           })}
         >
-          {/* `flex: none` overrides iconRecipe's `flex: 1` default so width/height set the size. */}
+          {/* Detail-page affordance. Command execution availability only affects the icon and text styling. */}
           <div
-            className={css({ flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center' })}
-            style={{ width: 20, height: 20 }}
-          >
-            <Icon cssRaw={css.raw({ flex: 'none' })} size={20} fill={token(disabled ? 'colors.gray50' : 'colors.fg')} />
-          </div>
-          <b
+            aria-hidden
             className={css({
-              minWidth: '4em',
-              whiteSpace: 'normal',
-              overflowWrap: 'break-word',
-              color: disabled ? 'gray45' : 'fg',
-              fontSize: '0.75rem',
-              fontWeight: 500,
-              lineHeight: 1.35,
+              position: 'absolute',
+              top: '0.5rem',
+              right: '0.5rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: 'none',
+              zIndex: 1,
             })}
           >
-            <HighlightedText value={label} match={search} disabled={disabled} />
-          </b>
-        </div>
+            <CircleEllipsisIcon size={20} fill={token(disabled ? 'colors.gray50' : 'colors.fg')} />
+          </div>
 
-        <p
-          className={css({
-            color: 'fgOverlay75',
-            marginTop: '0.267rem',
-            marginBottom: '0.267rem',
-            fontSize: '0.6875rem',
-            opacity: 0.8,
-            marginLeft: '-0.2rem',
-            lineHeight: 1.3,
-          })}
-        >
-          {description}
-        </p>
+          {/* Gesture diagram container. */}
+          {isTouch ? (
+            <div
+              className={css({
+                boxSizing: 'border-box',
+                minWidth: 0,
+                width: '100%',
+                textAlign: 'center',
+              })}
+            >
+              <div
+                className={css({
+                  width: '100%',
+                  aspectRatio: '1 / 1',
+                  maxWidth: '130px',
+                  margin: '0 auto',
+                })}
+              >
+                <GestureDiagram
+                  path={gestureString(command)}
+                  cssRaw={css.raw({ display: 'block' })}
+                  size={150}
+                  arrowSize={1}
+                  strokeWidth={12}
+                  arrowhead='outlined-wide'
+                  cornerRadius={12}
+                  rounded={command.rounded}
+                  gradient={GESTURE_GRADIENT}
+                  glow={false}
+                />
+              </div>
+            </div>
+          ) : null}
+
+          <div
+            className={css({
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              gap: '0.25em',
+              flexWrap: 'wrap',
+              fontWeight: 'normal',
+              width: '100%',
+            })}
+          >
+            {/* Command icon inline with the title. */}
+            <div
+              className={css({
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                width: '100%',
+                gap: '0.75rem',
+              })}
+            >
+              {/* `flex: none` overrides iconRecipe's `flex: 1` default so width/height set the size. */}
+              <div
+                className={css({ flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center' })}
+                style={{ width: 20, height: 20 }}
+              >
+                <Icon
+                  cssRaw={css.raw({ flex: 'none' })}
+                  size={20}
+                  fill={token(disabled ? 'colors.gray50' : 'colors.fg')}
+                />
+              </div>
+              <b
+                className={css({
+                  minWidth: '4em',
+                  whiteSpace: 'normal',
+                  overflowWrap: 'break-word',
+                  color: disabled ? 'gray45' : 'fg',
+                  fontSize: '0.75rem',
+                  fontWeight: 500,
+                  lineHeight: 1.35,
+                })}
+              >
+                <HighlightedText value={label} match={search} disabled={disabled} />
+              </b>
+            </div>
+
+            <p
+              className={css({
+                color: 'fgOverlay75',
+                marginTop: '0.267rem',
+                marginBottom: '0.267rem',
+                fontSize: '0.6875rem',
+                opacity: 0.8,
+                marginLeft: '-0.2rem',
+                lineHeight: 1.3,
+              })}
+            >
+              {description}
+            </p>
+          </div>
+        </button>
       </td>
     </tr>
   )

--- a/src/components/__tests__/MobileCommandUniverse.ts
+++ b/src/components/__tests__/MobileCommandUniverse.ts
@@ -1,0 +1,46 @@
+import { cleanup, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { act } from 'react'
+import { toggleMobileCommandUniverseActionCreator as toggleMobileCommandUniverse } from '../../actions/toggleMobileCommandUniverse'
+import indentCommand from '../../commands/indent'
+import store from '../../stores/app'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+
+beforeEach(createTestApp)
+afterEach(async () => {
+  cleanup()
+  await cleanupTestApp()
+})
+
+/** Opens the Commands dialog and settles its lazy imports. */
+const openCommandUniverse = async () => {
+  await act(async () => {
+    store.dispatch(toggleMobileCommandUniverse({ value: true }))
+    await vi.dynamicImportSettled()
+    await vi.runAllTimersAsync()
+  })
+}
+
+it('opens command details even when the command cannot execute in the current context', async () => {
+  await openCommandUniverse()
+  expect(indentCommand.canExecute(store.getState())).toBe(false)
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  await user.click(screen.getByRole('button', { name: 'Indent' }))
+  await act(vi.runAllTimersAsync)
+  expect(screen.getByRole('heading', { name: 'Indent' })).toBeVisible()
+  expect(screen.getByRole('button', { name: 'Back' })).toBeEnabled()
+})
+
+it.each(['{Enter}', ' '])('opens a detail page with %s and restores focus after Back', async key => {
+  await openCommandUniverse()
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  const cell = screen.getByRole('button', { name: 'New Thought' })
+  // Focus is the keyboard user's starting position. Activation still goes through the real key event.
+  cell.focus()
+  await user.keyboard(key)
+  await act(vi.runAllTimersAsync)
+  expect(screen.getByRole('heading', { name: 'New Thought' })).toHaveFocus()
+  await user.click(screen.getByRole('button', { name: 'Back' }))
+  await act(vi.runAllTimersAsync)
+  expect(screen.getByRole('button', { name: 'New Thought' })).toHaveFocus()
+})

--- a/src/components/dialog/DialogHeader.tsx
+++ b/src/components/dialog/DialogHeader.tsx
@@ -9,6 +9,10 @@ import CircleButton from './CircleButton'
 
 interface DialogHeaderProps {
   onClose: () => void
+  onBack?: () => void
+  onForward?: () => void
+  canGoBack?: boolean
+  canGoForward?: boolean
 }
 
 /**
@@ -16,9 +20,16 @@ interface DialogHeaderProps {
  * right button cluster (Help/Close). The flex:1 cluster wrappers balance the row so
  * the title stays optically centered.
  *
- * Back / Forward / Help are visual-only per the spec — they don't dispatch yet.
+ * Back and Forward navigate the dialog history. Help remains visual-only.
  */
-const DialogHeader: React.FC<PropsWithChildren<DialogHeaderProps>> = ({ children, onClose }) => {
+const DialogHeader: React.FC<PropsWithChildren<DialogHeaderProps>> = ({
+  children,
+  onClose,
+  onBack,
+  onForward,
+  canGoBack = false,
+  canGoForward = false,
+}) => {
   const iconFill = token('colors.dialogHeaderButtonIcon')
   // Left/right header cluster wrapper — the flex container that holds the circular header buttons.
   // `flex: 1` lets each cluster claim half the row so the centered title sits in the middle.
@@ -45,10 +56,10 @@ const DialogHeader: React.FC<PropsWithChildren<DialogHeaderProps>> = ({ children
       })}
     >
       <div className={headerSide}>
-        <CircleButton ariaLabel='Back'>
+        <CircleButton ariaLabel='Back' onClick={onBack} disabled={!canGoBack}>
           <ArrowLeftIcon size={24} fill={iconFill} />
         </CircleButton>
-        <CircleButton ariaLabel='Forward'>
+        <CircleButton ariaLabel='Forward' onClick={onForward} disabled={!canGoForward}>
           <ArrowRightIcon size={24} fill={iconFill} />
         </CircleButton>
       </div>

--- a/src/components/dialog/MobileCommandUniverse.tsx
+++ b/src/components/dialog/MobileCommandUniverse.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from '../../../styled-system/css'
 import { toggleMobileCommandUniverseActionCreator } from '../../actions/toggleMobileCommandUniverse'
+import useCommandUniverseNavigator from '../../hooks/useCommandUniverseNavigator'
 import CommandUniversePageRouter from '../CommandUniverse/CommandUniversePageRouter'
 import CommandUniverseProvider from '../CommandUniverse/CommandUniverseProvider'
 import FadeTransition from '../FadeTransition'
@@ -23,6 +24,7 @@ const HiddenDialogAssets = () => (
 const CommandUniverseDialog = ({ isOpen }: { isOpen: boolean }) => {
   const dispatch = useDispatch()
   const nodeRef = useRef<HTMLDivElement>(null)
+  const navigation = useCommandUniverseNavigator()
   const onClose = useCallback(() => {
     dispatch(toggleMobileCommandUniverseActionCreator({ value: false }))
   }, [dispatch])
@@ -32,8 +34,18 @@ const CommandUniverseDialog = ({ isOpen }: { isOpen: boolean }) => {
       <HiddenDialogAssets />
       <FadeTransition in={isOpen} unmountOnExit type='medium' nodeRef={nodeRef}>
         <Dialog onClose={onClose} nodeRef={nodeRef}>
-          <DialogHeader onClose={onClose}>Commands</DialogHeader>
-          <CommandUniversePageRouter />
+          <DialogHeader
+            onClose={onClose}
+            onBack={navigation.back}
+            onForward={navigation.forward}
+            canGoBack={navigation.canGoBack}
+            canGoForward={navigation.canGoForward}
+          >
+            Commands
+          </DialogHeader>
+          <div className={css({ height: 'min(70vh, 70dvh)', minHeight: 0 })}>
+            <CommandUniversePageRouter />
+          </div>
         </Dialog>
       </FadeTransition>
     </>

--- a/src/components/icons/CircleEllipsisIcon.tsx
+++ b/src/components/icons/CircleEllipsisIcon.tsx
@@ -1,0 +1,48 @@
+import { FC } from 'react'
+import { css, cx } from '../../../styled-system/css'
+import { iconRecipe } from '../../../styled-system/recipes'
+import { token } from '../../../styled-system/tokens'
+import IconType from '../../@types/IconType'
+
+/** Circle ellipsis icon: three horizontal dots inside a rounded square background. */
+const CircleEllipsisIcon: FC<IconType> = ({ size = 20, fill, cssRaw }) => {
+  const fillColor = fill || token('colors.fg')
+
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={size}
+      height={size}
+      viewBox='0 0 20 20'
+      fill='none'
+      className={cx(iconRecipe(), css(cssRaw))}
+    >
+      <rect width='20' height='20' rx='10' fill={fillColor} fillOpacity='0.08' />
+      <g opacity='0.5'>
+        <path
+          d='M10.0013 10.6654C10.3695 10.6654 10.668 10.3669 10.668 9.9987C10.668 9.63051 10.3695 9.33203 10.0013 9.33203C9.63311 9.33203 9.33464 9.63051 9.33464 9.9987C9.33464 10.3669 9.63311 10.6654 10.0013 10.6654Z'
+          stroke={fillColor}
+          strokeWidth='1.33333'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+        <path
+          d='M14.668 10.6654C15.0362 10.6654 15.3346 10.3669 15.3346 9.9987C15.3346 9.63051 15.0362 9.33203 14.668 9.33203C14.2998 9.33203 14.0013 9.63051 14.0013 9.9987C14.0013 10.3669 14.2998 10.6654 14.668 10.6654Z'
+          stroke={fillColor}
+          strokeWidth='1.33333'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+        <path
+          d='M5.33464 10.6654C5.70283 10.6654 6.0013 10.3669 6.0013 9.9987C6.0013 9.63051 5.70283 9.33203 5.33464 9.33203C4.96645 9.33203 4.66797 9.63051 4.66797 9.9987C4.66797 10.3669 4.96645 10.6654 5.33464 10.6654Z'
+          stroke={fillColor}
+          strokeWidth='1.33333'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+        />
+      </g>
+    </svg>
+  )
+}
+
+export default CircleEllipsisIcon

--- a/src/hooks/__tests__/useCommandUniverseNavigator.ts
+++ b/src/hooks/__tests__/useCommandUniverseNavigator.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { PropsWithChildren, createElement } from 'react'
 import { expectTypeOf } from 'vitest'
+import Command from '../../@types/Command'
 import CommandUniversePage from '../../@types/CommandUniversePage'
 import CommandUniversePageNavigator from '../../@types/CommandUniversePageNavigator'
 import CommandUniverseProvider from '../../components/CommandUniverse/CommandUniverseProvider'
@@ -12,9 +13,11 @@ const OpenProvider = ({ children }: PropsWithChildren) =>
 
 it('derives page ids and their required props from the registered components', () => {
   type OpenArguments = Parameters<CommandUniversePageNavigator['open']>
-  expectTypeOf<'grid'>().toMatchTypeOf<CommandUniversePage['pageId']>()
+  expectTypeOf<'grid' | 'detail'>().toMatchTypeOf<CommandUniversePage['pageId']>()
   expectTypeOf<['grid', Record<string, never>]>().toMatchTypeOf<OpenArguments>()
-  expectTypeOf<['grid', { unregistered: true }]>().not.toMatchTypeOf<OpenArguments>()
+  expectTypeOf<['detail', { command: Command }]>().toMatchTypeOf<OpenArguments>()
+  expectTypeOf<['detail', Record<string, never>]>().not.toMatchTypeOf<OpenArguments>()
+  expectTypeOf<['grid', { command: Command }]>().not.toMatchTypeOf<OpenArguments>()
   expectTypeOf<['missing', Record<string, never>]>().not.toMatchTypeOf<OpenArguments>()
 })
 


### PR DESCRIPTION
Part of #4200. Second of four stacked PRs, on top of #5511.

## Redux restack architectural plan

### 1. Existing surface area

The updated base routes application mutations by action filename:

`src/actions/app.ts:8-13`

```ts
/**
 * The main app reducer. Uses action.type to select the reducer with the same name. Otherwise throw an error with unknownAction.
 */
const appReducer = (state: State = initialState(), action: Action<ActionType>): State =>
  ((reducers as Index<any>)[action.type] || reducers.unknownAction)(state, action)
```

#5511 now exposes typed Redux actions rather than a context navigator:

`src/actions/commandUniverseNavigate.ts:8-16,34-44`

```ts
type NavigateArguments = {
  [Id in CommandUniversePage['pageId']]: [pageId: Id, props: Extract<CommandUniversePage, { pageId: Id }>['props']]
}[CommandUniversePage['pageId']]

const commandUniverseNavigate = (
  state: State,
  { entryId, page }: { entryId: string; page: CommandUniversePage },
): State => {
  if (!state.showMobileCommandUniverse) return state

export const commandUniverseNavigateActionCreator =
  (...args: NavigateArguments): Thunk =>
  dispatch => {
    // ...
  }
```

The old #5512 delta consumes the removed navigator hook from four places: opening a detail page, routing retained entries, coordinating focus, and wiring header controls:

`src/components/CommandUniverseGridItem.tsx:31-35,49-53` on the current #5512 head

```tsx
const CommandUniverseGridItem = ({ command, search = '' }) => {
  const navigator = useCommandUniverseNavigator()
  // ...
  <button onClick={() => navigator.open('detail', { command })}>
```

`src/components/CommandUniverse/CommandUniversePageTransitions.tsx:5-10` on the current #5512 head

```tsx
/** Coordinates retained page surfaces. The router supplies keyed content; the provider owns history. */
const CommandUniversePageTransitions = ({ children }: { children: ReactElement[] }) => {
  const { entries, activeEntryId, isOpen } = useCommandUniverseNavigator()
  const pages = useRef(new Map<string, HTMLDivElement>())
  const focusTargets = useRef(new Map<string, HTMLElement>())
```

Those maps are DOM-instance state. They restore focus within retained page surfaces and therefore belong in the component, while entries/index and back/forward availability belong in Redux.

The final animation PR currently adds transition state to the removed React reducer and manually switches on private action types:

`src/components/CommandUniverse/CommandUniverseProvider.tsx:21-31,49-63` on the current #5489 head

```ts
const reduceHistory = (state: HistoryState, action: HistoryAction): HistoryState => {
  if (action.type === 'reset') return /* ... */
  if (action.type === 'finish') return /* ... */
  if (action.type === 'navigate') return /* ... */
  // ...
  const index = state.index + (action.type === 'back' ? -1 : 1)
  // ...
}
```

### 2. Build vs. extend decision

Extend the Redux navigation slice and its existing action files. In #5512, components will dispatch `commandUniverseNavigate`, `commandUniverseBack`, and `commandUniverseForward`, and read `entries/index` with `useSelector`. No compatibility context or navigator facade will be reintroduced. In #5489, motion arrival/transition metadata will be added to the same slice; open/back/forward will calculate transitions, and a new filename-routed `commandUniverseFinishTransition` action will reject stale animation completions.

The stack will be advanced with merge commits, not rebased or force-pushed: merge the updated parent into #5512, then #5512 into #5513, then #5513 into #5489.

### 3. Adjacent behaviour surface

- Retained page instances must still preserve scroll and page-local state. The router will continue rendering every reachable entry keyed by `entryId`; Redux changes only where the entry list and active index come from.
- Search, sort, dropdown visibility, scroll positions, page elements, and focus targets stay local. They are owned by mounted page instances and are not command-addressable application state.
- Native button activation, disabled-command inspection, header back/forward availability, and focus restoration retain the existing #5512 JSDOM coverage.
- #5489 must preserve interruptible transitions, reverse the arrival edge on Back, replay it on Forward, ignore stale completions, and clear transition state on session reset. Those reducer semantics move into action tests rather than hook/provider tests.
- The merged grid page must continue using `main`'s `sections` API and stable section IDs.
- Navigation and transition actions remain non-undoable. No thought mutation, caret/selection, IME, copy/paste, editor backspace/delete, multicursor/collapse, or gesture-recognition behaviour changes.

### 4. Approaches considered

1. **Sequential merge restack with direct Redux consumers (chosen):** preserves branch history, avoids force pushes, extends the approved #5511 architecture, and keeps Commands able to dispatch navigation.
2. **Reintroduce `useCommandUniverseNavigator` as a Redux facade:** reduces edits in child PRs but preserves an unnecessary imperative abstraction and makes non-React Command consumers use a different API.
3. **Keep transition state in the Motion component:** keeps Redux smaller but splits one navigation state machine across Redux and React, recreating the state-management concern raised on #5511.
4. **Rebase the stack:** produces linear history but rewrites three published branches and is unnecessary when merge commits can advance each PR base safely.

### 5. Diff sketch

- **#5512:** merge #5511; replace hook calls with Redux selectors/actions; retain local DOM/focus maps; migrate registry typing assertions into the action test; keep the detail page, retained-page router, header controls, and JSDOM interaction tests.
- **#5513:** merge updated #5512 and resolve only any path/type conflicts caused by the restack; keep rich-description functionality unchanged.
- **#5489:** merge updated #5513; extend `CommandUniverseNavigation` and open/back/forward/reset actions with transition semantics; add `commandUniverseFinishTransition`; make Motion dispatch completion and select transition state; migrate provider tests to action tests.
- Update `docs/commands.md` in the PRs that change the documented navigation/animation architecture.

### Critique

- Re-grepping the child heads confirms every removed-hook consumer is covered above; no command or non-React caller depends on the hook.
- A facade would make the merge easier but would weaken the architecture the restack is meant to establish, so direct selectors/actions remain preferable.
- The first draft risked moving focus/scroll preservation into Redux. The actual transition component stores DOM nodes and focused elements, which are non-serializable page-instance concerns; the plan now explicitly leaves them local.
- Motion transition metadata is different: it determines the navigation edge, interruptibility, inert state, and stale-completion handling across components, so it belongs beside entries/index in Redux.
- The merge order follows the published PR base chain, and the diff sketch keeps each PR's original feature boundary intact.

---

#5511 added a navigator with one registered page, so nothing exercised it. This PR gives it a second page – the "command detail" screen. You can access the command detail page by tapping a gesture in the Command Universe.

Rich command descriptions arrive in #5513.

Animations are carved out for a follow-up PR in the stack.

<img width="864" height="1876" alt="CleanShot 2026-09-11 at 02 33 08@2x" src="https://github.com/user-attachments/assets/08a5fbe5-e257-4ff7-b481-0c6caefdc5e2" />

## Changes

- Add `CommandUniverseDetailPage` showing a command icon, label, description and gesture diagram, and register it.
- Make each grid cell a native button, so Enter and Space work alongside tap, with a corner affordance icon.
- Inspecting a command no longer depends on whether it can execute in the current context. Execution availability now only affects styling.
- `DialogHeader` gains optional Back and Forward handlers, disabled unless the history can move.
- `CommandUniversePageTransitions` keeps reachable pages mounted so their scroll positions survive navigation, marks inactive pages inert, and moves focus to the destination.
- Apply the approved detail-page inset, title/subtitle typography, and gesture-caption gradient.

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"d10390d2f6fc9c0f3a1522be1e35a6aa68a6db16","createdAt":"2026-09-22T14:01:58Z","url":"https://em-fn31treg2-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 22, 2026, 2:01 PM UTC · d10390d</summary>

<a href="https://em-fn31treg2-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/aae35e0d-6140-4e09-a3b9-512be158660b)</a>

</details>
<!-- preview-qr:end -->