### PR TITLE
Do not pre-populate a new context's childrenMap when creating it in the context view

### DIFF
--- a/src/actions/createThought.ts
+++ b/src/actions/createThought.ts
@@ -19,8 +19,6 @@ import keyValueBy from '../util/keyValueBy'
 import timestamp from '../util/timestamp'
 
 interface Payload {
-  // directly adds children to thought.childrenMap with no additional validation
-  children?: ThoughtId[]
   id?: ThoughtId
   /** Callback for when the updates have been synced with IDB. */
   idbSynced?: () => void
@@ -32,7 +30,7 @@ interface Payload {
 /**
  * Creates a new thought with a known context and rank. Does not update the cursor. Use the newThought reducer for a higher level function.
  */
-const createThought = (state: State, { path, value, rank, id, idbSynced, children, splitSource }: Payload) => {
+const createThought = (state: State, { path, value, rank, id, idbSynced, splitSource }: Payload) => {
   id = id || createId()
   const lexemeOld = getLexeme(state, value)
 
@@ -50,7 +48,7 @@ const createThought = (state: State, { path, value, rank, id, idbSynced, childre
   const parent = getThoughtById(state, parentId)
 
   if (!parent) {
-    console.error({ path, value, rank, id, idbSynced, children, splitSource })
+    console.error({ path, value, rank, id, idbSynced, splitSource })
     throw new Error(`createThought: Parent thought with id ${parentId} not found`)
   }
 
@@ -65,8 +63,9 @@ const createThought = (state: State, { path, value, rank, id, idbSynced, childre
   // }
 
   const thoughtNew: Thought = {
-    // Do not use createChildrenMap since the thoughts must exist and createThought does not require the thoughts to exist.
-    childrenMap: children ? keyValueBy(children || {}, id => ({ [id]: id })) : {},
+    // A new thought has no children yet. A caller that needs children creates them with further createThought calls
+    // once this thought exists, so the parent's childrenMap never references a thought that is not in the index.
+    childrenMap: {},
     created: timestamp(),
     id,
     lastUpdated: timestamp(),

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -166,7 +166,6 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
   const reducers = [
     // createThought
     createThought({
-      ...(insertContext ? { children: [newContextId!] } : null),
       path: insertContext ? ABSOLUTE_PATH : insertNewSubthought ? simplePath : parentPath,
       rank: newRank,
       value,


### PR DESCRIPTION
Fixes #5445

In the context view, `newThought` created the new empty thought under `ABSOLUTE_TOKEN` with its `childrenMap` already pointing at the context it was about to create in the next reducer. `createThought`'s missing-children sweep saw an id with no thought behind it, warned `Sibling … with missing thought found while creating new thought`, dropped the entry, and the following `createThought` re-added it. The state was correct; the warning was not.

### Change

- `newThought` no longer passes `children` to the first `createThought`. The second `createThought` inserts the new context into the parent's `childrenMap` itself (`childrenMapKey(parent.childrenMap, thoughtNew)`), so the resulting state is identical.
- `newThought` was the only caller of `createThought`'s `children` option, so the option is removed rather than left as dead API. Every other call site never passed it, so their new thoughts keep an empty `childrenMap` as before.

The alternative of skipping the created id inside the sweep was rejected: it would teach the sweep to tolerate a state the code should never produce, and the sweep still warns for children that are genuinely absent.

### Plan (per `.github/skills/plan`)

<details>
<summary>Existing surface, build-vs-extend, adjacent behaviour</summary>

**Existing surface area.** The sweep in `createThought.ts` (`keyValueBy(parent.childrenMap, …)` warning on `!getThoughtById(state, childId)`), which then unconditionally re-adds the created thought under `childrenMapKey`; the `children?: ThoughtId[]` payload option; its single caller in `newThought.ts`'s `insertContext` branch. No test or doc references `children`.

**Build vs. extend.** Extend by removal: the second reducer already produces the child entry, so the pre-population is redundant and the only source of an uncreated id in a parent's map.

**Adjacent behaviour.** The 14 other `createThought` call sites never pass `children`. Both reducers run inside one `newThought` action, so the undo step is unchanged. Context-view export and cursor placement are covered by the existing context-view tests. The interim state between the two reducers lacks the child for one synchronous `reducerFlow` step with no subscriber in between.

</details>

docs: unaffected — no document describes createThought's `children` option; `data-model.md` covers only how `childrenMap` is keyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fd4vvqGUWV42TDr5CEEzGf
