### PR TITLE
Move the cursor with the thought when a context is dragged in the context view

### DIFF
--- a/src/actions/__tests__/moveThought.ts
+++ b/src/actions/__tests__/moveThought.ts
@@ -1,7 +1,9 @@
 import State from '../../@types/State'
 import importText from '../../actions/importText'
+import moveThought from '../../actions/moveThought'
 import newSubthought from '../../actions/newSubthought'
 import newThought from '../../actions/newThought'
+import toggleContextView from '../../actions/toggleContextView'
 import { HOME_TOKEN } from '../../constants'
 import contextToPath from '../../selectors/contextToPath'
 import exportContext from '../../selectors/exportContext'
@@ -9,6 +11,7 @@ import getContexts from '../../selectors/getContexts'
 import getLexeme from '../../selectors/getLexeme'
 import getRankAfter from '../../selectors/getRankAfter'
 import pathToThought from '../../selectors/pathToThought'
+import contextToPathOrThrow from '../../test-helpers/contextToPathOrThrow'
 import contextToThought from '../../test-helpers/contextToThought'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import getAllChildrenByContext from '../../test-helpers/getAllChildrenByContext'
@@ -16,6 +19,8 @@ import getChildrenRankedByContext from '../../test-helpers/getChildrenRankedByCo
 import moveThoughtAtFirstMatch from '../../test-helpers/moveThoughtAtFirstMatch'
 import newThoughtAtFirstMatch from '../../test-helpers/newThoughtAtFirstMatch'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
+import appendToPath from '../../util/appendToPath'
+import head from '../../util/head'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 
@@ -279,6 +284,46 @@ it('moving unrelated thought should not update cursor', () => {
   const stateNew = reducerFlow(steps)(initialState())
 
   expectPathToEqual(stateNew, stateNew.cursor, ['a'])
+})
+
+it('moving a context in the context view should update the cursor to the moved thought', () => {
+  const steps = [
+    importText({
+      text: `
+        - a
+          - m
+        - b
+          - m
+      `,
+    }),
+    setCursor(['a', 'm']),
+    toggleContextView,
+    // drag the context a/m~/a onto the subthoughts drop zone of the context a/m~/b, i.e. move a/m into b/m
+    (state: State) => {
+      const contextA = contextToPathOrThrow(state, ['a', 'm', 'a'], 'moveThought')
+      const contextB = contextToPathOrThrow(state, ['a', 'm', 'b'], 'moveThought')
+      return moveThought(state, {
+        oldPath: contextA,
+        newPath: appendToPath(contextB, head(contextA)),
+        newRank: 0,
+      })
+    },
+  ]
+
+  const stateNew = reducerFlow(steps)(initialState())
+
+  const exported = exportContext(stateNew, [HOME_TOKEN], 'text/plain')
+
+  expect(exported).toBe(`- ${HOME_TOKEN}
+  - a
+  - b
+    - m
+      - m`)
+
+  // The cursor is on the nominal context m (a/m~), which is the thought that was moved, so it must follow the
+  // thought to b/m/m. Otherwise it is left on a/m, which no longer exists: expandThoughts can no longer reach it,
+  // freeThoughts deallocates the thought as no longer visible, and the next expandThoughts throws "Invalid path".
+  expectPathToEqual(stateNew, stateNew.cursor, ['b', 'm', 'm'])
 })
 
 it('move root thought into another root thought', () => {

--- a/src/actions/moveThought.ts
+++ b/src/actions/moveThought.ts
@@ -239,11 +239,23 @@ const moveThought = (state: State, payload: MoveThoughtPayload) => {
 
       const isPathInCursor = isDescendantPath(state.cursor, oldPath)
       const isCursorAtOldPath = state.cursor.length === oldPath.length
+
+      // In the context view the cursor is on the nominal context (the m of a/m~), while the dragged context row is
+      // the deeper Path a/m~/a that resolves to the same thought. oldPath is then not an ancestor of the cursor even
+      // though the moved thought is, so the cursor has to be rebased onto the thought's new location. Otherwise it
+      // keeps naming a parent that no longer contains the thought: expandThoughts can no longer reach the cursor,
+      // freeThoughts deallocates it as no longer visible, and the next expandThoughts throws "Invalid path".
+      // Skipped when the thought no longer exists, i.e. it was merged into a duplicate in the destination.
+      const isMovedThoughtInCursor =
+        !isPathInCursor && isDescendantPath(state.cursor, oldPathSimple) && !!getThoughtById(state, sourceThought.id)
+
       const newCursorPath = isPathInCursor
         ? isCursorAtOldPath
           ? newPath
           : ([...newPath, ...state.cursor.slice(newPath.length)] as Path)
-        : state.cursor
+        : isMovedThoughtInCursor
+          ? ([...destinationThoughtPath, sourceThought.id, ...state.cursor.slice(oldPathSimple.length)] as Path)
+          : state.cursor
 
       return {
         ...state,


### PR DESCRIPTION
Diagnosed from the debug log attached to the report of a minified React error. The log contains two occurrences of the same uncaught error, each one second after a drag in the context view:

```
Error: Invalid path 07c8…,ee3ddef0…,e64ea030…. No thought found with id e64ea030…
```

## Steps to Reproduce

```
- a
  - m
- b
  - m
```

1. Set the cursor on `a/m`.
2. Activate the Context View.
3. Drag the context `a/m~/a` into the context `a/m~/b` (the subthoughts drop zone).

## Current Behavior

`a/m` is moved into `b/m`, but the cursor is left on `a/m`, which no longer exists. About a second later the app throws `Invalid path … No thought found with id …` from [`expandThoughts`](https://github.com/cybersemics/em/blob/main/src/selectors/expandThoughts.ts), and keeps throwing on every subsequent action that recalculates the expansion.

## Expected Behavior

The cursor follows the moved thought to `b/m/m`, as it already does for a move in normal view, and nothing throws.

## Cause

`moveThought` updates the cursor only when the cursor is at or below `oldPath`. In the context view the drop passes the *context row* as `oldPath` (`a/m~/a`), while the cursor sits on the nominal context above it (`a/m`) — the very thought that `oldPath` resolves to. The cursor is an ancestor of `oldPath` rather than a descendant, so it is not updated, and it ends up naming a parent that no longer contains the thought.

From there the crash is mechanical:

1. `expandThoughts` descends from the root through real parent-child links, so it can no longer reach the cursor, and the cursor path drops out of `state.expanded`.
2. `freeThoughts` preserves expanded paths, so it treats the thought as no longer visible and deallocates the subtree it now lives in. `deleteThought`'s cursor repair does not catch this: the stale cursor is not literally a descendant of the deleted path, and its head is not the deleted thought.
3. The next `expandThoughts(state, state.cursor)` finds no thought for `head(cursor)` and throws.

The one-second delay is the `freeThoughts` middleware throttle (`{leading: false}`), which is also why the throwing action is missing from the debug log — actions are logged after their reducer runs.

## Changes

- `moveThought` now also compares the cursor against the *simplified* old path, and rebases it onto the moved thought's new location when it matches. In normal view the simplified path is `oldPath`, so this branch only applies when a context view is crossed. It is skipped when the thought no longer exists, i.e. it was merged into a duplicate in the destination.
- Added a reducer test covering the drag above. It fails on `main` with the cursor still on `['a', 'm']` and passes here with `['b', 'm', 'm']`; the export assertion above it passes in both, so the failure is the cursor alone.

## Notes

- `docs/` is unaffected: no document asserts how `moveThought` updates the cursor, and the context view and drag-and-drop docs describe path semantics and drop dispatch, both unchanged.
- Not fixed here, but worth a decision: nothing prevents a stale cursor from being fatal in general. `freeThoughts` does not preserve `state.cursor` (only expanded paths), so any cursor that goes stale for another reason deallocates the same way and takes the app down through the same throw. Preserving the cursor there would keep such a bug visible without making it fatal.
- The `docs-sync` routing table has no row covering `src/actions/**`, so a reducer change matches no document by path. Left alone rather than widening this PR into shared agent infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hNZCvB4e2ySt55SuMB99d

---
_Generated by [Claude Code](https://claude.ai/code/session_016hNZCvB4e2ySt55SuMB99d)_

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"eee790fd659e8bbb63c2d4beaee760f26ba28720","createdAt":"2026-09-11T09:18:57Z","url":"https://em-ocz3u7ptj-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 9:18 AM UTC · eee790f</summary>

<a href="https://em-ocz3u7ptj-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/4e862231-51f8-427d-9dfe-74753ebc6ac2)</a>

</details>
<!-- preview-qr:end -->