### PR TITLE
Add a Download link to the debug log

### DIFF
--- a/src/components/__tests__/ModalSettings.native.ts
+++ b/src/components/__tests__/ModalSettings.native.ts
@@ -1,0 +1,49 @@
+import { fireEvent, screen } from '@testing-library/dom'
+import { act } from 'react'
+import { showModalActionCreator as showModal } from '../../actions/showModal'
+import { toggleUserSettingActionCreator as toggleUserSetting } from '../../actions/toggleUserSetting'
+import { Settings } from '../../constants'
+import share from '../../device/share'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+
+// Emulate the native iOS/Android app, whose WebView has no download manager and so silently ignores the anchor
+// click that download() performs. See DebugLogging in Settings.
+vi.mock('../../browser', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../browser')>()
+  return {
+    ...actual,
+    isCapacitor: () => true,
+  }
+})
+
+// The native app's virtual keyboard handler registers Capacitor Keyboard listeners on init, which reject as
+// UNIMPLEMENTED against the web platform the test actually runs on.
+vi.mock('@capacitor/keyboard', () => ({
+  Keyboard: {
+    addListener: () => Promise.resolve({ remove: () => {} }),
+    hide: () => Promise.resolve(),
+    removeAllListeners: () => Promise.resolve(),
+    show: () => Promise.resolve(),
+  },
+}))
+
+vi.mock('../../device/share')
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('share the debug log through the native share sheet in the app, where there is no download manager', async () => {
+  await dispatch([toggleUserSetting({ key: Settings.debugCrashLog, value: true }), showModal({ id: 'settings' })])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Share debug log' }))
+  })
+
+  expect(share).toHaveBeenCalledWith({
+    text: expect.stringContaining('--- state.thoughts:'),
+    title: expect.stringMatching(/^em-debug-log-\d+\.txt$/),
+  })
+})

--- a/src/components/__tests__/ModalSettings.ts
+++ b/src/components/__tests__/ModalSettings.ts
@@ -1,0 +1,28 @@
+import { fireEvent, screen } from '@testing-library/dom'
+import { act } from 'react'
+import { showModalActionCreator as showModal } from '../../actions/showModal'
+import { toggleUserSettingActionCreator as toggleUserSetting } from '../../actions/toggleUserSetting'
+import { Settings } from '../../constants'
+import download from '../../device/download'
+import createTestApp, { cleanupTestApp } from '../../test-helpers/createTestApp'
+import dispatch from '../../test-helpers/dispatch'
+
+vi.mock('../../device/download')
+
+beforeEach(createTestApp)
+afterEach(cleanupTestApp)
+
+it('download the debug log as a text file', async () => {
+  await dispatch([toggleUserSetting({ key: Settings.debugCrashLog, value: true }), showModal({ id: 'settings' })])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Download debug log' }))
+  })
+
+  expect(download).toHaveBeenCalledWith(
+    expect.stringContaining('--- state.thoughts:'),
+    expect.stringMatching(/^em-debug-log-\d+\.txt$/),
+  )
+})

--- a/src/components/modals/Settings.tsx
+++ b/src/components/modals/Settings.tsx
@@ -1,12 +1,15 @@
 import { FC, PropsWithChildren, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { css } from '../../../styled-system/css'
+import { css, cx } from '../../../styled-system/css'
 import { extendTapRecipe } from '../../../styled-system/recipes'
 import { fontSizeActionCreator } from '../../actions/fontSize'
 import { showModalActionCreator as showModal } from '../../actions/showModal'
 import { toggleUserSettingActionCreator as toggleUserSetting } from '../../actions/toggleUserSetting'
+import { isCapacitor } from '../../browser'
 import { DEFAULT_FONT_SIZE, MAX_FONT_SIZE, MIN_FONT_SIZE, Settings } from '../../constants'
 import copy from '../../device/copy'
+import download from '../../device/download'
+import share from '../../device/share'
 import globals from '../../globals'
 import getUserSetting from '../../selectors/getUserSetting'
 import storageStatusStore from '../../stores/storageStatus'
@@ -15,6 +18,7 @@ import debugLog from '../../util/debugLog'
 import fastClick from '../../util/fastClick'
 import haptics from '../../util/haptics'
 import storage from '../../util/storage'
+import timestamp from '../../util/timestamp'
 import ThemeSwitch from '../ThemeSwitch'
 import ActionButton from './../ActionButton'
 import Checkbox from './../Checkbox'
@@ -117,7 +121,7 @@ const FontSize = () => {
   )
 }
 
-/** The Debug Logging setting together with the debug log copy/clear controls. On development and preview hosts (debugLog.autoEnabled), logging defaults to on and the checkbox controls a device-local opt-out instead of the synced user setting, so this device can be aligned with production (e.g. for performance testing) without enabling logging on the user's other devices. */
+/** The Debug Logging setting together with the debug log save/copy/clear controls. On development and preview hosts (debugLog.autoEnabled), logging defaults to on and the checkbox controls a device-local opt-out instead of the synced user setting, so this device can be aligned with production (e.g. for performance testing) without enabling logging on the user's other devices. */
 const DebugLogging = () => {
   const settingEnabled = useSelector(getUserSetting(Settings.debugCrashLog))
   // the device-local state on auto-enabled hosts; the logger has already applied any persisted opt-out at module load
@@ -128,6 +132,12 @@ const DebugLogging = () => {
 
   const intro =
     'Records a rolling log of app events to help diagnose rare, hard-to-reproduce bugs (such as freezes). Everything is stored locally on this device and nothing is transmitted. '
+
+  // A native WebView has no download manager, so the anchor click that download() performs is silently ignored in
+  // the iOS and Android apps. There the native share sheet is the only way off the device, as in the Export modal.
+  // Mobile browsers are unaffected: iOS Safari and Android Chrome both save the blob to Files/Downloads.
+  const isNative = isCapacitor()
+  const saveLabel = isNative ? 'Share debug log' : 'Download debug log'
 
   return (
     <>
@@ -141,28 +151,48 @@ const DebugLogging = () => {
           }}
         >
           {intro}Debug Logging is on by default in this development or preview version of em. Turning it off aligns this
-          device with production (e.g. for performance testing) and does not affect other devices. Use “Copy debug log”
-          to share the captured log.
+          device with production (e.g. for performance testing) and does not affect other devices. Use “{saveLabel}” or
+          “Copy debug log” to share the captured log.
         </Checkbox>
       ) : (
         <Setting settingsKey={Settings.debugCrashLog} title='Debug Logging'>
-          {intro}Leave this off unless a developer asks you to enable it. Use “Copy debug log” to share the captured
-          log.
+          {intro}Leave this off unless a developer asks you to enable it. Use “{saveLabel}” or “Copy debug log” to share
+          the captured log.
         </Setting>
       )}
       {enabled && (
-        <div className={css({ marginTop: '1em' })}>
+        // a flex row of nowrap links, so that a narrow screen breaks between the links rather than mid-label
+        <div className={css({ alignItems: 'baseline', display: 'flex', flexWrap: 'wrap', marginTop: '1em' })}>
           <a
             {...fastClick(() => {
               // dispatch a thunk to read fresh state, so format() can append the state.thoughts dump that resolves
               // the ids in the entries to values and shows current sibling order
               dispatch((_, getState) => {
                 const text = debugLog.format(getState())
+                const filename = `em-debug-log-${timestamp()}.txt`
+                if (isNative) {
+                  share({ text, title: filename })
+                } else {
+                  download(text, filename)
+                }
+                setStatus(`${isNative ? 'Shared' : 'Downloaded'} ${debugLog.read().length} entries`)
+              })
+            })}
+            className={cx(extendTapRecipe(), css({ whiteSpace: 'nowrap' }))}
+          >
+            {saveLabel}
+          </a>
+          <span className={css({ margin: '0 0.5em', color: 'dim' })}>·</span>
+          <a
+            {...fastClick(() => {
+              // read fresh state for the state.thoughts dump, as above
+              dispatch((_, getState) => {
+                const text = debugLog.format(getState())
                 copy(text)
                 setStatus(text ? `Copied ${debugLog.read().length} entries` : 'Log is empty')
               })
             })}
-            className={extendTapRecipe()}
+            className={cx(extendTapRecipe(), css({ whiteSpace: 'nowrap' }))}
           >
             Copy debug log
           </a>
@@ -172,7 +202,7 @@ const DebugLogging = () => {
               debugLog.clear()
               setStatus('Cleared')
             })}
-            className={extendTapRecipe()}
+            className={cx(extendTapRecipe(), css({ whiteSpace: 'nowrap' }))}
           >
             Clear debug log
           </a>


### PR DESCRIPTION
Copying to the clipboard was the only way to get the debug log off a device. That is unworkable on mobile, where the log runs to megabytes and has to be pasted somewhere by hand before it can be shared.

## Changes

- Adds a **Download debug log** link beside Copy and Clear in Settings → Debug Logging. It saves exactly what the Copy link produces — the rolling log, the last-frame marker, and the `state.thoughts` dump — as `em-debug-log-<timestamp>.txt`, reusing `device/download`.
- In the iOS and Android apps the WebView has no download manager, so the anchor click that `download()` performs is silently ignored. There the link reads **Share debug log** and opens the native share sheet via `device/share` instead — the same fallback the Export modal uses. Mobile browsers are unaffected: iOS Safari and Android Chrome both save the blob.
- The row is now a wrapping flex row of nowrap links, so a narrow screen breaks between the links rather than mid-label; a third link no longer fits on one line on a phone. It reads `Download debug log · Copy debug log · Clear debug log  (Downloaded 2 entries)`.

## Verification

Driven in Chrome against the dev server: enabling Debug Logging, opening Settings, and tapping the link downloads `em-debug-log-1789117721253.txt` containing the session entry, the `lastFrameAt` marker, and the `--- state.thoughts:` dump, with the status reading `(Downloaded 2 entries)`. Re-checked at iPhone width, where the row wraps between links.

Two JSDOM tests cover it: `src/components/__tests__/ModalSettings.ts` clicks the link and asserts the downloaded contents and filename, and `ModalSettings.native.ts` emulates the native app and asserts the share sheet is used instead. Both were confirmed to fail with the component change reverted.

No Puppeteer snapshot update is needed: `modal-settings` captures an 800×600 viewport that ends above the Debug Logging section, so the reworded description is outside the frame.

docs: unaffected — no document describes the Settings modal's debug log controls, and the one `debugLog` reference in `docs/persistence.md` covers the `push`/`pushSynced` entries, which are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfeZPgGqUuve9UxtYc8T8m