### PR TITLE
Tighten the context view animation onset and ease it out

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -439,8 +439,11 @@ export default defineConfig({
           easeInSlow: {
             value: 'cubic-bezier(.84, 0, 1, 1)',
           },
-          easeInSmooth: {
-            value: 'cubic-bezier(0.75, 0.00, 0.75, 0.90)',
+          // Rises out of the gate after only a brief shoulder, then decelerates into a long, flat landing.
+          // Used by the context view's appearing text animation: the short onset keeps the contexts from lagging
+          // behind the gesture that summoned them, while the long tail lets them settle into place rather than snap.
+          easeOutSmooth: {
+            value: 'cubic-bezier(0.35, 0.15, 0.2, 1)',
           },
           nodeCurveXLayer: {
             value: 'cubic-bezier(0.8,0,0.2,0.2)',

--- a/src/recipes/fadeTransition.ts
+++ b/src/recipes/fadeTransition.ts
@@ -92,6 +92,9 @@ const fadeTransitionRecipe = defineSlotRecipe({
         },
       },
       // Context view fades in from upper right.
+      // Enter and exit are eased differently on purpose, here and in disappearingLowerLeft below: text that is
+      // arriving should start resolving right after the toggle and then decelerate into place (easeOutSmooth),
+      // while text that is leaving has no such requirement and keeps the symmetric ease.
       disappearingUpperRight: {
         enter: {
           transform: 'skew(-100deg) translateX(10%) translateY(-100%)',
@@ -104,7 +107,7 @@ const fadeTransitionRecipe = defineSlotRecipe({
         enterActive: {
           transform: 'skew(0) translateX(0) translateY(0)',
           filter: 'blur(0px)',
-          transition: `opacity {durations.disappearingUpperRight} {easings.easeInSmooth}, transform {durations.disappearingUpperRight} {easings.easeInSmooth}, filter {durations.disappearingUpperRight} {easings.easeInSmooth}`,
+          transition: `opacity {durations.disappearingUpperRight} {easings.easeOutSmooth}, transform {durations.disappearingUpperRight} {easings.easeOutSmooth}, filter {durations.disappearingUpperRight} {easings.easeOutSmooth}`,
           // See: Safari skew note above
           _safari: {
             transform: 'skew(0) translateX(0) translateY(0)',
@@ -136,7 +139,7 @@ const fadeTransitionRecipe = defineSlotRecipe({
         enterActive: {
           transform: 'skew(0) translateX(0) translateY(0)',
           filter: 'blur(0px)',
-          transition: `opacity {durations.disappearingLowerLeft} {easings.easeInSmooth}, transform {durations.disappearingLowerLeft} {easings.easeInSmooth}, filter {durations.disappearingLowerLeft} {easings.easeInSmooth}`,
+          transition: `opacity {durations.disappearingLowerLeft} {easings.easeOutSmooth}, transform {durations.disappearingLowerLeft} {easings.easeOutSmooth}, filter {durations.disappearingLowerLeft} {easings.easeOutSmooth}`,
           // See: Safari skew note above
           _safari: {
             transform: 'skew(0) translateX(0) translateY(0)',


### PR DESCRIPTION
Tweaks the context view's disappearing text animation on two axes:

- **Onset** — less gap between activation and the appearance of the contexts.
- **Ease out** — the contexts decelerate into place instead of arriving at full speed.

Both come from one change: the easing on the *enter* half of `disappearingUpperRight` / `disappearingLowerLeft`. The 500ms duration is unchanged, so the tighter onset is spent on a longer tail rather than on a shorter animation.

| | before | after |
|---|---|---|
| easing | `cubic-bezier(0.75, 0.00, 0.75, 0.90)` (`easeInSmooth`) | `cubic-bezier(0.35, 0.15, 0.2, 1)` (`easeOutSmooth`) |

`easeInSmooth` held opacity, transform, and blur near their starting values for the first 40% of the animation, then covered most of the remaining distance in a rush — the contexts were a faint smear for the first fifth of a second and then snapped in.

## Measured in the running app

Opacity of the entering contexts, sampled every frame after `toggleContextView`, with `data-env=test` cleared so the duration tokens are not zeroed:

| opacity reaches | before | after |
|---|---|---|
| 5% | 193ms | **88ms** |
| 10% | 243ms | **104ms** |
| 50% | 410ms | **204ms** |
| 90% | 493ms | 354ms |
| 99% | 543ms | 471ms |

The onset gap drops by ~105ms. The tail inverts: the old curve went 0.27 → 0.98 over its final 200ms, the new one goes 0.78 → 1.00 over its final 200ms.

At 160ms after the toggle the first context is legible and nearly in place, where before it was still a ghost; by 320ms both contexts have settled while the old children are on their way out.

## Notes for design review

- The easing token is renamed `easeInSmooth` → `easeOutSmooth`, since the curve is no longer ease-in dominant. It had no other consumers. `easeInSlow` is untouched.
- Only the *enter* half changed. Exits still use `ease`, on the reasoning that text leaving does not need to become legible early — worth a look, since the crossfade is now less symmetric than it was.
- Because the entering contexts resolve sooner, they overlap the outgoing siblings more visibly during the middle of the crossfade. That overlap existed before; the faster onset makes it easier to notice.
- Puppeteer image snapshots are unaffected: the `_test` condition zeroes every duration token, so easing plays no part in them.

## Verification

- `yarn lint` (prettier, eslint, tsc, lockfile) passes.
- `src/commands/__tests__/toggleContextView.ts` passes.
- Animation observed and measured in the app running under `yarn start`, per the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8t9RrJKWCsHfgQW9p1sDg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8t9RrJKWCsHfgQW9p1sDg)_

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"8ba2246054557d20749e0fe76e6bb808f1783631","createdAt":"2026-09-11T09:40:28Z","url":"https://em-hgnl0afpf-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 9:40 AM UTC · 8ba2246</summary>

<a href="https://em-hgnl0afpf-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/a913ce1d-bb03-422f-90e1-43db71b4fbd0)</a>

</details>
<!-- preview-qr:end -->