### PR TITLE
Test that creating a context in the context view does not warn

### DIFF
--- a/src/actions/__tests__/newThought.ts
+++ b/src/actions/__tests__/newThought.ts
@@ -330,6 +330,41 @@ describe('context view', () => {
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm', ''])
   })
 
+  // https://github.com/cybersemics/em/issues/5445
+  it.skip('new subthought on a context view does not warn about a missing sibling', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const text = `
+      - a
+        - m
+          - x
+      - b
+        - m
+          - y
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      newThought({ insertNewSubthought: true }),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    // restore before asserting so a failure cannot leave console.warn mocked for the rest of the file
+    const warnings = [...consoleWarn.mock.calls]
+    consoleWarn.mockRestore()
+
+    // createThought's missing-children sweep must not report the context that newThought is in the middle of creating
+    expect(warnings).toEqual([])
+
+    // the new context must still be created, otherwise the absence of a warning proves nothing
+    const exportedAbs = exportContext(stateNew, [ABSOLUTE_TOKEN], 'text/plain')
+    expect(exportedAbs).toBe(`- ${ABSOLUTE_TOKEN}
+  - ${''}
+    - m`)
+  })
+
   it('new thought on a context adds a a new sibling context in the absolute context', () => {
     const text = `
       - a


### PR DESCRIPTION
#5445 is fixed by #5516, but nothing in the suite would go red if the spurious "Sibling … with missing thought" warning came back: the existing context-view tests only assert the final state, and `setupTests.ts` turns only React's act() `console.error` into a failure. This adds the test.

It runs the same steps as the issue (`importText`, `setCursor(['a', 'm'])`, `toggleContextView`, `newThought({ insertNewSubthought: true })`) with `console.warn` spied, and asserts the issue's expected behavior: no warning. It also asserts the absolute-context export, so the absence of a warning is not satisfied by the context failing to be created at all.

On `main` it fails on the warning assertion with the issue's exact message, where the sibling id is the id of the thought being created. With the change from #5516 applied it passes.

It is staged as `it.skip` per the TDD convention so CI stays green until the fix lands; the TDD workflow unskips it on `main` and expects it to fail there. The `.skip` comes off when this merges after #5516. If #5516 picks the test up and lands it unskipped instead, this can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
