### PR TITLE
Unskip the context-view missing-sibling test now that #5516 is on main

### DIFF
--- a/src/actions/__tests__/newThought.ts
+++ b/src/actions/__tests__/newThought.ts
@@ -331,7 +331,7 @@ describe('context view', () => {
   })
 
   // https://github.com/cybersemics/em/issues/5445
-  it.skip('new subthought on a context view does not warn about a missing sibling', () => {
+  it('new subthought on a context view does not warn about a missing sibling', () => {
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const text = `


### PR DESCRIPTION
#5527 merged with the transient `it.skip` still on the test it added, and #5516 landed right after it, so the fix the test waits for is on `main` and the test can come on. This removes the skip; nothing else changes.

The TDD workflow would otherwise run the test against `main`, where it now passes. The line below points it at the commit before #5516, where the warning still fires.

/tdd 396acb3af7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"6b496287da02b5e77660a83c9c581bced872a126","createdAt":"2026-09-11T22:02:44Z","url":"https://em-omjg5zu8a-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:02 PM UTC · 6b49628</summary>

<a href="https://em-omjg5zu8a-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/ffeadd5a-430a-4aa4-80d9-4fa267b4a079)</a>

</details>
<!-- preview-qr:end -->