### PR TITLE
Clean up newThought and createThought after #5516

### DIFF
--- a/src/actions/createThought.ts
+++ b/src/actions/createThought.ts
@@ -30,8 +30,9 @@ interface Payload {
 /**
  * Creates a new thought with a known context and rank. Does not update the cursor. Use the newThought reducer for a higher level function.
  */
-const createThought = (state: State, { path, value, rank, id, idbSynced, splitSource }: Payload) => {
-  id = id || createId()
+const createThought = (state: State, payload: Payload) => {
+  const { path, value, rank, idbSynced, splitSource } = payload
+  const id = payload.id || createId()
   const lexemeOld = getLexeme(state, value)
 
   // create Lexeme if it does not exist
@@ -48,7 +49,7 @@ const createThought = (state: State, { path, value, rank, id, idbSynced, splitSo
   const parent = getThoughtById(state, parentId)
 
   if (!parent) {
-    console.error({ path, value, rank, id, idbSynced, splitSource })
+    console.error(payload)
     throw new Error(`createThought: Parent thought with id ${parentId} not found`)
   }
 

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -159,9 +159,8 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
             : getNextRank(state, insertId)
           : getRankAfter(state, simplePath)
 
-  // when creating a new context in a context view, newThoughtId is the new empty thought (a/~m/_), and newContextId is the newly added Lexeme context (/ABS/_/m)
+  // when creating a new context in a context view, newThoughtId is the new empty thought (a/~m/_)
   const newThoughtId = createId()
-  const newContextId = insertContext ? createId() : null
 
   const reducers = [
     // createThought
@@ -180,7 +179,6 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
           path: [ABSOLUTE_TOKEN, newThoughtId] as unknown as SimplePath,
           rank: 0,
           value: headValue(state, insertNewSubthought ? path : parentOf(path)) ?? '',
-          id: newContextId!,
           splitSource,
         })
       : null,

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -179,7 +179,6 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
           path: [ABSOLUTE_TOKEN, newThoughtId] as unknown as SimplePath,
           rank: 0,
           value: headValue(state, insertNewSubthought ? path : parentOf(path)) ?? '',
-          splitSource,
         })
       : null,
 


### PR DESCRIPTION
#5516 (merged as b07edb0942), follow-up. Three small cleanups in `newThought` and `createThought` that came out of reviewing it. One commit per item. Behavior is identical.

1. **Remove `newContextId`.** `newThought` minted the new context's id up front only so the childrenMap pre-population removed in #5516 could reference the context thought before it existed. Both halves were introduced together in a2124e9383. `createThought` mints the id itself when none is passed, so the declaration, the `id:` argument, and its half of the comment go. The `createId` call order (thought id, then context id) is unchanged.

2. **Do not tag the new context thought as a split product.** `splitSource` was forwarded to the second `createThought` call, the one that creates the context thought (`/ABS/''/m`). Its only consumer is `deleteEmptyThought`, which compares it to the previous sibling's id to decide whether to restore a space on merge, and the context thought was never split from anything. This is unreachable today, since `splitThought` never sets `insertNewSubthought` and the `newThought` command refuses to split when the parent has the context view active, so it is hygiene rather than a fix.

3. **Log the whole payload when `createThought` cannot find the parent.** The `console.error` listed every `Payload` field by hand, so #5516 had to edit the interface, the destructuring, and the log in lockstep. `createThought` now takes `payload: Payload`, destructures in the body, and logs `payload`. `_.curryRight(createThought)` and `createThoughtActionCreator`'s `Parameters<typeof createThought>[1]` are unaffected. `importText` and `moveThought` have similar enumerated dumps and are left alone: `importText`'s payload carries the full imported `text`, which does not belong in the console, and `moveThought` already has `payload` in scope, so its dump is a one-line follow-up if we want it.

**Overlap with #5127.** That branch reads `newContextId` in its `setCursor` branch to build the cursor path for a new context. Against it, the first commit here merges clean textually but fails `tsc`. Whichever of the two merges second reconciles it: if #5127 lands first, drop the first commit here; if this lands first, #5127 mints the id again, since it needs the context's id before the thought exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"fefce20af00ee8b3bcdff47fb632f4ed2f6c39ec","createdAt":"2026-09-11T22:10:35Z","url":"https://em-bdo3svpp4-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:10 PM UTC · fefce20</summary>

<a href="https://em-bdo3svpp4-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/14e8abd8-ffd6-4255-a934-c64572f4c76d)</a>

</details>
<!-- preview-qr:end -->