### PR TITLE
Cover the childrenMap key and persistence of a context created in the context view

### DIFF
--- a/src/actions/__tests__/newThought.ts
+++ b/src/actions/__tests__/newThought.ts
@@ -2,10 +2,13 @@ import { importText, toggleContextView } from '../../actions'
 import { ABSOLUTE_TOKEN, HOME_TOKEN } from '../../constants'
 import contextToThoughtId from '../../selectors/contextToThoughtId'
 import exportContext from '../../selectors/exportContext'
+import findDescendant from '../../selectors/findDescendant'
 import { getLexeme } from '../../selectors/getLexeme'
+import getThoughtById from '../../selectors/getThoughtById'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import newThoughtAtFirstMatch from '../../test-helpers/newThoughtAtFirstMatch'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 import newThought from '../newThought'
@@ -328,6 +331,11 @@ describe('context view', () => {
 
     // cursor should be on the new context
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm', ''])
+
+    // the new context is keyed by its id in the new thought's childrenMap, which findDescendant, repairThought, and cursorForward read by key
+    const newThoughtId = head(stateNew.cursor!)
+    const contextId = findDescendant(stateNew, newThoughtId, 'm')
+    expect(getThoughtById(stateNew, newThoughtId)?.childrenMap).toEqual({ [contextId!]: contextId })
   })
 
   // https://github.com/cybersemics/em/issues/5445
@@ -406,6 +414,11 @@ describe('context view', () => {
 
     // cursor should be on the new context
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm', ''])
+
+    // the new context is keyed by its id in the new thought's childrenMap, which findDescendant, repairThought, and cursorForward read by key
+    const newThoughtId = head(stateNew.cursor!)
+    const contextId = findDescendant(stateNew, newThoughtId, 'm')
+    expect(getThoughtById(stateNew, newThoughtId)?.childrenMap).toEqual({ [contextId!]: contextId })
   })
 
   it('new subthought of context', () => {

--- a/src/redux-middleware/__tests__/pushQueue.ts
+++ b/src/redux-middleware/__tests__/pushQueue.ts
@@ -1,15 +1,22 @@
 import { act } from 'react'
 import { importTextActionCreator as importText } from '../../actions/importText'
 import { newThoughtActionCreator as newThought } from '../../actions/newThought'
+import { toggleContextViewActionCreator as toggleContextView } from '../../actions/toggleContextView'
+import { ABSOLUTE_TOKEN } from '../../constants'
 import getLexemeFromProvider from '../../data-providers/data-helpers/getLexeme'
+import getThoughtByIdFromDB from '../../data-providers/data-helpers/getThoughtById'
 import db from '../../data-providers/thoughtspace'
+import findDescendant from '../../selectors/findDescendant'
 import getLexemeFromState from '../../selectors/getLexeme'
+import getThoughtById from '../../selectors/getThoughtById'
 import store from '../../stores/app'
 import contextToThought from '../../test-helpers/contextToThought'
 import createTestApp, { cleanupTestApp, refreshTestApp } from '../../test-helpers/createTestApp'
 import dispatch from '../../test-helpers/dispatch'
 import { editThoughtByContextActionCreator as editThought } from '../../test-helpers/editThoughtByContext'
+import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import { setCursorFirstMatchActionCreator as setCursorFirstMatch } from '../../test-helpers/setCursorFirstMatch'
+import head from '../../util/head'
 
 beforeEach(createTestApp)
 afterEach(cleanupTestApp)
@@ -107,4 +114,59 @@ it.skip('a new thought should merge into an unloaded lexeme and persist both con
   const thoughtContextsState = getLexemeFromState(store.getState(), 'f')?.contexts
   expect(thoughtContextsState).toEqual(expect.arrayContaining([thoughtF?.id, thoughtFRoot?.id]))
   expect(thoughtContextsState).toHaveLength(2)
+})
+
+it('persist a new context created in the context view under the absolute root and reload it after a refresh', async () => {
+  await dispatch([
+    importText({
+      text: `
+        - a
+          - m
+            - x
+        - b
+          - m
+            - y
+      `,
+    }),
+    setCursorFirstMatch(['a', 'm']),
+    toggleContextView(),
+    newThought({ insertNewSubthought: true }),
+  ])
+
+  await act(vi.runOnlyPendingTimersAsync)
+
+  // the cursor is on the new context: an empty thought under the absolute root that holds the new instance of m
+  const state = store.getState()
+  expectPathToEqual(state, state.cursor, ['a', 'm', ''])
+  const newThoughtId = head(state.cursor!)
+  const contextId = findDescendant(state, newThoughtId, 'm')!
+
+  // the provider inserts each pushed thought under its parentId and rebuilds childrenMap from the tree on read, so the links must survive the write
+  const absoluteFromDb = await getThoughtByIdFromDB(db, ABSOLUTE_TOKEN)
+  expect(absoluteFromDb?.childrenMap).toEqual({ [newThoughtId]: newThoughtId })
+
+  const newThoughtFromDb = await getThoughtByIdFromDB(db, newThoughtId)
+  expect(newThoughtFromDb).toMatchObject({ value: '', parentId: ABSOLUTE_TOKEN })
+  expect(newThoughtFromDb?.childrenMap).toEqual({ [contextId]: contextId })
+
+  const contextFromDb = await getThoughtByIdFromDB(db, contextId)
+  expect(contextFromDb).toMatchObject({ value: 'm', parentId: newThoughtId, childrenMap: {} })
+
+  await refreshTestApp()
+
+  // nothing under the absolute root is loaded until the context view asks for the contexts of m
+  expect(getThoughtById(store.getState(), newThoughtId)).toBeUndefined()
+
+  await dispatch([setCursorFirstMatch(['a', 'm']), toggleContextView()])
+
+  await act(vi.runAllTimersAsync)
+
+  const stateAfterRefresh = store.getState()
+
+  const newThoughtAfterRefresh = getThoughtById(stateAfterRefresh, newThoughtId)
+  expect(newThoughtAfterRefresh).toMatchObject({ value: '', parentId: ABSOLUTE_TOKEN })
+  expect(newThoughtAfterRefresh?.childrenMap).toEqual({ [contextId]: contextId })
+
+  const contextAfterRefresh = getThoughtById(stateAfterRefresh, contextId)
+  expect(contextAfterRefresh).toMatchObject({ value: 'm', parentId: newThoughtId, childrenMap: {} })
 })


### PR DESCRIPTION
Two coverage gaps found while reviewing #5516.

The context-view tests in `newThought.ts` asserted the absolute context through `exportContext`, which reads `Object.values(childrenMap)`, so the key under which the new context is stored was never observed. `findDescendant`, `repairThought`, and `cursorForward` read `childrenMap` by key. Each of those tests now asserts that the new thought's `childrenMap` keys the context by its id. Keying it by value in `createThought` fails exactly those two assertions and nothing else in the file.

No active test round-tripped a context-view `newThought` through the push queue to TreeCRDT and back. The provider inserts each thought by `parentId` and rebuilds `childrenMap` from the tree on read, so the new test in the push queue middleware tests pins that contract: it reads the absolute root, the new thought, and the context back from the provider, refreshes the app, confirms nothing under the absolute root is loaded, and asserts the same links through the selectors once the context view pulls the contexts of `m` again. The two skipped tests already in that file are left alone; they cover lexeme merging across a refresh (#1074, #5426), which is a different problem.

`contextToThoughtId` walks from `state.rootContext`, so it cannot resolve a path under `ABSOLUTE_TOKEN`. The tests take the new thought from the cursor, which they already assert, and the context through `findDescendant`, which matches children by value rather than by key.

This covers behavior that already works on `main`, so there is no red side. The pull request changes only test files, which the TDD workflow skips on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"eb1764bbbe1b046dbd246d1793b29eb89fdc1273","createdAt":"2026-09-11T22:18:26Z","url":"https://em-5y4vmzofd-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:18 PM UTC · eb1764b</summary>

<a href="https://em-5y4vmzofd-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/09ec32bb-483b-4e28-a981-2cafcba5f0ff)</a>

</details>
<!-- preview-qr:end -->