### PR TITLE
Skip the redundant expandThoughts pass in newThought

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -82,7 +82,7 @@ A flat reference of project-specific terms used in code and docs. For deeper con
 
 **EM_TOKEN** — Sentinel `ThoughtId` (`'__EM__'`) for the hidden system context where user settings (e.g. `[EM, 'Settings']`) are stored. See [`constants.ts`](../src/constants.ts).
 
-**expanded** — `state.expanded: Index<boolean>`, keyed by `hashPath(path)`. A thought's children are walked by `linearizeTree` only if its path is in this map. Expansion is derived from the cursor _and_ the multicursor: a selected thought expands its ancestors but stays collapsed itself, so any reducer that changes `state.multicursors` must recalculate `expanded`. See [`expandThoughts`](../src/selectors/expandThoughts.ts).
+**expanded** — `state.expanded: Index<boolean>`, keyed by `hashPath(path)`. A thought's children are walked by `linearizeTree` only if its path is in this map. Expansion is derived from the cursor _and_ the multicursor: a selected thought expands its ancestors but stays collapsed itself, so any reducer that changes `state.multicursors` must recalculate `expanded`. [`setCursor`](../src/actions/setCursor.ts) recalculates it for the new cursor, and [`updateThoughts`](../src/actions/updateThoughts.ts) recalculates it after each batch of thought updates unless the caller passes `preventExpandThoughts`, which a reducer such as `newThought`, `importText`, or `moveThought` does when a later reducer in the same `reducerFlow` recalculates it anyway. See [`expandThoughts`](../src/selectors/expandThoughts.ts).
 
 ## F
 

--- a/src/actions/__tests__/newThought.ts
+++ b/src/actions/__tests__/newThought.ts
@@ -1,11 +1,13 @@
 import { importText, toggleContextView } from '../../actions'
 import { ABSOLUTE_TOKEN, HOME_TOKEN } from '../../constants'
+import contextToPath from '../../selectors/contextToPath'
 import contextToThoughtId from '../../selectors/contextToThoughtId'
 import exportContext from '../../selectors/exportContext'
 import { getLexeme } from '../../selectors/getLexeme'
 import expectPathToEqual from '../../test-helpers/expectPathToEqual'
 import newThoughtAtFirstMatch from '../../test-helpers/newThoughtAtFirstMatch'
 import setCursor from '../../test-helpers/setCursorFirstMatch'
+import hashPath from '../../util/hashPath'
 import initialState from '../../util/initialState'
 import reducerFlow from '../../util/reducerFlow'
 import newThought from '../newThought'
@@ -98,6 +100,39 @@ describe('normal view', () => {
     const stateNew = reducerFlow(steps)(initialState())
 
     expect(stateNew.cursor).toMatchObject([contextToThoughtId(stateNew, ['b'])!])
+  })
+
+  it('expand the new thought and collapse the children of the previous cursor', () => {
+    const text = `
+      - a
+        - b
+    `
+    const steps = [importText({ text }), setCursor(['a']), newThought({ value: 'c' })]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    // expansion is recalculated for the new cursor, so a, the previous cursor, is no longer expanded
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['c'])!)]).toBeTruthy()
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['a'])!)]).toBeFalsy()
+  })
+
+  it('recalculate expansion for the unchanged cursor when preventSetCursor is set', () => {
+    const text = `
+      - a
+        - b
+          - c
+    `
+    const stateBefore = reducerFlow([importText({ text }), setCursor(['a'])])(initialState())
+
+    // b is expanded as the only child of the cursor that has a child of its own
+    expect(stateBefore.expanded[hashPath(contextToPath(stateBefore, ['a', 'b'])!)]).toBeTruthy()
+
+    const stateNew = newThought(stateBefore, { value: 'd', insertNewSubthought: true, preventSetCursor: true })
+
+    expectPathToEqual(stateNew, stateNew.cursor, ['a'])
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['a'])!)]).toBeTruthy()
+    // b is no longer an only child, so a stale expansion from before the new thought would leave it expanded
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['a', 'b'])!)]).toBeFalsy()
   })
 
   describe('sorted', () => {
@@ -328,6 +363,28 @@ describe('context view', () => {
 
     // cursor should be on the new context
     expectPathToEqual(stateNew, stateNew.cursor, ['a', 'm', ''])
+  })
+
+  it('expand the new context', () => {
+    const text = `
+      - a
+        - m
+          - x
+      - b
+        - m
+          - y
+    `
+    const steps = [
+      importText({ text }),
+      setCursor(['a', 'm']),
+      toggleContextView,
+      newThought({ insertNewSubthought: true }),
+    ]
+
+    const stateNew = reducerFlow(steps)(initialState())
+
+    // the new context is the cursor, so it is expanded once both createThought reducers have run and setCursor has recalculated expansion
+    expect(stateNew.expanded[hashPath(contextToPath(stateNew, ['a', 'm', ''])!)]).toBeTruthy()
   })
 
   // https://github.com/cybersemics/em/issues/5445

--- a/src/actions/createThought.ts
+++ b/src/actions/createThought.ts
@@ -23,6 +23,8 @@ interface Payload {
   /** Callback for when the updates have been synced with IDB. */
   idbSynced?: () => void
   path: Path
+  /** Skips the expandThoughts recalculation in updateThoughts. Use when a later reducer in the same reducerFlow recalculates expansion anyway, such as the setCursor in newThought. See updateThoughts. */
+  preventExpandThoughts?: boolean
   rank: number
   splitSource?: ThoughtId
   value: string
@@ -30,7 +32,10 @@ interface Payload {
 /**
  * Creates a new thought with a known context and rank. Does not update the cursor. Use the newThought reducer for a higher level function.
  */
-const createThought = (state: State, { path, value, rank, id, idbSynced, splitSource }: Payload) => {
+const createThought = (
+  state: State,
+  { path, value, rank, id, idbSynced, preventExpandThoughts, splitSource }: Payload,
+) => {
   id = id || createId()
   const lexemeOld = getLexeme(state, value)
 
@@ -101,7 +106,7 @@ const createThought = (state: State, { path, value, rank, id, idbSynced, splitSo
     [hashThought(value)]: lexemeNew,
   }
 
-  return updateThoughts(state, { lexemeIndexUpdates, thoughtIndexUpdates, idbSynced })
+  return updateThoughts(state, { lexemeIndexUpdates, thoughtIndexUpdates, idbSynced, preventExpandThoughts })
 }
 
 /** Action-creator for createThought. */

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -163,6 +163,11 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
   const newThoughtId = createId()
   const newContextId = insertContext ? createId() : null
 
+  // setCursor below recalculates state.expanded for the new cursor, so the recalculation that updateThoughts would
+  // otherwise do for the old cursor after each createThought is skipped. When preventSetCursor is set, no setCursor
+  // runs and the createThought reducers must recalculate expansion themselves.
+  const preventExpandThoughts = !preventSetCursor
+
   const reducers = [
     // createThought
     createThought({
@@ -171,6 +176,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
       value,
       id: newThoughtId,
       idbSynced,
+      preventExpandThoughts,
       splitSource,
     }),
 
@@ -181,6 +187,7 @@ const newThought = (state: State, payload: NewThoughtPayload | string) => {
           rank: 0,
           value: headValue(state, insertNewSubthought ? path : parentOf(path)) ?? '',
           id: newContextId!,
+          preventExpandThoughts,
           splitSource,
         })
       : null,


### PR DESCRIPTION
Found while reviewing #5516.

`newThought` runs `createThought` (twice in the context view) and then `setCursor`. Each `createThought` ends in `updateThoughts`, which recalculates `state.expanded` for the cursor as it stands at that point, i.e. the old cursor. `setCursor` then recalculates it for the new cursor, so the earlier pass is discarded. It is paid on every Enter and scales with the visible children along the cursor path.

### Change

- `createThought` accepts `preventExpandThoughts` and forwards it to `updateThoughts`, which already had the option. `createThought` was hiding it.
- `newThought` sets it on both `createThought` calls whenever `setCursor` will run, i.e. when `preventSetCursor` is not set. With `preventSetCursor`, no `setCursor` runs, so `createThought` recalculates expansion as before.
- Three reducer tests assert `state.expanded` after `newThought`: the new thought is expanded and the previous cursor's children are collapsed (normal view); the unchanged cursor's expansion is recalculated under `preventSetCursor` (an only child that gains a sibling must collapse); and the new context is expanded (context view). Forcing `preventExpandThoughts` on unconditionally fails the second, and making `setCursor` reuse the stale map fails all three.

This is the same deferral `importText` makes ("thoughts will be expanded by setCursor, so no need to expand them here") and `moveThought` makes. The one exposure is shared with `importText`: while `globals.suppressExpansion` is set, `setCursor` reuses `state.expanded` instead of recalculating, so the map stays as it was before the new thought until `unsuppress` re-dispatches `setCursor` within 66 ms, or immediately on Meta keyup. `main` is no better off in that window, since its extra pass was also for the old cursor, and the new thought's parent is in the map either way. The flag is only set by `cursorNext`/`cursorPrev`, and keydown clears it unless the command modifier is held, so reaching the window takes Meta+ArrowDown followed within 66 ms by Meta+Enter, exactly as Cmd+V already can for `importText`.

### Measurements

Median of 400 `newThought` calls per round, 5 rounds with the two implementations interleaved in one vitest process, on a shared machine, so the absolute numbers are noisy. The last column is the standalone cost of the pass that is no longer made, measured in the same rounds. The benchmark is not committed.

| fixture | thoughts | `main` | this PR | one `expandThoughts` |
|---|---|---|---|---|
| cursor among 21 siblings, each with 20 children | 444 | 0.51 ms | 0.50 ms | 0.05 ms |
| cursor among 440 siblings | 443 | 2.74 ms | 1.76 ms | 0.63 ms |
| new context in a context view, 436 visible root siblings | 448 | 7.39 ms | 3.16 ms | 0.91 ms, twice on `main` |

The TDD workflow is skipped (`skip-tdd`): the new tests assert behavior that already holds on `main`, since the change removes work without changing the final state, so there is no red side.

### Plan (per `.github/skills/plan`)

<details>
<summary>Existing surface, build-vs-extend, adjacent behaviour</summary>

**Existing surface area.** `updateThoughts` documents `preventExpandThoughts` ("If a separate expandThoughts is called after updateThoughts within the same reducerFlow, then we can prevent expandThoughts here for better performance. See moveThought.") and recalculates `expanded` for `state.cursor` in its last reducer. `createThought` ends in `updateThoughts` without exposing the option. `newThought`'s reducer list is `createThought` (plus a second `createThought` when `insertContext`), then `setCursor` when `!preventSetCursor`, then the tutorial reducers. `setCursor` always assigns `expanded`, recalculated unless `globals.suppressExpansion`; its early returns only reject `[]`, `[HOME_TOKEN]`, and paths starting with `HOME_TOKEN`, which `newThought` never produces (`unroot`). Precedents: `importText` and `moveThought`.

**Build vs. extend.** Extend: forward the existing option through `createThought`. No new module or concept.

**Adjacent behaviour.** The `preventSetCursor` callers of `newThought` (`extractSubthought`, `archiveThought`, `swapNote`, `initUserToolbar`, `importFiles`, the toolbar drag-and-drop) get `preventExpandThoughts: false`, so nothing changes for them. The other 14 `createThought` callers leave the field undefined. Nothing between the `createThought` reducers and `setCursor` reads `state.expanded`, and the tutorial reducers run after it. Undo patches diff the final state, which is unchanged. The multicursor loop's restore runs after each `newThought` has already produced its final map.

**Rejected.** Also skipping the first `createThought`'s pass in the context-view branch when `preventSetCursor` is set (the second pass covers it). Correct, but the combination is rare and the request was to keep current behaviour under `preventSetCursor`.

</details>

docs: updated `docs/glossary.md`. The `expanded` entry now states which reducers recalculate it and when `preventExpandThoughts` defers that. `src/actions/createThought.ts` and `src/actions/newThought.ts` match no row of the `docs-sync` routing table; no document describes the thought-mutation reducers as a subsystem, and I did not add one.

Note: the #5445 regression test in `newThought.ts` is still `it.skip` on `main` although #5516 merged its fix. It passes when unskipped. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"a56ba40bae50e4b79a6872be796683c44fff3d8f","createdAt":"2026-09-11T22:21:05Z","url":"https://em-5l226x52t-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:21 PM UTC · a56ba40</summary>

<a href="https://em-5l226x52t-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/e46c85be-90ea-42db-a0cc-43c948cf1805)</a>

</details>
<!-- preview-qr:end -->