### PR TITLE
Unskip the test that creating a context in the context view does not warn

### DIFF
--- a/src/actions/__tests__/newThought.ts
+++ b/src/actions/__tests__/newThought.ts
@@ -331,7 +331,7 @@ describe('context view', () => {
   })
 
   // https://github.com/cybersemics/em/issues/5445
-  it.skip('new subthought on a context view does not warn about a missing sibling', () => {
+  it('new subthought on a context view does not warn about a missing sibling', () => {
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const text = `


### PR DESCRIPTION
#5445 was fixed by #5516. #5527 had staged the regression test as `it.skip`, with the skip to come off once the fix landed, but the two merged within two minutes of each other, #5527 first, and #5516 (b07edb0942) only touched `createThought.ts` and `newThought.ts`. So the skip was never removed, and the test has been switched off on `main` since. A skipped test documents the behavior but does not count as coverage, so the "Sibling … with missing thought" warning could come back without anything going red.

This removes the `.skip` and nothing else. The bare issue-URL comment stays above the test, as it does above every other regression test, and the assertion is the one #5527 shipped.

The red side was already proven: the TDD workflow on #5527 unskipped the test against the pre-fix `main` and confirmed it fails there. The test now passes on `main` with the fix in place, so this carries the `skip-tdd` label rather than expecting a red pre-fix run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"a80fbd9250e3745a2dea4e92bad75956817ca783","createdAt":"2026-09-11T22:35:15Z","url":"https://em-899oivhn9-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:35 PM UTC · a80fbd9</summary>

<a href="https://em-899oivhn9-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/479c994f-c10e-4acd-b181-de6b753ace95)</a>

</details>
<!-- preview-qr:end -->