### PR TITLE
Cancel New Thought and New Grandchild on the tutorial welcome step

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -388,7 +388,7 @@ https://github.com/user-attachments/assets/682334ea-823e-497b-818f-584639a5db5b
 
 ### New Thought
 
-Create a shiny new thought.
+Create a shiny new thought. The command is disabled while the tutorial is on its welcome step, which offers only Next — the first-thought step that follows is where the tutorial asks for Enter, so a thought created before then would jump ahead of it. Paste, import, and toolbar customization create thoughts through the same [`newThought`](../src/actions/newThought.ts) action-creator and are not affected, since the gate is the command's `canExecute` rather than the action-creator.
 
 <kbd>Enter</kbd>
 
@@ -426,7 +426,7 @@ https://github.com/user-attachments/assets/e7077d5d-2387-48b5-8a60-c944d38889ec
 
 ### New Grandchild
 
-Create a thought within the first subthought. With a multiselect, a new grandchild is created in every selected thought; the new grandchildren are then selected, with the cursor on the last of them. With no cursor, the root stands in for it, so the new thought is created within the first visible thought in the root. The command is disabled when any selected thought — or the root, when nothing is selected — has no subthought to create the grandchild in.
+Create a thought within the first subthought. With a multiselect, a new grandchild is created in every selected thought; the new grandchildren are then selected, with the cursor on the last of them. With no cursor, the root stands in for it, so the new thought is created within the first visible thought in the root. The command is disabled when any selected thought — or the root, when nothing is selected — has no subthought to create the grandchild in, and, like New Thought, while the tutorial is on its welcome step.
 
 ### Categorize
 

--- a/src/actions/newGrandChild.ts
+++ b/src/actions/newGrandChild.ts
@@ -1,10 +1,8 @@
 import State from '../@types/State'
 import Thunk from '../@types/Thunk'
 import newThought from '../actions/newThought'
-import { TUTORIAL_STEP_START } from '../constants'
 import { firstVisibleChild } from '../selectors/getChildren'
 import getRootPath from '../selectors/getRootPath'
-import getSetting from '../selectors/getSetting'
 import { registerActionMetadata } from '../util/actionMetadata.registry'
 import appendToPath from '../util/appendToPath'
 import head from '../util/head'
@@ -13,12 +11,6 @@ import head from '../util/head'
  * Creates a new grandchild at the first visible subthought of the cursor. When there is no cursor, the root stands in for it, so the new thought is created in the first visible child of the root.
  */
 const newGrandChild = (state: State): State => {
-  const tutorial = getSetting(state, 'Tutorial') !== 'Off'
-  const tutorialStep = +!getSetting(state, 'Tutorial Step')
-
-  // cancel if the tutorial has just started
-  if (tutorial && tutorialStep === TUTORIAL_STEP_START) return state
-
   const path = state.cursor || getRootPath(state)
   const firstChild = firstVisibleChild(state, head(path))
 

--- a/src/actions/newThought.ts
+++ b/src/actions/newThought.ts
@@ -24,7 +24,6 @@ import {
   TUTORIAL_STEP_FIRSTTHOUGHT_ENTER,
   TUTORIAL_STEP_SECONDTHOUGHT,
   TUTORIAL_STEP_SECONDTHOUGHT_ENTER,
-  TUTORIAL_STEP_START,
   TUTORIAL_STEP_SUBTHOUGHT,
 } from '../constants'
 import asyncFocus from '../device/asyncFocus'
@@ -238,13 +237,7 @@ export const newThoughtActionCreator =
   (dispatch, getState) => {
     const state = getState()
     const { cursor } = state
-    const tutorial = getSetting(state, 'Tutorial') !== 'Off'
-    const tutorialStep = +!getSetting(state, 'Tutorial Step')
-
     const path = at || cursor
-
-    // cancel if tutorial has just started
-    if (tutorial && tutorialStep === TUTORIAL_STEP_START) return
 
     if (!preventSetCursor && isTouch) {
       asyncFocus()

--- a/src/commands/__tests__/newGrandChild.ts
+++ b/src/commands/__tests__/newGrandChild.ts
@@ -366,3 +366,28 @@ describe('multicursor', () => {
     expect(state.expanded[hashPath(contextToPath(state, ['c', 'd'])!)]).toBeTruthy()
   })
 })
+
+describe('tutorial', () => {
+  beforeEach(() => initStore({ allowTutorial: true }))
+
+  // https://github.com/cybersemics/em/issues/5530
+  it.skip('does not create a grandchild on the welcome step', () => {
+    store.dispatch([
+      importText({
+        text: `
+          - a
+            - b
+        `,
+      }),
+      setCursor(['a']),
+    ])
+
+    executeCommandWithMulticursor(newGrandChildCommand, { store })
+
+    const state = store.getState()
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toEqual(`- ${HOME_TOKEN}
+  - a
+    - b`)
+    expectPathToEqual(state, state.cursor, ['a'])
+  })
+})

--- a/src/commands/__tests__/newGrandChild.ts
+++ b/src/commands/__tests__/newGrandChild.ts
@@ -1,7 +1,9 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
+import { tutorialStepActionCreator as setTutorialStep } from '../../actions/tutorialStep'
 import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommandWithMulticursor } from '../../commands'
-import { HOME_TOKEN } from '../../constants'
+import { HOME_TOKEN, TUTORIAL_STEP_START } from '../../constants'
 import contextToPath from '../../selectors/contextToPath'
 import exportContext from '../../selectors/exportContext'
 import store from '../../stores/app'
@@ -368,10 +370,11 @@ describe('multicursor', () => {
 })
 
 describe('tutorial', () => {
-  beforeEach(() => initStore({ allowTutorial: true }))
+  // Reopen the tutorial at the welcome step after the fixture has skipped it, as Help's Part I: Intro does.
+  beforeEach(() => store.dispatch([tutorial({ value: true }), setTutorialStep({ value: TUTORIAL_STEP_START })]))
 
   // https://github.com/cybersemics/em/issues/5530
-  it.skip('does not create a grandchild on the welcome step', () => {
+  it('does not create a grandchild on the welcome step', () => {
     store.dispatch([
       importText({
         text: `

--- a/src/commands/__tests__/newThought.ts
+++ b/src/commands/__tests__/newThought.ts
@@ -196,3 +196,16 @@ describe('multicursor', () => {
     expect(Object.values(state.multicursors).map(head)).toEqual(newThoughts.map(child => child.id))
   })
 })
+
+describe('tutorial', () => {
+  beforeEach(() => initStore({ allowTutorial: true }))
+
+  // https://github.com/cybersemics/em/issues/5530
+  it.skip('does not create a thought on the welcome step', () => {
+    executeCommandWithMulticursor(newThoughtCommand, { store })
+
+    const state = store.getState()
+    expect(exportContext(state, [HOME_TOKEN], 'text/plain')).toBe(`- ${HOME_TOKEN}`)
+    expect(state.cursor).toBeNull()
+  })
+})

--- a/src/commands/__tests__/newThought.ts
+++ b/src/commands/__tests__/newThought.ts
@@ -1,7 +1,9 @@
 import { importTextActionCreator as importText } from '../../actions/importText'
+import { tutorialActionCreator as tutorial } from '../../actions/tutorial'
+import { tutorialStepActionCreator as setTutorialStep } from '../../actions/tutorialStep'
 import { undoActionCreator as undo } from '../../actions/undo'
 import { executeCommandWithMulticursor } from '../../commands'
-import { HOME_TOKEN } from '../../constants'
+import { HOME_TOKEN, TUTORIAL_STEP_START } from '../../constants'
 import exportContext from '../../selectors/exportContext'
 import { getChildrenRanked } from '../../selectors/getChildren'
 import hasMulticursor from '../../selectors/hasMulticursor'
@@ -198,10 +200,11 @@ describe('multicursor', () => {
 })
 
 describe('tutorial', () => {
-  beforeEach(() => initStore({ allowTutorial: true }))
+  // Reopen the tutorial at the welcome step after the fixture has skipped it, as Help's Part I: Intro does.
+  beforeEach(() => store.dispatch([tutorial({ value: true }), setTutorialStep({ value: TUTORIAL_STEP_START })]))
 
   // https://github.com/cybersemics/em/issues/5530
-  it.skip('does not create a thought on the welcome step', () => {
+  it('does not create a thought on the welcome step', () => {
     executeCommandWithMulticursor(newThoughtCommand, { store })
 
     const state = store.getState()

--- a/src/commands/newGrandChild.ts
+++ b/src/commands/newGrandChild.ts
@@ -2,8 +2,11 @@ import Command from '../@types/Command'
 import State from '../@types/State'
 import { newGrandChildActionCreator as newGrandChild } from '../actions/newGrandChild'
 import SettingsIcon from '../components/icons/SettingsIcon'
+import { TUTORIAL_STEP_START } from '../constants'
 import { hasChildren } from '../selectors/getChildren'
 import getRootPath from '../selectors/getRootPath'
+import getSetting from '../selectors/getSetting'
+import isTutorial from '../selectors/isTutorial'
 import selectedPaths from '../selectors/selectedPaths'
 import head from '../util/head'
 import isDocumentEditable from '../util/isDocumentEditable'
@@ -26,7 +29,12 @@ const newGrandChildCommand = {
     const selected = selectedPaths(state)
     // Without a selection, the root stands in for the cursor: the new thought is created in the first visible child of the root, so the root must have a visible child.
     const paths = selected.length > 0 ? selected : [getRootPath(state)]
-    return isDocumentEditable() && paths.every(path => hasChildren(state, head(path)))
+    return (
+      isDocumentEditable() &&
+      // The tutorial's welcome step offers only Next, so creating a thought there would jump ahead of the tutorial.
+      !(isTutorial(state) && +(getSetting(state, 'Tutorial Step') || 1) === TUTORIAL_STEP_START) &&
+      paths.every(path => hasChildren(state, head(path)))
+    )
   },
   exec: dispatch => dispatch(newGrandChild()),
 } satisfies Command

--- a/src/commands/newThought.ts
+++ b/src/commands/newThought.ts
@@ -7,9 +7,12 @@ import { newThoughtActionCreator as newThought } from '../actions/newThought'
 import { splitThoughtActionCreator as splitThought } from '../actions/splitThought'
 import { isTouch } from '../browser'
 import Icon from '../components/icons/NewThoughtIcon'
+import { TUTORIAL_STEP_START } from '../constants'
 import * as selection from '../device/selection'
 import findDescendant from '../selectors/findDescendant'
+import getSetting from '../selectors/getSetting'
 import isContextViewActive from '../selectors/isContextViewActive'
+import isTutorial from '../selectors/isTutorial'
 import pathToThought from '../selectors/pathToThought'
 import rootedParentOf from '../selectors/rootedParentOf'
 import editingValueStore from '../stores/editingValue'
@@ -79,7 +82,10 @@ const newThoughtCommand = {
   svg: Icon,
   // Just chain the immediateyl useful outdent command for now. More can be added in the future.
   isChainable: command => command.id === 'outdent',
-  canExecute: () => isDocumentEditable(),
+  canExecute: (state: State) =>
+    isDocumentEditable() &&
+    // The tutorial's welcome step offers only Next, and the first-thought step is where it asks for Enter, so creating a thought before then would jump ahead of the tutorial.
+    !(isTutorial(state) && +(getSetting(state, 'Tutorial Step') || 1) === TUTORIAL_STEP_START),
   exec,
 } satisfies Command
 

--- a/src/hooks/__tests__/useFilteredCommands.ts
+++ b/src/hooks/__tests__/useFilteredCommands.ts
@@ -183,7 +183,11 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 describe('useFilteredCommands', () => {
   beforeEach(() => {
     // Reset stores
-    store.dispatch({ type: 'clear', full: true })
+    store.dispatch([
+      { type: 'clear', full: true },
+      // Skip the tutorial as initStore does. New Thought, which these tests rely on as an always executable command, is not executable on the tutorial's welcome step.
+      { type: 'tutorial', value: false },
+    ])
     gestureStore.update({ gesture: '', possibleCommands: [] })
     vi.clearAllMocks()
   })


### PR DESCRIPTION
Fixes #5530

New Thought and New Grandchild were meant to be cancelled while the tutorial is on its welcome step, but the guard has been dead since 2020. Commit ac7b47d919 moved it from the shortcut into the `newThought` action-creator and turned `+getSetting(state, 'Tutorial Step')` into `+!getSetting(state, 'Tutorial Step')`, and b1dd52c155 copied that form into `newGrandChild`. `+!x` is 1 only when the setting is falsy, and the setting is never falsy, since `getSetting` falls back to `'1'` and `tutorialStep` always writes a number's string. So the guard never fired, and Enter on the welcome step creates a stray empty thought.

I decided to restore the guard rather than delete it. The welcome step offers only Next, and the first-thought step that follows is where the tutorial asks for Enter, so a thought created before then jumps ahead of the tutorial. That is the behavior the original shortcut had, and the tutorial UI is still built around it.

The guard does not go back where it was, though. Fixing the expression in place would put a live guard under every caller of the `newThought` action-creator, and four of those callers were written after the guard died and never accounted for it. `importFiles` awaits a promise that only the action-creator's `idbSynced` callback resolves, so paste, file drop, and import resume on the welcome step would hang. Toolbar customization would silently drop the dragged command. The in-place fix would also newly gate New Subthought, New Thought Above, New Uncle, and New Subthought Top, which dispatch the same action-creator today but never went through the guard in 2020.

The gate now lives in `canExecute` on the two commands, and the dead guards are deleted from the action-creator and the reducer. `canExecute` is honored by every entry point already: keyboard, gesture, toolbar, Command Center, Command Universe, and the multicursor loop. It also matches the contract in `docs/commands.md`, which says a predicate that reports a command as executable when it would be a no-op leaves an enabled button that does nothing when tapped. Enter still swallows its newline on the welcome step, because `keyDown` sets `keyCommandId` before it checks `canExecute` and `beforeInput` prevents the default from that.

## Plan

**Existing surface area.** The dead guards were in `src/actions/newThought.ts` (the action-creator) and `src/actions/newGrandChild.ts` (the reducer). `TUTORIAL_STEP_START` is 1. `getSetting` falls back to `storageCache.tutorialStep` or `'1'`, and `storageCache` decodes the step as `+(s || 1)`. Beyond the five thought-creating commands, the action-creator is called by `importFiles`, `importData`, `useDragAndDropToolbarButton`, and the transient editable in `Editable`. `executeCommand` returns before `exec` when `canExecute` is false, the multicursor loop checks it per selected path, and `ToolbarButton`, `PanelCommand`, `CommandItem`, and `CommandUniverseGridItem` read it for the enabled appearance.

**Build vs. extend.** Extend `canExecute` on `newThoughtCommand` and `newGrandChildCommand`, the existing mechanism for state-dependent availability. No new files.

**Adjacent behavior.** Paste, import, import resume, toolbar customization, and the transient editable bypass the command layer and are unchanged. Enter with the caret mid-thought on the welcome step, which is reachable by reopening the tutorial from Help, no longer splits either, which matches the expected behavior in the issue. The other four thought-creating commands are unchanged and out of the issue's scope. Nothing is dispatched on the welcome step, so nothing lands in undo history. Both commands render as non-executable on the welcome step in a customized toolbar and in the Command Universe. Neither is in the default toolbar, and no Puppeteer run keeps the tutorial on, so no snapshot changes. The tutorial flow itself is unchanged: the JSDOM tutorial suite still creates the first thought with Enter on the first-thought step.

**Approaches considered.** Fixing the expression in place is the smallest diff but has the blast radius above. Deleting the guards would keep the stray thought. Gating in `canExecute` has the exact scope of the user-facing commands.

## Tests

Store-level tests in `src/commands/__tests__/newThought.ts` and `src/commands/__tests__/newGrandChild.ts` reopen the tutorial on the welcome step the way Help's Part I: Intro does, execute the command, and assert the exported outline is unchanged. Both fail on `main` with the stray empty thought in the export and pass here.

The tests arrange the tutorial with `tutorial` and `tutorialStep` rather than `initStore({ allowTutorial: true })`. After the file-level `initStore` has skipped the tutorial, that option still reports the tutorial as Off, because the skip is cached in `storageCache.tutorialComplete` and survives the reset.

`useFilteredCommands` used a full `clear` as its fixture, which leaves a fresh store on the welcome step, and two of its tests rely on New Thought being executable. Its fixture now skips the tutorial as `initStore` does.

docs: updated `docs/commands.md` (New Thought and New Grandchild entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"3c46de3338f672bc6f82de0fc7a2c49ed90dd283","createdAt":"2026-09-11T22:39:27Z","url":"https://em-fx39qucd1-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 11, 2026, 10:39 PM UTC · 3c46de3</summary>

<a href="https://em-fx39qucd1-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/3d39b4eb-2b12-4eff-8e71-6bf7831f15a0)</a>

</details>
<!-- preview-qr:end -->