### PR TITLE
Add device, user agent, version, and build commit to the top of the debug log

### DIFF
--- a/src/components/modals/Settings.tsx
+++ b/src/components/modals/Settings.tsx
@@ -187,9 +187,11 @@ const DebugLogging = () => {
             {...fastClick(() => {
               // read fresh state for the state.thoughts dump, as above
               dispatch((_, getState) => {
-                const text = debugLog.format(getState())
-                copy(text)
-                setStatus(text ? `Copied ${debugLog.read().length} entries` : 'Log is empty')
+                copy(debugLog.format(getState()))
+                // the formatted log always carries the environment header, so the status counts entries rather than
+                // testing the text for emptiness
+                const entries = debugLog.read().length
+                setStatus(entries ? `Copied ${entries} entries` : 'Log is empty')
               })
             })}
             className={cx(extendTapRecipe(), css({ whiteSpace: 'nowrap' }))}

--- a/src/components/modals/Settings.tsx
+++ b/src/components/modals/Settings.tsx
@@ -190,8 +190,8 @@ const DebugLogging = () => {
                 copy(debugLog.format(getState()))
                 // the formatted log always carries the environment header, so the status counts entries rather than
                 // testing the text for emptiness
-                const entries = debugLog.read().length
-                setStatus(entries ? `Copied ${entries} entries` : 'Log is empty')
+                const entryCount = debugLog.read().length
+                setStatus(entryCount ? `Copied ${entryCount} entries` : 'Log is empty')
               })
             })}
             className={cx(extendTapRecipe(), css({ whiteSpace: 'nowrap' }))}

--- a/src/util/__tests__/debugLog.ts
+++ b/src/util/__tests__/debugLog.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 afterEach(() => {
   debugLog.setEnabled(false)
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('enabled gate', () => {
@@ -153,12 +154,20 @@ describe('format', () => {
     debugLog.clear()
     debugLog.log('input')
     const lines = debugLog.format().split('\n')
-    // the device names the navigator platform (empty in jsdom), the Capacitor shell, the screen, and the pointer type
-    expect(lines[0]).toMatch(/^--- device: .+ \((web|ios|android)\), \d+x\d+, (touch|mouse)$/)
+    // the device names the navigator platform (empty in jsdom), the shell, the screen, and the pointer type
+    expect(lines[0]).toMatch(/^--- device: .+ \((web|ios|android|tauri)\), \d+x\d+, (touch|mouse)$/)
     expect(lines[1]).toBe(`--- userAgent: ${navigator.userAgent}`)
     expect(lines[2]).toBe(`--- version: ${pkg.version}`)
     expect(lines[3]).toBe(`--- commit: ${__COMMIT_HASH__}`)
     expect(lines[4]).toContain('#0 input')
+  })
+
+  it('names the tauri shell, which Capacitor reports as web', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    // the flag the Tauri runtime injects into the WebView, which is what @tauri-apps/api reads to detect the shell
+    vi.stubGlobal('isTauri', true)
+    expect(debugLog.format().split('\n')[0]).toContain('(tauri)')
   })
 
   it('renders the header even when the buffer is empty, so a log with no entries still identifies the build', () => {

--- a/src/util/__tests__/debugLog.ts
+++ b/src/util/__tests__/debugLog.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import pkg from '../../../package.json'
 import State from '../../@types/State'
 import debugLog from '../debugLog'
 import storage from '../storage'
@@ -147,6 +148,27 @@ describe('clear', () => {
 })
 
 describe('format', () => {
+  it('renders the device, user agent, em version, and build commit as the first four lines', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    debugLog.log('input')
+    const lines = debugLog.format().split('\n')
+    // the device names the navigator platform (empty in jsdom), the Capacitor shell, the screen, and the pointer type
+    expect(lines[0]).toMatch(/^--- device: .+ \((web|ios|android)\), \d+x\d+, (touch|mouse)$/)
+    expect(lines[1]).toBe(`--- userAgent: ${navigator.userAgent}`)
+    expect(lines[2]).toBe(`--- version: ${pkg.version}`)
+    expect(lines[3]).toBe(`--- commit: ${__COMMIT_HASH__}`)
+    expect(lines[4]).toContain('#0 input')
+  })
+
+  it('renders the header even when the buffer is empty, so a log with no entries still identifies the build', () => {
+    debugLog.setEnabled(true)
+    debugLog.clear()
+    const lines = debugLog.format().split('\n')
+    expect(lines.length).toBe(4)
+    expect(lines[3]).toBe(`--- commit: ${__COMMIT_HASH__}`)
+  })
+
   it('renders a one-line-per-entry text block', () => {
     debugLog.setEnabled(true)
     debugLog.clear()
@@ -227,7 +249,8 @@ describe('auto-enable', () => {
 
   it('does not auto-enable in the native Capacitor shell', async () => {
     vi.stubEnv('MODE', 'production')
-    vi.doMock('@capacitor/core', () => ({ Capacitor: { isNativePlatform: () => true } }))
+    // getPlatform is part of the shell that src/browser.ts reads at module load, so the double implements it too
+    vi.doMock('@capacitor/core', () => ({ Capacitor: { isNativePlatform: () => true, getPlatform: () => 'ios' } }))
     vi.resetModules()
     const fresh = (await import('../debugLog')).default
     expect(fresh.autoEnabled).toBe(false)

--- a/src/util/debugLog.ts
+++ b/src/util/debugLog.ts
@@ -1,4 +1,5 @@
 import { Capacitor } from '@capacitor/core'
+import { isTauri } from '@tauri-apps/api/core'
 import pkg from '../../package.json'
 import State from '../@types/State'
 import { isTouch } from '../browser'
@@ -223,11 +224,12 @@ const formatThought = (thought: {
 
 /** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. Prepends a header identifying the device, user agent, em version, and build commit. Appends the last-frame marker and, when state is provided, a compact dump of state.thoughts.thoughtIndex (one line per thought, grouped by parent and ordered by rank) so entry ids can be resolved to values and current sibling order is visible. */
 const format = (state?: State): string => {
-  // The device: the navigator platform, the shell em is served through (web, ios, or android), the screen dimensions,
-  // and the pointer type. The shell is worth naming separately because it is not recoverable from the user agent, which
-  // a Capacitor WebView shares with the mobile browser it embeds.
+  // The device: the navigator platform, the shell em is served through (web, ios, android, or tauri), the screen
+  // dimensions, and the pointer type. The shell is worth naming separately because it is not recoverable from the user
+  // agent: a Capacitor WebView shares its user agent with the mobile browser it embeds, and the Tauri desktop shell
+  // reports the web platform to Capacitor, so only the flag its runtime injects tells it apart from a browser.
   const device = [
-    `${(typeof navigator !== 'undefined' && navigator.platform) || 'unknown platform'} (${Capacitor.getPlatform()})`,
+    `${(typeof navigator !== 'undefined' && navigator.platform) || 'unknown platform'} (${isTauri() ? 'tauri' : Capacitor.getPlatform()})`,
     typeof window !== 'undefined' && window.screen
       ? `${window.screen.width}x${window.screen.height}`
       : 'unknown screen',

--- a/src/util/debugLog.ts
+++ b/src/util/debugLog.ts
@@ -1,6 +1,7 @@
 import { Capacitor } from '@capacitor/core'
 import pkg from '../../package.json'
 import State from '../@types/State'
+import { isTouch } from '../browser'
 import storage from './storage'
 
 /** The localStorage key prefix under which the rolling debug log is persisted. Entries are sharded across numbered chunk keys (`debugLog-0` … `debugLog-9`) so that appending an entry only rewrites the active chunk instead of the whole buffer. */
@@ -220,8 +221,30 @@ const formatThought = (thought: {
   return `${thought.id} ${JSON.stringify(value)} rank:${thought.rank} parent:${thought.parentId}${thought.pending ? ' pending' : ''}`
 }
 
-/** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. Appends the last-frame marker and, when state is provided, a compact dump of state.thoughts.thoughtIndex (one line per thought, grouped by parent and ordered by rank) so entry ids can be resolved to values and current sibling order is visible. */
+/** Renders the buffer to a copy-friendly, one-line-per-entry text block for pasting into an issue. Prepends a header identifying the device, user agent, em version, and build commit. Appends the last-frame marker and, when state is provided, a compact dump of state.thoughts.thoughtIndex (one line per thought, grouped by parent and ordered by rank) so entry ids can be resolved to values and current sibling order is visible. */
 const format = (state?: State): string => {
+  // The device: the navigator platform, the shell em is served through (web, ios, or android), the screen dimensions,
+  // and the pointer type. The shell is worth naming separately because it is not recoverable from the user agent, which
+  // a Capacitor WebView shares with the mobile browser it embeds.
+  const device = [
+    `${(typeof navigator !== 'undefined' && navigator.platform) || 'unknown platform'} (${Capacitor.getPlatform()})`,
+    typeof window !== 'undefined' && window.screen
+      ? `${window.screen.width}x${window.screen.height}`
+      : 'unknown screen',
+    isTouch ? 'touch' : 'mouse',
+  ].join(', ')
+
+  // The header is rendered here rather than read back from the session marker, which the rolling buffer evicts once
+  // capacity is exceeded — i.e. in exactly the long sessions whose logs are most worth reading. It describes the device
+  // and build the log was formatted on, so a hydrated log spanning an app update may still carry a session marker from
+  // the version that wrote the older entries.
+  const header = [
+    `--- device: ${device}`,
+    `--- userAgent: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
+    `--- version: ${pkg.version}`,
+    `--- commit: ${__COMMIT_HASH__}`,
+  ].join('\n')
+
   const entryLines = entries
     .map(({ seq, t, dt, type, ...fields }) => {
       const fieldStr = Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : ''
@@ -246,7 +269,7 @@ const format = (state?: State): string => {
       ].join('\n')
     : ''
 
-  return `${entryLines}${markerLine}${dump}`
+  return `${header}${entryLines ? `\n${entryLines}` : ''}${markerLine}${dump}`
 }
 
 /** Empties the buffer and removes all of its localStorage keys, including the legacy single-key buffer and the frame marker. */


### PR DESCRIPTION
A shared debug log is only actionable once you know what it came from. The environment was already recorded, but only in the `session` entry — and that entry lives in the rolling buffer, so it is evicted once 5000 entries accumulate. That is exactly the long session whose log is most worth reading: by the time a freeze has produced thousands of entries, the one entry naming the device and build is the first thing gone.

So `format()` now renders the environment as a header at format time rather than reading it back out of the buffer. Every downloaded, shared, or copied log identifies its origin regardless of how much has been logged since:

```
--- device: iPhone (ios), 390x844, touch
--- userAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) …
--- version: 351.2.0
--- commit: 60b8889
[2026-09-12T12:36:52.275Z] +0ms #0 session {…}
```

The device names the navigator platform, the shell em is served through (`web`, `ios`, `android`, or `tauri`), the screen dimensions, and the pointer type. The shell is worth naming separately because it is not recoverable from the user agent: a Capacitor WebView shares its user agent with the mobile browser it embeds, and the Tauri desktop shell reports the web platform to Capacitor, so only the flag its runtime injects tells the desktop app apart from a browser on the same machine. That flag is read through the detector `@tauri-apps/api` already provides, which is the first use of that package in `src/`.

The `session` entry keeps its own copy of the environment. The header describes the device the log was *formatted* on, so a log hydrated across an app update still carries a session marker from the version that wrote the older entries, which is where a version change between sessions shows up.

One consequence: the formatted log is never empty now, so the Copy status counts entries instead of testing the text for emptiness — otherwise “Log is empty” could never appear.

## Verification

- Ran the app on the dev server in Chromium, enabled Debug Logging in Settings, clicked “Download debug log”, and read the blob the download hands the user. It starts with the four header lines above.
- `src/util/__tests__/debugLog.ts` covers the header's content and ordering, that the tauri shell is named where Capacitor reports `web`, and that the header is still rendered when the buffer is empty. Each was checked to fail without the change.
- Full unit suite green (2645 passed, 64 pre-existing skips); `yarn build`, `tsc`, `eslint`, and `prettier` clean.

## Out of scope

- **`mode` is not in the header**, though it is the one `session` field the header does not reproduce. `import.meta.env.MODE` only separates the dev server from a build: a Vercel preview and production are both `production`, so it would not tell those apart, which is the distinction a shared log would actually want. Say the word and it goes in.
- **No doc describes the debug log's rendered output**, so nothing in `docs/` went stale. `docs/persistence.md` mentions debug logging only for the `push` / `pushSynced` entries, which are unchanged. Worth noting that no doc owns `src/util/debugLog.ts` at all; a subsystem doc for it would be a deliberate addition rather than something to slip into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199GTPKLD9AvUZgkfqK9iqW

---
_Generated by [Claude Code](https://claude.ai/code/session_0199GTPKLD9AvUZgkfqK9iqW)_

<!-- preview-qr:start -->
<!-- preview-qr:state {"stable":{"sha":"2f2a5b465715c4d9e0e64684c93b6b5f45188b74","createdAt":"2026-09-12T12:53:59Z","url":"https://em-547fsdwvw-cybersemics.vercel.app"},"pending":null} -->
<details>
<summary>Preview Deployment · Sep 12, 2026, 12:53 PM UTC · 2f2a5b4</summary>

<a href="https://em-547fsdwvw-cybersemics.vercel.app" target="_blank" rel="noopener noreferrer">![Preview deployment](https://github.com/user-attachments/assets/07e76fce-c2ff-418c-a5bd-ea9b019ce893)</a>

</details>
<!-- preview-qr:end -->